### PR TITLE
chore: drop python>=3.9 check in type serialization

### DIFF
--- a/haystack/utils/type_serialization.py
+++ b/haystack/utils/type_serialization.py
@@ -91,14 +91,6 @@ def deserialize_type(type_str: str) -> Any:  # pylint: disable=too-many-return-s
         If the type cannot be deserialized due to missing module or type.
     """
 
-    type_mapping = {
-        list: typing.List,
-        dict: typing.Dict,
-        set: typing.Set,
-        tuple: typing.Tuple,
-        frozenset: typing.FrozenSet,
-    }
-
     # Handle generics
     if "[" in type_str and type_str.endswith("]"):
         main_type_str, generics_str = type_str.split("[", 1)
@@ -109,10 +101,7 @@ def deserialize_type(type_str: str) -> Any:  # pylint: disable=too-many-return-s
 
         # Reconstruct
         try:
-            if sys.version_info >= (3, 9) or repr(main_type).startswith("typing."):
-                return main_type[tuple(generic_args) if len(generic_args) > 1 else generic_args[0]]
-            else:
-                return type_mapping[main_type][tuple(generic_args) if len(generic_args) > 1 else generic_args[0]]
+            return main_type[tuple(generic_args) if len(generic_args) > 1 else generic_args[0]]
         except (TypeError, AttributeError) as e:
             raise DeserializationError(f"Could not apply arguments {generic_args} to type {main_type}") from e
 


### PR DESCRIPTION
### Related Issues

- fixes #8991

### Proposed Changes:

- remove the check, since we only support python >= 3.9

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
