### PR TITLE
Feat/add deserialize text embedder inplace

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -16,7 +16,7 @@ from haystack.dataclasses import ChatMessage
 from haystack.dataclasses.streaming_chunk import StreamingCallbackT, select_streaming_callback
 from haystack.tools import Tool, Toolset, deserialize_tools_or_toolset_inplace, serialize_tools_or_toolset
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
-from haystack.utils.deserialization import deserialize_chatgenerator_inplace
+from haystack.utils.deserialization import deserialize_component_inplace
 
 from .state.state import State, _schema_from_dict, _schema_to_dict, _validate_schema
 from .state.state_utils import merge_lists
@@ -189,7 +189,7 @@ class Agent:
         """
         init_params = data.get("init_parameters", {})
 
-        deserialize_chatgenerator_inplace(init_params, key="chat_generator")
+        deserialize_component_inplace(init_params, key="chat_generator")
 
         if "state_schema" in init_params:
             init_params["state_schema"] = _schema_from_dict(init_params["state_schema"])

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -13,7 +13,7 @@ _import_structure = {
     "base_serialization": ["_deserialize_value_with_schema", "_serialize_value_with_schema"],
     "callable_serialization": ["deserialize_callable", "serialize_callable"],
     "device": ["ComponentDevice", "Device", "DeviceMap", "DeviceType"],
-    "deserialization": ["deserialize_document_store_in_init_params_inplace", "deserialize_chatgenerator_inplace"],
+    "deserialization": ["deserialize_document_store_in_init_params_inplace", "deserialize_component_inplace"],
     "filters": ["document_matches_filter", "raise_on_invalid_filter_syntax"],
     "jinja2_extensions": ["Jinja2TimeExtension"],
     "jupyter": ["is_in_jupyter"],
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from .azure import default_azure_ad_token_provider
     from .base_serialization import _deserialize_value_with_schema, _serialize_value_with_schema
     from .callable_serialization import deserialize_callable, serialize_callable
-    from .deserialization import deserialize_chatgenerator_inplace, deserialize_document_store_in_init_params_inplace
+    from .deserialization import deserialize_component_inplace, deserialize_document_store_in_init_params_inplace
     from .device import ComponentDevice, Device, DeviceMap, DeviceType
     from .filters import document_matches_filter, raise_on_invalid_filter_syntax
     from .jinja2_extensions import Jinja2TimeExtension

--- a/haystack/utils/deserialization.py
+++ b/haystack/utils/deserialization.py
@@ -39,7 +39,7 @@ def deserialize_document_store_in_init_params_inplace(data: Dict[str, Any], key:
         data["init_parameters"][key] = default_from_dict(doc_store_class, doc_store_data)
 
 
-def deserialize_chatgenerator_inplace(data: Dict[str, Any], key: str = "chat_generator") -> None:
+def deserialize_component_inplace(data: Dict[str, Any], key: str = "chat_generator") -> None:
     """
     Deserialize a ChatGenerator in a dictionary inplace.
 
@@ -69,35 +69,3 @@ def deserialize_chatgenerator_inplace(data: Dict[str, Any], key: str = "chat_gen
         raise DeserializationError(f"Class '{serialized_chat_generator['type']}' not correctly imported") from e
 
     data[key] = component_from_dict(cls=chat_generator_class, data=serialized_chat_generator, name="chat_generator")
-
-
-def deserialize_text_embedder_inplace(data: Dict[str, Any], key: str = "embedder") -> None:
-    """
-    Deserialize a TextEmbedder in a dictionary inplace.
-
-    :param data:
-        The dictionary with the serialized data.
-    :param key:
-        The key in the dictionary where the TextEmbedder is stored.
-
-    :raises DeserializationError:
-        If the key is missing in the serialized data, the value is not a dictionary,
-        the type key is missing, the class cannot be imported, or the class lacks a 'from_dict' method.
-    """
-    if key not in data:
-        raise DeserializationError(f"Missing '{key}' in serialization data")
-
-    serialized_embedder = data[key]
-
-    if not isinstance(serialized_embedder, dict):
-        raise DeserializationError(f"The value of '{key}' is not a dictionary")
-
-    if "type" not in serialized_embedder:
-        raise DeserializationError(f"Missing 'type' in {key} serialization data")
-
-    try:
-        embedder_class = import_class_by_name(serialized_embedder["type"])
-    except ImportError as e:
-        raise DeserializationError(f"Class '{serialized_embedder['type']}' not correctly imported") from e
-
-    data[key] = component_from_dict(cls=embedder_class, data=serialized_embedder, name="embedder")

--- a/haystack/utils/deserialization.py
+++ b/haystack/utils/deserialization.py
@@ -69,3 +69,35 @@ def deserialize_chatgenerator_inplace(data: Dict[str, Any], key: str = "chat_gen
         raise DeserializationError(f"Class '{serialized_chat_generator['type']}' not correctly imported") from e
 
     data[key] = component_from_dict(cls=chat_generator_class, data=serialized_chat_generator, name="chat_generator")
+
+
+def deserialize_text_embedder_inplace(data: Dict[str, Any], key: str = "embedder") -> None:
+    """
+    Deserialize a TextEmbedder in a dictionary inplace.
+
+    :param data:
+        The dictionary with the serialized data.
+    :param key:
+        The key in the dictionary where the TextEmbedder is stored.
+
+    :raises DeserializationError:
+        If the key is missing in the serialized data, the value is not a dictionary,
+        the type key is missing, the class cannot be imported, or the class lacks a 'from_dict' method.
+    """
+    if key not in data:
+        raise DeserializationError(f"Missing '{key}' in serialization data")
+
+    serialized_embedder = data[key]
+
+    if not isinstance(serialized_embedder, dict):
+        raise DeserializationError(f"The value of '{key}' is not a dictionary")
+
+    if "type" not in serialized_embedder:
+        raise DeserializationError(f"Missing 'type' in {key} serialization data")
+
+    try:
+        embedder_class = import_class_by_name(serialized_embedder["type"])
+    except ImportError as e:
+        raise DeserializationError(f"Class '{serialized_embedder['type']}' not correctly imported") from e
+
+    data[key] = component_from_dict(cls=embedder_class, data=serialized_embedder, name="embedder")


### PR DESCRIPTION
### Proposed Changes:

- renaming to `deserialize_chatgenerator_inplace()` to `deserialize_component_inplace` for reuse

### How did you test it?

- unit tests, integration tests, manual verification
- tested in this PR: https://github.com/deepset-ai/haystack-core-integrations/pull/1870 (still with the old name)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
