### PR TITLE
Fix OpenAIGenerator and OpenAIChatGenerator to allow wrapped streaming objects usage

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -274,10 +274,7 @@ class OpenAIChatGenerator:
             **api_args
         )
 
-        is_streaming = isinstance(chat_completion, Stream)
-        assert is_streaming or streaming_callback is None
-
-        if is_streaming:
+        if streaming_callback is not None:
             completions = self._handle_stream_response(
                 chat_completion,  # type: ignore
                 streaming_callback,  # type: ignore
@@ -353,10 +350,7 @@ class OpenAIChatGenerator:
             AsyncStream[ChatCompletionChunk], ChatCompletion
         ] = await self.async_client.chat.completions.create(**api_args)
 
-        is_streaming = isinstance(chat_completion, AsyncStream)
-        assert is_streaming or streaming_callback is None
-
-        if is_streaming:
+        if streaming_callback is not None:
             completions = await self._handle_async_stream_response(
                 chat_completion,  # type: ignore
                 streaming_callback,  # type: ignore

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -231,15 +231,17 @@ class OpenAIGenerator:
             chunks: List[StreamingChunk] = []
             last_chunk: Optional[ChatCompletionChunk] = None
 
-            # pylint: disable=not-an-iterable
-            for chunk_item in completion:
-                if isinstance(chunk_item, ChatCompletionChunk) and chunk_item.choices:
-                    last_chunk = chunk_item
-                    chunk_delta: StreamingChunk = self._build_chunk(last_chunk)
-                    chunks.append(chunk_delta)
-                    streaming_callback(chunk_delta)  # invoke callback with the chunk_delta
-            # Makes type checkers happy
+            for chunk in completion:
+                if isinstance(chunk, ChatCompletionChunk):
+                    last_chunk = chunk
+
+                    if chunk.choices:
+                        chunk_delta: StreamingChunk = self._build_chunk(chunk)
+                        chunks.append(chunk_delta)
+                        streaming_callback(chunk_delta)
+
             assert last_chunk is not None
+
             completions = [self._create_message_from_chunks(last_chunk, chunks)]
         elif isinstance(completion, ChatCompletion):
             completions = [self._build_message(completion, choice) for choice in completion.choices]

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -224,22 +224,23 @@ class OpenAIGenerator:
         )
 
         completions: List[ChatMessage] = []
-        if isinstance(completion, Stream):
+        if streaming_callback is not None:
             num_responses = generation_kwargs.pop("n", 1)
             if num_responses > 1:
                 raise ValueError("Cannot stream multiple responses, please set n=1.")
             chunks: List[StreamingChunk] = []
-            completion_chunk: Optional[ChatCompletionChunk] = None
+            last_chunk: Optional[ChatCompletionChunk] = None
 
             # pylint: disable=not-an-iterable
-            for completion_chunk in completion:
-                if completion_chunk.choices and streaming_callback:
-                    chunk_delta: StreamingChunk = self._build_chunk(completion_chunk)
+            for chunk_item in completion:
+                if isinstance(chunk_item, ChatCompletionChunk) and chunk_item.choices:
+                    last_chunk = chunk_item
+                    chunk_delta: StreamingChunk = self._build_chunk(last_chunk)
                     chunks.append(chunk_delta)
                     streaming_callback(chunk_delta)  # invoke callback with the chunk_delta
             # Makes type checkers happy
-            assert completion_chunk is not None
-            completions = [self._create_message_from_chunks(completion_chunk, chunks)]
+            assert last_chunk is not None
+            completions = [self._create_message_from_chunks(last_chunk, chunks)]
         elif isinstance(completion, ChatCompletion):
             completions = [self._build_message(completion, choice) for choice in completion.choices]
 

--- a/releasenotes/notes/fix-openai-chat-generator-wrapped-streaming-f3a08f83a7528c3f.yaml
+++ b/releasenotes/notes/fix-openai-chat-generator-wrapped-streaming-f3a08f83a7528c3f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix an issue where the OpenAI chat generator was not properly handling wrapped streaming responses from tools like Weave.

--- a/releasenotes/notes/fix-openai-chat-generator-wrapped-streaming-f3a08f83a7528c3f.yaml
+++ b/releasenotes/notes/fix-openai-chat-generator-wrapped-streaming-f3a08f83a7528c3f.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Fix an issue where the OpenAI chat generator was not properly handling wrapped streaming responses from tools like Weave.

--- a/releasenotes/notes/fix-openai-generators-wrapped-streaming-f3a08f83a7528c3f.yaml
+++ b/releasenotes/notes/fix-openai-generators-wrapped-streaming-f3a08f83a7528c3f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix an issue where OpenAIChatGenerator and OpenAIGenerator were not properly handling wrapped streaming responses from tools like Weave.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock, AsyncMock
 import pytest
 
 
@@ -363,6 +363,40 @@ class TestOpenAIChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
         assert "Hello" in response["replies"][0].text  # see openai_mock_chat_completion_chunk
+
+    def test_run_with_wrapped_stream_simulation(self, chat_messages, openai_mock_stream):
+        streaming_callback_called = False
+
+        def streaming_callback(chunk: StreamingChunk) -> None:
+            nonlocal streaming_callback_called
+            streaming_callback_called = True
+            assert isinstance(chunk, StreamingChunk)
+
+        chunk = ChatCompletionChunk(
+            id="id",
+            model="gpt-4",
+            object="chat.completion.chunk",
+            choices=[chat_completion_chunk.Choice(index=0, delta=chat_completion_chunk.ChoiceDelta(content="Hello"))],
+            created=int(datetime.now().timestamp()),
+        )
+
+        # Here we wrap the OpenAI stream in a MagicMock
+        # This is to simulate the behavior of some tools like Weave (https://github.com/wandb/weave)
+        # which wrap the OpenAI stream in their own stream
+        wrapped_openai_stream = MagicMock()
+        wrapped_openai_stream.__iter__.return_value = iter([chunk])
+
+        component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))
+
+        with patch.object(
+            component.client.chat.completions, "create", return_value=wrapped_openai_stream
+        ) as mock_create:
+            response = component.run(chat_messages, streaming_callback=streaming_callback)
+
+            mock_create.assert_called_once()
+            assert streaming_callback_called
+            assert "replies" in response
+            assert "Hello" in response["replies"][0].text
 
     def test_check_abnormal_completions(self, caplog):
         caplog.set_level(logging.INFO)


### PR DESCRIPTION
### Related Issues

- fixes #9014 

### Proposed Changes:

Since some tools like [weave](https://github.com/wandb/weave) are wrapping OpenAI `Stream` type, internal checks like `isinstance(chat_completion, Stream)` are breaking the streaming usage. I've updated the check to be less strict but still reliable and added tests for sync/async envs.

### How did you test it?

unit tests, integration tests, manual verification

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
