### PR TITLE
fix: Small fix to `HuggingFaceAPIChatGenerator` and update tests

### DIFF
--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -401,6 +401,7 @@ class HuggingFaceAPIChatGenerator:
 
         generated_text = ""
         first_chunk_time = None
+        meta: Dict[str, Any] = {}
 
         for chunk in api_output:
             # n is unused, so the API always returns only one choice
@@ -412,8 +413,6 @@ class HuggingFaceAPIChatGenerator:
             generated_text += text
 
             finish_reason = choice.finish_reason
-
-            meta: Dict[str, Any] = {}
             if finish_reason:
                 meta["finish_reason"] = finish_reason
 
@@ -426,7 +425,6 @@ class HuggingFaceAPIChatGenerator:
         meta.update(
             {
                 "model": self._client.model,
-                "finish_reason": finish_reason,
                 "index": 0,
                 "usage": {"prompt_tokens": 0, "completion_tokens": 0},  # not available in streaming
                 "completion_start_time": first_chunk_time,
@@ -434,7 +432,6 @@ class HuggingFaceAPIChatGenerator:
         )
 
         message = ChatMessage.from_assistant(text=generated_text, meta=meta)
-
         return {"replies": [message]}
 
     def _run_non_streaming(
@@ -485,6 +482,7 @@ class HuggingFaceAPIChatGenerator:
 
         generated_text = ""
         first_chunk_time = None
+        meta: Dict[str, Any] = {}
 
         async for chunk in api_output:
             choice = chunk.choices[0]
@@ -493,8 +491,6 @@ class HuggingFaceAPIChatGenerator:
             generated_text += text
 
             finish_reason = choice.finish_reason
-
-            meta: Dict[str, Any] = {}
             if finish_reason:
                 meta["finish_reason"] = finish_reason
 
@@ -507,7 +503,6 @@ class HuggingFaceAPIChatGenerator:
         meta.update(
             {
                 "model": self._async_client.model,
-                "finish_reason": finish_reason,
                 "index": 0,
                 "usage": {"prompt_tokens": 0, "completion_tokens": 0},
                 "completion_start_time": first_chunk_time,

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -671,9 +671,15 @@ class TestHuggingFaceAPIChatGenerator:
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) > 0
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-        assert "usage" in response["replies"][0].meta
-        assert "prompt_tokens" in response["replies"][0].meta["usage"]
-        assert "completion_tokens" in response["replies"][0].meta["usage"]
+        assert response["replies"][0].text is not None
+        meta = response["replies"][0].meta
+        assert "usage" in meta
+        assert "prompt_tokens" in meta["usage"]
+        assert meta["usage"]["prompt_tokens"] > 0
+        assert "completion_tokens" in meta["usage"]
+        assert meta["usage"]["completion_tokens"] > 0
+        assert meta["model"] == "microsoft/Phi-3.5-mini-instruct"
+        assert meta["finish_reason"] is not None
 
     @pytest.mark.integration
     @pytest.mark.slow
@@ -701,13 +707,18 @@ class TestHuggingFaceAPIChatGenerator:
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) > 0
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+        assert response["replies"][0].text is not None
 
         response_meta = response["replies"][0].meta
         assert "completion_start_time" in response_meta
         assert datetime.fromisoformat(response_meta["completion_start_time"]) <= datetime.now()
         assert "usage" in response_meta
         assert "prompt_tokens" in response_meta["usage"]
+        assert response_meta["usage"]["prompt_tokens"] == 0
         assert "completion_tokens" in response_meta["usage"]
+        assert response_meta["usage"]["completion_tokens"] == 0
+        assert response_meta["model"] == "microsoft/Phi-3.5-mini-instruct"
+        assert response_meta["finish_reason"] is not None
 
     @pytest.mark.integration
     @pytest.mark.slow
@@ -926,9 +937,16 @@ class TestHuggingFaceAPIChatGenerator:
             assert isinstance(response["replies"], list)
             assert len(response["replies"]) > 0
             assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-            assert "usage" in response["replies"][0].meta
-            assert "prompt_tokens" in response["replies"][0].meta["usage"]
-            assert "completion_tokens" in response["replies"][0].meta["usage"]
+            assert response["replies"][0].text is not None
+
+            meta = response["replies"][0].meta
+            assert "usage" in meta
+            assert "prompt_tokens" in meta["usage"]
+            assert meta["usage"]["prompt_tokens"] > 0
+            assert "completion_tokens" in meta["usage"]
+            assert meta["usage"]["completion_tokens"] > 0
+            assert meta["model"] == "microsoft/Phi-3.5-mini-instruct"
+            assert meta["finish_reason"] is not None
         finally:
             await generator._async_client.close()
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
The meta dict was initialized in a for loop instead of outside of it while still being accessed outside of the for loop. Saw originally via Pycharm with `Local variable 'meta' might be referenced before assignment`

Updated some integration tests to do more checks on returned content of meta data

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Ran against existing tests and made sure referenced before assignment warnings were gone.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
