### PR TITLE
chore: `TextFileToDocument` - fix erroneous docstring

### DIFF
--- a/haystack/components/converters/txt.py
+++ b/haystack/components/converters/txt.py
@@ -60,7 +60,7 @@ class TextFileToDocument:
         Converts text files to documents.
 
         :param sources:
-            List of txt file paths or ByteStream objects to convert.
+            List of text file paths or ByteStream objects to convert.
         :param meta:
             Optional metadata to attach to the documents.
             This value can be a list of dictionaries or a single dictionary.

--- a/haystack/components/converters/txt.py
+++ b/haystack/components/converters/txt.py
@@ -60,7 +60,7 @@ class TextFileToDocument:
         Converts text files to documents.
 
         :param sources:
-            List of HTML file paths or ByteStream objects to convert.
+            List of txt file paths or ByteStream objects to convert.
         :param meta:
             Optional metadata to attach to the documents.
             This value can be a list of dictionaries or a single dictionary.


### PR DESCRIPTION
### Proposed Changes:
- fix the erroneous docstring: for `TextFileToDocument`, "HTML file paths" should be "text file paths"

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
