### PR TITLE
feat: Streamline using `Agent` as a `ComponentTool`

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -86,6 +86,7 @@ class Agent:
         :param streaming_callback: A callback that will be invoked when a response is streamed from the LLM.
             The same callback can be configured to emit tool results when a tool is called.
         :raises TypeError: If the chat_generator does not support tools parameter in its run method.
+        :raises ValueError: If the exit_conditions are not valid.
         """
         # Check if chat_generator supports tools parameter
         chat_generator_run_method = inspect.signature(chat_generator.run)
@@ -124,7 +125,7 @@ class Agent:
         self.raise_on_tool_invocation_failure = raise_on_tool_invocation_failure
         self.streaming_callback = streaming_callback
 
-        output_types = {}
+        output_types = {"last_message": ChatMessage}
         for param, config in self.state_schema.items():
             output_types[param] = config["type"]
             # Skip setting input types for parameters that are already in the run method
@@ -225,14 +226,19 @@ class Agent:
         **kwargs: Dict[str, Any],
     ) -> Dict[str, Any]:
         """
-        Process messages and execute tools until the exit condition is met.
+        Process messages and execute tools until an exit condition is met.
 
-        :param messages: List of chat messages to process
+        :param messages: List of Haystack ChatMessage objects to process.
+            If a list of dictionaries is provided, each dictionary will be converted to a ChatMessage object.
         :param streaming_callback: A callback that will be invoked when a response is streamed from the LLM.
             The same callback can be configured to emit tool results when a tool is called.
         :param kwargs: Additional data to pass to the State schema used by the Agent.
             The keys must match the schema defined in the Agent's `state_schema`.
-        :return: Dictionary containing messages and outputs matching the defined output types
+        :returns:
+            A dictionary with the following keys:
+            - "messages": List of all messages exchanged during the agent's run.
+            - "last_message": The last message exchanged during the agent's run.
+            - Any additional keys defined in the `state_schema`.
         """
         if not self._is_warmed_up and hasattr(self.chat_generator, "warm_up"):
             raise RuntimeError("The component Agent wasn't warmed up. Run 'warm_up()' before calling 'run()'.")
@@ -240,16 +246,14 @@ class Agent:
         if self.system_prompt is not None:
             messages = [ChatMessage.from_system(self.system_prompt)] + messages
 
+        state = State(schema=self.state_schema, data=kwargs)
+        state.set("messages", messages)
+        component_visits = dict.fromkeys(["chat_generator", "tool_invoker"], 0)
+
         streaming_callback = select_streaming_callback(
             init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=False
         )
-
-        state = State(schema=self.state_schema, data=kwargs)
-        state.set("messages", messages)
-
         generator_inputs = self._prepare_generator_inputs(streaming_callback=streaming_callback)
-
-        component_visits = dict.fromkeys(["chat_generator", "tool_invoker"], 0)
         with self._create_agent_span() as span:
             span.set_content_tag(
                 "haystack.agent.input",
@@ -258,13 +262,14 @@ class Agent:
             counter = 0
             while counter < self.max_agent_steps:
                 # 1. Call the ChatGenerator
-                llm_messages = Pipeline._run_component(
+                result = Pipeline._run_component(
                     component_name="chat_generator",
                     component={"instance": self.chat_generator},
                     inputs={"messages": messages, **generator_inputs},
                     component_visits=component_visits,
                     parent_span=span,
-                )["replies"]
+                )
+                llm_messages = result["replies"]
                 state.set("messages", llm_messages)
 
                 # 2. Check if any of the LLM responses contain a tool call or if the LLM is not using tools
@@ -301,7 +306,12 @@ class Agent:
                 )
             span.set_content_tag("haystack.agent.output", state.data)
             span.set_tag("haystack.agent.steps_taken", counter)
-        return state.data
+
+        result = {**state.data}
+        all_messages = state.get("messages")
+        if all_messages:
+            result.update({"last_message": all_messages[-1]})
+        return result
 
     async def run_async(
         self,
@@ -321,7 +331,11 @@ class Agent:
             The same callback can be configured to emit tool results when a tool is called.
         :param kwargs: Additional data to pass to the State schema used by the Agent.
             The keys must match the schema defined in the Agent's `state_schema`.
-        :return: Dictionary containing messages and outputs matching the defined output types
+        :returns:
+            A dictionary with the following keys:
+            - "messages": List of all messages exchanged during the agent's run.
+            - "last_message": The last message exchanged during the agent's run.
+            - Any additional keys defined in the `state_schema`.
         """
         if not self._is_warmed_up and hasattr(self.chat_generator, "warm_up"):
             raise RuntimeError("The component Agent wasn't warmed up. Run 'warm_up()' before calling 'run_async()'.")
@@ -329,16 +343,14 @@ class Agent:
         if self.system_prompt is not None:
             messages = [ChatMessage.from_system(self.system_prompt)] + messages
 
+        state = State(schema=self.state_schema, data=kwargs)
+        state.set("messages", messages)
+        component_visits = dict.fromkeys(["chat_generator", "tool_invoker"], 0)
+
         streaming_callback = select_streaming_callback(
             init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=True
         )
-
-        state = State(schema=self.state_schema, data=kwargs)
-        state.set("messages", messages)
-
         generator_inputs = self._prepare_generator_inputs(streaming_callback=streaming_callback)
-
-        component_visits = dict.fromkeys(["chat_generator", "tool_invoker"], 0)
         with self._create_agent_span() as span:
             span.set_content_tag(
                 "haystack.agent.input",
@@ -394,7 +406,12 @@ class Agent:
                 )
             span.set_content_tag("haystack.agent.output", state.data)
             span.set_tag("haystack.agent.steps_taken", counter)
-        return state.data
+
+        result = {**state.data}
+        all_messages = state.get("messages")
+        if all_messages:
+            result.update({"last_message": all_messages[-1]})
+        return result
 
     def _check_exit_conditions(self, llm_messages: List[ChatMessage], tool_messages: List[ChatMessage]) -> bool:
         """

--- a/haystack/components/generators/utils.py
+++ b/haystack/components/generators/utils.py
@@ -30,18 +30,15 @@ def print_streaming_chunk(chunk: StreamingChunk) -> None:
                 if tool_call.function.name and not tool_call.function.arguments:
                     print("[TOOL CALL]\n", flush=True, end="")
                     print(f"Tool: {tool_call.function.name} ", flush=True, end="")
+                    print("\nArguments: ", flush=True, end="")
 
                 # print the tool arguments
                 if tool_call.function.arguments:
-                    if tool_call.function.arguments.startswith("{"):
-                        print("\nArguments: ", flush=True, end="")
                     print(tool_call.function.arguments, flush=True, end="")
-                    if tool_call.function.arguments.endswith("}"):
-                        print("\n\n", flush=True, end="")
 
     # Print tool call results if available (from ToolInvoker)
     if chunk.meta.get("tool_result"):
-        print(f"[TOOL RESULT]\n{chunk.meta['tool_result']}\n\n", flush=True, end="")
+        print(f"\n\n[TOOL RESULT]\n{chunk.meta['tool_result']}\n\n", flush=True, end="")
 
     # Print the main content of the chunk (from ChatGenerator)
     if chunk.content:

--- a/haystack/components/tools/tool_invoker.py
+++ b/haystack/components/tools/tool_invoker.py
@@ -475,7 +475,7 @@ class ToolInvoker:
                     streaming_callback(
                         StreamingChunk(
                             content="",
-                            meta={"tool_result": tool_messages[-1].tool_call_result.result, "tool_call": tool_call},
+                            meta={"tool_result": tool_messages[-1].tool_call_results[0].result, "tool_call": tool_call},
                         )
                     )
 

--- a/haystack/components/tools/tool_invoker.py
+++ b/haystack/components/tools/tool_invoker.py
@@ -19,6 +19,7 @@ from haystack.tools import (
     serialize_tools_or_toolset,
 )
 from haystack.tools.errors import ToolInvocationError
+from haystack.tracing.utils import _serializable_value
 
 logger = logging.getLogger(__name__)
 
@@ -226,12 +227,30 @@ class ToolInvoker:
         :param result: The tool result to convert to a string.
         :returns: The converted tool result as a string.
         """
+        # We iterate through all items in result and call to_dict() if present
+        # Relevant for a few reasons:
+        # - If using convert_result_to_json_string we'd rather convert Haystack objects to JSON serializable dicts
+        # - If using default str() we prefer converting Haystack objects to dicts rather than relying on the
+        #   __repr__ method
+        serializable = _serializable_value(result)
+
         if self.convert_result_to_json_string:
-            # We disable ensure_ascii so special chars like emojis are not converted
-            tool_result_str = json.dumps(result, ensure_ascii=False)
-        else:
-            tool_result_str = str(result)
-        return tool_result_str
+            try:
+                # We disable ensure_ascii so special chars like emojis are not converted
+                str_result = json.dumps(serializable, ensure_ascii=False)
+            except Exception as error:
+                # If the result is not JSON serializable, we fall back to str
+                logger.warning(
+                    "Tool result is not JSON serializable. Falling back to str conversion. "
+                    "Result: {result}\n"
+                    "Error: {error}",
+                    result=result,
+                    err=error,
+                )
+                str_result = str(result)
+            return str_result
+
+        return str(serializable)
 
     def _prepare_tool_result_message(self, result: Any, tool_call: ToolCall, tool_to_invoke: Tool) -> ChatMessage:
         """
@@ -454,7 +473,10 @@ class ToolInvoker:
 
                 if streaming_callback is not None:
                     streaming_callback(
-                        StreamingChunk(content="", meta={"tool_result": tool_result, "tool_call": tool_call})
+                        StreamingChunk(
+                            content="",
+                            meta={"tool_result": tool_messages[-1].tool_call_result.result, "tool_call": tool_call},
+                        )
                     )
 
         return {"tool_messages": tool_messages, "state": state}

--- a/releasenotes/notes/agent-as-a-component-tool-78696bd25deedad2.yaml
+++ b/releasenotes/notes/agent-as-a-component-tool-78696bd25deedad2.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    A variety of improvements have been made so an Agent component can be directly used in ComponentTool enabling straightforward building of Multi-Agent systems.
+    These improvements include:
+    - Adding a `last_message` field to the Agent's output which returns the last generated ChatMessage.
+    - Improving the `_default_output_handler` in the `ToolInvoker` to try and first serialize the outputs in the tool result before converting it into a string. This is especially relevant for getting a better representation when stringifying dataclasses like ChatMessage.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -162,7 +162,8 @@ class TestAgent:
         chat_generator = OpenAIChatGenerator()
         agent = Agent(chat_generator=chat_generator, tools=[weather_tool, component_tool])
         assert agent.__haystack_output__._sockets_dict == {
-            "messages": OutputSocket(name="messages", type=List[ChatMessage], receivers=[])
+            "messages": OutputSocket(name="messages", type=List[ChatMessage], receivers=[]),
+            "last_message": OutputSocket(name="last_message", type=ChatMessage, receivers=[]),
         }
 
     def test_to_dict(self, weather_tool, component_tool, monkeypatch):
@@ -532,6 +533,8 @@ class TestAgent:
         assert len(response["messages"]) == 2
         assert [isinstance(reply, ChatMessage) for reply in response["messages"]]
         assert "Hello" in response["messages"][1].text  # see openai_mock_chat_completion_chunk
+        assert "last_message" in response
+        assert isinstance(response["last_message"], ChatMessage)
 
     def test_run_with_run_streaming(self, openai_mock_chat_completion_chunk, weather_tool):
         chat_generator = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))
@@ -556,6 +559,8 @@ class TestAgent:
         assert len(response["messages"]) == 2
         assert [isinstance(reply, ChatMessage) for reply in response["messages"]]
         assert "Hello" in response["messages"][1].text  # see openai_mock_chat_completion_chunk
+        assert "last_message" in response
+        assert isinstance(response["last_message"], ChatMessage)
 
     def test_keep_generator_streaming(self, openai_mock_chat_completion_chunk, weather_tool):
         streaming_callback_called = False
@@ -582,6 +587,8 @@ class TestAgent:
         assert len(response["messages"]) == 2
         assert [isinstance(reply, ChatMessage) for reply in response["messages"]]
         assert "Hello" in response["messages"][1].text  # see openai_mock_chat_completion_chunk
+        assert "last_message" in response
+        assert isinstance(response["last_message"], ChatMessage)
 
     def test_chat_generator_must_support_tools(self, weather_tool):
         chat_generator = MockChatGeneratorWithoutTools()
@@ -614,6 +621,9 @@ class TestAgent:
             result["messages"][-1].tool_call_result.result
             == "{'weather': 'mostly sunny', 'temperature': 7, 'unit': 'celsius'}"
         )
+        assert "last_message" in result
+        assert isinstance(result["last_message"], ChatMessage)
+        assert result["messages"][-1] == result["last_message"]
 
     def test_exceed_max_steps(self, monkeypatch, weather_tool, caplog):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
@@ -663,6 +673,9 @@ class TestAgent:
             result["messages"][-1].tool_call_result.result
             == "{'weather': 'mostly sunny', 'temperature': 7, 'unit': 'celsius'}"
         )
+        assert "last_message" in result
+        assert isinstance(result["last_message"], ChatMessage)
+        assert result["messages"][-1] == result["last_message"]
 
     def test_agent_with_no_tools(self, monkeypatch, caplog):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
@@ -688,6 +701,9 @@ class TestAgent:
         assert [isinstance(reply, ChatMessage) for reply in response["messages"]]
         assert response["messages"][0].text == "What is the capital of Germany?"
         assert response["messages"][1].text == "Berlin"
+        assert "last_message" in response
+        assert isinstance(response["last_message"], ChatMessage)
+        assert response["messages"][-1] == response["last_message"]
 
     def test_run_with_system_prompt(self, weather_tool):
         chat_generator = MockChatGeneratorWithoutRunAsync()
@@ -731,6 +747,9 @@ class TestAgent:
         assert response["messages"][1].tool_calls[0].arguments is not None
         assert response["messages"][2].tool_call_results[0].result is not None
         assert response["messages"][2].tool_call_results[0].origin is not None
+        assert "last_message" in response
+        assert isinstance(response["last_message"], ChatMessage)
+        assert response["messages"][-1] == response["last_message"]
 
     @pytest.mark.asyncio
     async def test_run_async_falls_back_to_run_when_chat_generator_has_no_run_async(self, weather_tool):
@@ -754,6 +773,9 @@ class TestAgent:
         assert len(result["messages"]) == 2
         assert [isinstance(reply, ChatMessage) for reply in result["messages"]]
         assert "Hello" in result["messages"][1].text
+        assert "last_message" in result
+        assert isinstance(result["last_message"], ChatMessage)
+        assert result["messages"][-1] == result["last_message"]
 
     @pytest.mark.asyncio
     async def test_run_async_uses_chat_generator_run_async_when_available(self, weather_tool):
@@ -778,6 +800,9 @@ class TestAgent:
         assert len(result["messages"]) == 2
         assert [isinstance(reply, ChatMessage) for reply in result["messages"]]
         assert "Hello from run_async" in result["messages"][1].text
+        assert "last_message" in result
+        assert isinstance(result["last_message"], ChatMessage)
+        assert result["messages"][-1] == result["last_message"]
 
     @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
     def test_agent_streaming_with_tool_call(self, monkeypatch, weather_tool):
@@ -796,6 +821,7 @@ class TestAgent:
 
         assert result is not None
         assert result["messages"] is not None
+        assert result["last_message"] is not None
         assert streaming_callback_called
 
 


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9313
- fixes https://github.com/deepset-ai/haystack/issues/9293

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

A variety of improvements have been made so an Agent component can be directly used in ComponentTool enabling straightforward building of Multi-Agent systems.

These improvements include:
- Adding a `last_message` field to the Agent's output which returns the last generated ChatMessage.
- Improving the `_default_output_handler` in the `ToolInvoker` to try and first serialize the outputs in the tool result before converting it into a string. This is especially relevant for getting a better representation when stringifying dataclasses like ChatMessage.
- Updated the `ToolCallResult` `StreamingChunk` to respect `outputs_to_string` when sending the tool result in the `StreamingChunk`

Tangentially made a slight improvement to the `print_streaming_chunk` utility method to work when the tool call input arguments are nested dicts.

Here is an example of output before
```
[TOOL CALL]
Tool: joker_agent 
Arguments: {"messages":[
Arguments: {"role":"user","content":[
Arguments: {"text":"Can you make me a funny joke?"}

]}

]}

[TOOL RESULT]
{'role': 'assistant', 'meta': {'model': 'gpt-4o-mini-2024-07-18', 'index': 0, 'finish_reason': 'stop', 'usage': {'completion_tokens': 43, 'prompt_tokens': 144, 'total_tokens': 187, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}}, 'name': None, 'content': [{'text': "Here's a funny joke for you: \n\nWhat did the LLM say after acing the Turing test? I’d like to thank my training data — without you, I’m nothing but random noise!"}]}

Here's a funny joke for you: 

What did the LLM say after acing the Turing test? I’d like to thank my training data — without you, I’m nothing but random noise!
```
and after
```
[TOOL CALL]
Tool: joker_agent 
Arguments: {"messages":[{"role":"user","content":[{"text":"Can you make me a funny joke?"}]}]}

[TOOL RESULT]
{'role': 'assistant', 'meta': {'model': 'gpt-4o-mini-2024-07-18', 'index': 0, 'finish_reason': 'stop', 'usage': {'completion_tokens': 44, 'prompt_tokens': 144, 'total_tokens': 188, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}}, 'name': None, 'content': [{'text': 'Here’s a funny joke for you: \n\nWhat did the LLM say after acing the Turing test? I’d like to thank my training data — without you, I’m nothing but random noise!'}]}

Here’s a funny joke for you: 

What did the LLM say after acing the Turing test? I’d like to thank my training data — without you, I’m nothing but random noise!
```

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- updated unit tests
- tested a multi-agent system locally

Here is the example script
```python
import os

os.environ["OPENAI_API_KEY"] = ""

from haystack.components.agents import Agent
from haystack.components.generators.chat import OpenAIChatGenerator
from haystack.components.generators.utils import print_streaming_chunk
from haystack.dataclasses import ChatMessage
from haystack.tools import ComponentTool, Tool, tool


# Define math functions
def add_numbers(a: int, b: int) -> int:
    print("add_numbers")
    return a + b

def subtract_numbers(a: int, b: int) -> int:
    print("subtract_numbers")
    return a - b

# Create tools with proper schemas
add_tool = Tool(
    name="add",
    description="Add two numbers",
    parameters={
        "type": "object",
        "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
        "required": ["a", "b"],
    },
    function=add_numbers,
)

subtract_tool = Tool(
    name="subtract",
    description="Subtract b from a",
    parameters={
        "type": "object",
        "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
        "required": ["a", "b"],
    },
    function=subtract_numbers,
)

math_agent = Agent(
    chat_generator=OpenAIChatGenerator(),
    system_prompt="You are a tool calling agent that can do math calculations. Select the right tools for calculations",
    tools=[add_tool, subtract_tool],
)

math_agent_tool = ComponentTool(
    component=math_agent,
    description="Use this tool to make math calculations",
    name="math_agent",
    outputs_to_string={"source": "last_message"},
)

@tool
def funny_joke():
    """Use this tool to get a funny joke"""
    return "What did the LLM say after acing the Turing test? I’d like to thank my training data — without you, I’m nothing but random noise!"

@tool
def sad_joke():
    """Use this tool to get a sad joke"""
    return "Why did the LLM get dumped by its user? Because it couldn’t stop hallucinating"

joker_agent = Agent(
    chat_generator=OpenAIChatGenerator(),
    system_prompt="You are a tool calling agent that can make really nice jokes. Select the right tools to make relevant jokes",
    tools=[funny_joke, sad_joke],
)

# Ideally we would want this but this doesn't work
joker_tool = ComponentTool(
    component=joker_agent,
    description="Use this tool to make funny or sad jokes",
    name="joker_agent",
    outputs_to_string={"source": "last_message"},
)

main_agent = Agent(
    chat_generator=OpenAIChatGenerator(), tools=[math_agent_tool, joker_tool], streaming_callback=print_streaming_chunk
)

result = main_agent.run(messages=[ChatMessage.from_user("Can you make me a funny joke?")])
# print(result["last_message"])
```

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
