### PR TITLE
fix: Improve typing of @component allow TypedDict output types

### DIFF
--- a/releasenotes/notes/improve-component-typing-7aca4d188be6b549.yaml
+++ b/releasenotes/notes/improve-component-typing-7aca4d188be6b549.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Improve the type annotations for `@component` and the `Component` protocol.
+    The type checker can now ensure that a @component class provides a
+    compatible `run()` method, whose required return type has been changed
+    from `Dict[str, Any]` (invariant) to the `Mapping[str, Any]` to allow
+    `TypedDict` to be used for output types.


### PR DESCRIPTION
### Proposed Changes:

- Add type annotations to the `_Component.__call__` function that backs `@component`. This fixes "decorator ignored" warnings of Pyright in "strict" type-checking mode.

- Type-check that a `@component` class conforms to the `Component` protocol (i.e., that it has a `run()` method).

- Relax the `run()` return type required by the `Component` protocol from `Dict[str, Any]` to `Mapping[str, Any]`. The former is incompatible with `TypedDict`, which makes it impossible to type a component's precise outputs. `Mapping` fixes this because it is covariant, i.e. the value type may be more specific than `Any`.

### How did you test it?

I checked the changes against the following script using Pyright in "strict" type-checking mode. Placing the file somewhere in the Haystack repo and opening in Visual Studio Code with the Pylance extension should be sufficient to reproduce.

```python
from typing import TypedDict, get_type_hints

from haystack import Pipeline, component
from haystack.core.component import Component


@component
class ExampleComponent:
    class Outputs(TypedDict):
        value: int

    @component.output_types(**get_type_hints(Outputs))
    def run(self, value: int) -> Outputs:
        return {"value": value}


outputs = ExampleComponent().run(1)
# => outputs: ExampleComponent.Outputs

instance: Component = ExampleComponent()
# => should type-check

pipeline = Pipeline()
pipeline.add_component("example", ExampleComponent())
# => should type-check
```

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
