### PR TITLE
chore: remove deprecated `deserialize tools inplace` function

### DIFF
--- a/haystack/tools/__init__.py
+++ b/haystack/tools/__init__.py
@@ -6,7 +6,7 @@
 
 # ruff: noqa: I001 (ignore import order as we need to import Tool before ComponentTool)
 from .from_function import create_tool_from_function, tool
-from .tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
+from .tool import Tool, _check_duplicate_tool_names
 from .component_tool import ComponentTool
 from .serde_utils import deserialize_tools_or_toolset_inplace, serialize_tools_or_toolset
 from .toolset import Toolset
@@ -15,7 +15,6 @@ __all__ = [
     "_check_duplicate_tool_names",
     "ComponentTool",
     "create_tool_from_function",
-    "deserialize_tools_inplace",
     "deserialize_tools_or_toolset_inplace",
     "serialize_tools_or_toolset",
     "Tool",

--- a/haystack/tools/serde_utils.py
+++ b/haystack/tools/serde_utils.py
@@ -2,18 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import Any, Dict, List, Union
 
 from haystack.core.errors import DeserializationError
 from haystack.core.serialization import import_class_by_name
-
-if TYPE_CHECKING:
-    from haystack.tools.tool import Tool
-    from haystack.tools.toolset import Toolset
+from haystack.tools.tool import Tool
+from haystack.tools.toolset import Toolset
 
 
 def serialize_tools_or_toolset(
-    tools: Union["Toolset", List["Tool"], None],
+    tools: Union[Toolset, List[Tool], None],
 ) -> Union[Dict[str, Any], List[Dict[str, Any]], None]:
     """
     Serialize a Toolset or a list of Tools to a dictionary or a list of tool dictionaries.
@@ -21,8 +19,6 @@ def serialize_tools_or_toolset(
     :param tools: A Toolset, a list of Tools, or None
     :returns: A dictionary, a list of tool dictionaries, or None if tools is None
     """
-    from haystack.tools.toolset import Toolset
-
     if tools is None:
         return None
     if isinstance(tools, Toolset):
@@ -39,9 +35,6 @@ def deserialize_tools_or_toolset_inplace(data: Dict[str, Any], key: str = "tools
     :param key:
         The key in the dictionary where the list of Tools or Toolset is stored.
     """
-    from haystack.tools.tool import Tool
-    from haystack.tools.toolset import Toolset
-
     if key in data:
         serialized_tools = data[key]
 

--- a/haystack/tools/tool.py
+++ b/haystack/tools/tool.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import warnings
 from dataclasses import asdict, dataclass
 from typing import Any, Callable, Dict, List, Optional
 
@@ -11,7 +10,6 @@ from jsonschema.exceptions import SchemaError
 
 from haystack.core.serialization import generate_qualified_class_name
 from haystack.tools.errors import ToolInvocationError
-from haystack.tools.serde_utils import deserialize_tools_or_toolset_inplace
 from haystack.utils import deserialize_callable, serialize_callable
 
 
@@ -175,22 +173,3 @@ def _check_duplicate_tool_names(tools: Optional[List[Tool]]) -> None:
     duplicate_tool_names = {name for name in tool_names if tool_names.count(name) > 1}
     if duplicate_tool_names:
         raise ValueError(f"Duplicate tool names found: {duplicate_tool_names}")
-
-
-def deserialize_tools_inplace(data: Dict[str, Any], key: str = "tools"):
-    """
-    Deserialize a list of Tools or a Toolset in a dictionary inplace.
-
-    Deprecated in favor of `deserialize_tools_or_toolset_inplace`. It will be removed in Haystack 2.14.0.
-
-    :param data:
-        The dictionary with the serialized data.
-    :param key:
-        The key in the dictionary where the list of Tools or Toolset is stored.
-    """
-    warnings.warn(
-        "`deserialize_tools_inplace` is deprecated and will be removed in Haystack 2.14.0. "
-        "Use `deserialize_tools_or_toolset_inplace` instead.",
-        DeprecationWarning,
-    )
-    deserialize_tools_or_toolset_inplace(data, key)

--- a/releasenotes/notes/rm-deserialize_tools_inplace-cb3b1a9a36f17e3d.yaml
+++ b/releasenotes/notes/rm-deserialize_tools_inplace-cb3b1a9a36f17e3d.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The deprecated `deserialize_tools_inplace` utility function has been removed.
+    Use `deserialize_tools_or_toolset_inplace` instead, importing it as follows:
+    `from haystack.tools import deserialize_tools_or_toolset_inplace`.


### PR DESCRIPTION
### Related Issues

- fixes #9197

### Proposed Changes:
- remove the deprecated function
- remove some inner imports introduced in https://github.com/deepset-ai/haystack/pull/9301

### How did you test it?
CI


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
