### PR TITLE
feat: ComponentTool - preserve docstrings from underlying pipeline components

### DIFF
--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -17,7 +17,7 @@ from haystack.core.serialization import (
 from haystack.tools import Tool
 from haystack.tools.errors import SchemaGenerationError
 from haystack.tools.from_function import _remove_title_from_schema
-from haystack.tools.parameters_schema_utils import _get_param_descriptions, _resolve_type
+from haystack.tools.parameters_schema_utils import _get_component_param_descriptions, _resolve_type
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
 
 logger = logging.getLogger(__name__)
@@ -270,7 +270,7 @@ class ComponentTool(Tool):
         :raises SchemaGenerationError: If schema generation fails
         :returns: OpenAI tools schema for the component's run method parameters.
         """
-        component_run_description, param_descriptions = _get_param_descriptions(component.run)
+        component_run_description, param_descriptions = _get_component_param_descriptions(component)
 
         # collect fields (types and defaults) and descriptions from function parameters
         fields: Dict[str, Any] = {}

--- a/haystack/tools/parameters_schema_utils.py
+++ b/haystack/tools/parameters_schema_utils.py
@@ -57,28 +57,54 @@ def _get_component_param_descriptions(component: Any) -> Tuple[str, Dict[str, st
     :param component: The component to extract parameter descriptions from
     :returns: A tuple of (short_description, param_descriptions)
     """
-    # Import here to avoid circular imports
-    from haystack.core import SuperComponent
+    from haystack.core.super_component.super_component import _SuperComponent
 
     # Get descriptions from the component's run method
     short_desc, param_descriptions = _get_param_descriptions(component.run)
 
     # If it's a SuperComponent, enhance the descriptions from the original components
-    if isinstance(component, SuperComponent):
+    if isinstance(component, _SuperComponent):
+        # Collect descriptions from components in the pipeline
+        component_descriptions = []
+        processed_components = set()
+
+        # First gather descriptions from all components that have inputs mapped
         for super_param_name, pipeline_paths in component.input_mapping.items():
+            # Collect descriptions from all mapped components
+            descriptions = []
             for path in pipeline_paths:
                 try:
-                    # Get the component and socket this input is mapped from
+                    # Get the component and socket this input is mapped fromq
                     comp_name, socket_name = component._split_component_path(path)
                     pipeline_component = component.pipeline.get_component(comp_name)
 
-                    # Get descriptions from the component's run method
-                    _, pipeline_param_descriptions = _get_param_descriptions(pipeline_component.run)
-                    if socket_name in pipeline_param_descriptions:
-                        param_descriptions[super_param_name] = pipeline_param_descriptions[socket_name]
-                        break
+                    # Get run method descriptions for this component
+                    run_desc, run_param_descriptions = _get_param_descriptions(pipeline_component.run)
+
+                    # Don't add the same component description multiple times
+                    if comp_name not in processed_components:
+                        processed_components.add(comp_name)
+                        if run_desc:
+                            component_descriptions.append(f"'{comp_name}': {run_desc}")
+
+                    # Add parameter description if available
+                    if input_param_mapping := run_param_descriptions.get(socket_name):
+                        descriptions.append(f"Provided to the '{comp_name}' component as: '{input_param_mapping}'")
                 except Exception as e:
                     logger.debug(f"Error extracting description for {super_param_name} from {path}: {str(e)}")
+
+            # We don't only handle a one to one description mapping of input parameters, but a one to many mapping.
+            # i.e. for a combined_input parameter description:
+            # super_comp = SuperComponent(
+            #   pipeline=pipeline,
+            #   input_mapping={"combined_input": ["comp_a.query", "comp_b.text"]},
+            # )
+            if descriptions:
+                param_descriptions[super_param_name] = ", and ".join(descriptions) + "."
+
+        # We also create a combined description for the SuperComponent based on its components
+        if component_descriptions:
+            short_desc = f"A component that combines: {', '.join(component_descriptions)}"
 
     return short_desc, param_descriptions
 

--- a/releasenotes/notes/preserve-docstrings-super-component-tools-1fd9eb8a73b5c312.yaml
+++ b/releasenotes/notes/preserve-docstrings-super-component-tools-1fd9eb8a73b5c312.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    ComponentTool now preserves docstrings from underlying pipeline components when wrapping a SuperComponent.
+    When a SuperComponent is used with ComponentTool, the parameter descriptions are now extracted from the
+    original components in the wrapped pipeline, making it much more helpful when using SuperComponents with
+    LLM function calling as the LLM will get detailed parameter information directly from the underlying components.

--- a/releasenotes/notes/preserve-docstrings-super-component-tools-1fd9eb8a73b5c312.yaml
+++ b/releasenotes/notes/preserve-docstrings-super-component-tools-1fd9eb8a73b5c312.yaml
@@ -1,7 +1,16 @@
 ---
 enhancements:
   - |
-    ComponentTool now preserves docstrings from underlying pipeline components when wrapping a SuperComponent.
-    When a SuperComponent is used with ComponentTool, the parameter descriptions are now extracted from the
-    original components in the wrapped pipeline, making it much more helpful when using SuperComponents with
-    LLM function calling as the LLM will get detailed parameter information directly from the underlying components.
+    ComponentTool now preserves and combines docstrings from underlying pipeline components when wrapping a SuperComponent.
+    When a SuperComponent is used with ComponentTool, two key improvements are made:
+
+    1. Parameter descriptions are now extracted from the original components in the wrapped pipeline. When
+       a single input is mapped to multiple components, the parameter descriptions are combined from all
+       mapped components, providing comprehensive information about how the parameter is used throughout the pipeline.
+
+    2. The overall component description is now generated from the descriptions of all underlying components
+       instead of using the generic SuperComponent description. This helps LLMs understand what the component
+       actually does rather than just seeing "Runs the wrapped pipeline with the provided inputs."
+
+    These changes make SuperComponents much more useful with LLM function calling as the LLM will get detailed
+    information about both the component's purpose and its parameters.


### PR DESCRIPTION
## Why:

SuperComponents currently don't preserve parameter docstrings from underlying pipeline components, making them less informative when used with tools like ComponentTool. This limits their usefulness with LLMs for function calling.

- fixes https://github.com/deepset-ai/haystack/issues/9291

## What:
Adds docstring preservation for SuperComponent runtime input parameters by:
- Creating a new utility function to extract parameter descriptions from components
- Adding support to retrieve docstrings from underlying pipeline components
- Preserving these descriptions when a SuperComponent is used with ComponentTool

## How can it be used:
LLMs get more descriptive parameter information when working with SuperComponents:

```python
from haystack import Pipeline, SuperComponent
from haystack.components.websearch.serper_dev import SerperDevWebSearch
from haystack.components.fetchers.link_content import LinkContentFetcher
from haystack.components.converters.html import HTMLToDocument
from haystack.tools import ComponentTool

# Create a pipeline with well-documented components
search_pipeline = Pipeline()
search_pipeline.add_component("search", SerperDevWebSearch())
search_pipeline.add_component("fetcher", LinkContentFetcher())
search_pipeline.add_component("converter", HTMLToDocument())
search_pipeline.connect("search.results", "fetcher.urls")
search_pipeline.connect("fetcher.documents", "converter.documents")

# Create a SuperComponent that preserves docstrings
web_search = SuperComponent(
    pipeline=search_pipeline,
    input_mapping={"query": ["search.query"]},
    output_mapping={"converter.documents": "documents"}
)

# When used with ComponentTool, parameter descriptions from original components are preserved
tool = ComponentTool(component=web_search, name="web_search")

# LLMs now see detailed parameter descriptions rather than generic ones
```

## How did you test it:
- Existing unit tests all still pass
- Integration tests validate ComponentTool works correctly with SuperComponents
