### PR TITLE
ci: disable caching on Windows tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,7 +162,7 @@ jobs:
 
       - uses: actions/cache/save@v4
         id: cache
-        if: matrix.os != 'ubuntu-latest'
+        if: matrix.os == 'macos-latest'
         with:
           path: ${{ steps.hatch.outputs.env }}
           key: ${{ runner.os }}-${{ github.sha }}
@@ -414,12 +414,6 @@ jobs:
         run: |
           pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/cache/restore@v4
-        id: cache
-        with:
-          path: ${{ steps.hatch.outputs.env }}
-          key: ${{ runner.os }}-${{ github.sha }}
 
       - name: Run
         run: hatch run test:integration-only-fast

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 requires = ["hatchling>=1.8.0"]
 build-backend = "hatchling.build"
 
+# trigger
+
 [project]
 name = "haystack-ai"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,6 @@
 requires = ["hatchling>=1.8.0"]
 build-backend = "hatchling.build"
 
-# trigger
-
 [project]
 name = "haystack-ai"
 dynamic = ["version"]


### PR DESCRIPTION
### Related Issues

- investigated in #9319

### Proposed Changes:
- disable caching on Windows tests

### How did you test it?

CI - triggered tests in https://github.com/deepset-ai/haystack/pull/9318/commits/c33c2dd932fdfb5a20911510e0b338eb9787151c

#### CI Runtime Comparison

Non-Windows test times are included for context but are unaffected by the Windows caching configuration.

| Test | [With Windows Cache](https://github.com/deepset-ai/haystack/actions/runs/14709162118) | [Without Windows Cache](https://github.com/deepset-ai/haystack/actions/runs/14712345305) |
|------|-------------------|----------------------|
| Unit / windows-latest | 5m 2s | 4m 58s |
| Integration / windows-latest | 6m 11s | **3m 24s** |
| Integration / ubuntu-latest | 2m 7s (not impacted) | 2m 0s (not impacted) |
| Integration / macos-latest | 2m 12s (not impacted) | 1m 51s (not impacted) |
| Total tests workflow duration | 12m 8s | **9m 12s** |

Although the root cause of the cache slowdown on Windows is still unclear (investigation in #9319), disabling it offers two benefits:
- Significant runtime improvement in `Integration / windows-latest` job (slowest job in tests).
- While not visible in the table, saving the cache in `Unit / windows-latest` requires about 15s. Skipping this allows integration tests start sooner.

### Notes for the reviewer
Over time, we should evaluate if it's worth re-enabling cache.