### PR TITLE
ci: stop rerunning tests on PRs ready for review

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - ready_for_review
     paths:
       - "e2e/**/*.py"
       - ".github/workflows/e2e.yml"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - ready_for_review
     paths:
       # Keep the list in sync with the paths defined in the `tests_skipper_trigger.yml` workflow
       - "haystack/**/*.py"


### PR DESCRIPTION
### Related Issues

I noticed that we currently re-run tests (and e2e tests) when a PR is marked as "Ready for review".

Since tests already run when the PR is opened, reopened or synchronized, this should not be necessary.

Avoiding this behavior, we can save time and compute.

### Proposed Changes:
- stop rerunning tests on PRs ready for review

### How did you test it?
CI

### Notes for the reviewer
In case something does not work as expected, it is easy to revert this change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
