### PR TITLE
fix: Fix add_component() type error with Mypy

### DIFF
--- a/haystack/components/converters/multi_file_converter.py
+++ b/haystack/components/converters/multi_file_converter.py
@@ -82,22 +82,22 @@ class MultiFileConverter:
 
         # We use type ignore here to avoid type checking errors
         # This is due to how the run method within the Component protocol is defined
-        pp.add_component("router", router)  # type: ignore[arg-type]
-        pp.add_component("docx", DOCXToDocument(link_format="markdown"))  # type: ignore[arg-type]
+        pp.add_component("router", router)
+        pp.add_component("docx", DOCXToDocument(link_format="markdown"))
         pp.add_component(
             "html",
-            HTMLToDocument(  # type: ignore[arg-type]
+            HTMLToDocument(
                 extraction_kwargs={"output_format": "markdown", "include_tables": True, "include_links": True}
             ),
         )
-        pp.add_component("json", JSONConverter(content_key=self.json_content_key))  # type: ignore[arg-type]
-        pp.add_component("md", TextFileToDocument(encoding=self.encoding))  # type: ignore[arg-type]
-        pp.add_component("text", TextFileToDocument(encoding=self.encoding))  # type: ignore[arg-type]
-        pp.add_component("pdf", PyPDFToDocument())  # type: ignore[arg-type]
-        pp.add_component("pptx", PPTXToDocument())  # type: ignore[arg-type]
-        pp.add_component("xlsx", XLSXToDocument())  # type: ignore[arg-type]
-        pp.add_component("joiner", DocumentJoiner())  # type: ignore[arg-type]
-        pp.add_component("csv", CSVToDocument(encoding=self.encoding))  # type: ignore[arg-type]
+        pp.add_component("json", JSONConverter(content_key=self.json_content_key))
+        pp.add_component("md", TextFileToDocument(encoding=self.encoding))
+        pp.add_component("text", TextFileToDocument(encoding=self.encoding))
+        pp.add_component("pdf", PyPDFToDocument())
+        pp.add_component("pptx", PPTXToDocument())
+        pp.add_component("xlsx", XLSXToDocument())
+        pp.add_component("joiner", DocumentJoiner())
+        pp.add_component("csv", CSVToDocument(encoding=self.encoding))
 
         for mime_type in ConverterMimeType:
             pp.connect(f"router.{mime_type.value}", str(mime_type).lower().rsplit(".", maxsplit=1)[-1])

--- a/haystack/components/preprocessors/document_preprocessor.py
+++ b/haystack/components/preprocessors/document_preprocessor.py
@@ -129,8 +129,8 @@ class DocumentPreprocessor:
 
         # We use type ignore here to avoid type checking errors
         # This is due to how the run method within the Component protocol is defined
-        pp.add_component("splitter", splitter)  # type: ignore[arg-type]
-        pp.add_component("cleaner", cleaner)  # type: ignore[arg-type]
+        pp.add_component("splitter", splitter)
+        pp.add_component("cleaner", cleaner)
 
         # Connect the splitter output to cleaner
         pp.connect("splitter.documents", "cleaner.documents")

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -76,7 +76,7 @@ from contextvars import ContextVar
 from copy import deepcopy
 from dataclasses import dataclass
 from types import new_class
-from typing import Any, Dict, Optional, Protocol, Type, TypeVar, Union, runtime_checkable
+from typing import Any, Dict, Mapping, Optional, Protocol, Type, TypeVar, Union, runtime_checkable
 
 from typing_extensions import ParamSpec
 
@@ -165,7 +165,8 @@ class Component(Protocol):
     # arguments. Even defining here a method with `**kwargs` doesn't work as the
     # expected signature must be identical.
     # This makes most Language Servers and type checkers happy and shows less errors.
-    run: Callable[..., Dict[str, Any]]
+    @property
+    def run(self) -> Callable[..., Dict[str, Any]]: ...  # pylint: disable=missing-function-docstring # noqa: D102
 
 
 class ComponentMeta(type):


### PR DESCRIPTION
### Related Issues

None, though some `# type: ignore` comments in the codebase demonstrate that the core team hit this issue. :)

### Proposed Changes:

When calling `pipeline.add_component()` with any component instance, Mypy complains:

```
error: Argument 2 to "add_component" of "PipelineBase" has incompatible type "X"; expected "Component"  [arg-type]
note: Protocol member Component.run expected settable variable, got read-only attribute
```

The issue is that `run` of the `Component` protocol is currently defined as a mutable attribute (`run: ...`). Use `@property` instead to only require a getter.

### How did you test it?

I ran the type tests with `hatch run test:types` after making the change.

### Notes for the reviewer

An additional improvement - and my original goal before I got side-tracked by this - would be to change the required return type of `run()` from `Dict` to `Mapping` so that it becomes possible to define a `run()` return type as a `TypedDict`. I will create a separate follow-up PR for this, though.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
