### PR TITLE
feat: `ChatMessage.to_openai_dict_format` - add `require_tool_call_ids` parameter

### DIFF
--- a/releasenotes/notes/to_openai_dict_format-require-tool-call-ids-9e40a5751740ad89.yaml
+++ b/releasenotes/notes/to_openai_dict_format-require-tool-call-ids-9e40a5751740ad89.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Add a new parameter `require_tool_call_ids` to `ChatMessage.to_openai_dict_format`.
+    The default is `True`, for compatibility with OpenAI's Chat API: if the `id` field is missing in a Tool Call,
+    an error is raised.  Using `False` is useful for shallow OpenAI-compatible APIs, where the `id` field is not
+    required.

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -342,14 +342,31 @@ def test_to_openai_dict_format_invalid():
     with pytest.raises(ValueError):
         message.to_openai_dict_format()
 
+
+def test_to_openai_dict_format_require_tool_call_ids():
     tool_call_null_id = ToolCall(id=None, tool_name="weather", arguments={"city": "Paris"})
     message = ChatMessage.from_assistant(tool_calls=[tool_call_null_id])
     with pytest.raises(ValueError):
-        message.to_openai_dict_format()
+        message.to_openai_dict_format(require_tool_call_ids=True)
 
     message = ChatMessage.from_tool(tool_result="result", origin=tool_call_null_id)
     with pytest.raises(ValueError):
-        message.to_openai_dict_format()
+        message.to_openai_dict_format(require_tool_call_ids=True)
+
+
+def test_to_openai_dict_format_require_tool_call_ids_false():
+    tool_call_null_id = ToolCall(id=None, tool_name="weather", arguments={"city": "Paris"})
+    message = ChatMessage.from_assistant(tool_calls=[tool_call_null_id])
+    openai_msg = message.to_openai_dict_format(require_tool_call_ids=False)
+
+    assert openai_msg == {
+        "role": "assistant",
+        "tool_calls": [{"type": "function", "function": {"name": "weather", "arguments": '{"city": "Paris"}'}}],
+    }
+
+    message = ChatMessage.from_tool(tool_result="result", origin=tool_call_null_id)
+    openai_msg = message.to_openai_dict_format(require_tool_call_ids=False)
+    assert openai_msg == {"role": "tool", "content": "result"}
 
 
 def test_from_openai_dict_format_user_message():


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack-core-integrations/issues/1780

### Proposed Changes:
- add `require_tool_call_ids` parameter to `ChatMessage.to_openai_dict_format`
  - If `True` (default), if the `id` field is missing in a Tool Call, an error is raised.
  - Using `False` is useful for shallow OpenAI-compatible APIs, where the `id` field is not
    required.

### How did you test it?
CI; new tests


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
