### PR TITLE
fix: Fix invoker to work when using dataclass with from_dict but dataclass…

### DIFF
--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -159,15 +159,19 @@ class ComponentTool(Tool):
                 target_type = get_args(param_type)[0] if get_origin(param_type) is list else param_type
                 if hasattr(target_type, "from_dict"):
                     if isinstance(param_value, list):
-                        param_value = [target_type.from_dict(item) for item in param_value if isinstance(item, dict)]
+                        resolved_param_value = [
+                            target_type.from_dict(item) if isinstance(item, dict) else item for item in param_value
+                        ]
                     elif isinstance(param_value, dict):
-                        param_value = target_type.from_dict(param_value)
+                        resolved_param_value = target_type.from_dict(param_value)
+                    else:
+                        resolved_param_value = param_value
                 else:
                     # Let TypeAdapter handle both single values and lists
                     type_adapter = TypeAdapter(param_type)
-                    param_value = type_adapter.validate_python(param_value)
+                    resolved_param_value = type_adapter.validate_python(param_value)
 
-                converted_kwargs[param_name] = param_value
+                converted_kwargs[param_name] = resolved_param_value
             logger.debug(f"Invoking component {type(component)} with kwargs: {converted_kwargs}")
             return component.run(**converted_kwargs)
 

--- a/releasenotes/notes/fix-component-invoker-dataclass-2efe773f03df8a93.yaml
+++ b/releasenotes/notes/fix-component-invoker-dataclass-2efe773f03df8a93.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix component_invoker used by ComponentTool to work when a dataclass like ChatMessage is directly passed to `component_tool.invoke(...)`.
+    Previously this would either cause an error or silently skip your input.

--- a/test/tools/test_component_tool.py
+++ b/test/tools/test_component_tool.py
@@ -23,7 +23,6 @@ from haystack.core.pipeline.utils import _deepcopy_with_exceptions
 from haystack.dataclasses import ChatMessage, ChatRole, Document
 from haystack.tools import ComponentTool
 from haystack.utils.auth import Secret
-from my_tests.mistral_chat_template import messages
 
 from test.tools.test_parameters_schema_utils import BYTE_STREAM_SCHEMA, DOCUMENT_SCHEMA, SPARSE_EMBEDDING_SCHEMA
 

--- a/test/tools/test_component_tool.py
+++ b/test/tools/test_component_tool.py
@@ -23,11 +23,27 @@ from haystack.core.pipeline.utils import _deepcopy_with_exceptions
 from haystack.dataclasses import ChatMessage, ChatRole, Document
 from haystack.tools import ComponentTool
 from haystack.utils.auth import Secret
+from my_tests.mistral_chat_template import messages
 
 from test.tools.test_parameters_schema_utils import BYTE_STREAM_SCHEMA, DOCUMENT_SCHEMA, SPARSE_EMBEDDING_SCHEMA
 
 
 # Component and Model Definitions
+
+
+@component
+class SimpleComponentUsingChatMessages:
+    """A simple component that generates text."""
+
+    @component.output_types(reply=str)
+    def run(self, messages: List[ChatMessage]) -> Dict[str, str]:
+        """
+        A simple component that generates text.
+
+        :param messages: Users messages
+        :return: A dictionary with the generated text.
+        """
+        return {"reply": f"Hello, {messages[0].text}!"}
 
 
 @component
@@ -305,6 +321,13 @@ class TestComponentTool:
 
         with pytest.raises(ValueError):
             ComponentTool(component=not_a_component, name="invalid_tool", description="This should fail")
+
+    def test_component_invoker_with_chat_message_input(self):
+        tool = ComponentTool(
+            component=SimpleComponentUsingChatMessages(), name="simple_tool", description="A simple tool"
+        )
+        result = tool.invoke(messages=[ChatMessage.from_user(text="world")])
+        assert result == {"reply": "Hello, world!"}
 
 
 # Integration tests


### PR DESCRIPTION


### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fix invoker to work when using dataclass with from_dict but dataclas is already given

Updated the `component_invoker` method to allow fully formed dataclass objects to pass through. Otherwise we silently remove the parameter value.

Originally found by @bilgeyucel when creating an tool using Agent + ComponentTool and calling

```python
agent_tool.invoke(messages=[ChatMessage.from_user("Tell me the latest news about gpus")])
```

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
