### PR TITLE
fix: Allow Agent to run with no tools

### DIFF
--- a/releasenotes/notes/fix-agent-with-no-tools-aadc4274e2f72033.yaml
+++ b/releasenotes/notes/fix-agent-with-no-tools-aadc4274e2f72033.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Now when you call an Agent with no tools it acts like a ChatGenerator which means it returns a ChatMessage based on a user input.


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9220

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Updates the init and run logic of Agent to truly allow Tools to be optional. This means an Agent can be run with no Tools now which makes it act like a normal ChatGenerator. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added a test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
