### PR TITLE
feat: Extend AnswerBuilder for Agent

### DIFF
--- a/haystack/components/builders/answer_builder.py
+++ b/haystack/components/builders/answer_builder.py
@@ -54,8 +54,8 @@ class AnswerBuilder:
             Example: `\\[(\\d+)\\]` finds "1" in a string "this is an answer[1]".
 
         :param last_message_only:
-            If True, only the last message is used as the answer.
-            If False, all messages are used as the answer.
+           If False (default value), all messages are used as the answer.
+           If True, only the last message is used as the answer.
         """
         if pattern:
             AnswerBuilder._check_num_groups_in_regex(pattern)

--- a/haystack/components/builders/answer_builder.py
+++ b/haystack/components/builders/answer_builder.py
@@ -129,9 +129,7 @@ class AnswerBuilder:
         for reply, given_metadata in zip(replies_to_iterate, meta_to_iterate):
             # Extract content from ChatMessage objects if reply is a ChatMessages, else use the string as is
             if isinstance(reply, ChatMessage):
-                extracted_reply = ""
-                if reply.text:
-                    extracted_reply = reply.text
+                extracted_reply = reply.text or ""
             else:
                 extracted_reply = str(reply)
             extracted_metadata = reply.meta if isinstance(reply, ChatMessage) else {}

--- a/haystack/components/builders/answer_builder.py
+++ b/haystack/components/builders/answer_builder.py
@@ -114,6 +114,7 @@ class AnswerBuilder:
         for reply, given_metadata in zip(replies, meta):
             # Extract content from ChatMessage objects if reply is a ChatMessages, else use the string as is
             if isinstance(reply, ChatMessage):
+                extracted_reply = ""
                 if reply.text:
                     extracted_reply = reply.text
             else:

--- a/haystack/components/builders/answer_builder.py
+++ b/haystack/components/builders/answer_builder.py
@@ -114,14 +114,14 @@ class AnswerBuilder:
         for reply, given_metadata in zip(replies, meta):
             # Extract content from ChatMessage objects if reply is a ChatMessages, else use the string as is
             if isinstance(reply, ChatMessage):
-                if reply.text is None:
-                    raise ValueError(f"The provided ChatMessage has no text. ChatMessage: {reply}")
-                extracted_reply = reply.text
+                if reply.text:
+                    extracted_reply = reply.text
             else:
                 extracted_reply = str(reply)
             extracted_metadata = reply.meta if isinstance(reply, ChatMessage) else {}
 
             extracted_metadata = {**extracted_metadata, **given_metadata}
+            extracted_metadata["all_messages"] = replies
 
             referenced_docs = []
             if documents:

--- a/releasenotes/notes/adjust-answer-builder-for-agent-f4428aea59e32809.yaml
+++ b/releasenotes/notes/adjust-answer-builder-for-agent-f4428aea59e32809.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The AnswerBuilder component now stores all generated messages in the `meta` field of the GeneratedAnswer objects under an `all_messages` key. This enhancement improves traceability and debugging capabilities for agent workflows by providing access to the complete history of generated messages.

--- a/releasenotes/notes/adjust-answer-builder-for-agent-f4428aea59e32809.yaml
+++ b/releasenotes/notes/adjust-answer-builder-for-agent-f4428aea59e32809.yaml
@@ -1,4 +1,6 @@
 ---
 enhancements:
   - |
-    The AnswerBuilder component now stores all generated messages in the `meta` field of the GeneratedAnswer objects under an `all_messages` key. This enhancement improves traceability and debugging capabilities for agent workflows by providing access to the complete history of generated messages.
+    Enhanced the AnswerBuilder component with two agent-friendly features:
+    1. All generated messages are now stored in the `meta` field of the GeneratedAnswer objects under an `all_messages` key, improving traceability and debugging capabilities.
+    2. Added a new `last_message_only` parameter that, when set to `True`, processes only the last message in the replies while still preserving the complete conversation history in metadata. This is particularly useful for agent workflows where only the final response needs to be processed.

--- a/test/components/builders/test_answer_builder.py
+++ b/test/components/builders/test_answer_builder.py
@@ -10,6 +10,12 @@ from haystack.components.builders.answer_builder import AnswerBuilder
 from haystack.dataclasses.chat_message import ChatMessage, ChatRole
 
 
+def _check_metadata_excluding_all_messages(actual_meta, expected_meta):
+    """Helper function to check metadata while ignoring the all_messages field"""
+    actual_without_messages = {k: v for k, v in actual_meta.items() if k != "all_messages"}
+    assert actual_without_messages == expected_meta
+
+
 class TestAnswerBuilder:
     def test_run_unmatching_input_len(self):
         component = AnswerBuilder()
@@ -21,7 +27,8 @@ class TestAnswerBuilder:
         output = component.run(query="query", replies=["reply1"])
         answers = output["answers"]
         assert answers[0].data == "reply1"
-        assert answers[0].meta == {}
+        _check_metadata_excluding_all_messages(answers[0].meta, {})
+        assert "all_messages" in answers[0].meta  # Check that all_messages exists
         assert answers[0].query == "query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -31,7 +38,8 @@ class TestAnswerBuilder:
         output = component.run(query="query", replies=["reply1"], meta=[])
         answers = output["answers"]
         assert answers[0].data == "reply1"
-        assert answers[0].meta == {}
+        _check_metadata_excluding_all_messages(answers[0].meta, {})
+        assert "all_messages" in answers[0].meta
         assert answers[0].query == "query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -41,7 +49,8 @@ class TestAnswerBuilder:
         output = component.run(query="query", replies=["reply1"], meta=[{"test": "meta"}])
         answers = output["answers"]
         assert answers[0].data == "reply1"
-        assert answers[0].meta == {"test": "meta"}
+        _check_metadata_excluding_all_messages(answers[0].meta, {"test": "meta"})
+        assert "all_messages" in answers[0].meta
         assert answers[0].query == "query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -52,7 +61,8 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "Answer: AnswerString"
-        assert answers[0].meta == {}
+        _check_metadata_excluding_all_messages(answers[0].meta, {})
+        assert "all_messages" in answers[0].meta
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -63,7 +73,8 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "AnswerString"
-        assert answers[0].meta == {}
+        _check_metadata_excluding_all_messages(answers[0].meta, {})
+        assert "all_messages" in answers[0].meta
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -74,7 +85,8 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "'AnswerString'"
-        assert answers[0].meta == {}
+        _check_metadata_excluding_all_messages(answers[0].meta, {})
+        assert "all_messages" in answers[0].meta
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -89,7 +101,8 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "AnswerString"
-        assert answers[0].meta == {}
+        _check_metadata_excluding_all_messages(answers[0].meta, {})
+        assert "all_messages" in answers[0].meta
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -105,7 +118,8 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "Answer: AnswerString"
-        assert answers[0].meta == {}
+        _check_metadata_excluding_all_messages(answers[0].meta, {})
+        assert "all_messages" in answers[0].meta
         assert answers[0].query == "test query"
         assert len(answers[0].documents) == 2
         assert answers[0].documents[0].content == "test doc 1"
@@ -122,7 +136,8 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "Answer: AnswerString[2]"
-        assert answers[0].meta == {}
+        _check_metadata_excluding_all_messages(answers[0].meta, {})
+        assert "all_messages" in answers[0].meta
         assert answers[0].query == "test query"
         assert len(answers[0].documents) == 1
         assert answers[0].documents[0].content == "test doc 2"
@@ -139,7 +154,8 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "Answer: AnswerString[3]"
-        assert answers[0].meta == {}
+        _check_metadata_excluding_all_messages(answers[0].meta, {})
+        assert "all_messages" in answers[0].meta
         assert answers[0].query == "test query"
         assert len(answers[0].documents) == 0
         assert "Document index '3' referenced in Generator output is out of range." in caplog.text
@@ -156,7 +172,8 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "Answer: AnswerString[2][3]"
-        assert answers[0].meta == {}
+        _check_metadata_excluding_all_messages(answers[0].meta, {})
+        assert "all_messages" in answers[0].meta
         assert answers[0].query == "test query"
         assert len(answers[0].documents) == 2
         assert answers[0].documents[0].content == "test doc 2"
@@ -177,7 +194,12 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "Answer: AnswerString"
-        assert answers[0].meta == message_meta
+
+        # Check metadata excluding all_messages
+        expected_meta = message_meta.copy()
+        _check_metadata_excluding_all_messages(answers[0].meta, expected_meta)
+        assert "all_messages" in answers[0].meta
+
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -197,7 +219,12 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "AnswerString"
-        assert answers[0].meta == message_meta
+
+        # Check metadata excluding all_messages
+        expected_meta = message_meta.copy()
+        _check_metadata_excluding_all_messages(answers[0].meta, expected_meta)
+        assert "all_messages" in answers[0].meta
+
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -221,7 +248,12 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "Answer: AnswerString[2]"
-        assert answers[0].meta == message_meta
+
+        # Check metadata excluding all_messages
+        expected_meta = message_meta.copy()
+        _check_metadata_excluding_all_messages(answers[0].meta, expected_meta)
+        assert "all_messages" in answers[0].meta
+
         assert answers[0].query == "test query"
         assert len(answers[0].documents) == 1
         assert answers[0].documents[0].content == "test doc 2"
@@ -240,7 +272,12 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "AnswerString"
-        assert answers[0].meta == message_meta
+
+        # Check metadata excluding all_messages
+        expected_meta = message_meta.copy()
+        _check_metadata_excluding_all_messages(answers[0].meta, expected_meta)
+        assert "all_messages" in answers[0].meta
+
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -259,13 +296,18 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "AnswerString"
-        assert answers[0].meta == {
+
+        # Check metadata excluding all_messages
+        expected_meta = {
             "model": "gpt-4o-mini",
             "index": 0,
             "finish_reason": "stop",
             "usage": {"prompt_tokens": 32, "completion_tokens": 153, "total_tokens": 185},
             "test": "meta",
         }
+        _check_metadata_excluding_all_messages(answers[0].meta, expected_meta)
+        assert "all_messages" in answers[0].meta
+
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -278,7 +320,29 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "AnswerString"
-        assert answers[0].meta == {"test": "meta"}
+
+        # Check metadata excluding all_messages
+        _check_metadata_excluding_all_messages(answers[0].meta, {"test": "meta"})
+        assert "all_messages" in answers[0].meta
+
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
+
+    def test_conversation_history_in_all_messages(self):
+        """Test that multiple messages in replies are stored in all_messages."""
+        component = AnswerBuilder()
+        replies = [
+            ChatMessage.from_user("What is Haystack?"),
+            ChatMessage.from_assistant("Haystack is a framework for building LLM applications."),
+        ]
+        output = component.run(query="test query", replies=replies)
+
+        answers = output["answers"]
+        assert len(answers) == 2  # One answer for each message in replies
+
+        # Check that each answer contains the full conversation history
+        for answer in answers:
+            assert "all_messages" in answer.meta
+            assert answer.meta["all_messages"] == replies
+            assert len(answer.meta["all_messages"]) == 2

--- a/test/components/builders/test_answer_builder.py
+++ b/test/components/builders/test_answer_builder.py
@@ -196,8 +196,7 @@ class TestAnswerBuilder:
         assert answers[0].data == "Answer: AnswerString"
 
         # Check metadata excluding all_messages
-        expected_meta = message_meta.copy()
-        _check_metadata_excluding_all_messages(answers[0].meta, expected_meta)
+        _check_metadata_excluding_all_messages(answers[0].meta, message_meta)
         assert "all_messages" in answers[0].meta
 
         assert answers[0].query == "test query"
@@ -220,9 +219,7 @@ class TestAnswerBuilder:
         assert len(answers) == 1
         assert answers[0].data == "AnswerString"
 
-        # Check metadata excluding all_messages
-        expected_meta = message_meta.copy()
-        _check_metadata_excluding_all_messages(answers[0].meta, expected_meta)
+        _check_metadata_excluding_all_messages(answers[0].meta, message_meta)
         assert "all_messages" in answers[0].meta
 
         assert answers[0].query == "test query"
@@ -250,8 +247,7 @@ class TestAnswerBuilder:
         assert answers[0].data == "Answer: AnswerString[2]"
 
         # Check metadata excluding all_messages
-        expected_meta = message_meta.copy()
-        _check_metadata_excluding_all_messages(answers[0].meta, expected_meta)
+        _check_metadata_excluding_all_messages(answers[0].meta, message_meta)
         assert "all_messages" in answers[0].meta
 
         assert answers[0].query == "test query"
@@ -274,8 +270,7 @@ class TestAnswerBuilder:
         assert answers[0].data == "AnswerString"
 
         # Check metadata excluding all_messages
-        expected_meta = message_meta.copy()
-        _check_metadata_excluding_all_messages(answers[0].meta, expected_meta)
+        _check_metadata_excluding_all_messages(answers[0].meta, message_meta)
         assert "all_messages" in answers[0].meta
 
         assert answers[0].query == "test query"

--- a/test/components/builders/test_answer_builder.py
+++ b/test/components/builders/test_answer_builder.py
@@ -329,9 +329,12 @@ class TestAnswerBuilder:
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
 
-    def test_conversation_history_in_all_messages(self):
-        """Test that multiple messages in replies are stored in all_messages."""
-        component = AnswerBuilder()
+    @pytest.mark.parametrize("last_message_only", [True, False])
+    def test_conversation_history_in_all_messages(self, last_message_only):
+        """Test behavior with last_message_only flag"""
+
+        # Test with two messages in replies
+        component = AnswerBuilder(last_message_only=last_message_only)
         replies = [
             ChatMessage.from_user("What is Haystack?"),
             ChatMessage.from_assistant("Haystack is a framework for building LLM applications."),
@@ -339,10 +342,34 @@ class TestAnswerBuilder:
         output = component.run(query="test query", replies=replies)
 
         answers = output["answers"]
-        assert len(answers) == 2  # One answer for each message in replies
+
+        if last_message_only:
+            assert len(answers) == 1  # Only one answer when last_message_only=True
+            # Check that the answer is the last message
+            assert answers[0].data == "Haystack is a framework for building LLM applications."
+        else:
+            assert len(answers) == 2  # One answer for each message in replies
+            assert answers[0].data == "What is Haystack?"
+            assert answers[1].data == "Haystack is a framework for building LLM applications."
 
         # Check that each answer contains the full conversation history
         for answer in answers:
             assert "all_messages" in answer.meta
-            assert answer.meta["all_messages"] == replies
             assert len(answer.meta["all_messages"]) == 2
+            assert answer.meta["all_messages"] == replies
+
+        # Test with one message in replies
+        component = AnswerBuilder(last_message_only=last_message_only)
+        replies = [ChatMessage.from_user("What is Haystack?")]
+        output = component.run(query="test query", replies=replies)
+
+        answers = output["answers"]
+        assert len(answers) == 1  # Always one answer when there's only one message
+
+        # Check that the answer is the message
+        assert answers[0].data == "What is Haystack?"
+
+        # Check that the conversation history is stored in all_messages
+        assert "all_messages" in answers[0].meta
+        assert answers[0].meta["all_messages"] == replies
+        assert len(answers[0].meta["all_messages"]) == 1

--- a/test/core/pipeline/features/test_run.py
+++ b/test/core/pipeline/features/test_run.py
@@ -942,7 +942,7 @@ def pipeline_that_has_a_component_with_only_default_inputs(pipeline_class):
                                         score=1.2536639934227616,
                                     ),
                                 ],
-                                meta={},
+                                meta={"all_messages": ["Paris"]},
                             )
                         ]
                     }
@@ -2711,13 +2711,13 @@ def that_has_an_answer_joiner_variadic_component(pipeline_class):
                                 data="This is a test answer",
                                 query="What's Natural Language Processing?",
                                 documents=[],
-                                meta={},
+                                meta={"all_messages": ["This is a test answer"]},
                             ),
                             GeneratedAnswer(
                                 data="This is a second test answer",
                                 query="What's Natural Language Processing?",
                                 documents=[],
-                                meta={},
+                                meta={"all_messages": ["This is a second test answer"]},
                             ),
                         ]
                     }
@@ -2746,7 +2746,7 @@ def that_has_an_answer_joiner_variadic_component(pipeline_class):
                                     data="This is a test answer",
                                     query="What's Natural Language Processing?",
                                     documents=[],
-                                    meta={},
+                                    meta={"all_messages": ["This is a test answer"]},
                                 )
                             ],
                             [
@@ -2754,7 +2754,7 @@ def that_has_an_answer_joiner_variadic_component(pipeline_class):
                                     data="This is a second test answer",
                                     query="What's Natural Language Processing?",
                                     documents=[],
-                                    meta={},
+                                    meta={"all_messages": ["This is a second test answer"]},
                                 )
                             ],
                         ],
@@ -2999,7 +2999,11 @@ def that_has_a_loop_in_the_middle(pipeline_class):
                     "answer_builder": {"query": question},
                 },
                 expected_outputs={
-                    "answer_builder": {"answers": [GeneratedAnswer(data="42", query=question, documents=[])]}
+                    "answer_builder": {
+                        "answers": [
+                            GeneratedAnswer(data="42", query=question, documents=[], meta={"all_messages": ["42"]})
+                        ]
+                    }
                 },
                 expected_component_calls={
                     ("answer_builder", 1): {
@@ -3454,7 +3458,14 @@ Documents:
                 },
                 expected_outputs={
                     "answer_builder": {
-                        "answers": [GeneratedAnswer(data="answer: here is my answer", query=query, documents=[])]
+                        "answers": [
+                            GeneratedAnswer(
+                                data="answer: here is my answer",
+                                query=query,
+                                documents=[],
+                                meta={"all_messages": ["answer: here is my answer"]},
+                            )
+                        ]
                     }
                 },
                 expected_component_calls={
@@ -3676,7 +3687,13 @@ Provide additional feedback on why it fails.
             PipelineRunData(
                 inputs={"code_prompt": {"task": task}, "answer_builder": {"query": task}},
                 expected_outputs={
-                    "answer_builder": {"answers": [GeneratedAnswer(data="valid code", query=task, documents=[])]}
+                    "answer_builder": {
+                        "answers": [
+                            GeneratedAnswer(
+                                data="valid code", query=task, documents=[], meta={"all_messages": ["valid code"]}
+                            )
+                        ]
+                    }
                 },
                 expected_component_calls={
                     ("answer_builder", 1): {
@@ -3841,7 +3858,13 @@ Provide additional feedback on why it fails.
             PipelineRunData(
                 inputs={"code_prompt": {"task": task}, "answer_builder": {"query": task}},
                 expected_outputs={
-                    "answer_builder": {"answers": [GeneratedAnswer(data="valid code", query=task, documents=[])]}
+                    "answer_builder": {
+                        "answers": [
+                            GeneratedAnswer(
+                                data="valid code", query=task, documents=[], meta={"all_messages": ["valid code"]}
+                            )
+                        ]
+                    }
                 },
                 expected_component_calls={
                     ("answer_builder", 1): {
@@ -4673,7 +4696,7 @@ def passes_outputs_outside_cycle(pipeline_class):
     class AnswerBuilderWithPrompt:
         @component.output_types(answers=List[GeneratedAnswer])
         def run(self, replies: List[str], query: str, prompt: Optional[str] = None) -> Dict[str, Any]:
-            answer = GeneratedAnswer(data=replies[0], query=query, documents=[])
+            answer = GeneratedAnswer(data=replies[0], query=query, documents=[], meta={"all_messages": replies})
 
             if prompt is not None:
                 answer.meta["prompt"] = prompt
@@ -4767,7 +4790,10 @@ FAIL, come on, try again."""
                     "answer_builder": {
                         "answers": [
                             GeneratedAnswer(
-                                data=valid_response, query=task, documents=[], meta={"prompt": expected_prompt}
+                                data=valid_response,
+                                query=task,
+                                documents=[],
+                                meta={"prompt": expected_prompt, "all_messages": [valid_response]},
                             )
                         ]
                     }


### PR DESCRIPTION
## Why:

Enhances the AnswerBuilder component to preserve conversation history when processing Agent outputs.
- fixes https://github.com/deepset-ai/haystack/issues/9330

- Addresses the need to maintain agent message context in GeneratedAnswer objects
- Enables seamless integration between Agent components and the AnswerBuilder

## What:
- Updates AnswerBuilder to store entire conversation history in metadata
- Adds "all_messages" field to GeneratedAnswer metadata containing all messages
- Preserves backward compatibility with existing pipelines
- Updates tests to verify the new functionality

## How can it be used:
Connect Agent and AnswerBuilder in a pipeline to maintain conversation context:

```python
from haystack import Pipeline
from haystack.components.builders import AnswerBuilder
from haystack.components.agents import Agent
from haystack.components.generators.chat import OpenAIChatGenerator

# Create components
agent = Agent(chat_generator=OpenAIChatGenerator())
answer_builder = AnswerBuilder()

# Create pipeline
pipeline = Pipeline()
pipeline.add_component("agent", agent)
pipeline.add_component("answer_builder", answer_builder)

# Connect components
pipeline.connect("agent.messages", "answer_builder.replies")

# Run the pipeline
result = pipeline.run(data={"agent": {"messages": [user_message]}})

# Conversation history is preserved in the answer metadata
conversation_history = result["answer_builder"]["answers"][0].meta["all_messages"]
```

## How did you test it:
- Unit tests verify that conversation history is properly stored in metadata
- Added helper function to test metadata while ignoring the new field
- Tests ensure backward compatibility with existing code

