### PR TITLE
fix: `HuggingFaceAPIChatGenerator` - make tool conversion compatible with `huggingface_hub>=0.31.0`

### DIFF
--- a/releasenotes/notes/hf-tool-definition-0.31.0-c8403da8769fff1d.yaml
+++ b/releasenotes/notes/hf-tool-definition-0.31.0-c8403da8769fff1d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Make internal tool conversion in the HuggingFaceAPICompatibleChatGenerator compatible with huggingface_hub>=0.31.0.
+    In the huggingface_hub library, `arguments` attribute of `ChatCompletionInputFunctionDefinition` has been renamed to
+    `parameters`.
+    Our implementation is compatible with both the legacy version and the new one.

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -10,6 +10,7 @@ from haystack import Pipeline
 from haystack.dataclasses import StreamingChunk
 from haystack.utils.auth import Secret
 from haystack.utils.hf import HFGenerationAPIType
+
 from huggingface_hub import (
     ChatCompletionOutput,
     ChatCompletionOutputComplete,
@@ -21,9 +22,14 @@ from huggingface_hub import (
     ChatCompletionStreamOutputChoice,
     ChatCompletionStreamOutputDelta,
 )
-from huggingface_hub.utils import RepositoryNotFoundError
+from huggingface_hub.errors import RepositoryNotFoundError
 
-from haystack.components.generators.chat.hugging_face_api import HuggingFaceAPIChatGenerator, _convert_hfapi_tool_calls
+from haystack.components.generators.chat.hugging_face_api import (
+    HuggingFaceAPIChatGenerator,
+    _convert_hfapi_tool_calls,
+    _convert_tools_to_hfapi_tools,
+)
+
 from haystack.tools import Tool
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.tools.toolset import Toolset
@@ -980,3 +986,41 @@ class TestHuggingFaceAPIChatGenerator:
             },
         }
         assert data["init_parameters"]["tools"] == expected_tools_data
+
+    def test_convert_tools_to_hfapi_tools(self):
+        assert _convert_tools_to_hfapi_tools(None) is None
+        assert _convert_tools_to_hfapi_tools([]) is None
+
+        tool = Tool(
+            name="weather",
+            description="useful to determine the weather in a given location",
+            parameters={"city": {"type": "string"}},
+            function=get_weather,
+        )
+        hf_tools = _convert_tools_to_hfapi_tools([tool])
+        assert len(hf_tools) == 1
+        assert hf_tools[0].type == "function"
+        assert hf_tools[0].function.name == "weather"
+        assert hf_tools[0].function.description == "useful to determine the weather in a given location"
+        assert hf_tools[0].function.parameters == {"city": {"type": "string"}}
+
+    def test_convert_tools_to_hfapi_tools_legacy(self):
+        # this satisfies the check hasattr(ChatCompletionInputFunctionDefinition, "arguments")
+        mock_class = MagicMock()
+
+        with patch(
+            "haystack.components.generators.chat.hugging_face_api.ChatCompletionInputFunctionDefinition", mock_class
+        ):
+            tool = Tool(
+                name="weather",
+                description="useful to determine the weather in a given location",
+                parameters={"city": {"type": "string"}},
+                function=get_weather,
+            )
+            _convert_tools_to_hfapi_tools([tool])
+
+        mock_class.assert_called_once_with(
+            name="weather",
+            arguments={"city": {"type": "string"}},
+            description="useful to determine the weather in a given location",
+        )


### PR DESCRIPTION
### Related Issues

In `huggingface_hub==0.31.0`, released today, `arguments` attribute of `ChatCompletionInputFunctionDefinition` has been renamed to `parameters` (see https://github.com/huggingface/huggingface_hub/pull/3015).

This breaks our implementation. https://github.com/deepset-ai/haystack/actions/runs/14886759255/job/41808326761

### Proposed Changes:
- make tool conversion compatible with both the legacy and the new version (also because we cannot pin `huggingface_hub`, which is only a test dependency)
- extract tool conversion in a new utility function

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
