### PR TITLE
fix: Fix f-string interpolation of `received` variable in llm_evaluator

### DIFF
--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -374,7 +374,7 @@ class LLMEvaluator:
         if not all(output in parsed_output for output in expected):
             if self.raise_on_failure:
                 raise ValueError(
-                    f"Expected response from LLM evaluator to be JSON with keys {expected}, got {{received}}."
+                    f"Expected response from LLM evaluator to be JSON with keys {expected}, got {received}."
                 )
             logger.warning(
                 "Expected response from LLM evaluator to be JSON with keys {expected}, got {received}.",


### PR DESCRIPTION
### Related Issues

-

### Proposed Changes:

The bug was caused by using double braces ({{received}}) in the f‑string, which escaped the placeholder and rendered the literal text {received} instead of substituting the variable’s value. This change updates the f‑string in llm_evaluator.py to use single braces ({received}), ensuring the variable is correctly interpolated.


### How did you test it?

Manually verified by invoking the evaluator with a mock response and inspecting the output string.

### Notes for the reviewer

-

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
