### PR TITLE
docs: Update openapi.py to use arguments

### DIFF
--- a/haystack/components/connectors/openapi.py
+++ b/haystack/components/connectors/openapi.py
@@ -35,7 +35,7 @@ class OpenAPIConnector:
     )
     response = connector.run(
         operation_id="search",
-        parameters={"q": "Who was Nikola Tesla?"}
+        arguments={"q": "Who was Nikola Tesla?"}
     )
     ```
     Note:
@@ -91,7 +91,7 @@ class OpenAPIConnector:
         Invokes a REST endpoint specified in the OpenAPI specification.
 
         :param operation_id: The operationId from the OpenAPI spec to invoke
-        :param parameters: Optional parameters for the endpoint (query, path, or body parameters)
+        :param arguments: Optional parameters for the endpoint (query, path, or body parameters)
         :return: Dictionary containing the service response
         """
         payload = {"name": operation_id, "arguments": arguments or {}}


### PR DESCRIPTION
### Proposed Changes:

The documentation uses `parameters` but the actual name is `arguments`.

### How did you test it?

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
