### PR TITLE
fix: make mypy run + some type fixes on Agent

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -245,7 +245,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.sha }}
 
       - name: Mypy
-        if: steps.files.outputs.any_changed == 'true'
+        if: steps.files.outputs.python_any_changed == 'true' || steps.files.outputs.pyproject_any_changed == 'true'
         run: |
           mkdir .mypy_cache
           hatch run test:types

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -132,6 +132,7 @@ class Agent:
             component.set_input_type(self, name=param, type=config["type"], default=None)
         component.set_output_types(self, **output_types)
 
+        self._tool_invoker = None
         if self.tools:
             self._tool_invoker = ToolInvoker(tools=self.tools, raise_on_failure=self.raise_on_tool_invocation_failure)
         else:
@@ -139,7 +140,7 @@ class Agent:
                 "No tools provided to the Agent. The Agent will behave like a ChatGenerator and only return text "
                 "responses. To enable tool usage, pass tools directly to the Agent, not to the chat_generator."
             )
-            self._tool_invoker = None
+
         self._is_warmed_up = False
 
     def warm_up(self) -> None:
@@ -199,7 +200,7 @@ class Agent:
 
     def _prepare_generator_inputs(self, streaming_callback: Optional[StreamingCallbackT] = None) -> Dict[str, Any]:
         """Prepare inputs for the chat generator."""
-        generator_inputs = {"tools": self.tools}
+        generator_inputs: Dict[str, Any] = {"tools": self.tools}
         selected_callback = streaming_callback or self.streaming_callback
         if selected_callback is not None:
             generator_inputs["streaming_callback"] = selected_callback

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -206,7 +206,7 @@ class Agent:
             generator_inputs["streaming_callback"] = selected_callback
         return generator_inputs
 
-    def _create_agent_span(self) -> Iterator[tracing.Span]:
+    def _create_agent_span(self) -> Any:
         """Create a span for the agent run."""
         return tracing.tracer.trace(
             "haystack.agent.run",

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -4,7 +4,7 @@
 
 import inspect
 from copy import deepcopy
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, List, Optional
 
 from haystack import component, default_from_dict, default_to_dict, logging, tracing
 from haystack.components.generators.chat.types import ChatGenerator


### PR DESCRIPTION
### Related Issues

- after #9217, mypy is not running since `steps.files.outputs.any_changed == 'true'` is not valid when using `files_yaml`
- for this reason, mypy did not run on #9240 and now some issues are detected on `Agent`

### Proposed Changes:
- fix lint job appropriately
- fix some type errors on `Agent`

### How did you test it?
CI

### Notes for the reviewer
I could not fix all type errors without altering `Agent` tracing, so I need help from @sjrl to fix the remaining errors.
See https://github.com/deepset-ai/haystack/actions/runs/14494497923/job/40659163363?pr=9250

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
