### PR TITLE
fix: Fix `from_dict` of `DocumentPreprocessor` super component

### DIFF
--- a/haystack/components/preprocessors/document_preprocessor.py
+++ b/haystack/components/preprocessors/document_preprocessor.py
@@ -186,9 +186,7 @@ class DocumentPreprocessor:
         :returns:
             Deserialized SuperComponent.
         """
-        if "splitting_function" in data["init_parameters"]:
-            data["init_parameters"]["splitting_function"] = deserialize_callable(
-                data["init_parameters"]["splitting_function"]
-            )
-
+        splitting_function = data["init_parameters"].get("splitting_function", None)
+        if splitting_function:
+            data["init_parameters"]["splitting_function"] = deserialize_callable(splitting_function)
         return default_from_dict(cls, data)

--- a/test/components/preprocessors/test_document_preprocessor.py
+++ b/test/components/preprocessors/test_document_preprocessor.py
@@ -45,22 +45,29 @@ class TestDocumentPreprocessor:
         assert splitter.language == "en"
 
     def test_from_dict(self) -> None:
-        preprocessor = DocumentPreprocessor.from_dict(
-            {
-                "init_parameters": {
-                    "remove_empty_lines": True,
-                    "remove_extra_whitespaces": True,
-                    "remove_repeated_substrings": False,
-                    "keep_id": True,
-                    "split_by": "word",
-                    "split_length": 3,
-                    "split_overlap": 1,
-                    "respect_sentence_boundary": False,
-                    "language": "en",
-                },
-                "type": "haystack.components.preprocessors.document_preprocessor.DocumentPreprocessor",
-            }
-        )
+        data = {
+            "init_parameters": {
+                "remove_empty_lines": True,
+                "remove_extra_whitespaces": True,
+                "remove_repeated_substrings": False,
+                "keep_id": True,
+                "remove_substrings": None,
+                "remove_regex": None,
+                "unicode_normalization": None,
+                "ascii_only": False,
+                "split_by": "word",
+                "split_length": 3,
+                "split_overlap": 1,
+                "split_threshold": 0,
+                "splitting_function": None,
+                "respect_sentence_boundary": False,
+                "language": "en",
+                "use_split_rules": True,
+                "extend_abbreviations": True,
+            },
+            "type": "haystack.components.preprocessors.document_preprocessor.DocumentPreprocessor",
+        }
+        preprocessor = DocumentPreprocessor.from_dict(data)
         assert isinstance(preprocessor, DocumentPreprocessor)
 
     def test_to_dict(self, preprocessor: DocumentPreprocessor) -> None:


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Updates `from_dict` to handle `splitting_function: None`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated from_dict test for this behavior

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
