### PR TITLE
feat : adding a new `Protocol` for `TextEmbedder` 

### DIFF
--- a/haystack/components/embedders/types/__init__.py
+++ b/haystack/components/embedders/types/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .protocol import TextEmbedder
+
+__all__ = ["TextEmbedder"]

--- a/haystack/components/embedders/types/protocol.py
+++ b/haystack/components/embedders/types/protocol.py
@@ -26,22 +26,4 @@ class TextEmbedder(Protocol):
         """
         ...
 
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Convert the component to a dictionary representation.
-
-        :returns:
-            A dictionary representation of the component.
-        """
-        ...
-
-    def from_dict(self, data: Dict[str, Any]) -> T:
-        """
-        Create a component instance from a dictionary representation.
-
-        :param data:
-            A dictionary representation of the component.
-        :returns:
-            An instance of the component.
-        """
-        ...
+    # small test class

--- a/haystack/components/embedders/types/protocol.py
+++ b/haystack/components/embedders/types/protocol.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Protocol, TypeVar
+from typing import Any, Dict, Protocol, TypeVar
 
 T = TypeVar("T", bound="TextEmbedder")
 

--- a/haystack/components/embedders/types/protocol.py
+++ b/haystack/components/embedders/types/protocol.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Dict, List, Protocol, TypeVar
+
+T = TypeVar("T", bound="TextEmbedder")
+
+
+class TextEmbedder(Protocol):
+    """
+    Protocol for Text Embedders.
+    """
+
+    def run(self, text: str) -> Dict[str, Any]:
+        """
+        Generate embeddings for the input text.
+
+        Implementing classes may accept additional optional parameters in their run method.
+        For example: `def run (self, text: str, param_a="default", param_b="another_default")`.
+
+        :param text:
+            The input text to be embedded.
+        :returns:
+            A dictionary containing the embedding and metadata.
+        """
+        ...
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Convert the component to a dictionary representation.
+
+        :returns:
+            A dictionary representation of the component.
+        """
+        ...
+
+    def from_dict(self, data: Dict[str, Any]) -> T:
+        """
+        Create a component instance from a dictionary representation.
+
+        :param data:
+            A dictionary representation of the component.
+        :returns:
+            An instance of the component.
+        """
+        ...

--- a/test/components/embedders/embedders/types/test_protocol.py
+++ b/test/components/embedders/embedders/types/test_protocol.py
@@ -1,0 +1,38 @@
+import pytest
+from typing import Any, Dict
+
+from haystack.components.embedders.types.protocol import TextEmbedder
+
+
+class MockTextEmbedder:
+    def run(self, text: str, param_a: str = "default", param_b: str = "another_default") -> Dict[str, Any]:
+        """
+        Mock implementation that returns a simple embedding and metadata.
+        """
+        return {"embedding": [0.1, 0.2, 0.3], "metadata": {"text": text, "param_a": param_a, "param_b": param_b}}
+
+
+def test_protocol_implementation():
+    embedder: TextEmbedder = MockTextEmbedder()  # should not raise any type errors
+
+    result = embedder.run("test text")
+    assert isinstance(result, dict)
+    assert "embedding" in result
+    assert "metadata" in result
+    assert isinstance(result["embedding"], list)
+    assert isinstance(result["metadata"], dict)
+
+
+def test_protocol_optional_parameters():
+    embedder: TextEmbedder = MockTextEmbedder()  # should not raise any type errors
+
+    # default parameters
+    result1 = embedder.run("test text")
+
+    # with custom parameters
+    result2 = embedder.run("test text", param_a="custom_a", param_b="custom_b")
+
+    assert result1["metadata"]["param_a"] == "default"
+    assert result1["metadata"]["param_b"] == "another_default"
+    assert result2["metadata"]["param_a"] == "custom_a"
+    assert result2["metadata"]["param_b"] == "custom_b"

--- a/test/components/embedders/types/test_protocol.py
+++ b/test/components/embedders/types/test_protocol.py
@@ -1,0 +1,36 @@
+from typing import Any, Dict
+
+from haystack.components.embedders.types.protocol import TextEmbedder
+
+
+class MockTextEmbedder:
+    def run(self, text: str, param_a: str = "default", param_b: str = "another_default") -> Dict[str, Any]:
+        """
+        Mock implementation that returns a simple embedding and metadata.
+        """
+        return {"embedding": [0.1, 0.2, 0.3], "metadata": {"text": text, "param_a": param_a, "param_b": param_b}}
+
+
+def test_protocol_implementation():
+    embedder: TextEmbedder = MockTextEmbedder()  # should not raise any type errors
+
+    result = embedder.run("test text")
+    assert isinstance(result, dict)
+    assert "embedding" in result
+    assert "metadata" in result
+    assert isinstance(result["embedding"], list)
+    assert isinstance(result["metadata"], dict)
+
+
+def test_protocol_optional_parameters():
+    embedder = MockTextEmbedder()
+
+    # default parameters
+    result1 = embedder.run("test text")
+
+    # with custom parameters
+    result2 = embedder.run("test text", param_a="custom_a", param_b="custom_b")
+
+    assert result1["metadata"]["param_a"] == "default"
+    assert result2["metadata"]["param_a"] == "custom_a"
+    assert result2["metadata"]["param_b"] == "custom_b"


### PR DESCRIPTION
### Related Issues

- fixes #9351


### Proposed Changes:

- Adding a new Protocol for a `TextEmbedder`

### How did you test it?

- I added some unit tests, and I'm also using this Protocol to built a TextEmbedder agnostic HybridRetrieval using an `OpenSearchDocumentStore`

### Notes for the reviewer

I tried to have tests that trigger a `TypeError` or any kind of error. For instance, having a different signature, a wrong parameter type, `int` instead of `str` but the type error is not triggered

```python
class InvalidEmbedder:
    def run(self, text: int) -> Dict[str, Any]:
        return {"embedding": [0.1], "metadata": {}}
    
    with pytest.raises(TypeError):
        embedder: TextEmbedder = InvalidEmbedder()  # type: ignore
```

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
