### PR TITLE
feat: return common type in SuperComponent type compatibility check

### DIFF
--- a/haystack/core/super_component/super_component.py
+++ b/haystack/core/super_component/super_component.py
@@ -210,16 +210,20 @@ class _SuperComponent:
                         aggregated_inputs[wrapper_input_name]["default"] = _delegate_default
                     continue
 
-                if not _is_compatible(existing_socket_info["type"], socket_info["type"]):
+                is_compatible, common_type = _is_compatible(existing_socket_info["type"], socket_info["type"])
+
+                if not is_compatible:
                     raise InvalidMappingTypeError(
                         f"Type conflict for input '{socket_name}' from component '{comp_name}'. "
                         f"Existing type: {existing_socket_info['type']}, new type: {socket_info['type']}."
                     )
 
+                # Use the common type for the aggregated input
+                aggregated_inputs[wrapper_input_name]["type"] = common_type
+
                 # If any socket requires mandatory inputs then the aggregated input is also considered mandatory.
                 # So we use the type of the mandatory input and remove the default value if it exists.
                 if socket_info["is_mandatory"]:
-                    aggregated_inputs[wrapper_input_name]["type"] = socket_info["type"]
                     aggregated_inputs[wrapper_input_name].pop("default", None)
 
         return aggregated_inputs

--- a/releasenotes/notes/super-component-common-type-30ee9b5522e97ec6.yaml
+++ b/releasenotes/notes/super-component-common-type-30ee9b5522e97ec6.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Enhance SuperComponent's type compatibility check to return the detected common type between two input types.

--- a/test/core/super_component/test_super_component.py
+++ b/test/core/super_component/test_super_component.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import List
+from typing import Any, List, Optional, Union
 
 import pytest
 from haystack import Document, SuperComponent, Pipeline, AsyncPipeline, component, super_component
@@ -314,3 +314,70 @@ class TestSuperComponent:
         assert isinstance(custom_super_component, CustomSuperComponent)
         assert custom_super_component.var1 == 1
         assert custom_super_component.var2 == "test"
+
+    def test_input_types_reconciliation(self):
+        """Test that input types are properly reconciled when they are compatible but not identical."""
+
+        @component
+        class TypeTestComponent:
+            @component.output_types(result_int=int, result_any=Any)
+            def run(self, input_int: int, input_any: Any):
+                return {"result_int": input_int, "result_any": input_any}
+
+        pipeline = Pipeline()
+        pipeline.add_component("test1", TypeTestComponent())
+        pipeline.add_component("test2", TypeTestComponent())
+
+        input_mapping = {"number": ["test1.input_int", "test2.input_any"]}
+        output_mapping = {"test2.result_int": "result_int"}
+        wrapper = SuperComponent(pipeline=pipeline, input_mapping=input_mapping, output_mapping=output_mapping)
+
+        input_sockets = wrapper.__haystack_input__._sockets_dict
+        assert "number" in input_sockets
+        assert input_sockets["number"].type == int
+
+    def test_union_type_reconciliation(self):
+        """Test that Union types are properly reconciled when creating a SuperComponent."""
+
+        @component
+        class UnionTypeComponent1:
+            @component.output_types(result=Union[int, str])
+            def run(self, input: Union[int, str]):
+                return {"result": input}
+
+        @component
+        class UnionTypeComponent2:
+            @component.output_types(result=Union[float, str])
+            def run(self, input: Union[float, str]):
+                return {"result": input}
+
+        pipeline = Pipeline()
+        pipeline.add_component("test1", UnionTypeComponent1())
+        pipeline.add_component("test2", UnionTypeComponent2())
+
+        input_mapping = {"data": ["test1.input", "test2.input"]}
+        output_mapping = {"test2.result": "result"}
+        wrapper = SuperComponent(pipeline=pipeline, input_mapping=input_mapping, output_mapping=output_mapping)
+
+        input_sockets = wrapper.__haystack_input__._sockets_dict
+        assert "data" in input_sockets
+        assert input_sockets["data"].type == Union[str]
+
+    def test_input_types_with_any(self):
+        """Test that Any type is properly handled when reconciling types."""
+
+        @component
+        class AnyTypeComponent:
+            @component.output_types(result=str)
+            def run(self, specific: str, generic: Any):
+                return {"result": specific}
+
+        pipeline = Pipeline()
+        pipeline.add_component("test", AnyTypeComponent())
+
+        input_mapping = {"text": ["test.specific", "test.generic"]}
+        wrapper = SuperComponent(pipeline=pipeline, input_mapping=input_mapping)
+
+        input_sockets = wrapper.__haystack_input__._sockets_dict
+        assert "text" in input_sockets
+        assert input_sockets["text"].type == str


### PR DESCRIPTION
### Related Issues

- fixes #9076 

### Proposed Changes:

- modified _types_are_compatible to return Tuple[bool, Optional[T]]
- updated super_component.py to use the common type returned by _types_are_compatible

### How did you test it?

- added unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
