### PR TITLE
chore: removing all unused imports from `tests/core`

### DIFF
--- a/test/core/component/test_sockets.py
+++ b/test/core/component/test_sockets.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from haystack.core.component.sockets import InputSocket, Sockets
-from haystack.core.pipeline import Pipeline
 from haystack.testing.factory import component_class
 
 

--- a/test/core/pipeline/test_templates.py
+++ b/test/core/pipeline/test_templates.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import tempfile
-from unittest import mock
 
 import pytest
 

--- a/test/core/sample_components/test_add_value.py
+++ b/test/core/sample_components/test_add_value.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 from haystack.testing.sample_components import AddFixedValue
-from haystack.core.serialization import component_to_dict, component_from_dict
 
 
 def test_run():

--- a/test/core/sample_components/test_concatenate.py
+++ b/test/core/sample_components/test_concatenate.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 from haystack.testing.sample_components import Concatenate
-from haystack.core.serialization import component_to_dict, component_from_dict
 
 
 def test_input_lists():

--- a/test/core/sample_components/test_double.py
+++ b/test/core/sample_components/test_double.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from haystack.testing.sample_components import Double
-from haystack.core.serialization import component_to_dict, component_from_dict
 
 
 def test_double_default():

--- a/test/core/sample_components/test_greet.py
+++ b/test/core/sample_components/test_greet.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 from haystack.testing.sample_components import Greet
-from haystack.core.serialization import component_to_dict, component_from_dict
 
 
 def test_greet_message(caplog):

--- a/test/core/sample_components/test_parity.py
+++ b/test/core/sample_components/test_parity.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 from haystack.testing.sample_components import Parity
-from haystack.core.serialization import component_to_dict, component_from_dict
 
 
 def test_parity():

--- a/test/core/sample_components/test_remainder.py
+++ b/test/core/sample_components/test_remainder.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from haystack.testing.sample_components import Remainder
-from haystack.core.serialization import component_to_dict, component_from_dict
 
 
 def test_remainder_default():

--- a/test/core/sample_components/test_repeat.py
+++ b/test/core/sample_components/test_repeat.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 from haystack.testing.sample_components import Repeat
-from haystack.core.serialization import component_to_dict, component_from_dict
 
 
 def test_repeat_default():

--- a/test/core/sample_components/test_subtract.py
+++ b/test/core/sample_components/test_subtract.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 from haystack.testing.sample_components import Subtract
-from haystack.core.serialization import component_to_dict, component_from_dict
 
 
 def test_subtract():

--- a/test/core/sample_components/test_sum.py
+++ b/test/core/sample_components/test_sum.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from haystack.testing.sample_components import Sum
-from haystack.core.serialization import component_to_dict, component_from_dict
 
 
 def test_sum_receives_no_values():

--- a/test/core/sample_components/test_threshold.py
+++ b/test/core/sample_components/test_threshold.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 from haystack.testing.sample_components import Threshold
-from haystack.core.serialization import component_to_dict, component_from_dict
 
 
 def test_threshold():


### PR DESCRIPTION
### Proposed Changes:

- removing all unused imports from `tests/core`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
