### PR TITLE
fix: make `ChatMessage.from_dict` handle cases where optional fields are missing

### DIFF
--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -361,7 +361,11 @@ class ChatMessage:
             The created object.
         """
         if "content" in data:
-            init_params = {"_role": ChatRole(data["role"]), "_name": data["name"], "_meta": data["meta"]}
+            init_params: Dict[str, Any] = {
+                "_role": ChatRole(data["role"]),
+                "_name": data.get("name"),
+                "_meta": data.get("meta") or {},
+            }
 
             if isinstance(data["content"], list):
                 # current format - the serialized `content` field is a list of dictionaries
@@ -378,8 +382,8 @@ class ChatMessage:
             return cls(
                 _role=ChatRole(data["_role"]),
                 _content=_deserialize_content(data["_content"]),
-                _name=data["_name"],
-                _meta=data["_meta"],
+                _name=data.get("_name"),
+                _meta=data.get("_meta") or {},
             )
 
         raise ValueError(f"Missing 'content' or '_content' in serialized ChatMessage: `{data}`")

--- a/releasenotes/notes/chatmessage-from-dict-fix-bd361b59071651ae.yaml
+++ b/releasenotes/notes/chatmessage-from-dict-fix-bd361b59071651ae.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix `ChatMessage.from_dict` to handle cases where optional fields like `name` and `meta` are missing.

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -226,6 +226,16 @@ def test_from_dict_with_pre29_format():
     assert msg.meta == {"some": "info"}
 
 
+def test_from_dict_with_pre29_format_some_fields_missing():
+    serialized_msg_pre_29 = {"role": "user", "content": "This is a message"}
+    msg = ChatMessage.from_dict(serialized_msg_pre_29)
+
+    assert msg.role == ChatRole.USER
+    assert msg._content == [TextContent(text="This is a message")]
+    assert msg.name is None
+    assert msg.meta == {}
+
+
 def test_from_dict_with_pre212_format():
     """
     Test that we can deserialize messages serialized with versions >=2.9.0 and <2.12.0,
@@ -243,6 +253,16 @@ def test_from_dict_with_pre212_format():
     assert msg._content == [TextContent(text="This is a message")]
     assert msg.name == "some_name"
     assert msg.meta == {"some": "info"}
+
+
+def test_from_dict_with_pre212_format_some_fields_missing():
+    serialized_msg_pre_212 = {"_role": "user", "_content": [{"text": "This is a message"}]}
+    msg = ChatMessage.from_dict(serialized_msg_pre_212)
+
+    assert msg.role == ChatRole.USER
+    assert msg._content == [TextContent(text="This is a message")]
+    assert msg.name is None
+    assert msg.meta == {}
 
 
 def test_from_dict_missing_content_field():


### PR DESCRIPTION


### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
