### PR TITLE
fix: make QUOTE_SPANS_RE regex ReDoS-safe

### DIFF
--- a/haystack/components/preprocessors/sentence_tokenizer.py
+++ b/haystack/components/preprocessors/sentence_tokenizer.py
@@ -40,7 +40,7 @@ ISO639_TO_NLTK = {
     "ml": "malayalam",
 }
 
-QUOTE_SPANS_RE = re.compile(r"\W(\"+|\'+).*?\1")
+QUOTE_SPANS_RE = re.compile(r'\W"[^"\n]*"|\'[^\']*\'')
 
 if nltk_imports.is_successful():
 

--- a/releasenotes/notes/SentenceSplitter-ReDoS-fix-ca91b020cab50bf6.yaml
+++ b/releasenotes/notes/SentenceSplitter-ReDoS-fix-ca91b020cab50bf6.yaml
@@ -1,0 +1,8 @@
+---
+security:
+  - |
+    Made QUOTE_SPANS_RE regex ReDoS-safe
+    This prevents potential catastrophic backtracking on malicious inputs
+fixes:
+  - |
+    Fixed a potential ReDoS issue in QUOTE_SPANS_RE regex used inside the SentenceSplitter component.


### PR DESCRIPTION
### Related Issues

- fixes #9315

### Proposed Changes:

Replaced the vulnerable regular expression pattern in `QUOTE_SPANS_RE` inside `SentenceSplitter` with a ReDoS-safe alternative.

### How did you test it?

- Ran unit tests locally using `hatch run test:unit`
- Ensured that all pre-commit hooks passed

### Notes for the reviewer

- The change only affects the regex pattern; no logic was modified outside the pattern.
- Please verify that the change preserves expected behavior in edge cases (e.g., multiple quoted spans, nested quotes).

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue

