### PR TITLE
feat: add py.typed; adjust `Component` protocol

### DIFF
--- a/e2e/pipelines/test_evaluation_pipeline.py
+++ b/e2e/pipelines/test_evaluation_pipeline.py
@@ -36,14 +36,14 @@ def indexing_pipeline(documents: List[Document]):
     doc_writer = DocumentWriter(document_store=document_store, policy=DuplicatePolicy.SKIP)
     doc_embedder = SentenceTransformersDocumentEmbedder(model=EMBEDDINGS_MODEL, progress_bar=False)
     ingestion_pipe = Pipeline()
-    ingestion_pipe.add_component(instance=doc_embedder, name="doc_embedder")  # type: ignore
-    ingestion_pipe.add_component(instance=doc_writer, name="doc_writer")  # type: ignore
+    ingestion_pipe.add_component(instance=doc_embedder, name="doc_embedder")
+    ingestion_pipe.add_component(instance=doc_writer, name="doc_writer")
     ingestion_pipe.connect("doc_embedder.documents", "doc_writer.documents")
     ingestion_pipe.run({"doc_embedder": {"documents": documents}})
     return document_store
 
 
-def rag_pipeline(document_store: InMemoryDocumentStore, top_k: int):  # type: ignore
+def rag_pipeline(document_store: InMemoryDocumentStore, top_k: int):
     """RAG pipeline"""
     template = [
         ChatMessage.from_system(
@@ -59,11 +59,11 @@ def rag_pipeline(document_store: InMemoryDocumentStore, top_k: int):  # type: ig
         ),
     ]
     rag = Pipeline()
-    rag.add_component("embedder", SentenceTransformersTextEmbedder(model=EMBEDDINGS_MODEL, progress_bar=False))  # type: ignore
-    rag.add_component("retriever", InMemoryEmbeddingRetriever(document_store, top_k=top_k))  # type: ignore
-    rag.add_component("prompt_builder", ChatPromptBuilder(template=template))  # type: ignore
-    rag.add_component("generator", OpenAIChatGenerator(model="gpt-4o-mini"))  # type: ignore
-    rag.add_component("answer_builder", AnswerBuilder())  # type: ignore
+    rag.add_component("embedder", SentenceTransformersTextEmbedder(model=EMBEDDINGS_MODEL, progress_bar=False))
+    rag.add_component("retriever", InMemoryEmbeddingRetriever(document_store, top_k=top_k))
+    rag.add_component("prompt_builder", ChatPromptBuilder(template=template))
+    rag.add_component("generator", OpenAIChatGenerator(model="gpt-4o-mini"))
+    rag.add_component("answer_builder", AnswerBuilder())
     rag.connect("embedder", "retriever.query_embedding")
     rag.connect("retriever", "prompt_builder.documents")
     rag.connect("prompt_builder", "generator")

--- a/haystack/components/converters/multi_file_converter.py
+++ b/haystack/components/converters/multi_file_converter.py
@@ -80,24 +80,22 @@ class MultiFileConverter:
         # Create pipeline and add components
         pp = Pipeline()
 
-        # We use type ignore here to avoid type checking errors
-        # This is due to how the run method within the Component protocol is defined
-        pp.add_component("router", router)  # type: ignore[arg-type]
-        pp.add_component("docx", DOCXToDocument(link_format="markdown"))  # type: ignore[arg-type]
+        pp.add_component("router", router)
+        pp.add_component("docx", DOCXToDocument(link_format="markdown"))
         pp.add_component(
             "html",
-            HTMLToDocument(  # type: ignore[arg-type]
+            HTMLToDocument(
                 extraction_kwargs={"output_format": "markdown", "include_tables": True, "include_links": True}
             ),
         )
-        pp.add_component("json", JSONConverter(content_key=self.json_content_key))  # type: ignore[arg-type]
-        pp.add_component("md", TextFileToDocument(encoding=self.encoding))  # type: ignore[arg-type]
-        pp.add_component("text", TextFileToDocument(encoding=self.encoding))  # type: ignore[arg-type]
-        pp.add_component("pdf", PyPDFToDocument())  # type: ignore[arg-type]
-        pp.add_component("pptx", PPTXToDocument())  # type: ignore[arg-type]
-        pp.add_component("xlsx", XLSXToDocument())  # type: ignore[arg-type]
-        pp.add_component("joiner", DocumentJoiner())  # type: ignore[arg-type]
-        pp.add_component("csv", CSVToDocument(encoding=self.encoding))  # type: ignore[arg-type]
+        pp.add_component("json", JSONConverter(content_key=self.json_content_key))
+        pp.add_component("md", TextFileToDocument(encoding=self.encoding))
+        pp.add_component("text", TextFileToDocument(encoding=self.encoding))
+        pp.add_component("pdf", PyPDFToDocument())
+        pp.add_component("pptx", PPTXToDocument())
+        pp.add_component("xlsx", XLSXToDocument())
+        pp.add_component("joiner", DocumentJoiner())
+        pp.add_component("csv", CSVToDocument(encoding=self.encoding))
 
         for mime_type in ConverterMimeType:
             pp.connect(f"router.{mime_type.value}", str(mime_type).lower().rsplit(".", maxsplit=1)[-1])

--- a/haystack/components/preprocessors/document_preprocessor.py
+++ b/haystack/components/preprocessors/document_preprocessor.py
@@ -127,10 +127,8 @@ class DocumentPreprocessor:
         # Build the Pipeline
         pp = Pipeline()
 
-        # We use type ignore here to avoid type checking errors
-        # This is due to how the run method within the Component protocol is defined
-        pp.add_component("splitter", splitter)  # type: ignore[arg-type]
-        pp.add_component("cleaner", cleaner)  # type: ignore[arg-type]
+        pp.add_component("splitter", splitter)
+        pp.add_component("cleaner", cleaner)
 
         # Connect the splitter output to cleaner
         pp.connect("splitter.documents", "cleaner.documents")

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -160,12 +160,27 @@ class Component(Protocol):
         isinstance(MyComponent, Component)
     """
 
-    # This is the most reliable way to define the protocol for the `run` method.
-    # Defining a method doesn't work as different Components will have different
-    # arguments. Even defining here a method with `**kwargs` doesn't work as the
-    # expected signature must be identical.
-    # This makes most Language Servers and type checkers happy and shows less errors.
-    # run: Callable[..., Dict[str, Any]]
+    # The following expression defines a run method compatible with any input signature.
+    # Its type is equivalent to Callable[..., Dict[str, Any]].
+    # See https://typing.python.org/en/latest/spec/callables.html#meaning-of-in-callable.
+    #
+    # Using `run: Callable[..., Dict[str, Any]]` directly leads to type errors: the protocol would expect a settable
+    # attribute `run`, while the actual implementation is a read-only method.
+    # For example:
+    # from haystack import Pipeline, component
+    # @component
+    # class MyComponent:
+    #     @component.output_types(out=str)
+    #     def run(self):
+    #         return {"out": "Hello, world!"}
+    # pipeline = Pipeline()
+    # pipeline.add_component("my_component", MyComponent())
+    #
+    # mypy raises:
+    # error: Argument 2 to "add_component" of "PipelineBase" has incompatible type "MyComponent"; expected "Component"
+    # [arg-type]
+    # note: Protocol member Component.run expected settable variable, got read-only attribute
+
     def run(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring # noqa: D102
         ...
 

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -165,7 +165,9 @@ class Component(Protocol):
     # arguments. Even defining here a method with `**kwargs` doesn't work as the
     # expected signature must be identical.
     # This makes most Language Servers and type checkers happy and shows less errors.
-    run: Callable[..., Dict[str, Any]]
+    # run: Callable[..., Dict[str, Any]]
+    def run(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring # noqa: D102
+        ...
 
 
 class ComponentMeta(type):

--- a/releasenotes/notes/py-typed-724eea7222640e6d.yaml
+++ b/releasenotes/notes/py-typed-724eea7222640e6d.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    We've added a `py.typed` file to Haystack to enable type information to be used by downstream projects, in line
+    with PEP 561. This means Haystack's type hints will now be visible to type checkers in projects that depend on it.
+    Haystack is primarily type checked using mypy (not pyright) and, despite our efforts, some type information can
+    be incomplete or unreliable.
+    If you use static type checking in your own project, you may notice some changes: previously, Haystack's types were
+    effectively treated as `Any`, but now actual type information will be available and enforced.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -894,7 +894,7 @@ class TestOpenAIChatGenerator:
         assert message.meta["finish_reason"] == "stop"
         assert message.meta["usage"]["prompt_tokens"] > 0
 
-    async def test_run_with_wrong_model(self):
+    def test_run_with_wrong_model(self):
         mock_client = MagicMock()
         mock_client.chat.completions.create.side_effect = OpenAIError("Invalid model name")
 

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -409,7 +409,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
     # Test async/await methods and concurrency
 
     @pytest.mark.asyncio
-    async def test_write_documents(self, document_store: InMemoryDocumentStore):
+    async def test_write_documents_async(self, document_store: InMemoryDocumentStore):
         docs = [Document(id="1")]
         assert await document_store.write_documents_async(docs) == 1
         with pytest.raises(DuplicateDocumentError):
@@ -443,7 +443,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert await document_store.count_documents_async() == 0
 
     @pytest.mark.asyncio
-    async def test_bm25_retrieval(self, document_store: InMemoryDocumentStore):
+    async def test_bm25_retrieval_async(self, document_store: InMemoryDocumentStore):
         # Tests if the bm25_retrieval method returns the correct document based on the input query.
         docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]
         await document_store.write_documents_async(docs)
@@ -452,7 +452,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert results[0].content == "Haystack supports multiple languages"
 
     @pytest.mark.asyncio
-    async def test_embedding_retrieval(self):
+    async def test_embedding_retrieval_async(self):
         docstore = InMemoryDocumentStore(embedding_similarity_function="cosine")
         # Tests if the embedding retrieval method returns the correct document based on the input query embedding.
         docs = [


### PR DESCRIPTION
### Related Issues

- fixes #9289

### Proposed Changes:
- Add py.typed file to the repository: this enables type information to be used by downstream projects, in line
    with PEP 561 ([Python typing docs](https://typing.python.org/en/latest/spec/distributing.html#packaging-typed-libraries)). Previously, users got `Skipping analyzing "haystack": module is installed, but missing library stubs or py.typed marker` and all Haystack types were treated as `Any`.
- Change how we define the `run` method in the `Component` Protocol. This reverts https://github.com/deepset-ai/haystack/pull/7270 because I found that the previous definition caused type-checking issues (better explained in the code comments).

### How did you test it?
The main risk of this change is that users performing static type checking may start seeing new errors, since Haystack types were previously treated as `Any`.

While some errors are expected and are probably the temporary price to pay to leverage Haystack types in downstream projects, I wanted to evaluate the impact of this change. For this reason, I converted our tutorials into python scripts (`jupyter nbconvert --to python --RegexRemovePreprocessor.patterns '%%bash' ./tutorials/*.ipynb`) and run mypy on them.

- Before this PR
  - Found 176 errors in 17 files (checked 17 source files)
  - most errors like `tutorials/scripts/44_Creating_Custom_SuperComponents.py:52: error: Skipping analyzing "haystack": module is installed, but missing library stubs or py.typed marker  [import-untyped]
`

- After adding py.typed (https://github.com/deepset-ai/haystack/pull/9329/commits/22a089d92fd2b25a4611c0084198d758fbf81b15)
  - Found 151 errors in 17 files (checked 17 source files)
  - most errors like `tutorials/scripts/41_Query_Classification_with_TransformersTextRouter_and_TransformersZeroShotTextRouter.py:338: error: Argument 2 to "add_component" of "PipelineBase" has incompatible type "TransformersTextRouter"; expected "Component"  [arg-type]`
  `note: Protocol member Component.run expected settable variable, got read-only attribute`
  related to `run` method signature

- py.typed + `Component` protocol change (this PR)
  - Found 32 errors in 13 files (checked 17 source files)

<details>
  <summary>Errors</summary>
tutorials/scripts/41_Query_Classification_with_TransformersTextRouter_and_TransformersZeroShotTextRouter.py:89: error: Library stubs not installed for "pandas"  [import-untyped]
tutorials/scripts/41_Query_Classification_with_TransformersTextRouter_and_TransformersZeroShotTextRouter.py:91: error: Need type annotation for "results"  [var-annotated]
tutorials/scripts/41_Query_Classification_with_TransformersTextRouter_and_TransformersZeroShotTextRouter.py:159: error: Need type annotation for "sent_results"  [var-annotated]
tutorials/scripts/41_Query_Classification_with_TransformersTextRouter_and_TransformersZeroShotTextRouter.py:182: error: Incompatible types in assignment (expression has type "TransformersZeroShotTextRouter", variable has type "TransformersTextRouter")  [assignment]
tutorials/scripts/41_Query_Classification_with_TransformersTextRouter_and_TransformersZeroShotTextRouter.py:216: error: Incompatible types in assignment (expression has type "TransformersZeroShotTextRouter", variable has type "TransformersTextRouter")  [assignment]
tutorials/scripts/41_Query_Classification_with_TransformersTextRouter_and_TransformersZeroShotTextRouter.py:275: error: Cannot find implementation or library stub for module named "datasets"  [import-not-found]
tutorials/scripts/40_Building_Chat_Application_with_Function_Calling.py:334: error: Cannot find implementation or library stub for module named "gradio"  [import-not-found]
tutorials/scripts/39_Embedding_Metadata_for_Improved_Retrieval.py:100: error: Cannot find implementation or library stub for module named "wikipedia"  [import-not-found]
tutorials/scripts/37_Simplifying_Pipeline_Inputs_with_Multiplexer.py:168: error: Cannot find implementation or library stub for module named "haystack.components.others"  [import-not-found]
tutorials/scripts/34_Extractive_QA_Pipeline.py:54: error: Cannot find implementation or library stub for module named "datasets"  [import-not-found]
tutorials/scripts/33_Hybrid_Retrieval.py:69: error: Cannot find implementation or library stub for module named "datasets"  [import-not-found]
tutorials/scripts/30_File_Type_Preprocessing_Index_Pipeline.py:59: error: Cannot find implementation or library stub for module named "gdown"  [import-not-found]
tutorials/scripts/28_Structured_Output_With_Loop.py:92: error: Library stubs not installed for "colorama"  [import-untyped]
tutorials/scripts/28_Structured_Output_With_Loop.py:92: note: Hint: "python3 -m pip install types-colorama"
tutorials/scripts/28_Structured_Output_With_Loop.py:92: note: (or run "mypy --install-types" to install all missing stub packages)
tutorials/scripts/28_Structured_Output_With_Loop.py:113: error: Argument 1 to "loads" has incompatible type "str | None"; expected "str | bytes | bytearray"  [arg-type]
tutorials/scripts/28_Structured_Output_With_Loop.py:137: error: Argument "pydantic_model" to "OutputValidator" has incompatible type "type[CitiesData]"; expected "BaseModel"  [arg-type]
tutorials/scripts/27_First_RAG_Pipeline.py:72: error: Cannot find implementation or library stub for module named "datasets"  [import-not-found]
tutorials/scripts/27_First_RAG_Pipeline.py:72: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
tutorials/scripts/44_Creating_Custom_SuperComponents.py:58: error: Cannot find implementation or library stub for module named "datasets"  [import-not-found]
tutorials/scripts/44_Creating_Custom_SuperComponents.py:97: error: "HybridRetriever" has no attribute "run"  [attr-defined]
tutorials/scripts/44_Creating_Custom_SuperComponents.py:182: error: Incompatible types in assignment (expression has type "HybridRetrieverWithRanker", variable has type "HybridRetriever")  [assignment]
tutorials/scripts/44_Creating_Custom_SuperComponents.py:183: error: "HybridRetriever" has no attribute "run"  [attr-defined]
tutorials/scripts/44_Creating_Custom_SuperComponents.py:301: error: Incompatible types in assignment (expression has type "AdvancedHybridRetriever", variable has type "HybridRetriever")  [assignment]
tutorials/scripts/44_Creating_Custom_SuperComponents.py:302: error: "HybridRetriever" has no attribute "run"  [attr-defined]
tutorials/scripts/42_Sentence_Window_Retriever.py:131: error: Incompatible types in assignment (expression has type "TextIOWrapper[_WrappedBuffer]", variable has type "str")  [assignment]
tutorials/scripts/42_Sentence_Window_Retriever.py:148: error: Library stubs not installed for "requests"  [import-untyped]
tutorials/scripts/42_Sentence_Window_Retriever.py:148: note: Hint: "python3 -m pip install types-requests"
tutorials/scripts/42_Sentence_Window_Retriever.py:155: error: "Document" has no attribute "iter_content"  [attr-defined]
tutorials/scripts/43_Building_a_Tool_Calling_Agent.py:217: error: Cannot find implementation or library stub for module named "IPython.display"  [import-not-found]
tutorials/scripts/35_Evaluating_RAG_Pipelines.py:81: error: Cannot find implementation or library stub for module named "datasets"  [import-not-found]
tutorials/scripts/35_Evaluating_RAG_Pipelines.py:305: error: Library stubs not installed for "pandas"  [import-untyped]
tutorials/scripts/35_Evaluating_RAG_Pipelines.py:305: note: Hint: "python3 -m pip install pandas-stubs"
tutorials/scripts/35_Evaluating_RAG_Pipelines.py:307: error: Item "dict[str, list[Any]]" of "dict[str, list[Any]] | Any | str" has no attribute "nlargest"  [union-attr]
tutorials/scripts/35_Evaluating_RAG_Pipelines.py:307: error: Item "str" of "dict[str, list[Any]] | Any | str" has no attribute "nlargest"  [union-attr]
tutorials/scripts/35_Evaluating_RAG_Pipelines.py:308: error: Item "dict[str, list[Any]]" of "dict[str, list[Any]] | Any | str" has no attribute "nsmallest"  [union-attr]
tutorials/scripts/35_Evaluating_RAG_Pipelines.py:308: error: Item "str" of "dict[str, list[Any]] | Any | str" has no attribute "nsmallest"  [union-attr]
Found 32 errors in 13 files (checked 17 source files)
</details>

In short, this analysis suggests that no serious type issues related to Haystack types remain after these changes.

**I also verified that reverting #7270 does not cause regressions in VSCode/Pylance.**

### Notes for the reviewer
I also rely on the fact that platform will test this change before the next Haystack release.  If any serious issues come up, the changes are easy to revert.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
