### PR TITLE
fix: Add `batch_size` to `to_dict` of TransformersSimilarityRanker

### DIFF
--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -173,6 +173,7 @@ class TransformersSimilarityRanker:
             score_threshold=self.score_threshold,
             model_kwargs=self.model_kwargs,
             tokenizer_kwargs=self.tokenizer_kwargs,
+            batch_size=self.batch_size,
         )
 
         serialize_hf_model_kwargs(serialization_dict["init_parameters"]["model_kwargs"])

--- a/releasenotes/notes/fix-to-dict-transformer-ranker-f981b37f67f6eec5.yaml
+++ b/releasenotes/notes/fix-to-dict-transformer-ranker-f981b37f67f6eec5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The batch_size parameter has now been added to to_dict function of TransformersSimilarityRanker. This means serialization of batch_size now works as expected.

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -34,6 +34,7 @@ class TestSimilarityRanker:
                 "score_threshold": None,
                 "model_kwargs": {"device_map": ComponentDevice.resolve_device(None).to_hf()},
                 "tokenizer_kwargs": {},
+                "batch_size": 16,
             },
         }
 
@@ -50,6 +51,7 @@ class TestSimilarityRanker:
             score_threshold=0.01,
             model_kwargs={"torch_dtype": torch.float16},
             tokenizer_kwargs={"model_max_length": 512},
+            batch_size=32,
         )
         data = component.to_dict()
         assert data == {
@@ -71,6 +73,7 @@ class TestSimilarityRanker:
                     "device_map": ComponentDevice.from_str("cuda:0").to_hf(),
                 },  # torch_dtype is correctly serialized
                 "tokenizer_kwargs": {"model_max_length": 512},
+                "batch_size": 32,
             },
         }
 
@@ -106,6 +109,7 @@ class TestSimilarityRanker:
                     "device_map": ComponentDevice.resolve_device(None).to_hf(),
                 },
                 "tokenizer_kwargs": {},
+                "batch_size": 16,
             },
         }
 
@@ -137,6 +141,7 @@ class TestSimilarityRanker:
                 "score_threshold": None,
                 "model_kwargs": {"device_map": expected},
                 "tokenizer_kwargs": {},
+                "batch_size": 16,
             },
         }
 
@@ -157,6 +162,7 @@ class TestSimilarityRanker:
                 "score_threshold": 0.01,
                 "model_kwargs": {"torch_dtype": "torch.float16"},
                 "tokenizer_kwargs": {"model_max_length": 512},
+                "batch_size": 32,
             },
         }
 
@@ -178,6 +184,7 @@ class TestSimilarityRanker:
             "device_map": ComponentDevice.resolve_device(None).to_hf(),
         }
         assert component.tokenizer_kwargs == {"model_max_length": 512}
+        assert component.batch_size == 32
 
     def test_from_dict_no_default_parameters(self):
         data = {
@@ -199,6 +206,8 @@ class TestSimilarityRanker:
         assert component.score_threshold is None
         # torch_dtype is correctly deserialized
         assert component.model_kwargs == {"device_map": ComponentDevice.resolve_device(None).to_hf()}
+        assert component.tokenizer_kwargs == {}
+        assert component.batch_size == 16
 
     @patch("torch.sigmoid")
     @patch("torch.sort")


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add `batch_size` to `to_dict` of TransformersSimilarityRanker. This means serialization of batch_size now works as expected.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated to_dict and from_dict tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
