### PR TITLE
feat: Update `print_streaming_chunk` to work with dict version of `ChoiceDeltaToolCall`

### DIFF
--- a/haystack/components/generators/utils.py
+++ b/haystack/components/generators/utils.py
@@ -25,18 +25,23 @@ def print_streaming_chunk(chunk: StreamingChunk) -> None:
     # Print tool call metadata if available (from ChatGenerator)
     if chunk.meta.get("tool_calls"):
         for tool_call in chunk.meta["tool_calls"]:
-            if isinstance(tool_call, ChoiceDeltaToolCall) and tool_call.function:
+            if isinstance(tool_call, ChoiceDeltaToolCall):
+                tool_call_dict = tool_call.to_dict()
+            else:
+                tool_call_dict = tool_call
+
+            if tool_call_dict.get("function"):
                 # print the tool name
-                if tool_call.function.name and not tool_call.function.arguments:
+                if tool_call_dict["function"].get("name") and not tool_call_dict["function"].get("arguments"):
                     print("[TOOL CALL]\n", flush=True, end="")
-                    print(f"Tool: {tool_call.function.name} ", flush=True, end="")
+                    print(f"Tool: {tool_call_dict['function']['name']} ", flush=True, end="")
 
                 # print the tool arguments
-                if tool_call.function.arguments:
-                    if tool_call.function.arguments.startswith("{"):
+                if tool_call_dict["function"].get("arguments"):
+                    if tool_call_dict["function"]["arguments"].startswith("{"):
                         print("\nArguments: ", flush=True, end="")
-                    print(tool_call.function.arguments, flush=True, end="")
-                    if tool_call.function.arguments.endswith("}"):
+                    print(tool_call_dict["function"]["arguments"], flush=True, end="")
+                    if tool_call_dict["function"]["arguments"].endswith("}"):
                         print("\n\n", flush=True, end="")
 
     # Print tool call results if available (from ToolInvoker)


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Make print streaming chunk work with dict version of ChoiceDeltaToolCall

This allows us to use this streaming callback with the new release 3.6.0 of the BedrockChatGenerator to stream tool calls

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
