### PR TITLE
fix: `RecursiveSplitter` bug in the case when the recursive chunking is triggered

### DIFF
--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -336,7 +336,6 @@ class RecursiveDocumentSplitter:
                             chunks.extend(fall_back_chunks)
                         else:
                             chunks.extend(self._chunk_text(split_text))
-                        current_length += self._chunk_length(split_text)
 
                     else:
                         current_chunk.append(split_text)

--- a/releasenotes/notes/fixing-bug-recursive-splitter-88d5714529f84e4e.yaml
+++ b/releasenotes/notes/fixing-bug-recursive-splitter-88d5714529f84e4e.yaml
@@ -2,4 +2,4 @@
 
 fixes:
   - |
-     bug with the `RecursiveDocumentSplitter` was fixed for the case where a `split_text` is longer than the `split_length` and recursive chunking is triggered.
+     A bug in the `RecursiveDocumentSplitter` was fixed for the case where a `split_text` is longer than the `split_length` and recursive chunking is triggered.

--- a/releasenotes/notes/fixing-bug-recursive-splitter-88d5714529f84e4e.yaml
+++ b/releasenotes/notes/fixing-bug-recursive-splitter-88d5714529f84e4e.yaml
@@ -1,0 +1,5 @@
+---
+
+fixes:
+  - |
+     bug with the `RecursiveDocumentSplitter` was fixed for the case where a `split_text` is longer than the `split_length` and recursive chunking is triggered.


### PR DESCRIPTION
### Related Issues

- fixes #9311 

### Proposed Changes

- Removed the line that was making a cumulative count in the case where a `split_text` is found to be longer than `split_length` and recursive chunking is triggered.

- A new test case was added to the `RecursiveDocumentSplitter` that verifies its behavior regarding the issue mentioned above.

## How did you test it?

- Adding the new test function `test_run_complex_text_with_multiple_separators()` to the existing test file
- Running the test suite to verify that the new test passes + CI tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
