### PR TITLE
perf: Don't deepcopy Components, Tools, or Toolsets

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -10,7 +10,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.components.tools import ToolInvoker
 from haystack.core.pipeline.async_pipeline import AsyncPipeline
 from haystack.core.pipeline.pipeline import Pipeline
-from haystack.core.pipeline.utils import deepcopy_with_fallback
+from haystack.core.pipeline.utils import _deepcopy_with_exceptions
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.dataclasses.state import State, _schema_from_dict, _schema_to_dict, _validate_schema
@@ -111,7 +111,7 @@ class Agent:
         self._state_schema = state_schema or {}
 
         # Initialize state schema
-        resolved_state_schema = deepcopy_with_fallback(self._state_schema)
+        resolved_state_schema = _deepcopy_with_exceptions(self._state_schema)
         if resolved_state_schema.get("messages") is None:
             resolved_state_schema["messages"] = {"type": List[ChatMessage], "handler": merge_lists}
         self.state_schema = resolved_state_schema
@@ -253,7 +253,7 @@ class Agent:
         with self._create_agent_span() as span:
             span.set_content_tag(
                 "haystack.agent.input",
-                deepcopy_with_fallback({"messages": messages, "streaming_callback": streaming_callback, **kwargs}),
+                _deepcopy_with_exceptions({"messages": messages, "streaming_callback": streaming_callback, **kwargs}),
             )
             counter = 0
             while counter < self.max_agent_steps:
@@ -342,7 +342,7 @@ class Agent:
         with self._create_agent_span() as span:
             span.set_content_tag(
                 "haystack.agent.input",
-                deepcopy_with_fallback({"messages": messages, "streaming_callback": streaming_callback, **kwargs}),
+                _deepcopy_with_exceptions({"messages": messages, "streaming_callback": streaming_callback, **kwargs}),
             )
             counter = 0
             while counter < self.max_agent_steps:

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -244,8 +244,6 @@ class Agent:
             init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=False
         )
 
-        input_data = deepcopy_with_fallback({"messages": messages, "streaming_callback": streaming_callback, **kwargs})
-
         state = State(schema=self.state_schema, data=kwargs)
         state.set("messages", messages)
 
@@ -253,7 +251,10 @@ class Agent:
 
         component_visits = dict.fromkeys(["chat_generator", "tool_invoker"], 0)
         with self._create_agent_span() as span:
-            span.set_content_tag("haystack.agent.input", input_data)
+            span.set_content_tag(
+                "haystack.agent.input",
+                deepcopy_with_fallback({"messages": messages, "streaming_callback": streaming_callback, **kwargs}),
+            )
             counter = 0
             while counter < self.max_agent_steps:
                 # 1. Call the ChatGenerator
@@ -332,8 +333,6 @@ class Agent:
             init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=True
         )
 
-        input_data = deepcopy_with_fallback({"messages": messages, "streaming_callback": streaming_callback, **kwargs})
-
         state = State(schema=self.state_schema, data=kwargs)
         state.set("messages", messages)
 
@@ -341,7 +340,10 @@ class Agent:
 
         component_visits = dict.fromkeys(["chat_generator", "tool_invoker"], 0)
         with self._create_agent_span() as span:
-            span.set_content_tag("haystack.agent.input", input_data)
+            span.set_content_tag(
+                "haystack.agent.input",
+                deepcopy_with_fallback({"messages": messages, "streaming_callback": streaming_callback, **kwargs}),
+            )
             counter = 0
             while counter < self.max_agent_steps:
                 # 1. Call the ChatGenerator

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
-from copy import deepcopy
 from typing import Any, Dict, List, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict, logging, tracing
@@ -11,6 +10,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.components.tools import ToolInvoker
 from haystack.core.pipeline.async_pipeline import AsyncPipeline
 from haystack.core.pipeline.pipeline import Pipeline
+from haystack.core.pipeline.utils import deepcopy_with_fallback
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.dataclasses.state import State, _schema_from_dict, _schema_to_dict, _validate_schema
@@ -111,7 +111,7 @@ class Agent:
         self._state_schema = state_schema or {}
 
         # Initialize state schema
-        resolved_state_schema = deepcopy(self._state_schema)
+        resolved_state_schema = deepcopy_with_fallback(self._state_schema)
         if resolved_state_schema.get("messages") is None:
             resolved_state_schema["messages"] = {"type": List[ChatMessage], "handler": merge_lists}
         self.state_schema = resolved_state_schema
@@ -244,7 +244,7 @@ class Agent:
             init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=False
         )
 
-        input_data = deepcopy({"messages": messages, "streaming_callback": streaming_callback, **kwargs})
+        input_data = deepcopy_with_fallback({"messages": messages, "streaming_callback": streaming_callback, **kwargs})
 
         state = State(schema=self.state_schema, data=kwargs)
         state.set("messages", messages)
@@ -332,7 +332,7 @@ class Agent:
             init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=True
         )
 
-        input_data = deepcopy({"messages": messages, "streaming_callback": streaming_callback, **kwargs})
+        input_data = deepcopy_with_fallback({"messages": messages, "streaming_callback": streaming_callback, **kwargs})
 
         state = State(schema=self.state_schema, data=kwargs)
         state.set("messages", messages)

--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -15,7 +15,7 @@ from haystack.core.pipeline.base import (
     ComponentPriority,
     PipelineBase,
 )
-from haystack.core.pipeline.utils import deepcopy_with_fallback
+from haystack.core.pipeline.utils import _deepcopy_with_exceptions
 from haystack.telemetry import pipeline_running
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ class AsyncPipeline(PipelineBase):
         with PipelineBase._create_component_span(
             component_name=component_name, instance=instance, inputs=component_inputs, parent_span=parent_span
         ) as span:
-            span.set_content_tag(_COMPONENT_INPUT, deepcopy_with_fallback(component_inputs))
+            span.set_content_tag(_COMPONENT_INPUT, _deepcopy_with_exceptions(component_inputs))
             logger.info("Running component {component_name}", component_name=component_name)
 
             if getattr(instance, "__haystack_supports_async__", False):
@@ -76,7 +76,7 @@ class AsyncPipeline(PipelineBase):
                 raise PipelineRuntimeError.from_invalid_output(component_name, instance.__class__, outputs)
 
             span.set_tag(_COMPONENT_VISITS, component_visits[component_name])
-            span.set_content_tag(_COMPONENT_OUTPUT, deepcopy_with_fallback(outputs))
+            span.set_content_tag(_COMPONENT_OUTPUT, _deepcopy_with_exceptions(outputs))
 
             return outputs
 
@@ -238,7 +238,7 @@ class AsyncPipeline(PipelineBase):
                         partial_result = finished.result()
                         scheduled_components.discard(finished_component_name)
                         if partial_result:
-                            yield_dict = {finished_component_name: deepcopy_with_fallback(partial_result)}
+                            yield_dict = {finished_component_name: _deepcopy_with_exceptions(partial_result)}
                             yield yield_dict  # partial outputs
 
                 if component_name in scheduled_components:
@@ -274,7 +274,7 @@ class AsyncPipeline(PipelineBase):
 
                 scheduled_components.remove(component_name)
                 if pruned:
-                    yield {component_name: deepcopy_with_fallback(pruned)}
+                    yield {component_name: _deepcopy_with_exceptions(pruned)}
 
             async def _schedule_task(component_name: str) -> None:
                 """
@@ -337,7 +337,7 @@ class AsyncPipeline(PipelineBase):
                         partial_result = finished.result()
                         scheduled_components.discard(finished_component_name)
                         if partial_result:
-                            yield {finished_component_name: deepcopy_with_fallback(partial_result)}
+                            yield {finished_component_name: _deepcopy_with_exceptions(partial_result)}
 
             async def _wait_for_all_tasks_to_complete() -> AsyncIterator[Dict[str, Any]]:
                 """
@@ -350,7 +350,7 @@ class AsyncPipeline(PipelineBase):
                         partial_result = finished.result()
                         scheduled_components.discard(finished_component_name)
                         if partial_result:
-                            yield {finished_component_name: deepcopy_with_fallback(partial_result)}
+                            yield {finished_component_name: _deepcopy_with_exceptions(partial_result)}
 
             # -------------------------------------------------
             # MAIN SCHEDULING LOOP
@@ -428,7 +428,7 @@ class AsyncPipeline(PipelineBase):
                 yield partial_res
 
             # 4) Yield final pipeline outputs
-            yield deepcopy_with_fallback(pipeline_outputs)
+            yield _deepcopy_with_exceptions(pipeline_outputs)
 
     async def run_async(
         self, data: Dict[str, Any], include_outputs_from: Optional[Set[str]] = None, concurrency_limit: int = 4

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -32,7 +32,7 @@ from haystack.core.pipeline.component_checks import (
     is_any_greedy_socket_ready,
     is_socket_lazy_variadic,
 )
-from haystack.core.pipeline.utils import FIFOPriorityQueue, deepcopy_with_fallback, parse_connect_string
+from haystack.core.pipeline.utils import FIFOPriorityQueue, _deepcopy_with_exceptions, parse_connect_string
 from haystack.core.serialization import DeserializationCallbacks, component_from_dict, component_to_dict
 from haystack.core.type_utils import _type_name, _types_are_compatible
 from haystack.marshal import Marshaller, YamlMarshaller
@@ -175,7 +175,7 @@ class PipelineBase:
         :returns:
             Deserialized component.
         """
-        data_copy = deepcopy_with_fallback(data)  # to prevent modification of original data
+        data_copy = _deepcopy_with_exceptions(data)  # to prevent modification of original data
         metadata = data_copy.get("metadata", {})
         max_runs_per_component = data_copy.get("max_runs_per_component", 100)
         connection_type_validation = data_copy.get("connection_type_validation", True)
@@ -894,7 +894,7 @@ class PipelineBase:
         # deepcopying the inputs prevents the Pipeline run logic from being altered unexpectedly
         # when the same input reference is passed to multiple components.
         for component_name, component_inputs in data.items():
-            data[component_name] = {k: deepcopy_with_fallback(v) for k, v in component_inputs.items()}
+            data[component_name] = {k: _deepcopy_with_exceptions(v) for k, v in component_inputs.items()}
 
         return data
 

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -14,7 +14,7 @@ from haystack.core.pipeline.base import (
     ComponentPriority,
     PipelineBase,
 )
-from haystack.core.pipeline.utils import deepcopy_with_fallback
+from haystack.core.pipeline.utils import _deepcopy_with_exceptions
 from haystack.telemetry import pipeline_running
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class Pipeline(PipelineBase):
         ) as span:
             # We deepcopy the inputs otherwise we might lose that information
             # when we delete them in case they're sent to other Components
-            span.set_content_tag(_COMPONENT_INPUT, deepcopy_with_fallback(inputs))
+            span.set_content_tag(_COMPONENT_INPUT, _deepcopy_with_exceptions(inputs))
             logger.info("Running component {component_name}", component_name=component_name)
             try:
                 component_output = instance.run(**inputs)
@@ -252,7 +252,7 @@ class Pipeline(PipelineBase):
                 )
 
                 if component_pipeline_outputs:
-                    pipeline_outputs[component_name] = deepcopy_with_fallback(component_pipeline_outputs)
+                    pipeline_outputs[component_name] = _deepcopy_with_exceptions(component_pipeline_outputs)
                 if self._is_queue_stale(priority_queue):
                     priority_queue = self._fill_queue(ordered_component_names, inputs, component_visits)
 

--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -8,6 +8,7 @@ from itertools import count
 from typing import Any, List, Optional, Tuple
 
 from haystack import logging
+from haystack.core.component import Component
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,11 @@ def deepcopy_with_fallback(obj: Any, max_depth: Optional[int] = 100) -> Any:
     :param max_depth: The maximum depth to recurse during deep copying. If 0, returns the object as-is.
     :return: A deep copy of the object if successful; otherwise, the original object.
     """
+    # Components often contain objects that we do not want to deepcopy or are not deepcopyable
+    # (e.g. models, clients, etc.). In this case we return the object as-is.
+    if isinstance(obj, Component):
+        return obj
+
     if max_depth is not None and max_depth <= 0:
         return obj
 

--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -28,20 +28,14 @@ def deepcopy_with_fallback(obj: Any) -> Any:
     :returns:
         A deep-copied version of the object, or the original object if deepcopying fails.
     """
-    if isinstance(obj, list):
-        return [deepcopy_with_fallback(v) for v in obj]
-
-    if isinstance(obj, tuple):
-        return tuple(deepcopy_with_fallback(v) for v in obj)
-
-    if isinstance(obj, set):
-        return {deepcopy_with_fallback(v) for v in obj}
+    if isinstance(obj, (list, tuple, set)):
+        return type(obj)(deepcopy_with_fallback(v) for v in obj)
 
     if isinstance(obj, dict):
         return {k: deepcopy_with_fallback(v) for k, v in obj.items()}
 
     # Components and Tools often contain objects that we do not want to deepcopy or are not deepcopyable
-    # (e.g. pytorch models, clients, etc.). In this case we return the object as-is.
+    # (e.g. models, clients, etc.). In this case we return the object as-is.
     if isinstance(obj, (Component, Tool, Toolset)):
         return obj
 

--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -9,6 +9,7 @@ from typing import Any, List, Optional, Tuple
 
 from haystack import logging
 from haystack.core.component import Component
+from haystack.tools import Tool, Toolset
 
 logger = logging.getLogger(__name__)
 
@@ -25,9 +26,9 @@ def deepcopy_with_fallback(obj: Any, max_depth: Optional[int] = 100) -> Any:
     :param max_depth: The maximum depth to recurse during deep copying. If 0, returns the object as-is.
     :return: A deep copy of the object if successful; otherwise, the original object.
     """
-    # Components often contain objects that we do not want to deepcopy or are not deepcopyable
-    # (e.g. models, clients, etc.). In this case we return the object as-is.
-    if isinstance(obj, Component):
+    # Components and Tools often contain objects that we do not want to deepcopy or are not deepcopyable
+    # (e.g. pytorch models, clients, etc.). In this case we return the object as-is.
+    if isinstance(obj, (Component, Tool, Toolset)):
         return obj
 
     if max_depth is not None and max_depth <= 0:

--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -14,46 +14,40 @@ from haystack.tools import Tool, Toolset
 logger = logging.getLogger(__name__)
 
 
-def deepcopy_with_fallback(obj: Any, max_depth: Optional[int] = 100) -> Any:
+def deepcopy_with_fallback(obj: Any) -> Any:
     """
-    Attempts to create a deep copy of the given object with a safe fallback mechanism.
+    Attempts to perform a deep copy of the given object.
 
-    If the object is a dictionary, each value is copied individually using this function recursively.
-    If an individual item fails to be copied, the original value is used as a fallback.
-    A maximum recursion depth is enforced to avoid deep or cyclic structures from causing issues.
+    This function recursively handles common container types (lists, tuples, sets, and dicts) to ensure deep copies
+    of nested structures. For specific object types that are known to be problematic for deepcopying—such as
+    instances of `Component`, `Tool`, or `Toolset` - the original object is returned as-is.
+    If `deepcopy` fails for any other reason, the original object is returned and a log message is recorded.
 
-    :param obj: The object to attempt to deep copy.
-    :param max_depth: The maximum depth to recurse during deep copying. If 0, returns the object as-is.
-    :return: A deep copy of the object if successful; otherwise, the original object.
+    :param obj: The object to be deep-copied.
+
+    :returns:
+        A deep-copied version of the object, or the original object if deepcopying fails.
     """
+    if isinstance(obj, list):
+        return [deepcopy_with_fallback(v) for v in obj]
+
+    if isinstance(obj, tuple):
+        return tuple(deepcopy_with_fallback(v) for v in obj)
+
+    if isinstance(obj, set):
+        return {deepcopy_with_fallback(v) for v in obj}
+
+    if isinstance(obj, dict):
+        return {k: deepcopy_with_fallback(v) for k, v in obj.items()}
+
     # Components and Tools often contain objects that we do not want to deepcopy or are not deepcopyable
     # (e.g. pytorch models, clients, etc.). In this case we return the object as-is.
     if isinstance(obj, (Component, Tool, Toolset)):
         return obj
 
-    if max_depth is not None and max_depth <= 0:
-        return obj
-
     try:
         return deepcopy(obj)
     except Exception as e:
-        # If the deepcopy fails we try to deepcopy each individual value if the object is a dictionary
-        next_depth = None if max_depth is None else max_depth - 1
-        if isinstance(obj, dict):
-            logger.info(
-                "Deepcopy failed for object of type '{obj_type}'. Error: {error}. Attempting item-wise copy.",
-                obj_type=type(obj).__name__,
-                error=e,
-            )
-            return {key: deepcopy_with_fallback(value, next_depth) for key, value in obj.items()}
-        elif isinstance(obj, (list, tuple, set)):
-            logger.info(
-                "Deepcopy failed for object of type '{obj_type}'. Error: {error}. Attempting item-wise copy.",
-                obj_type=type(obj).__name__,
-                error=e,
-            )
-            return type(obj)(deepcopy_with_fallback(item, next_depth) for item in obj)
-
         logger.info(
             "Deepcopy failed for object of type '{obj_type}'. Error: {error}. Returning original object instead.",
             obj_type=type(obj).__name__,

--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -5,7 +5,7 @@
 import heapq
 from copy import deepcopy
 from itertools import count
-from typing import Any, List, Optional, Tuple, TypeVar
+from typing import Any, List, Optional, Tuple, TypeVar, cast
 
 from haystack import logging
 from haystack.core.component import Component
@@ -31,15 +31,15 @@ def _deepcopy_with_exceptions(obj: T) -> T:
         A deep-copied version of the object, or the original object if deepcopying fails.
     """
     if isinstance(obj, (list, tuple, set)):
-        return type(obj)(_deepcopy_with_exceptions(v) for v in obj)
+        return cast(T, type(obj)(_deepcopy_with_exceptions(v) for v in obj))
 
     if isinstance(obj, dict):
-        return {k: _deepcopy_with_exceptions(v) for k, v in obj.items()}
+        return cast(T, {k: _deepcopy_with_exceptions(v) for k, v in obj.items()})
 
     # Components and Tools often contain objects that we do not want to deepcopy or are not deepcopyable
     # (e.g. models, clients, etc.). In this case we return the object as-is.
     if isinstance(obj, (Component, Tool, Toolset)):
-        return obj
+        return cast(T, obj)
 
     try:
         return deepcopy(obj)

--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -5,7 +5,7 @@
 import heapq
 from copy import deepcopy
 from itertools import count
-from typing import Any, List, Optional, Tuple, TypeVar, cast
+from typing import Any, List, Optional, Tuple
 
 from haystack import logging
 from haystack.core.component import Component
@@ -13,10 +13,8 @@ from haystack.tools import Tool, Toolset
 
 logger = logging.getLogger(__name__)
 
-T = TypeVar("T")
 
-
-def _deepcopy_with_exceptions(obj: T) -> T:
+def _deepcopy_with_exceptions(obj: Any) -> Any:
     """
     Attempts to perform a deep copy of the given object.
 
@@ -31,15 +29,15 @@ def _deepcopy_with_exceptions(obj: T) -> T:
         A deep-copied version of the object, or the original object if deepcopying fails.
     """
     if isinstance(obj, (list, tuple, set)):
-        return cast(T, type(obj)(_deepcopy_with_exceptions(v) for v in obj))
+        return type(obj)(_deepcopy_with_exceptions(v) for v in obj)
 
     if isinstance(obj, dict):
-        return cast(T, {k: _deepcopy_with_exceptions(v) for k, v in obj.items()})
+        return {k: _deepcopy_with_exceptions(v) for k, v in obj.items()}
 
     # Components and Tools often contain objects that we do not want to deepcopy or are not deepcopyable
     # (e.g. models, clients, etc.). In this case we return the object as-is.
     if isinstance(obj, (Component, Tool, Toolset)):
-        return cast(T, obj)
+        return obj
 
     try:
         return deepcopy(obj)

--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -5,7 +5,7 @@
 import heapq
 from copy import deepcopy
 from itertools import count
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, TypeVar
 
 from haystack import logging
 from haystack.core.component import Component
@@ -13,13 +13,15 @@ from haystack.tools import Tool, Toolset
 
 logger = logging.getLogger(__name__)
 
+T = TypeVar("T")
 
-def deepcopy_with_fallback(obj: Any) -> Any:
+
+def _deepcopy_with_exceptions(obj: T) -> T:
     """
     Attempts to perform a deep copy of the given object.
 
     This function recursively handles common container types (lists, tuples, sets, and dicts) to ensure deep copies
-    of nested structures. For specific object types that are known to be problematic for deepcopying—such as
+    of nested structures. For specific object types that are known to be problematic for deepcopying-such as
     instances of `Component`, `Tool`, or `Toolset` - the original object is returned as-is.
     If `deepcopy` fails for any other reason, the original object is returned and a log message is recorded.
 
@@ -29,10 +31,10 @@ def deepcopy_with_fallback(obj: Any) -> Any:
         A deep-copied version of the object, or the original object if deepcopying fails.
     """
     if isinstance(obj, (list, tuple, set)):
-        return type(obj)(deepcopy_with_fallback(v) for v in obj)
+        return type(obj)(_deepcopy_with_exceptions(v) for v in obj)
 
     if isinstance(obj, dict):
-        return {k: deepcopy_with_fallback(v) for k, v in obj.items()}
+        return {k: _deepcopy_with_exceptions(v) for k, v in obj.items()}
 
     # Components and Tools often contain objects that we do not want to deepcopy or are not deepcopyable
     # (e.g. models, clients, etc.). In this case we return the object as-is.

--- a/releasenotes/notes/dont-deepcopy-components-tools-b1be7ef7b4365116.yaml
+++ b/releasenotes/notes/dont-deepcopy-components-tools-b1be7ef7b4365116.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Updated pipeline execution logic to use a new utility method `deepcopy_with_fallback`,
+    which skips deep-copying of `Component`, `Tool`, and `Toolset` instances when used as
+    runtime parameters. This prevents errors and unintended behavior caused by trying to
+    deepcopy objects that contain non-copyable attributes (e.g. Jinja2 templates, clients).

--- a/test/core/pipeline/test_utils.py
+++ b/test/core/pipeline/test_utils.py
@@ -251,26 +251,22 @@ class TestDeepcopyWithFallback:
         copy["objects"][1].name = "copied_obj2"
         assert copy["objects"][1].name == original["objects"][1].name
 
-    def test_deepcopy_with_fallback_tool(self, caplog):
+    def test_deepcopy_with_fallback_tool(self):
         tool = ComponentTool(
             name="problematic_tool", description="This is a problematic tool.", component=PromptBuilder("{{query}}")
         )
         original = {"tools": tool}
-        with caplog.at_level(logging.INFO):
-            copy = deepcopy_with_fallback(original)
-            assert "Deepcopy failed for object of type 'dict'" in caplog.text
+        copy = deepcopy_with_fallback(original)
         assert copy["tools"] == original["tools"]
         # Not a copy so changing the name in the copy should also affect the original
         copy["tools"].name = "copied_tool"
         assert copy["tools"] == original["tools"]
 
-    def test_deepcopy_with_fallback_component(self, monkeypatch, caplog):
+    def test_deepcopy_with_fallback_component(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test")
         comp = OpenAIChatGenerator()
         original = {"component": comp}
-        with caplog.at_level(logging.INFO):
-            res = deepcopy_with_fallback(original)
-            assert "Deepcopy failed for object of type 'dict'" in caplog.text
+        res = deepcopy_with_fallback(original)
         assert res == original
         # Change an attribute of the copy and check original also updates
         res["component"].model = "a-model"

--- a/test/core/pipeline/test_utils.py
+++ b/test/core/pipeline/test_utils.py
@@ -6,6 +6,7 @@ import logging
 import pytest
 
 from haystack.components.builders.prompt_builder import PromptBuilder
+from haystack.components.generators.chat.openai import OpenAIChatGenerator
 from haystack.core.pipeline.utils import parse_connect_string, FIFOPriorityQueue, deepcopy_with_fallback
 from haystack.tools import ComponentTool, Tool
 
@@ -259,3 +260,12 @@ class TestDeepcopyWithFallback:
         # second should be a shallow copy so changing the name in the copy should also affect the original
         copy["tools"][1].name = "copied_tool2"
         assert copy["tools"][1] == original["tools"][1]
+
+    def test_deepcopy_with_fallback_component(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test")
+        comp = OpenAIChatGenerator()
+        res = deepcopy_with_fallback(comp)
+        assert res == comp
+        # Change an attribute of the copy and check original also updates
+        res.model = "a-model"
+        assert res.model == comp.model

--- a/test/core/pipeline/test_utils.py
+++ b/test/core/pipeline/test_utils.py
@@ -251,22 +251,27 @@ class TestDeepcopyWithFallback:
         copy["objects"][1].name = "copied_obj2"
         assert copy["objects"][1].name == original["objects"][1].name
 
-    def test_deepcopy_with_fallback_tool(self):
+    def test_deepcopy_with_fallback_tool(self, caplog):
         tool = ComponentTool(
             name="problematic_tool", description="This is a problematic tool.", component=PromptBuilder("{{query}}")
         )
         original = {"tools": tool}
-        copy = deepcopy_with_fallback(original)
+        with caplog.at_level(logging.INFO):
+            copy = deepcopy_with_fallback(original)
+            assert "Deepcopy failed for object of type 'dict'" in caplog.text
         assert copy["tools"] == original["tools"]
         # Not a copy so changing the name in the copy should also affect the original
         copy["tools"].name = "copied_tool"
         assert copy["tools"] == original["tools"]
 
-    def test_deepcopy_with_fallback_component(self, monkeypatch):
+    def test_deepcopy_with_fallback_component(self, monkeypatch, caplog):
         monkeypatch.setenv("OPENAI_API_KEY", "test")
         comp = OpenAIChatGenerator()
-        res = deepcopy_with_fallback(comp)
-        assert res == comp
+        original = {"component": comp}
+        with caplog.at_level(logging.INFO):
+            res = deepcopy_with_fallback(original)
+            assert "Deepcopy failed for object of type 'dict'" in caplog.text
+        assert res == original
         # Change an attribute of the copy and check original also updates
-        res.model = "a-model"
-        assert res.model == comp.model
+        res["component"].model = "a-model"
+        assert res["component"].model == original["component"].model

--- a/test/tools/test_component_tool.py
+++ b/test/tools/test_component_tool.py
@@ -644,10 +644,6 @@ class TestToolComponentInPipelineWithOpenAI:
             ComponentTool(component=component)
 
     def test_deepcopy_with_jinja_based_component(self):
-        # Jinja2 templates throw an Exception when we deepcopy them (see https://github.com/pallets/jinja/issues/758)
-        # When we use a ComponentTool in a pipeline at runtime, we deepcopy the tool
-        # We overwrite ComponentTool.__deepcopy__ to fix this in experimental until a more comprehensive fix is merged.
-        # We track the issue here: https://github.com/deepset-ai/haystack/issues/9011
         builder = PromptBuilder("{{query}}")
         tool = ComponentTool(component=builder)
         result = tool.function(query="Hello")

--- a/test/tools/test_component_tool.py
+++ b/test/tools/test_component_tool.py
@@ -19,7 +19,7 @@ from haystack.components.builders import PromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.tools import ToolInvoker
 from haystack.components.websearch.serper_dev import SerperDevWebSearch
-from haystack.core.pipeline.utils import deepcopy_with_fallback
+from haystack.core.pipeline.utils import _deepcopy_with_exceptions
 from haystack.dataclasses import ChatMessage, ChatRole, Document
 from haystack.tools import ComponentTool
 from haystack.utils.auth import Secret
@@ -647,7 +647,7 @@ class TestToolComponentInPipelineWithOpenAI:
         builder = PromptBuilder("{{query}}")
         tool = ComponentTool(component=builder)
         result = tool.function(query="Hello")
-        tool_copy = deepcopy_with_fallback(tool)
+        tool_copy = _deepcopy_with_exceptions(tool)
         result_from_copy = tool_copy.function(query="Hello")
         assert "prompt" in result_from_copy
         assert result_from_copy["prompt"] == result["prompt"]


### PR DESCRIPTION
### Related Issues

- partially address https://github.com/deepset-ai/haystack/issues/9349

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
In our pipeline run methods we deepcopy the inputs and outputs of components to ensure that we don't cause unintended behavior such as altering the Pipeline run logic unepxectedly when the same input reference is passed to multiple components. 

This has worked well under the assumption that all run time inputs and outputs are data-like objects (e.g. strings, dataclasses, numbers, etc.) but has recently caused issues with the introduction of being able to pass Tools as runtime parameters to ChatGenerators. Since Tools can and often contain Components (e.g. ComponentTool) or even full pipelines (e.g. SuperComponent wrapped by ComponentTool) we find that our Pipeline run logic tries to deepcopy said tool leading to deepcopying of Components, Document Stores, etc. 

This has unsurprisingly caused issues since many of our Components contain attributes that aren't deepcopyable such as Jinja2 templates or some clients (e.g. ProxyClient). Or they contain objects that'd we'd prefer not to deepcopy such as local ML models.  

So I think it makes sense to update the new utility method `deepcopy_with_fallback` to automatically skip over Component, Tool or Toolset if they are passed into the deepcopy. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Updated unit tests.
- Also manually triggered end to end tests https://github.com/deepset-ai/haystack/actions/runs/14905702825

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

Some performance checks on the deepcopying
```python
import time
import tracemalloc

from haystack.core.pipeline.utils import deepcopy_with_fallback
from haystack.components.rankers.transformers_similarity import TransformersSimilarityRanker
from haystack.tools import ComponentTool
from haystack.utils import ComponentDevice


st = TransformersSimilarityRanker(device=ComponentDevice.from_str("cpu"))
st.warm_up()

tracemalloc.start()
start_time = time.time()

comp_tool = ComponentTool(
    component=st,
    name="text_embedder",
    description="Use this tool to embed text.",
)

_ = deepcopy_with_fallback(
    {
        "tools": [
            comp_tool, comp_tool, comp_tool, comp_tool, comp_tool, comp_tool, comp_tool, comp_tool, comp_tool, comp_tool
        ]
    }
)

end_time = time.time()
current, peak = tracemalloc.get_traced_memory()
tracemalloc.stop()

print(f"Time elapsed: {end_time - start_time:.4f} seconds")
print(f"Current memory usage: {current / 1024**2:.2f} MB; Peak: {peak / 1024**2:.2f} MB")

# When skipping copying of Tool 
# Ten tools
# Time elapsed: 0.0273 seconds
# Current memory usage: 0.14 MB; Peak: 0.16 MB

# When deepcopying Tool
# Ten tools
# Time elapsed: 0.4356 seconds
# Current memory usage: 3.81 MB; Peak: 4.54 MB
```

Another example with a custom component that contains an attribute that causes a circular deepcopy
```python
import time
import tracemalloc

import logging
logging.basicConfig(level=logging.INFO)

from haystack import component
from haystack.core.pipeline.utils import deepcopy_with_fallback
from haystack.tools import ComponentTool
from ddtrace.settings._config import Config


@component
class BadComponent:
    def __init__(self):
        # Object that can't be deepcopied
        self.config = Config()

    @component.output_types(result=str)
    def run(self, inp: str):
        return inp


bad_component = BadComponent()

tracemalloc.start()
start_time = time.time()

comp_tool = ComponentTool(
    component=bad_component,
    name="bad_component",
    description="Use this tool to return text.",
)

# _ = deepcopy_with_fallback({"tools": [comp_tool]})
_ = deepcopy_with_fallback(
    {
        "tools": [
            comp_tool, comp_tool, comp_tool, comp_tool, comp_tool, comp_tool, comp_tool, comp_tool, comp_tool, comp_tool
        ]
    }
)

end_time = time.time()
current, peak = tracemalloc.get_traced_memory()
tracemalloc.stop()

print(f"Time elapsed: {end_time - start_time:.4f} seconds")
print(f"Current memory usage: {current / 1024**2:.2f} MB; Peak: {peak / 1024**2:.2f} MB")

# When using new version
# One tool
# Time elapsed: 0.0033 seconds
# Current memory usage: 0.06 MB; Peak: 0.06 MB
# Ten tools
# Time elapsed: 0.0036 seconds
# Current memory usage: 0.06 MB; Peak: 0.06 MB

# When using old version
# One tool
# Time elapsed: 0.0611 seconds
# Current memory usage: 0.15 MB; Peak: 0.56 MB
# Ten tools
# Time elapsed: 0.6274 seconds
# Current memory usage: 0.15 MB; Peak: 0.57 MB
```

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
