### PR TITLE
fix: Copy context when using `ThreadPoolExecutor` in `AsyncPipeline.run_async

### DIFF
--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import contextvars
 from typing import Any, AsyncIterator, Dict, List, Optional, Set
 
 from haystack import logging, tracing
@@ -68,7 +69,8 @@ class AsyncPipeline(PipelineBase):
                     raise PipelineRuntimeError.from_exception(component_name, instance.__class__, error) from error
             else:
                 loop = asyncio.get_running_loop()
-                outputs = await loop.run_in_executor(None, lambda: instance.run(**component_inputs))
+                ctx = contextvars.copy_context()
+                outputs = await loop.run_in_executor(None, lambda: ctx.run(lambda: instance.run(**component_inputs)))
 
             component_visits[component_name] += 1
 

--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -69,6 +69,8 @@ class AsyncPipeline(PipelineBase):
                     raise PipelineRuntimeError.from_exception(component_name, instance.__class__, error) from error
             else:
                 loop = asyncio.get_running_loop()
+                # Important: contextvars (e.g. active tracing Span) don’t propagate to running loop's ThreadPoolExecutor
+                # We use ctx.run(...) to preserve context like the active tracing span
                 ctx = contextvars.copy_context()
                 outputs = await loop.run_in_executor(None, lambda: ctx.run(lambda: instance.run(**component_inputs)))
 

--- a/releasenotes/notes/preserve-context-async-pipeline-ce363ae95bbdb8bf.yaml
+++ b/releasenotes/notes/preserve-context-async-pipeline-ce363ae95bbdb8bf.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    To properly preserve the context when AsyncPipeline with components that only have sync run methods we copy the context using contextvars.copy_context() and run the component using `ctx.run(...)` so we can preserve context like the active tracing span.
+    This now means if your component 1) only has a sync run method and 2) it logs something to the tracer then this trace will be properly nested within the parent context.


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9203
- fixes https://github.com/deepset-ai/haystack/issues/8864

The underlying issue occurs as follows:
1. Create an AsyncPipeline
2. Add a component that only has a sync run method (so no run_async) **and** this component has tracing set up inside it's run method. 
3. Run the AsyncPipeline

The component from Step 2 then tries to log something to the tracer, but this trace has lost the parent context so is logged as a new trace.

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Following the suggestion here https://github.com/deepset-ai/haystack/issues/9203#issuecomment-2826581005 we add 
```python
import contextvars

ctx = contextvars.copy_context()
outputs = await loop.run_in_executor(None, lambda: ctx.run(lambda: instance.run(**component_inputs)))
```
in the `AsyncPipeline._run_component_async` method.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Tested locally using OpenTelemetry + Jaegar. To make it easier to reproduce the issue I commented out the `run_async` method of the `OpenAIChatGenerator` to reproduce the issue seen [here](https://github.com/deepset-ai/haystack/issues/8864#issue-2856753524) where `openai.chat` is not properly nested under the parent span. 

Set up of Jaegar was done following our docs [here](https://docs.haystack.deepset.ai/docs/tracing#visualizing-traces-during-development)

Here is the script I used
```python
import logging

logging.basicConfig(level=logging.INFO)

from opentelemetry.sdk.resources import Resource
from opentelemetry.semconv.resource import ResourceAttributes

from opentelemetry import trace
from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import BatchSpanProcessor

# NOTE: This is needed to get `openai.chat` to show up in the traces
# !pip install opentelemetry-instrumentation-openai
from opentelemetry.instrumentation.openai import OpenAIInstrumentor
OpenAIInstrumentor().instrument()

# Service name is required for most backends
resource = Resource(attributes={
    ResourceAttributes.SERVICE_NAME: "haystack"
})

tracer_provider = TracerProvider(resource=resource)
processor = BatchSpanProcessor(OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces"))
tracer_provider.add_span_processor(processor)
trace.set_tracer_provider(tracer_provider)

# Tell Haystack to auto-detect the configured tracer
import haystack.tracing

haystack.tracing.auto_enable_tracing()

import os

os.environ["OPENAI_API_KEY"] = ""

import asyncio
from haystack import AsyncPipeline, component
from typing import List, Optional, Any, Dict, Union

from openai import AsyncStream
from openai.types.chat import ChatCompletion, ChatCompletionChunk

from haystack.dataclasses import ChatMessage, StreamingCallbackT
from haystack.dataclasses.streaming_chunk import select_streaming_callback
from haystack.tools import Tool, Toolset
from haystack.components.builders import ChatPromptBuilder
from haystack.components.generators.chat.openai import OpenAIChatGenerator


pipe = AsyncPipeline()
pipe.add_component(
    "prompt_builder",
    ChatPromptBuilder(template=[ChatMessage.from_user("{{query}}")])
)
pipe.add_component("llm", OpenAIChatGenerator())

pipe.connect("prompt_builder.prompt", "llm.messages")

result = asyncio.run(pipe.run_async(data={"query": "What's the weather in Berlin?"}))
``` 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

Here is the before
- Note that we have two separate spans in this case
<img width="1076" alt="Screenshot 2025-05-23 at 13 39 05" src="https://github.com/user-attachments/assets/c918dfa0-eaa5-4804-805c-133518ac224f" />


And after
- Note now the `openai.chat` is properly nested
<img width="747" alt="Screenshot 2025-05-23 at 13 38 41" src="https://github.com/user-attachments/assets/211f9cad-1f2e-470b-b565-a070a690cd3e" />


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
