### PR TITLE
fix: Component decorator type hinting

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -88,7 +88,7 @@ from .types import InputSocket, OutputSocket, _empty
 
 logger = logging.getLogger(__name__)
 
-ClassT = TypeVar("ClassT", bound=type)
+ClassT = TypeVar("ClassT")  # , bound=type)
 
 RunParamsT = ParamSpec("RunParamsT")
 SyncRunReturnT = TypeVar("SyncRunReturnT", bound=Dict[str, Any])
@@ -559,10 +559,9 @@ class _Component:
         # Recreate the decorated component class so it uses our metaclass.
         # We must explicitly redefine the type of the class to make sure language servers
         # and type checkers understand that the class is of the correct type.
-        # mypy doesn't like that we do this though so we explicitly ignore the type check.
         new_cls: Type[ClassT] = new_class(
             cls.__name__, cls.__bases__, {"metaclass": ComponentMeta}, copy_class_namespace
-        )  # type: ignore[no-redef]
+        )
 
         # Save the component in the class registry (for deserialization)
         class_path = f"{new_cls.__module__}.{new_cls.__name__}"
@@ -579,7 +578,11 @@ class _Component:
         logger.debug("Registered Component {component}", component=new_cls)
 
         # Override the __repr__ method with a default one
-        new_cls.__repr__ = _component_repr
+        # mypy is not happy that:
+        # 1) we are assigning a method to a class
+        # 2) _component_repr has a different type (Callable[[Component], str]) than the expected
+        # __repr__ method (Callable[[object], str])
+        new_cls.__repr__ = _component_repr  # type: ignore[assignment]
 
         return new_cls
 

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -88,12 +88,12 @@ from .types import InputSocket, OutputSocket, _empty
 
 logger = logging.getLogger(__name__)
 
-ClassT = TypeVar("ClassT")  # , bound=type)
-
 RunParamsT = ParamSpec("RunParamsT")
 SyncRunReturnT = TypeVar("SyncRunReturnT", bound=Dict[str, Any])
 AsyncRunReturnT = TypeVar("AsyncRunReturnT", bound=Coroutine[Any, Any, Dict[str, Any]])
 RunReturnT = Union[SyncRunReturnT, AsyncRunReturnT]
+
+T = TypeVar("T")
 
 
 @dataclass
@@ -534,7 +534,7 @@ class _Component:
 
         return output_types_decorator
 
-    def _component(self, cls: Type[ClassT]) -> Type[ClassT]:
+    def _component(self, cls: Type[T]) -> Type[T]:
         """
         Decorator validating the structure of the component and registering it in the components registry.
         """
@@ -559,9 +559,7 @@ class _Component:
         # Recreate the decorated component class so it uses our metaclass.
         # We must explicitly redefine the type of the class to make sure language servers
         # and type checkers understand that the class is of the correct type.
-        new_cls: Type[ClassT] = new_class(
-            cls.__name__, cls.__bases__, {"metaclass": ComponentMeta}, copy_class_namespace
-        )
+        new_cls: Type[T] = new_class(cls.__name__, cls.__bases__, {"metaclass": ComponentMeta}, copy_class_namespace)
 
         # Save the component in the class registry (for deserialization)
         class_path = f"{new_cls.__module__}.{new_cls.__name__}"

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -88,6 +88,8 @@ from .types import InputSocket, OutputSocket, _empty
 
 logger = logging.getLogger(__name__)
 
+ClassT = TypeVar("ClassT", bound=type)
+
 RunParamsT = ParamSpec("RunParamsT")
 SyncRunReturnT = TypeVar("SyncRunReturnT", bound=Dict[str, Any])
 AsyncRunReturnT = TypeVar("AsyncRunReturnT", bound=Coroutine[Any, Any, Dict[str, Any]])
@@ -532,7 +534,7 @@ class _Component:
 
         return output_types_decorator
 
-    def _component(self, cls: Any):
+    def _component(self, cls: Type[ClassT]) -> Type[ClassT]:
         """
         Decorator validating the structure of the component and registering it in the components registry.
         """
@@ -558,7 +560,7 @@ class _Component:
         # We must explicitly redefine the type of the class to make sure language servers
         # and type checkers understand that the class is of the correct type.
         # mypy doesn't like that we do this though so we explicitly ignore the type check.
-        new_cls: cls.__name__ = new_class(
+        new_cls: Type[ClassT] = new_class(
             cls.__name__, cls.__bases__, {"metaclass": ComponentMeta}, copy_class_namespace
         )  # type: ignore[no-redef]
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
