### PR TITLE
feat: Add super component decorator

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -13,7 +13,7 @@ from haystack.core.component import component
 from haystack.core.errors import ComponentError, DeserializationError
 from haystack.core.pipeline import AsyncPipeline, Pipeline, PredefinedPipeline
 from haystack.core.serialization import default_from_dict, default_to_dict
-from haystack.core.super_component import SuperComponent
+from haystack.core.super_component.super_component import SuperComponent, super_component
 from haystack.dataclasses import Answer, Document, ExtractedAnswer, GeneratedAnswer
 from haystack.version import __version__
 
@@ -35,6 +35,7 @@ __all__ = [
     "Pipeline",
     "PredefinedPipeline",
     "SuperComponent",
+    "super_component",
     "component",
     "default_from_dict",
     "default_to_dict",

--- a/haystack/core/super_component/__init__.py
+++ b/haystack/core/super_component/__init__.py
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .super_component import SuperComponent
+from .super_component import SuperComponent, super_component
 
-__all__ = ["SuperComponent"]
+__all__ = ["SuperComponent", "super_component"]

--- a/test/core/super_component/test_super_component.py
+++ b/test/core/super_component/test_super_component.py
@@ -4,7 +4,7 @@
 from typing import List
 
 import pytest
-from haystack import Document, SuperComponent, Pipeline, AsyncPipeline, component
+from haystack import Document, SuperComponent, Pipeline, AsyncPipeline, component, super_component
 from haystack.components.builders import AnswerBuilder, PromptBuilder
 from haystack.components.generators import OpenAIGenerator
 from haystack.components.joiners import DocumentJoiner
@@ -254,14 +254,40 @@ class TestSuperComponent:
         assert result["documents"][0].content == "Paris is the capital of France."
 
     def test_subclass_serialization(self, rag_pipeline):
-        super_component = SuperComponent(rag_pipeline)
-        serialized = super_component.to_dict()
+        super_comp = SuperComponent(rag_pipeline)
+        serialized = super_comp.to_dict()
 
         @component
         class CustomSuperComponent(SuperComponent):
             def __init__(self, pipeline, instance_attribute="test"):
                 self.instance_attribute = instance_attribute
                 super(CustomSuperComponent, self).__init__(pipeline)
+
+            def to_dict(self):
+                return default_to_dict(
+                    self, instance_attribute=self.instance_attribute, pipeline=self.pipeline.to_dict()
+                )
+
+            @classmethod
+            def from_dict(cls, data):
+                data["init_parameters"]["pipeline"] = Pipeline.from_dict(data["init_parameters"]["pipeline"])
+                return default_from_dict(cls, data)
+
+        custom_super_component = CustomSuperComponent(rag_pipeline)
+        custom_serialized = custom_super_component.to_dict()
+
+        assert custom_serialized["type"] == "test_super_component.CustomSuperComponent"
+        assert custom_super_component._to_super_component_dict() == serialized
+
+    def test_subclass_serialization_decorator(self, rag_pipeline):
+        super_comp = SuperComponent(rag_pipeline)
+        serialized = super_comp.to_dict()
+
+        @super_component
+        class CustomSuperComponent:
+            def __init__(self, pipeline, instance_attribute="test"):
+                self.instance_attribute = instance_attribute
+                self.pipeline = pipeline
 
             def to_dict(self):
                 return default_to_dict(


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9175

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Creates a base `_SuperComponent` class that contains everything except `to_dict` and `from_dict`. Then in `SuperComponent` we add the default `to_dict` and `from_dict` methods. This should allow users to still directly use `SuperComponent` and allows us to use the `_SuperComponent` base class in the `super_component` decorator where we don't want `to_dict` or `from_dict` to be set. 
- Adds a `super_component` decorator that still preserves the original class information including the signature of the init method. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Added a test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
