### PR TITLE
test: improve some slow tests

### DIFF
--- a/test/components/fetchers/test_link_content_fetcher.py
+++ b/test/components/fetchers/test_link_content_fetcher.py
@@ -123,7 +123,7 @@ class TestLinkContentFetcher:
     def test_run_bad_status_code(self):
         """Test behavior when a request results in an error status code"""
         empty_byte_stream = b""
-        fetcher = LinkContentFetcher(raise_on_failure=False)
+        fetcher = LinkContentFetcher(raise_on_failure=False, retry_attempts=0)
         mock_response = Mock(status_code=403)
         mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
             "403 Client Error", request=Mock(), response=mock_response
@@ -304,12 +304,12 @@ class TestLinkContentFetcherAsync:
             mock_get.return_value = mock_response
 
             # With raise_on_failure=False
-            fetcher = LinkContentFetcher(raise_on_failure=False)
+            fetcher = LinkContentFetcher(raise_on_failure=False, retry_attempts=0)
             streams = (await fetcher.run_async(urls=["https://www.example.com"]))["streams"]
             assert len(streams) == 1  # Returns an empty stream
 
             # With raise_on_failure=True
-            fetcher = LinkContentFetcher(raise_on_failure=True)
+            fetcher = LinkContentFetcher(raise_on_failure=True, retry_attempts=0)
             with pytest.raises(httpx.HTTPStatusError):
                 await fetcher.run_async(urls=["https://www.example.com"])
 

--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -310,16 +310,11 @@ class TestOpenAIGenerator:
     def test_run_with_system_prompt(self):
         generator = OpenAIGenerator(
             model="gpt-4o-mini",
-            system_prompt="You answer in Portuguese, regardless of the language on which a question is asked",
+            system_prompt="Answer in Italian, regardless of the language in which the question is asked.",
         )
-        result = generator.run("Can you explain the Pitagoras therom?")
-        assert "teorema" in result["replies"][0].lower()
-
-        result = generator.run(
-            "Can you explain the Pitagoras therom? Repeat the name of the theorem in German.",
-            system_prompt="You answer in German, regardless of the language on which a question is asked.",
-        )
-        assert "pythag" in result["replies"][0].lower()
+        result = generator.run("What's the capital of Italy?")
+        print(result["replies"])
+        assert "roma" in result["replies"][0].lower()
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),

--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -308,12 +308,8 @@ class TestOpenAIGenerator:
     )
     @pytest.mark.integration
     def test_run_with_system_prompt(self):
-        generator = OpenAIGenerator(
-            model="gpt-4o-mini",
-            system_prompt="Answer in Italian, regardless of the language in which the question is asked.",
-        )
+        generator = OpenAIGenerator(model="gpt-4o-mini", system_prompt="Answer in Italian using only one word.")
         result = generator.run("What's the capital of Italy?")
-        print(result["replies"])
         assert "roma" in result["replies"][0].lower()
 
     @pytest.mark.skipif(

--- a/test/core/pipeline/test_async_pipeline.py
+++ b/test/core/pipeline/test_async_pipeline.py
@@ -7,7 +7,7 @@ def test_async_pipeline_reentrance(waiting_component, spying_tracer):
     pp = AsyncPipeline()
     pp.add_component("wait", waiting_component())
 
-    run_data = [{"wait_for": 1}, {"wait_for": 2}]
+    run_data = [{"wait_for": 0.001}, {"wait_for": 0.002}]
 
     async def run_all():
         # Create concurrent tasks for each pipeline run

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -23,7 +23,7 @@ class TestPipeline:
         pp = Pipeline()
         pp.add_component("wait", waiting_component())
 
-        run_data = [{"wait_for": 1}, {"wait_for": 2}]
+        run_data = [{"wait_for": 0.001}, {"wait_for": 0.002}]
 
         # Use ThreadPoolExecutor to run pipeline calls in parallel
         with ThreadPoolExecutor(max_workers=len(run_data)) as executor:


### PR DESCRIPTION
### Related Issues

As suggested by @mpangrazzi, I did some profiling to detect more slow tests (on macOS).

**Unit tests**
```
12.08s call     test/components/fetchers/test_link_content_fetcher.py::TestLinkContentFetcherAsync::test_run_async_error_handling
2.03s  call     test/components/fetchers/test_link_content_fetcher.py::TestLinkContentFetcher::test_run_bad_status_code
2.01s  call     test/core/pipeline/test_pipeline.py::TestPipeline::test_pipeline_thread_safety
2.00s  call     test/core/pipeline/test_async_pipeline.py::test_async_pipeline_reentrance
```

**Integration tests**
I'm treating most of them in #9296 (by running them on a separate workflow) but I also found that
`test/components/generators/test_openai.py::TestOpenAIGenerator::test_run_with_system_prompt`
is quite slow (around 7s).

### Proposed Changes:
- fix the slow tests
  - if they use `time.sleep`, reduce sleeping time
  - if they retry mocked HTTP requests, avoid retrying
  - simplify the OpenAI generator test

### How did you test it?
CI, local tests

```
0.04s  call     test/components/fetchers/test_link_content_fetcher.py::TestLinkContentFetcherAsync::test_run_async_error_handling
0.02s  call     test/components/fetchers/test_link_content_fetcher.py::TestLinkContentFetcher::test_run_bad_status_code
0.00s  call     test/core/pipeline/test_pipeline.py::TestPipeline::test_pipeline_thread_safety
0.00s  call     test/core/pipeline/test_async_pipeline.py::test_async_pipeline_reentrance
```

`0.65s  call     test/components/generators/test_openai.py::TestOpenAIGenerator::test_run_with_system_prompt`

*I'm saving around 24s* (on macOS)

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
