### PR TITLE
fix: Update to ComponentTool `__deepcopy__`

### DIFF
--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -435,7 +435,7 @@ class ComponentTool(Tool):
             try:
                 # Try to deep copy the attribute
                 setattr(result, key, deepcopy(value, memo))
-            except TypeError:
+            except (TypeError, NotImplementedError):
                 # Fall back to using the original attribute for components that use Jinja2-templates
                 logger.debug(
                     "deepcopy of ComponentTool {tool_name} failed. Using original attribute '{attribute}' instead.",

--- a/releasenotes/notes/fix-component-tool-deepcopy-969c611ca028d294.yaml
+++ b/releasenotes/notes/fix-component-tool-deepcopy-969c611ca028d294.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Update the __deepcopy__ of ComponentTool to gracefully handle NotImplementedError when trying to deepcopy attributes.


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Updates the error catching in the `__deepcopy__` of ComponentTool to handle `NotImplementedError`

The original error was 
```
NotImplementedError: object proxy must define __deepcopy__()
/home/haystackd/.local/lib/python3.12/site-packages/haystack/core/pipeline/pipeline.py, line 60, _run_component
/home/haystackd/.local/lib/python3.12/site-packages/haystack/components/agents/agent.py, line 255, run
/home/haystackd/.local/lib/python3.12/site-packages/haystack/core/pipeline/pipeline.py, line 57, _run_component
/usr/local/lib/python3.12/copy.py, line 136, deepcopy
/usr/local/lib/python3.12/copy.py, line 221, _deepcopy_dict
/usr/local/lib/python3.12/copy.py, line 136, deepcopy
/usr/local/lib/python3.12/copy.py, line 196, _deepcopy_list
/usr/local/lib/python3.12/copy.py, line 143, deepcopy
/home/haystackd/.local/lib/python3.12/site-packages/haystack/tools/component_tool.py, line 437, __deepcopy__
```
which came from (most likely) trying to deep copy an OpenSearchDocumentStore

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
