### PR TITLE
fix: Update deepcopying in Pipeline to have a fallback in case of error

### DIFF
--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-from copy import deepcopy
 from typing import Any, AsyncIterator, Dict, List, Optional, Set
 
 from haystack import logging, tracing
@@ -16,6 +15,7 @@ from haystack.core.pipeline.base import (
     ComponentPriority,
     PipelineBase,
 )
+from haystack.core.pipeline.utils import deepcopy_with_fallback
 from haystack.telemetry import pipeline_running
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ class AsyncPipeline(PipelineBase):
         with PipelineBase._create_component_span(
             component_name=component_name, instance=instance, inputs=component_inputs, parent_span=parent_span
         ) as span:
-            span.set_content_tag(_COMPONENT_INPUT, deepcopy(component_inputs))
+            span.set_content_tag(_COMPONENT_INPUT, deepcopy_with_fallback(component_inputs))
             logger.info("Running component {component_name}", component_name=component_name)
 
             if getattr(instance, "__haystack_supports_async__", False):
@@ -76,7 +76,7 @@ class AsyncPipeline(PipelineBase):
                 raise PipelineRuntimeError.from_invalid_output(component_name, instance.__class__, outputs)
 
             span.set_tag(_COMPONENT_VISITS, component_visits[component_name])
-            span.set_content_tag(_COMPONENT_OUTPUT, deepcopy(outputs))
+            span.set_content_tag(_COMPONENT_OUTPUT, deepcopy_with_fallback(outputs))
 
             return outputs
 
@@ -238,7 +238,7 @@ class AsyncPipeline(PipelineBase):
                         partial_result = finished.result()
                         scheduled_components.discard(finished_component_name)
                         if partial_result:
-                            yield_dict = {finished_component_name: deepcopy(partial_result)}
+                            yield_dict = {finished_component_name: deepcopy_with_fallback(partial_result)}
                             yield yield_dict  # partial outputs
 
                 if component_name in scheduled_components:
@@ -274,7 +274,7 @@ class AsyncPipeline(PipelineBase):
 
                 scheduled_components.remove(component_name)
                 if pruned:
-                    yield {component_name: deepcopy(pruned)}
+                    yield {component_name: deepcopy_with_fallback(pruned)}
 
             async def _schedule_task(component_name: str) -> None:
                 """
@@ -337,7 +337,7 @@ class AsyncPipeline(PipelineBase):
                         partial_result = finished.result()
                         scheduled_components.discard(finished_component_name)
                         if partial_result:
-                            yield {finished_component_name: deepcopy(partial_result)}
+                            yield {finished_component_name: deepcopy_with_fallback(partial_result)}
 
             async def _wait_for_all_tasks_to_complete() -> AsyncIterator[Dict[str, Any]]:
                 """
@@ -350,7 +350,7 @@ class AsyncPipeline(PipelineBase):
                         partial_result = finished.result()
                         scheduled_components.discard(finished_component_name)
                         if partial_result:
-                            yield {finished_component_name: deepcopy(partial_result)}
+                            yield {finished_component_name: deepcopy_with_fallback(partial_result)}
 
             # -------------------------------------------------
             # MAIN SCHEDULING LOOP
@@ -428,7 +428,7 @@ class AsyncPipeline(PipelineBase):
                 yield partial_res
 
             # 4) Yield final pipeline outputs
-            yield deepcopy(pipeline_outputs)
+            yield deepcopy_with_fallback(pipeline_outputs)
 
     async def run_async(
         self, data: Dict[str, Any], include_outputs_from: Optional[Set[str]] = None, concurrency_limit: int = 4

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -4,7 +4,6 @@
 
 import itertools
 from collections import defaultdict
-from copy import deepcopy
 from datetime import datetime
 from enum import IntEnum
 from pathlib import Path
@@ -33,7 +32,7 @@ from haystack.core.pipeline.component_checks import (
     is_any_greedy_socket_ready,
     is_socket_lazy_variadic,
 )
-from haystack.core.pipeline.utils import FIFOPriorityQueue, parse_connect_string
+from haystack.core.pipeline.utils import FIFOPriorityQueue, deepcopy_with_fallback, parse_connect_string
 from haystack.core.serialization import DeserializationCallbacks, component_from_dict, component_to_dict
 from haystack.core.type_utils import _type_name, _types_are_compatible
 from haystack.marshal import Marshaller, YamlMarshaller
@@ -176,7 +175,7 @@ class PipelineBase:
         :returns:
             Deserialized component.
         """
-        data_copy = deepcopy(data)  # to prevent modification of original data
+        data_copy = deepcopy_with_fallback(data)  # to prevent modification of original data
         metadata = data_copy.get("metadata", {})
         max_runs_per_component = data_copy.get("max_runs_per_component", 100)
         connection_type_validation = data_copy.get("connection_type_validation", True)
@@ -895,7 +894,7 @@ class PipelineBase:
         # deepcopying the inputs prevents the Pipeline run logic from being altered unexpectedly
         # when the same input reference is passed to multiple components.
         for component_name, component_inputs in data.items():
-            data[component_name] = {k: deepcopy(v) for k, v in component_inputs.items()}
+            data[component_name] = {k: deepcopy_with_fallback(v) for k, v in component_inputs.items()}
 
         return data
 

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from copy import deepcopy
 from typing import Any, Dict, Mapping, Optional, Set, cast
 
 from haystack import logging, tracing
@@ -15,6 +14,7 @@ from haystack.core.pipeline.base import (
     ComponentPriority,
     PipelineBase,
 )
+from haystack.core.pipeline.utils import deepcopy_with_fallback
 from haystack.telemetry import pipeline_running
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class Pipeline(PipelineBase):
         ) as span:
             # We deepcopy the inputs otherwise we might lose that information
             # when we delete them in case they're sent to other Components
-            span.set_content_tag(_COMPONENT_INPUT, deepcopy(inputs))
+            span.set_content_tag(_COMPONENT_INPUT, deepcopy_with_fallback(inputs))
             logger.info("Running component {component_name}", component_name=component_name)
             try:
                 component_output = instance.run(**inputs)
@@ -252,7 +252,7 @@ class Pipeline(PipelineBase):
                 )
 
                 if component_pipeline_outputs:
-                    pipeline_outputs[component_name] = deepcopy(component_pipeline_outputs)
+                    pipeline_outputs[component_name] = deepcopy_with_fallback(component_pipeline_outputs)
                 if self._is_queue_stale(priority_queue):
                     priority_queue = self._fill_queue(ordered_component_names, inputs, component_visits)
 

--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -12,7 +12,7 @@ from haystack import logging
 logger = logging.getLogger(__name__)
 
 
-def deepcopy_with_fallback(obj: Any, max_depth: Optional[int] = 2) -> Any:
+def deepcopy_with_fallback(obj: Any, max_depth: Optional[int] = 3) -> Any:
     """
     Attempts to create a deep copy of the given object with a safe fallback mechanism.
 

--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -12,7 +12,7 @@ from haystack import logging
 logger = logging.getLogger(__name__)
 
 
-def deepcopy_with_fallback(obj: Any, max_depth: Optional[int] = 3) -> Any:
+def deepcopy_with_fallback(obj: Any, max_depth: Optional[int] = 100) -> Any:
     """
     Attempts to create a deep copy of the given object with a safe fallback mechanism.
 
@@ -39,9 +39,17 @@ def deepcopy_with_fallback(obj: Any, max_depth: Optional[int] = 3) -> Any:
                 error=e,
             )
             return {key: deepcopy_with_fallback(value, next_depth) for key, value in obj.items()}
+        elif isinstance(obj, (list, tuple, set)):
+            logger.info(
+                "Standard deepcopy failed for object of type '{obj_type}'. Error: {error}. Attempting item-wise copy.",
+                obj_type=type(obj).__name__,
+                error=e,
+            )
+            return type(obj)(deepcopy_with_fallback(item, next_depth) for item in obj)
 
         logger.info(
-            "Deepcopy failed for object of type '{obj_type}'. Error: {error}. Returning original object instead.",
+            "Standard deepcopy failed for object of type '{obj_type}'. Error: {error}. "
+            "Returning original object instead.",
             obj_type=type(obj).__name__,
             error=e,
         )

--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -34,22 +34,21 @@ def deepcopy_with_fallback(obj: Any, max_depth: Optional[int] = 100) -> Any:
         next_depth = None if max_depth is None else max_depth - 1
         if isinstance(obj, dict):
             logger.info(
-                "Standard deepcopy failed for object of type '{obj_type}'. Error: {error}. Attempting item-wise copy.",
+                "Deepcopy failed for object of type '{obj_type}'. Error: {error}. Attempting item-wise copy.",
                 obj_type=type(obj).__name__,
                 error=e,
             )
             return {key: deepcopy_with_fallback(value, next_depth) for key, value in obj.items()}
         elif isinstance(obj, (list, tuple, set)):
             logger.info(
-                "Standard deepcopy failed for object of type '{obj_type}'. Error: {error}. Attempting item-wise copy.",
+                "Deepcopy failed for object of type '{obj_type}'. Error: {error}. Attempting item-wise copy.",
                 obj_type=type(obj).__name__,
                 error=e,
             )
             return type(obj)(deepcopy_with_fallback(item, next_depth) for item in obj)
 
         logger.info(
-            "Standard deepcopy failed for object of type '{obj_type}'. Error: {error}. "
-            "Returning original object instead.",
+            "Deepcopy failed for object of type '{obj_type}'. Error: {error}. Returning original object instead.",
             obj_type=type(obj).__name__,
             error=e,
         )

--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -3,8 +3,39 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import heapq
+from copy import deepcopy
 from itertools import count
 from typing import Any, List, Optional, Tuple
+
+from haystack import logging
+
+logger = logging.getLogger(__name__)
+
+
+def deepcopy_with_fallback(obj: Any) -> Any:
+    """
+    Attempts to create a deep copy of the given object.
+
+    If the deep copy operation fails (e.g., due to unsupported object types),
+    the original object is returned instead. This provides a safe fallback mechanism
+    in scenarios where deepcopying may not be guaranteed to succeed.
+
+    :param obj: The object to attempt to deep copy.
+    :return: A deep copy of the object if successful; otherwise, the original object.
+    """
+    # TODO We should try to be a bit more sophisticated here and iterate over the items of the object
+    #      to deepcopy only the values that are deepcopiable. This would allow us to deep copy more objects
+    #      and avoid the need to return the entire original object.
+    try:
+        return deepcopy(obj)
+    except Exception as e:
+        # We log at INFO level to avoid cluttering logs with deep copy errors
+        logger.info(
+            "Deep copy failed for object of type '{obj_type}'. Error: {error}. Returning original object instead.",
+            obj_type=type(obj).__name__,
+            error=e,
+        )
+        return obj
 
 
 def parse_connect_string(connection: str) -> Tuple[str, Optional[str]]:

--- a/releasenotes/notes/fix-deepcopy-in-pipeline-run-2b575c7b860f642f.yaml
+++ b/releasenotes/notes/fix-deepcopy-in-pipeline-run-2b575c7b860f642f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Introduced `deepcopy_with_fallback` to improve robustness in the `Pipeline.run` method.
+    Previously, standard `deepcopy` was used on inputs and outputs to avoid unintended side effects from shared mutable data structures, as these values are accessed in multiple parts of the pipeline. However, certain Python objects cannot be deepcopied, which could lead to runtime errors.
+    The new `deepcopy_with_fallback` function attempts to deep copy an object and safely falls back to the original object if copying fails. This ensures pipeline execution remains stable while maintaining the protective behavior against shared-state modification.

--- a/test/core/pipeline/test_utils.py
+++ b/test/core/pipeline/test_utils.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import pytest
 
-from haystack.core.pipeline.utils import parse_connect_string, FIFOPriorityQueue
+from haystack.core.pipeline.utils import parse_connect_string, FIFOPriorityQueue, deepcopy_with_fallback
 
 
 def test_parse_connection():
@@ -175,3 +176,82 @@ def test_queue_ordering_parametrized(empty_queue, items):
     sorted_items = sorted(items, key=lambda x: (x[0], items.index(x)))
     for priority, item in sorted_items:
         assert empty_queue.pop() == (priority, item)
+
+
+from haystack.tools import ComponentTool, Tool
+from haystack.components.builders.prompt_builder import PromptBuilder
+
+
+def get_weather_report(city: str) -> str:
+    return f"Weather report for {city}: 20°C, sunny"
+
+
+class TestDeepcopyWithFallback:
+    def test_deepcopy_with_fallback_copyable(self, caplog):
+        tool = Tool(
+            name="weather",
+            description="Get weather report",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            function=get_weather_report,
+        )
+        original = {"tools": tool}
+        with caplog.at_level(logging.INFO):
+            copy = deepcopy_with_fallback(original)
+            assert "Standard deepcopy failed for object of type" not in caplog.text
+        # This should be a true copy
+        copy["tools"].name = "copied_tool"
+        assert copy["tools"] != original["tools"]
+
+    def test_deepcopy_with_fallback_not_copyable(self, caplog):
+        problematic_tool = ComponentTool(
+            name="problematic_tool", description="This is a problematic tool.", component=PromptBuilder("{{query}}")
+        )
+        original = {"tools": problematic_tool}
+        with caplog.at_level(logging.INFO):
+            copy = deepcopy_with_fallback(original)
+            assert "Deepcopy failed for object of type 'ComponentTool'" in caplog.text
+        # Not a true copy but a shallow copy
+        copy["tools"].name = "copied_tool"
+        assert copy["tools"] == original["tools"]
+
+    def test_deepcopy_with_fallback_mixed_copyable_list(self, caplog):
+        tool1 = Tool(
+            name="tool1",
+            description="Get weather report",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            function=get_weather_report,
+        )
+        tool2 = ComponentTool(
+            name="problematic_tool", description="This is a problematic tool.", component=PromptBuilder("{{query}}")
+        )
+        original = {"tools": [tool1, tool2]}
+        with caplog.at_level(logging.INFO):
+            copy = deepcopy_with_fallback(original)
+            assert "Deepcopy failed for object of type 'ComponentTool'" in caplog.text
+        # First tool should be a true copy
+        copy["tools"][0].name = "copied_tool1"
+        assert copy["tools"][0] != original["tools"][0]
+        # second should be a shallow copy
+        copy["tools"][1].name = "copied_tool2"
+        assert copy["tools"][1] == original["tools"][1]
+
+    def test_deepcopy_with_fallback_mixed_copyable_tuple(self, caplog):
+        tool1 = Tool(
+            name="tool1",
+            description="Get weather report",
+            parameters={"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            function=get_weather_report,
+        )
+        tool2 = ComponentTool(
+            name="problematic_tool", description="This is a problematic tool.", component=PromptBuilder("{{query}}")
+        )
+        original = {"tools": (tool1, tool2)}
+        with caplog.at_level(logging.INFO):
+            copy = deepcopy_with_fallback(original)
+            assert "Deepcopy failed for object of type 'ComponentTool'" in caplog.text
+        # First tool should be a true copy
+        copy["tools"][0].name = "copied_tool1"
+        assert copy["tools"][0] != original["tools"][0]
+        # second should be a shallow copy
+        copy["tools"][1].name = "copied_tool2"
+        assert copy["tools"][1] == original["tools"][1]

--- a/test/core/pipeline/test_utils.py
+++ b/test/core/pipeline/test_utils.py
@@ -197,7 +197,7 @@ class TestDeepcopyWithFallback:
         original = {"tools": tool}
         with caplog.at_level(logging.INFO):
             copy = deepcopy_with_fallback(original)
-            assert "Standard deepcopy failed for object of type" not in caplog.text
+            assert "Deepcopy failed for object of type" not in caplog.text
         # This should be a true copy
         copy["tools"].name = "copied_tool"
         assert copy["tools"] != original["tools"]

--- a/test/tools/test_component_tool.py
+++ b/test/tools/test_component_tool.py
@@ -2,19 +2,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import patch
+
 import json
 import os
-from copy import deepcopy
 from dataclasses import dataclass
 from typing import Dict, List
 
 import pytest
+
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
 
 from haystack import Pipeline, component
 from haystack.components.builders import PromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.tools import ToolInvoker
 from haystack.components.websearch.serper_dev import SerperDevWebSearch
+from haystack.core.pipeline.utils import deepcopy_with_fallback
 from haystack.dataclasses import ChatMessage, ChatRole, Document
 from haystack.tools import ComponentTool
 from haystack.utils.auth import Secret
@@ -643,15 +648,36 @@ class TestToolComponentInPipelineWithOpenAI:
         # When we use a ComponentTool in a pipeline at runtime, we deepcopy the tool
         # We overwrite ComponentTool.__deepcopy__ to fix this in experimental until a more comprehensive fix is merged.
         # We track the issue here: https://github.com/deepset-ai/haystack/issues/9011
-
         builder = PromptBuilder("{{query}}")
-
         tool = ComponentTool(component=builder)
         result = tool.function(query="Hello")
-
-        tool_copy = deepcopy(tool)
-
+        tool_copy = deepcopy_with_fallback(tool)
         result_from_copy = tool_copy.function(query="Hello")
-
         assert "prompt" in result_from_copy
         assert result_from_copy["prompt"] == result["prompt"]
+
+    def test_jinja_based_component_tool_in_pipeline(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        with patch("openai.resources.chat.completions.Completions.create") as mock_create:
+            mock_create.return_value = ChatCompletion(
+                id="test",
+                model="gpt-4o-mini",
+                object="chat.completion",
+                choices=[
+                    Choice(
+                        finish_reason="length",
+                        index=0,
+                        message=ChatCompletionMessage(role="assistant", content="A response from the model"),
+                    )
+                ],
+                created=1234567890,
+            )
+
+            builder = PromptBuilder("{{query}}")
+            tool = ComponentTool(component=builder)
+            pipeline = Pipeline()
+            pipeline.add_component("llm", OpenAIChatGenerator(model="gpt-4o-mini"))
+            result = pipeline.run({"llm": {"messages": [ChatMessage.from_user(text="Hello")], "tools": [tool]}})
+
+        assert result["llm"]["replies"][0].text == "A response from the model"


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9011

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Adds a `deepcopy_with_fallback` utility function that gracefully handles deepcopy errors by returning the original object in the case the deepcopy fails. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

- Added test in ComponentTool when using a Jinja2 based component (e.g. PromptBuilder)
- Also manually triggered end to end tests in GH which passed

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
