### PR TITLE
fix: Document field precedence in to_dict()

### DIFF
--- a/haystack/dataclasses/document.py
+++ b/haystack/dataclasses/document.py
@@ -132,7 +132,7 @@ class Document(metaclass=_BackwardCompatible):
 
         if flatten:
             meta = data.pop("meta")
-            return {**data, **meta}
+            return {**meta, **data}
 
         return data
 


### PR DESCRIPTION
### Related Issues

- fixes #9180

### Proposed Changes:

- prioritize documents first-level fields over meta fields by overriding meta fields in case of representation.

### How did you test it?

- added unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
