### PR TITLE
test: prevent `DocumentWriter` tests from blocking CI

### DIFF
--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -126,7 +126,5 @@ class DocumentWriter:
         if not hasattr(self.document_store, "write_documents_async"):
             raise TypeError(f"Document store {type(self.document_store).__name__} does not provide async support.")
 
-        documents_written = await self.document_store.write_documents_async(  # type: ignore
-            documents=documents, policy=policy
-        )
+        documents_written = await self.document_store.write_documents_async(documents=documents, policy=policy)
         return {"documents_written": documents_written}


### PR DESCRIPTION
### Related Issues
Recently, the CI sometimes blocks during `DocumentWriter` tests. An example: https://github.com/deepset-ai/haystack/actions/runs/15205617087/job/42767953097?pr=9345

While this does not always happen, I was able to reproduce it locally when running all unit tests (`hatch run test:unit`).

The `InMemoryDocumentStore` creates a `ThreadPoolExecutor` for async operations.
It also has a `__del__` method, that calls `executor.shutdown(wait=True)`.

My impression is that garbage collection doesn't play well with the test event loop.
When `__del__` is called during unpredictable garbage collection (maybe during event loop teardown), the `shutdown(wait=True)` call can hang indefinitely.

### Proposed Changes:
- Use a Document Store fixture that gets created and destroyed for each test, in a predictable way.

### How did you test it?
CI; I also ran locally all tests several times.

### Notes for the reviewer
I am not sure that this will fix this CI issue but it's worth trying.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
