### PR TITLE
using permute to reverse the dimensions of a tensor

### DIFF
--- a/haystack/components/rankers/sentence_transformers_diversity.py
+++ b/haystack/components/rankers/sentence_transformers_diversity.py
@@ -369,7 +369,6 @@ class SentenceTransformersDiversityRanker:
                     doc_embeddings[idx] @ doc_embeddings[j].permute(*torch.arange(doc_embeddings[j].ndim - 1, -1, -1))
                     for j in selected
                 )
-
                 mmr_score = lambda_threshold * relevance_score - (1 - lambda_threshold) * diversity_score
                 if mmr_score > best_score:
                     best_score = mmr_score

--- a/haystack/components/rankers/sentence_transformers_diversity.py
+++ b/haystack/components/rankers/sentence_transformers_diversity.py
@@ -365,7 +365,11 @@ class SentenceTransformersDiversityRanker:
                 if idx in selected:
                     continue
                 relevance_score = query_similarities[idx]
-                diversity_score = max(doc_embeddings[idx] @ doc_embeddings[j].T for j in selected)
+                diversity_score = max(
+                    doc_embeddings[idx] @ doc_embeddings[j].permute(*torch.arange(doc_embeddings[j].ndim - 1, -1, -1))
+                    for j in selected
+                )
+
                 mmr_score = lambda_threshold * relevance_score - (1 - lambda_threshold) * diversity_score
                 if mmr_score > best_score:
                     best_score = mmr_score


### PR DESCRIPTION
### Related Issues

Dealing with the warning: 

```text
The use of x.T on tensors of dimension other than 2 to reverse their shape is deprecated and it will throw an error in a future release
```

Full warning:

```text
haystack/components/rankers/sentence_transformers_diversity.py:368: UserWarning: The use of x.T on tensors of dimension other than 2 to reverse their shape is deprecated and it will throw an error in a future release. Consider x.mT to transpose batches of matrices or x.permute(*torch.arange(x.ndim - 1, -1, -1)) to reverse the dimensions of a tensor. (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/native/TensorShape.cpp:4416.)
    diversity_score = max(doc_embeddings[idx] @ doc_embeddings[j].T for j in selected)
```

### Proposed Changes:

using 

```python
x.permute(*torch.arange(x.ndim - 1, -1, -1))
```

to reverse the dimensions of a tensor.

### How did you test it?

- unit tests, integration tests, CI tests


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
