### PR TITLE
fix: Add missing `timeout` and `max_retries` to `OpenAITextEmbedder` and `OpenAIDocumentEmbedder`

### DIFF
--- a/haystack/components/embedders/openai_document_embedder.py
+++ b/haystack/components/embedders/openai_document_embedder.py
@@ -147,17 +147,19 @@ class OpenAIDocumentEmbedder:
         """
         return default_to_dict(
             self,
+            api_key=self.api_key.to_dict(),
             model=self.model,
             dimensions=self.dimensions,
-            organization=self.organization,
             api_base_url=self.api_base_url,
+            organization=self.organization,
             prefix=self.prefix,
             suffix=self.suffix,
             batch_size=self.batch_size,
             progress_bar=self.progress_bar,
             meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
-            api_key=self.api_key.to_dict(),
+            timeout=self.client.timeout,
+            max_retries=self.client.max_retries,
             http_client_kwargs=self.http_client_kwargs,
         )
 

--- a/haystack/components/embedders/openai_document_embedder.py
+++ b/haystack/components/embedders/openai_document_embedder.py
@@ -112,6 +112,8 @@ class OpenAIDocumentEmbedder:
         self.progress_bar = progress_bar
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
+        self.timeout = timeout
+        self.max_retries = max_retries
         self.http_client_kwargs = http_client_kwargs
 
         if timeout is None:
@@ -158,8 +160,8 @@ class OpenAIDocumentEmbedder:
             progress_bar=self.progress_bar,
             meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
-            timeout=self.client.timeout,
-            max_retries=self.client.max_retries,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
             http_client_kwargs=self.http_client_kwargs,
         )
 

--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -94,6 +94,8 @@ class OpenAITextEmbedder:
         self.prefix = prefix
         self.suffix = suffix
         self.api_key = api_key
+        self.timeout = timeout
+        self.max_retries = max_retries
         self.http_client_kwargs = http_client_kwargs
 
         if timeout is None:
@@ -136,8 +138,8 @@ class OpenAITextEmbedder:
             organization=self.organization,
             prefix=self.prefix,
             suffix=self.suffix,
-            timeout=self.client.timeout,
-            max_retries=self.client.max_retries,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
             http_client_kwargs=self.http_client_kwargs,
         )
 

--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -129,13 +129,15 @@ class OpenAITextEmbedder:
         """
         return default_to_dict(
             self,
+            api_key=self.api_key.to_dict(),
             model=self.model,
+            dimensions=self.dimensions,
             api_base_url=self.api_base_url,
             organization=self.organization,
             prefix=self.prefix,
             suffix=self.suffix,
-            dimensions=self.dimensions,
-            api_key=self.api_key.to_dict(),
+            timeout=self.client.timeout,
+            max_retries=self.client.max_retries,
             http_client_kwargs=self.http_client_kwargs,
         )
 

--- a/releasenotes/notes/add-timeout-and-max-retries-to-dict-openai-c9ad3661609ba339.yaml
+++ b/releasenotes/notes/add-timeout-and-max-retries-to-dict-openai-c9ad3661609ba339.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Add the init parameters timeout and max_retries to the to_dict methods of OpenAITextEmbedder and OpenAIDocumentEmbedder.
+    This ensures that these values are properly serialized when using the to_dict method of these components.

--- a/test/components/embedders/test_openai_document_embedder.py
+++ b/test/components/embedders/test_openai_document_embedder.py
@@ -122,8 +122,8 @@ class TestOpenAIDocumentEmbedder:
                 "progress_bar": True,
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
-                "timeout": 30.0,
-                "max_retries": 5,
+                "timeout": None,
+                "max_retries": None,
             },
         }
 

--- a/test/components/embedders/test_openai_document_embedder.py
+++ b/test/components/embedders/test_openai_document_embedder.py
@@ -122,6 +122,8 @@ class TestOpenAIDocumentEmbedder:
                 "progress_bar": True,
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
+                "timeout": 30.0,
+                "max_retries": 5,
             },
         }
 
@@ -138,6 +140,8 @@ class TestOpenAIDocumentEmbedder:
             progress_bar=False,
             meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
+            timeout=10.0,
+            max_retries=2,
         )
         data = component.to_dict()
         assert data == {
@@ -155,6 +159,8 @@ class TestOpenAIDocumentEmbedder:
                 "progress_bar": False,
                 "meta_fields_to_embed": ["test_field"],
                 "embedding_separator": " | ",
+                "timeout": 10.0,
+                "max_retries": 2,
             },
         }
 

--- a/test/components/embedders/test_openai_text_embedder.py
+++ b/test/components/embedders/test_openai_text_embedder.py
@@ -86,8 +86,8 @@ class TestOpenAITextEmbedder:
                 "http_client_kwargs": None,
                 "prefix": "",
                 "suffix": "",
-                "timeout": 30.0,
-                "max_retries": 5,
+                "timeout": None,
+                "max_retries": None,
             },
         }
 

--- a/test/components/embedders/test_openai_text_embedder.py
+++ b/test/components/embedders/test_openai_text_embedder.py
@@ -86,6 +86,8 @@ class TestOpenAITextEmbedder:
                 "http_client_kwargs": None,
                 "prefix": "",
                 "suffix": "",
+                "timeout": 30.0,
+                "max_retries": 5,
             },
         }
 
@@ -98,6 +100,8 @@ class TestOpenAITextEmbedder:
             organization="fake-organization",
             prefix="prefix",
             suffix="suffix",
+            timeout=10.0,
+            max_retries=2,
             http_client_kwargs={"proxy": "http://localhost:8080"},
         )
         data = component.to_dict()
@@ -112,6 +116,8 @@ class TestOpenAITextEmbedder:
                 "http_client_kwargs": {"proxy": "http://localhost:8080"},
                 "prefix": "prefix",
                 "suffix": "suffix",
+                "timeout": 10.0,
+                "max_retries": 2,
             },
         }
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add missing params to to_dict method of `OpenAITextEmbedder` and `OpenAIDocumentEmbedder`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
