### PR TITLE
 feat: add `run_async` for `HuggingFaceAPIDocumentEmbedder`

### DIFF
--- a/haystack/components/embedders/hugging_face_api_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_document_embedder.py
@@ -4,7 +4,6 @@
 
 from typing import Any, Dict, List, Optional, Union
 
-from more_itertools import batched
 from tqdm import tqdm
 from tqdm.asyncio import tqdm as async_tqdm
 
@@ -291,7 +290,7 @@ class HuggingFaceAPIDocumentEmbedder:
                 logger.warning(msg)
                 normalize = None
 
-        all_embeddings = []
+        all_embeddings: List = []
         for i in async_tqdm(
             range(0, len(texts_to_embed), batch_size), disable=not self.progress_bar, desc="Calculating embeddings"
         ):

--- a/releasenotes/notes/add-async-support-for-HuggingFaceAPIDocumentEmbedder-016bbb1f8964cf3f.yaml
+++ b/releasenotes/notes/add-async-support-for-HuggingFaceAPIDocumentEmbedder-016bbb1f8964cf3f.yaml
@@ -1,0 +1,32 @@
+---
+highlights: >
+    Replace this text with content to appear at the top of the section for this
+    release. The highlights might repeat some details that are also present in other notes
+    from the same release, that's ok. Not every release note requires highlights,
+    use this section only to describe major features or notable changes.
+upgrade:
+  - |
+    List upgrade notes here, or remove this section.
+    Upgrade notes should be rare: only list known/potential breaking changes,
+    or major changes that require user action before the upgrade.
+    Notes here must include steps that users can follow to 1. know if they're
+    affected and 2. handle the change gracefully on their end.
+features:
+  - |
+    List new features here, or remove this section.
+enhancements:
+  - |
+    List new behavior that is too small to be
+    considered a new feature, or remove this section.
+issues:
+  - |
+    List known issues here, or remove this section. For example, if some change is experimental or known to not work in some cases, it should be mentioned here.
+deprecations:
+  - |
+    List deprecations notes here, or remove this section. Deprecations should not be used for something that is removed in the release, use upgrade section instead. Deprecation should allow time for users to make necessary changes for the removal to happen in a future release.
+security:
+  - |
+    Add security notes here, or remove this section.
+fixes:
+  - |
+    Add normal bug fixes here, or remove this section.

--- a/releasenotes/notes/add-async-support-for-HuggingFaceAPIDocumentEmbedder-016bbb1f8964cf3f.yaml
+++ b/releasenotes/notes/add-async-support-for-HuggingFaceAPIDocumentEmbedder-016bbb1f8964cf3f.yaml
@@ -1,32 +1,5 @@
 ---
-highlights: >
-    Replace this text with content to appear at the top of the section for this
-    release. The highlights might repeat some details that are also present in other notes
-    from the same release, that's ok. Not every release note requires highlights,
-    use this section only to describe major features or notable changes.
-upgrade:
-  - |
-    List upgrade notes here, or remove this section.
-    Upgrade notes should be rare: only list known/potential breaking changes,
-    or major changes that require user action before the upgrade.
-    Notes here must include steps that users can follow to 1. know if they're
-    affected and 2. handle the change gracefully on their end.
 features:
   - |
-    List new features here, or remove this section.
-enhancements:
-  - |
-    List new behavior that is too small to be
-    considered a new feature, or remove this section.
-issues:
-  - |
-    List known issues here, or remove this section. For example, if some change is experimental or known to not work in some cases, it should be mentioned here.
-deprecations:
-  - |
-    List deprecations notes here, or remove this section. Deprecations should not be used for something that is removed in the release, use upgrade section instead. Deprecation should allow time for users to make necessary changes for the removal to happen in a future release.
-security:
-  - |
-    Add security notes here, or remove this section.
-fixes:
-  - |
-    Add normal bug fixes here, or remove this section.
+    Add `run_async` method to HuggingFaceAPIDocumentEmbedder. This method enriches Documents with embeddings.
+    It supports the same parameters as the `run` method. It returns a coroutine that can be awaited.

--- a/test/components/embedders/test_hugging_face_api_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_document_embedder.py
@@ -544,32 +544,3 @@ class TestHuggingFaceAPIDocumentEmbedder:
             assert len(doc.embedding) == 384
             assert all(isinstance(x, float) for x in doc.embedding)
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=5)
-    @pytest.mark.asyncio
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("HF_API_TOKEN", None),
-        reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
-    )
-    async def test_live_run_async_serverless(self):
-        docs = [
-            Document(content="I love cheese", meta={"topic": "Cuisine"}),
-            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
-        ]
-
-        embedder = HuggingFaceAPIDocumentEmbedder(
-            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
-            meta_fields_to_embed=["topic"],
-            embedding_separator=" | ",
-        )
-        result = await embedder.run_async(documents=docs)
-        documents_with_embeddings = result["documents"]
-
-        assert isinstance(documents_with_embeddings, list)
-        assert len(documents_with_embeddings) == len(docs)
-        for doc in documents_with_embeddings:
-            assert isinstance(doc, Document)
-            assert isinstance(doc.embedding, list)
-            assert len(doc.embedding) == 384
-            assert all(isinstance(x, float) for x in doc.embedding)

--- a/test/components/embedders/test_hugging_face_api_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_document_embedder.py
@@ -356,6 +356,19 @@ class TestHuggingFaceAPIDocumentEmbedder:
             assert len(doc.embedding) == 384
             assert all(isinstance(x, float) for x in doc.embedding)
 
+    def test_adjust_api_parameters(self):
+        truncate, normalize = HuggingFaceAPIDocumentEmbedder._adjust_api_parameters(
+            True, False, HFEmbeddingAPIType.SERVERLESS_INFERENCE_API
+        )
+        assert truncate is None
+        assert normalize is None
+
+        truncate, normalize = HuggingFaceAPIDocumentEmbedder._adjust_api_parameters(
+            True, False, HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE
+        )
+        assert truncate is True
+        assert normalize is False
+
     @pytest.mark.flaky(reruns=5, reruns_delay=5)
     @pytest.mark.integration
     @pytest.mark.skipif(
@@ -543,4 +556,3 @@ class TestHuggingFaceAPIDocumentEmbedder:
             assert isinstance(doc.embedding, list)
             assert len(doc.embedding) == 384
             assert all(isinstance(x, float) for x in doc.embedding)
-


### PR DESCRIPTION
### Related Issues

- fixes #9018


### Proposed Changes:

I refactored the code for HuggingFaceAPIDocumentEmbedder  to add async support.

### How did you test it?

I have added an integration test. All the unit tests are passing locally.

### Notes for the reviewer

issues in the implantation:

- doc string: unsure how to update it to give an example of run_async

- code duplication: Async/sync Python requires separate implementations.  As a result I just did the tests pretty much twice and embed_batch/embed_batch_async and run/run_Async where 90 percent of the code. How can I do it smarter? I tried but the problem is I can't call an async function from a sync one thus having to duplicate my code( especially tests!)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
