### PR TITLE
ci: add `timeout-minutes` to relevant CI jobs

### DIFF
--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -92,6 +92,7 @@ jobs:
     name: Slow Tests / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: check-if-changed
+    timeout-minutes: 30
     # Run tests if: manual trigger, scheduled, PR has label, release branch, or relevant files changed
     if: |
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,6 +135,7 @@ jobs:
   unit-tests:
     name: Unit / ${{ matrix.os }}
     needs: format
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -285,7 +286,7 @@ jobs:
     name: Integration / ubuntu-latest
     needs: unit-tests
     runs-on: ubuntu-latest
-
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -339,6 +340,7 @@ jobs:
     name: Integration / macos-latest
     needs: unit-tests
     runs-on: macos-latest
+    timeout-minutes: 30
     env:
       HAYSTACK_MPS_ENABLED: false
 
@@ -401,6 +403,7 @@ jobs:
     name: Integration / windows-latest
     needs: unit-tests
     runs-on: windows-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### Related Issues

Sometimes some tests jobs get stuck and run for 6h before being automatically cancelled,
resulting in a waste of computational resources.

### Proposed Changes:
- Set [`timeout-minutes`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) to 30 for some test jobs
  (unfortunately, there's no way to set a default for this parameter, so I'm only setting it where relevant. If needed, we can modify more jobs in the future)

### How did you test it?
We cannot test it. We'll keep tests durations monitored.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
