### PR TITLE
fix: Move `deserialize_tools_inplace` to original import path

### DIFF
--- a/haystack/components/generators/openai_dalle.py
+++ b/haystack/components/generators/openai_dalle.py
@@ -127,9 +127,14 @@ class DALLEImageGenerator:
         response = self.client.images.generate(
             model=self.model, prompt=prompt, size=size, quality=quality, response_format=response_format, n=1
         )
-        image: Image = response.data[0]
-        image_str = image.url or image.b64_json or ""
-        return {"images": [image_str], "revised_prompt": image.revised_prompt or ""}
+        if response.data is not None:
+            image: Image = response.data[0]
+            image_str = image.url or image.b64_json or ""
+            revised_prompt = image.revised_prompt or ""
+        else:
+            image_str = ""
+            revised_prompt = ""
+        return {"images": [image_str], "revised_prompt": revised_prompt}
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/haystack/tools/__init__.py
+++ b/haystack/tools/__init__.py
@@ -6,9 +6,9 @@
 
 # ruff: noqa: I001 (ignore import order as we need to import Tool before ComponentTool)
 from .from_function import create_tool_from_function, tool
-from .tool import Tool, _check_duplicate_tool_names
+from .tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from .component_tool import ComponentTool
-from .serde_utils import deserialize_tools_or_toolset_inplace, serialize_tools_or_toolset, deserialize_tools_inplace
+from .serde_utils import deserialize_tools_or_toolset_inplace, serialize_tools_or_toolset
 from .toolset import Toolset
 
 __all__ = [

--- a/haystack/tools/serde_utils.py
+++ b/haystack/tools/serde_utils.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from haystack.core.errors import DeserializationError

--- a/haystack/tools/serde_utils.py
+++ b/haystack/tools/serde_utils.py
@@ -79,22 +79,3 @@ def deserialize_tools_or_toolset_inplace(data: Dict[str, Any], key: str = "tools
             deserialized_tools.append(tool_class.from_dict(tool))
 
         data[key] = deserialized_tools
-
-
-def deserialize_tools_inplace(data: Dict[str, Any], key: str = "tools"):
-    """
-    Deserialize a list of Tools or a Toolset in a dictionary inplace.
-
-    Deprecated in favor of `deserialize_tools_or_toolset_inplace`. It will be removed in Haystack 2.14.0.
-
-    :param data:
-        The dictionary with the serialized data.
-    :param key:
-        The key in the dictionary where the list of Tools or Toolset is stored.
-    """
-    warnings.warn(
-        "`deserialize_tools_inplace` is deprecated and will be removed in Haystack 2.14.0. "
-        "Use `deserialize_tools_or_toolset_inplace` instead.",
-        DeprecationWarning,
-    )
-    deserialize_tools_or_toolset_inplace(data, key)

--- a/haystack/tools/serde_utils.py
+++ b/haystack/tools/serde_utils.py
@@ -3,16 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
-from typing import Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from haystack.core.errors import DeserializationError
 from haystack.core.serialization import import_class_by_name
-from haystack.tools.tool import Tool
-from haystack.tools.toolset import Toolset
+
+if TYPE_CHECKING:
+    from haystack.tools.tool import Tool
+    from haystack.tools.toolset import Toolset
 
 
 def serialize_tools_or_toolset(
-    tools: Union[Toolset, List[Tool], None],
+    tools: Union["Toolset", List["Tool"], None],
 ) -> Union[Dict[str, Any], List[Dict[str, Any]], None]:
     """
     Serialize a Toolset or a list of Tools to a dictionary or a list of tool dictionaries.
@@ -20,6 +22,8 @@ def serialize_tools_or_toolset(
     :param tools: A Toolset, a list of Tools, or None
     :returns: A dictionary, a list of tool dictionaries, or None if tools is None
     """
+    from haystack.tools.toolset import Toolset
+
     if tools is None:
         return None
     if isinstance(tools, Toolset):
@@ -36,6 +40,9 @@ def deserialize_tools_or_toolset_inplace(data: Dict[str, Any], key: str = "tools
     :param key:
         The key in the dictionary where the list of Tools or Toolset is stored.
     """
+    from haystack.tools.tool import Tool
+    from haystack.tools.toolset import Toolset
+
     if key in data:
         serialized_tools = data[key]
 

--- a/haystack/tools/tool.py
+++ b/haystack/tools/tool.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from dataclasses import asdict, dataclass
 from typing import Any, Callable, Dict, List, Optional
 
@@ -10,7 +11,7 @@ from jsonschema.exceptions import SchemaError
 
 from haystack.core.serialization import generate_qualified_class_name
 from haystack.tools.errors import ToolInvocationError
-from haystack.tools.serde_utils import deserialize_tools_inplace  # noqa: F401
+from haystack.tools.serde_utils import deserialize_tools_or_toolset_inplace
 from haystack.utils import deserialize_callable, serialize_callable
 
 
@@ -174,3 +175,22 @@ def _check_duplicate_tool_names(tools: Optional[List[Tool]]) -> None:
     duplicate_tool_names = {name for name in tool_names if tool_names.count(name) > 1}
     if duplicate_tool_names:
         raise ValueError(f"Duplicate tool names found: {duplicate_tool_names}")
+
+
+def deserialize_tools_inplace(data: Dict[str, Any], key: str = "tools"):
+    """
+    Deserialize a list of Tools or a Toolset in a dictionary inplace.
+
+    Deprecated in favor of `deserialize_tools_or_toolset_inplace`. It will be removed in Haystack 2.14.0.
+
+    :param data:
+        The dictionary with the serialized data.
+    :param key:
+        The key in the dictionary where the list of Tools or Toolset is stored.
+    """
+    warnings.warn(
+        "`deserialize_tools_inplace` is deprecated and will be removed in Haystack 2.14.0. "
+        "Use `deserialize_tools_or_toolset_inplace` instead.",
+        DeprecationWarning,
+    )
+    deserialize_tools_or_toolset_inplace(data, key)

--- a/haystack/tools/tool.py
+++ b/haystack/tools/tool.py
@@ -10,6 +10,7 @@ from jsonschema.exceptions import SchemaError
 
 from haystack.core.serialization import generate_qualified_class_name
 from haystack.tools.errors import ToolInvocationError
+from haystack.tools.serde_utils import deserialize_tools_inplace  # noqa: F401
 from haystack.utils import deserialize_callable, serialize_callable
 
 

--- a/releasenotes/notes/move-deserialize_tools_inplace-b379fd7465eeb1b8.yaml
+++ b/releasenotes/notes/move-deserialize_tools_inplace-b379fd7465eeb1b8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Move deserialize_tools_inplace back to original import path of from haystack.tools.tool import deserialize_tools_inplace.


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
