### PR TITLE
feat: DRAFT (de)serialize Secrets, StreamingCallbacks, Tools, Toolset by default and add from_dict/to_dict to components

### DIFF
--- a/haystack/tools/__init__.py
+++ b/haystack/tools/__init__.py
@@ -5,20 +5,19 @@
 # NOTE: we do not use LazyImporter here because it creates conflicts between the tool module and the tool decorator
 
 # ruff: noqa: I001 (ignore import order as we need to import Tool before ComponentTool)
-from .from_function import create_tool_from_function, tool
-from .tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
-from .component_tool import ComponentTool
-from .serde_utils import deserialize_tools_or_toolset_inplace, serialize_tools_or_toolset
+from .tool import Tool, _check_duplicate_tool_names
 from .toolset import Toolset
+from .from_function import create_tool_from_function, tool
+from .serde_utils import serialize_tools_or_toolset, deserialize_tools_or_toolset_inplace
+from .component_tool import ComponentTool
 
 __all__ = [
-    "_check_duplicate_tool_names",
-    "ComponentTool",
-    "create_tool_from_function",
-    "deserialize_tools_inplace",
-    "deserialize_tools_or_toolset_inplace",
-    "serialize_tools_or_toolset",
     "Tool",
     "Toolset",
+    "create_tool_from_function",
     "tool",
+    "serialize_tools_or_toolset",
+    "deserialize_tools_or_toolset_inplace",
+    "ComponentTool",
+    "_check_duplicate_tool_names",
 ]

--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -10,16 +10,12 @@ from pydantic import TypeAdapter
 
 from haystack import logging
 from haystack.core.component import Component
-from haystack.core.serialization import (
-    component_from_dict,
-    component_to_dict,
-    generate_qualified_class_name,
-    import_class_by_name,
-)
+from haystack.core.serialization import component_from_dict, component_to_dict, generate_qualified_class_name
 from haystack.lazy_imports import LazyImport
 from haystack.tools import Tool
 from haystack.tools.errors import SchemaGenerationError
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
+from haystack.utils.importing import import_class_by_name
 
 with LazyImport(message="Run 'pip install docstring-parser'") as docstring_parser_import:
     from docstring_parser import parse

--- a/haystack/tools/serde_utils.py
+++ b/haystack/tools/serde_utils.py
@@ -5,7 +5,7 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from haystack.core.errors import DeserializationError
-from haystack.core.serialization import import_class_by_name
+from haystack.utils.importing import import_class_by_name
 
 if TYPE_CHECKING:
     from haystack.tools.tool import Tool

--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -225,10 +225,7 @@ class Toolset:
         lead to issues where outdated or incorrect Tool configurations are loaded, potentially causing errors or
         unexpected behavior.
         """
-        return {
-            "type": generate_qualified_class_name(type(self)),
-            "data": {"tools": [tool.to_dict() for tool in self.tools]},
-        }
+        return {"type": generate_qualified_class_name(type(self)), "data": [tool.to_dict() for tool in self.tools]}
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Toolset":
@@ -238,8 +235,7 @@ class Toolset:
         :param data: Dictionary representation of the Toolset
         :returns: A new Toolset instance
         """
-        inner_data = data["data"]
-        tools_data = inner_data.get("tools", [])
+        tools_data = data["data"]
 
         tools = []
         for tool_data in tools_data:

--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -5,8 +5,9 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterator, List, Union
 
-from haystack.core.serialization import generate_qualified_class_name, import_class_by_name
+from haystack.core.serialization import generate_qualified_class_name
 from haystack.tools.tool import Tool, _check_duplicate_tool_names
+from haystack.utils.importing import import_class_by_name
 
 
 @dataclass

--- a/haystack/utils/base_serialization.py
+++ b/haystack/utils/base_serialization.py
@@ -5,7 +5,8 @@
 from typing import Any, Dict
 
 from haystack.core.errors import DeserializationError, SerializationError
-from haystack.core.serialization import generate_qualified_class_name, import_class_by_name
+from haystack.core.serialization import generate_qualified_class_name
+from haystack.utils.importing import import_class_by_name
 
 
 def serialize_class_instance(obj: Any) -> Dict[str, Any]:

--- a/haystack/utils/deserialization.py
+++ b/haystack/utils/deserialization.py
@@ -4,8 +4,9 @@
 
 from typing import Any, Dict
 
-from haystack import DeserializationError
-from haystack.core.serialization import component_from_dict, default_from_dict, import_class_by_name
+from haystack.core.errors import DeserializationError
+from haystack.core.serialization import component_from_dict, default_from_dict
+from haystack.utils.importing import import_class_by_name
 
 
 def deserialize_document_store_in_init_params_inplace(data: Dict[str, Any], key: str = "document_store"):

--- a/haystack/utils/importing.py
+++ b/haystack/utils/importing.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+def import_class_by_name(fully_qualified_name: str) -> type:
+    """
+    Utility function to import (load) a class object based on its fully qualified class name.
+
+    This function dynamically imports a class based on its string name.
+    It splits the name into module path and class name, imports the module,
+    and returns the class object.
+
+    :param fully_qualified_name: the fully qualified class name as a string
+    :returns: the class object.
+    :raises ImportError: If the class cannot be imported or found.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    from haystack.utils.type_serialization import thread_safe_import
+
+    try:
+        module_path, class_name = fully_qualified_name.rsplit(".", 1)
+        logger.debug(
+            "Attempting to import class '{cls_name}' from module '{md_path}'", cls_name=class_name, md_path=module_path
+        )
+        module = thread_safe_import(module_path)
+        return getattr(module, class_name)
+    except (ImportError, AttributeError) as error:
+        logger.error("Failed to import class '{full_name}'", full_name=fully_qualified_name)
+        raise ImportError(f"Could not import class '{fully_qualified_name}'") from error

--- a/test/core/component/test_component_serialization.py
+++ b/test/core/component/test_component_serialization.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+from typing import Any, Dict, List
+
+from haystack import component
+from haystack.core.serialization import default_to_dict, default_from_dict
+from haystack.tools import Tool, Toolset
+from haystack.utils import Secret
+
+
+def mock_tool_function(x: str) -> str:
+    """A mock function for testing tool serialization."""
+    return x
+
+
+def test_default_serialization_methods_added():
+    """Test that default to_dict and from_dict methods are added when not present."""
+
+    @component
+    class SimpleComponent:
+        def __init__(self, value: int = 42):
+            self.value = value
+
+        def run(self, input_value: int) -> Dict[str, Any]:
+            return {"output": input_value + self.value}
+
+    # Create an instance
+    comp = SimpleComponent(value=10)
+
+    # Test to_dict
+    data = comp.to_dict()
+    assert data == {"type": "test_component_serialization.SimpleComponent", "init_parameters": {"value": 10}}
+
+    # Test from_dict
+    new_comp = SimpleComponent.from_dict(data)
+    assert isinstance(new_comp, SimpleComponent)
+    assert new_comp.value == 10
+
+
+def test_custom_serialization_methods_preserved():
+    """Test that custom to_dict and from_dict methods are preserved."""
+
+    @component
+    class CustomComponent:
+        def __init__(self, value: int = 42):
+            self.value = value
+
+        def run(self, input_value: int) -> Dict[str, Any]:
+            return {"output": input_value + self.value}
+
+        def to_dict(self) -> Dict[str, Any]:
+            return {"type": "custom", "value": self.value}
+
+        @classmethod
+        def from_dict(cls, data: Dict[str, Any]) -> "CustomComponent":
+            return cls(value=data["value"])
+
+    # Create an instance
+    comp = CustomComponent(value=10)
+
+    # Test custom to_dict
+    data = comp.to_dict()
+    assert data == {"type": "custom", "value": 10}
+
+    # Test custom from_dict
+    new_comp = CustomComponent.from_dict(data)
+    assert isinstance(new_comp, CustomComponent)
+    assert new_comp.value == 10
+
+
+def test_inherited_serialization_methods_preserved():
+    """Test that inherited to_dict and from_dict methods are preserved."""
+
+    class BaseComponent:
+        def __init__(self, value: int = 42):
+            self.value = value
+
+        def to_dict(self) -> Dict[str, Any]:
+            return {"type": "base", "value": self.value}
+
+        @classmethod
+        def from_dict(cls, data: Dict[str, Any]) -> "BaseComponent":
+            return cls(value=data["value"])
+
+    @component
+    class InheritedComponent(BaseComponent):
+        def run(self, input_value: int) -> Dict[str, Any]:
+            return {"output": input_value + self.value}
+
+    # Create an instance
+    comp = InheritedComponent(value=10)
+
+    # Test inherited to_dict
+    data = comp.to_dict()
+    assert data == {"type": "base", "value": 10}
+
+    # Test inherited from_dict
+    new_comp = InheritedComponent.from_dict(data)
+    assert isinstance(new_comp, InheritedComponent)
+    assert new_comp.value == 10
+
+
+def test_serialization_with_complex_init_parameters():
+    """Test serialization with complex initialization parameters."""
+
+    @component
+    class ComplexComponent:
+        def __init__(self, value: int = 42, name: str = "test", enabled: bool = True):
+            self.value = value
+            self.name = name
+            self.enabled = enabled
+
+        def run(self, input_value: int) -> Dict[str, Any]:
+            return {"output": input_value + self.value}
+
+    # Create an instance with multiple parameters
+    comp = ComplexComponent(value=10, name="complex", enabled=False)
+
+    # Test to_dict
+    data = comp.to_dict()
+    assert data == {
+        "type": "test_component_serialization.ComplexComponent",
+        "init_parameters": {"value": 10, "name": "complex", "enabled": False},
+    }
+
+    # Test from_dict
+    new_comp = ComplexComponent.from_dict(data)
+    assert isinstance(new_comp, ComplexComponent)
+    assert new_comp.value == 10
+    assert new_comp.name == "complex"
+    assert new_comp.enabled is False
+
+
+def test_serialization_with_tools():
+    """Test serialization of components with tools using default serialization methods."""
+
+    @component
+    class ToolComponent:
+        def __init__(self, tools: List[Tool]):
+            self.tools = tools
+
+        def run(self, input_value: str) -> Dict[str, Any]:
+            return {"output": input_value}
+
+    # Create a tool
+    tool = Tool(
+        name="test_tool",
+        description="A test tool",
+        parameters={"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]},
+        function=mock_tool_function,
+    )
+
+    # Create an instance with tools
+    comp = ToolComponent(tools=[tool])
+
+    # Test to_dict
+    data = comp.to_dict()
+    assert data["type"] == "test_component_serialization.ToolComponent"
+    assert "tools" in data["init_parameters"]
+    assert len(data["init_parameters"]["tools"]) == 1
+    assert data["init_parameters"]["tools"][0]["type"] == "haystack.tools.tool.Tool"
+    assert data["init_parameters"]["tools"][0]["data"]["name"] == "test_tool"
+
+    # Test from_dict
+    new_comp = ToolComponent.from_dict(data)
+    assert isinstance(new_comp, ToolComponent)
+    assert len(new_comp.tools) == 1
+    assert isinstance(new_comp.tools[0], Tool)
+    assert new_comp.tools[0].name == "test_tool"
+
+
+def test_serialization_with_toolset():
+    """Test serialization of components with Toolset using default serialization methods."""
+
+    @component
+    class ToolsetComponent:
+        def __init__(self, tools: Toolset):
+            self.tools = tools
+
+        def run(self, input_value: str) -> Dict[str, Any]:
+            return {"output": input_value}
+
+    # Create a tool
+    tool = Tool(
+        name="test_tool",
+        description="A test tool",
+        parameters={"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]},
+        function=mock_tool_function,
+    )
+
+    # Create a toolset
+    toolset = Toolset(tools=[tool])
+
+    # Create an instance with toolset
+    comp = ToolsetComponent(tools=toolset)
+
+    # Test to_dict
+    data = comp.to_dict()
+    assert data["type"] == "test_component_serialization.ToolsetComponent"
+    assert "tools" in data["init_parameters"]
+    assert data["init_parameters"]["tools"]["type"] == "haystack.tools.toolset.Toolset"
+    assert len(data["init_parameters"]["tools"]["data"]) == 1
+    assert data["init_parameters"]["tools"]["data"][0]["data"]["name"] == "test_tool"
+
+    # Test from_dict
+    new_comp = ToolsetComponent.from_dict(data)
+    assert isinstance(new_comp, ToolsetComponent)
+    # The tools should be a dictionary in the serialized format
+    assert isinstance(new_comp.tools, dict)
+    assert new_comp.tools["type"] == "haystack.tools.toolset.Toolset"
+    assert len(new_comp.tools["data"]) == 1
+    assert new_comp.tools["data"][0]["data"]["name"] == "test_tool"
+
+
+def test_serialization_with_secrets(monkeypatch):
+    """Test serialization of components with secrets using default serialization methods."""
+    monkeypatch.setenv("TEST_API_KEY", "test-api-key")
+
+    @component
+    class SecretComponent:
+        def __init__(self, api_key: Secret):
+            self.api_key = api_key
+
+        def run(self, input_value: str) -> Dict[str, Any]:
+            return {"output": input_value}
+
+    secret = Secret.from_env_var("TEST_API_KEY")
+    comp = SecretComponent(api_key=secret)
+
+    # Test to_dict
+    data = comp.to_dict()
+    assert data["type"] == "test_component_serialization.SecretComponent"
+    assert "api_key" in data["init_parameters"]
+    assert data["init_parameters"]["api_key"]["type"] == "env_var"
+    assert "TEST_API_KEY" in data["init_parameters"]["api_key"]["env_vars"]
+
+    # Test from_dict
+    new_comp = SecretComponent.from_dict(data)
+    assert isinstance(new_comp, SecretComponent)
+    assert isinstance(new_comp.api_key, Secret)
+    assert new_comp.api_key.resolve_value() == "test-api-key"

--- a/test/core/component/test_component_serialization.py
+++ b/test/core/component/test_component_serialization.py
@@ -171,6 +171,12 @@ def test_serialization_with_tools():
     assert len(new_comp.tools) == 1
     assert isinstance(new_comp.tools[0], Tool)
     assert new_comp.tools[0].name == "test_tool"
+    assert new_comp.tools[0].description == "A test tool"
+    assert new_comp.tools[0].parameters == {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "required": ["x"],
+    }
 
 
 def test_serialization_with_toolset():
@@ -214,6 +220,12 @@ def test_serialization_with_toolset():
     assert new_comp.tools["type"] == "haystack.tools.toolset.Toolset"
     assert len(new_comp.tools["data"]) == 1
     assert new_comp.tools["data"][0]["data"]["name"] == "test_tool"
+    assert new_comp.tools["data"][0]["data"]["description"] == "A test tool"
+    assert new_comp.tools["data"][0]["data"]["parameters"] == {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "required": ["x"],
+    }
 
 
 def test_serialization_with_secrets(monkeypatch):

--- a/test/core/test_serialization.py
+++ b/test/core/test_serialization.py
@@ -14,12 +14,12 @@ from haystack.core.serialization import (
     default_to_dict,
     default_from_dict,
     generate_qualified_class_name,
-    import_class_by_name,
     component_to_dict,
 )
 from haystack.utils import Secret
-from haystack.tools import Tool, Toolset
-from haystack.dataclasses.streaming_chunk import StreamingChunk, StreamingCallbackT
+from haystack.tools import Tool
+from haystack.dataclasses.streaming_chunk import StreamingChunk
+from haystack.utils.importing import import_class_by_name
 
 
 def test_default_component_to_dict():

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -5,7 +5,8 @@
 import re
 import pytest
 
-from haystack.tools import Tool, _check_duplicate_tool_names
+from haystack.tools import Tool
+from haystack.tools.tool import _check_duplicate_tool_names
 from haystack.tools.errors import ToolInvocationError
 
 


### PR DESCRIPTION
### Related Issues

- Related to #9206 

### Proposed Changes:

- Change default_from_dict and default_to_dict implementations to handle Secrets, StreamingCallbacks, Tools, Toolset by default
- Add `to_dict` and `from_dict` to components via the `@component` decorator if there is no custom implementation in that component or any of its parent classes

### How did you test it?

- I removed the custom `to_dict` and `from_dict`  implementations from OpenAIChatGenerator and at least the OpenAIChatGenerator tests still pass.
- Added test/core/component/test_component_serialization.py

### Notes for the reviewer

This is just a draft and not meant to be merged.
Circular import errors are the reason for some changes to other files and creating haystack/utils/importing.py in this draft.
There are several test errors.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
