### PR TITLE
fix: make `SentenceSplitter` QUOTE_SPANS_RE regex ReDoS-safe

### DIFF
--- a/haystack/components/preprocessors/sentence_tokenizer.py
+++ b/haystack/components/preprocessors/sentence_tokenizer.py
@@ -40,7 +40,7 @@ ISO639_TO_NLTK = {
     "ml": "malayalam",
 }
 
-QUOTE_SPANS_RE = re.compile(r"\W(\"+|\'+).*?\1")
+QUOTE_SPANS_RE = re.compile(r'\W"[^"\n]*"|\'[^\']*\'')
 
 if nltk_imports.is_successful():
 

--- a/haystack/components/preprocessors/sentence_tokenizer.py
+++ b/haystack/components/preprocessors/sentence_tokenizer.py
@@ -40,7 +40,7 @@ ISO639_TO_NLTK = {
     "ml": "malayalam",
 }
 
-QUOTE_SPANS_RE = re.compile(r'\W"[^"\n]*"|\'[^\']*\'')
+QUOTE_SPANS_RE = re.compile(r'"[^"]*"|\'[^\']*\'')
 
 if nltk_imports.is_successful():
 

--- a/releasenotes/notes/SentenceSplitter-ReDoS-fix-ca91b020cab50bf6.yaml
+++ b/releasenotes/notes/SentenceSplitter-ReDoS-fix-ca91b020cab50bf6.yaml
@@ -1,8 +1,7 @@
 ---
 security:
   - |
-    Made QUOTE_SPANS_RE regex ReDoS-safe
-    This prevents potential catastrophic backtracking on malicious inputs
+    Made QUOTE_SPANS_RE regex ReDoS-safe. This prevents potential catastrophic backtracking on malicious inputs
 fixes:
   - |
     Fixed a potential ReDoS issue in QUOTE_SPANS_RE regex used inside the SentenceSplitter component.

--- a/releasenotes/notes/SentenceSplitter-ReDoS-fix-ca91b020cab50bf6.yaml
+++ b/releasenotes/notes/SentenceSplitter-ReDoS-fix-ca91b020cab50bf6.yaml
@@ -1,0 +1,8 @@
+---
+security:
+  - |
+    Made QUOTE_SPANS_RE regex ReDoS-safe
+    This prevents potential catastrophic backtracking on malicious inputs
+fixes:
+  - |
+    Fixed a potential ReDoS issue in QUOTE_SPANS_RE regex used inside the SentenceSplitter component.

--- a/test/components/preprocessors/test_sentence_tokenizer.py
+++ b/test/components/preprocessors/test_sentence_tokenizer.py
@@ -65,3 +65,38 @@ def test_read_abbreviations_missing_file(caplog: LogCaptureFixture):
         result = SentenceSplitter._read_abbreviations("pt")
         assert result == []
         assert "No abbreviations file found for pt. Using default abbreviations." in caplog.text
+
+
+def test_quote_spans_regex():
+    """Test the QUOTE_SPANS_RE regex pattern for detecting quoted text spans."""
+    from haystack.components.preprocessors.sentence_tokenizer import QUOTE_SPANS_RE
+
+    # Test cases with double quotes
+    text1 = 'He said "Hello world" and left.'
+    matches1 = list(QUOTE_SPANS_RE.finditer(text1))
+    assert len(matches1) == 1
+    assert matches1[0].group() == '"Hello world"'
+
+    # Test cases with single quotes
+    text2 = "She replied 'Goodbye world' and smiled."
+    matches2 = list(QUOTE_SPANS_RE.finditer(text2))
+    assert len(matches2) == 1
+    assert matches2[0].group() == "'Goodbye world'"
+
+    # Test case with multiple quotes
+    text3 = 'First "quote" and second "quote" in same text.'
+    matches3 = list(QUOTE_SPANS_RE.finditer(text3))
+    assert len(matches3) == 2
+    assert matches3[0].group() == '"quote"'
+    assert matches3[1].group() == '"quote"'
+
+    # Test case with quotes containing newlines
+    text4 = 'Text with "quote\nspanning\nmultiple\nlines"'
+    matches4 = list(QUOTE_SPANS_RE.finditer(text4))
+    assert len(matches4) == 1
+    assert matches4[0].group() == '"quote\nspanning\nmultiple\nlines"'
+
+    # Test case with no quotes
+    text5 = "This text has no quotes."
+    matches5 = list(QUOTE_SPANS_RE.finditer(text5))
+    assert len(matches5) == 0

--- a/test/components/preprocessors/test_sentence_tokenizer.py
+++ b/test/components/preprocessors/test_sentence_tokenizer.py
@@ -106,9 +106,9 @@ def test_split_sentences_performance() -> None:
     # https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS
     # this is a very long string, roughly 500 MB, but it should not take more than 5 seconds to process
     splitter = SentenceSplitter()
-    text = " " + '"' * 20 + "A" * 500000000 + "B"
+    text = " " + '"' * 20 + "A" * 50000000 + "B"
     start = time.time()
     _ = splitter.split_sentences(text)
     end = time.time()
 
-    assert end - start < 5, f"Execution time exceeded 5 seconds: {end - start:.2f} seconds"
+    assert end - start < 2, f"Execution time exceeded 2 seconds: {end - start:.2f} seconds"

--- a/test/components/preprocessors/test_sentence_tokenizer.py
+++ b/test/components/preprocessors/test_sentence_tokenizer.py
@@ -1,3 +1,4 @@
+import time
 import pytest
 from unittest.mock import patch
 from pathlib import Path
@@ -98,3 +99,16 @@ def test_quote_spans_regex():
     text5 = "This text has no quotes."
     matches5 = list(QUOTE_SPANS_RE.finditer(text5))
     assert len(matches5) == 0
+
+
+def test_split_sentences_performance() -> None:
+    # make sure our regex is not vulnerable to Regex Denial of Service (ReDoS)
+    # https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS
+    # this is a very long string, roughly 500 MB, but it should not take more than 5 seconds to process
+    splitter = SentenceSplitter()
+    text = " " + '"' * 20 + "A" * 500000000 + "B"
+    start = time.time()
+    _ = splitter.split_sentences(text)
+    end = time.time()
+
+    assert end - start < 5, f"Execution time exceeded 5 seconds: {end - start:.2f} seconds"

--- a/test/components/preprocessors/test_sentence_tokenizer.py
+++ b/test/components/preprocessors/test_sentence_tokenizer.py
@@ -104,7 +104,7 @@ def test_quote_spans_regex():
 def test_split_sentences_performance() -> None:
     # make sure our regex is not vulnerable to Regex Denial of Service (ReDoS)
     # https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS
-    # this is a very long string, roughly 500 MB, but it should not take more than 2 seconds to process
+    # this is a very long string, roughly 50 MB, but it should not take more than 2 seconds to process
     splitter = SentenceSplitter()
     text = " " + '"' * 20 + "A" * 50000000 + "B"
     start = time.time()

--- a/test/components/preprocessors/test_sentence_tokenizer.py
+++ b/test/components/preprocessors/test_sentence_tokenizer.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from pathlib import Path
 
 from haystack.components.preprocessors.sentence_tokenizer import SentenceSplitter
+from haystack.components.preprocessors.sentence_tokenizer import QUOTE_SPANS_RE
 
 from pytest import LogCaptureFixture
 
@@ -68,8 +69,6 @@ def test_read_abbreviations_missing_file(caplog: LogCaptureFixture):
 
 
 def test_quote_spans_regex():
-    from haystack.components.preprocessors.sentence_tokenizer import QUOTE_SPANS_RE
-
     # double quotes
     text1 = 'He said "Hello world" and left.'
     matches1 = list(QUOTE_SPANS_RE.finditer(text1))

--- a/test/components/preprocessors/test_sentence_tokenizer.py
+++ b/test/components/preprocessors/test_sentence_tokenizer.py
@@ -104,7 +104,7 @@ def test_quote_spans_regex():
 def test_split_sentences_performance() -> None:
     # make sure our regex is not vulnerable to Regex Denial of Service (ReDoS)
     # https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS
-    # this is a very long string, roughly 500 MB, but it should not take more than 5 seconds to process
+    # this is a very long string, roughly 500 MB, but it should not take more than 2 seconds to process
     splitter = SentenceSplitter()
     text = " " + '"' * 20 + "A" * 50000000 + "B"
     start = time.time()

--- a/test/components/preprocessors/test_sentence_tokenizer.py
+++ b/test/components/preprocessors/test_sentence_tokenizer.py
@@ -68,35 +68,34 @@ def test_read_abbreviations_missing_file(caplog: LogCaptureFixture):
 
 
 def test_quote_spans_regex():
-    """Test the QUOTE_SPANS_RE regex pattern for detecting quoted text spans."""
     from haystack.components.preprocessors.sentence_tokenizer import QUOTE_SPANS_RE
 
-    # Test cases with double quotes
+    # double quotes
     text1 = 'He said "Hello world" and left.'
     matches1 = list(QUOTE_SPANS_RE.finditer(text1))
     assert len(matches1) == 1
     assert matches1[0].group() == '"Hello world"'
 
-    # Test cases with single quotes
+    # single quotes
     text2 = "She replied 'Goodbye world' and smiled."
     matches2 = list(QUOTE_SPANS_RE.finditer(text2))
     assert len(matches2) == 1
     assert matches2[0].group() == "'Goodbye world'"
 
-    # Test case with multiple quotes
+    # multiple quotes
     text3 = 'First "quote" and second "quote" in same text.'
     matches3 = list(QUOTE_SPANS_RE.finditer(text3))
     assert len(matches3) == 2
     assert matches3[0].group() == '"quote"'
     assert matches3[1].group() == '"quote"'
 
-    # Test case with quotes containing newlines
+    # quotes containing newlines
     text4 = 'Text with "quote\nspanning\nmultiple\nlines"'
     matches4 = list(QUOTE_SPANS_RE.finditer(text4))
     assert len(matches4) == 1
     assert matches4[0].group() == '"quote\nspanning\nmultiple\nlines"'
 
-    # Test case with no quotes
+    # no quotes
     text5 = "This text has no quotes."
     matches5 = list(QUOTE_SPANS_RE.finditer(text5))
     assert len(matches5) == 0


### PR DESCRIPTION
### Related Issues

- fixes #9315 

### Proposed Changes:

Replaced the vulnerable regular expression pattern in QUOTE_SPANS_RE inside SentenceSplitter with a ReDoS-safe alternative.

### How did you test it?

- Ran unit tests locally using hatch run test:unit
- Ensured that all pre-commit hooks passed

### Notes for the reviewer

- This was originally from this [PR ](https://github.com/deepset-ai/haystack/pull/9335) - but due to the way I cloned the repo/branch or permissions I (@davidsbatista) could not push my changes into the community member PR, therefore this new one. Still, user commits are tracked on this PR, and he will be credited as contributor.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
