### PR TITLE
fix: Fix state_schema serialization for agent tracing

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -214,7 +214,7 @@ class Agent:
                 "haystack.agent.max_steps": self.max_agent_steps,
                 "haystack.agent.tools": self.tools,
                 "haystack.agent.exit_conditions": self.exit_conditions,
-                "haystack.agent.state_schema": self.state_schema,
+                "haystack.agent.state_schema": _schema_to_dict(self.state_schema),
             },
         )
 

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -740,7 +740,12 @@ class TestAgentTracing:
                 )
             ],
             ["text"],
-            {"messages": {"type": List[ChatMessage], "handler": merge_lists}},
+            {
+                "messages": {
+                    "type": "typing.List[haystack.dataclasses.chat_message.ChatMessage]",
+                    "handler": "haystack.dataclasses.state_utils.merge_lists",
+                }
+            },
             {"messages": [ChatMessage.from_user(text="What's the weather in Paris?")], "streaming_callback": None},
             {
                 "messages": [
@@ -836,7 +841,12 @@ class TestAgentTracing:
                 )
             ],
             ["text"],
-            {"messages": {"type": List[ChatMessage], "handler": merge_lists}},
+            {
+                "messages": {
+                    "type": "typing.List[haystack.dataclasses.chat_message.ChatMessage]",
+                    "handler": "haystack.dataclasses.state_utils.merge_lists",
+                }
+            },
             {"messages": [ChatMessage.from_user(text="What's the weather in Paris?")], "streaming_callback": None},
             {
                 "messages": [


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Uses `_schema_to_dict` when creating the span for the agent tracing. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated tracing tests to reflect this

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
