### PR TITLE
feat: Improve ChatMessage _deserialize_content ValueError - make it more LLM friendly

### DIFF
--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -368,6 +368,14 @@ class ChatMessage:
             The created object.
         """
         if "content" in data:
+            if not "role" in data:
+                raise ValueError(
+                    "The `role` field is required in the message dictionary. "
+                    f"Expected a dictionary with 'role' field containing one of: {[role.value for role in ChatRole]}. "
+                    f"Common roles are 'user' (for user messages) and 'assistant' (for AI responses). "
+                    f"Received dictionary with keys: {list(data.keys())}"
+                )
+
             init_params: Dict[str, Any] = {
                 "_role": ChatRole(data["role"]),
                 "_name": data.get("name"),

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -114,9 +114,9 @@ def _deserialize_content(serialized_content: List[Dict[str, Any]]) -> List[ChatM
             content.append(tcr)
         else:
             raise ValueError(
-                f"Unsupported part in the serialized ChatMessage: {part}. "
-                "The serialized ChatMessage must be a list of dictionaries, where each dictionary contains "
-                "one of these keys: 'text', 'tool_call', or 'tool_call_result'. "
+                f"Unsupported content part in the serialized ChatMessage: {part}. "
+                "The `content` field of the serialized ChatMessage must be a list of dictionaries, where each "
+                "dictionary contains one of these keys: 'text', 'tool_call', or 'tool_call_result'. "
                 f"Valid formats: [{{'text': 'Hello'}}, "
                 f"{{'tool_call': {{'tool_name': 'search', 'arguments': {{}}, 'id': 'call_123'}}}}, "
                 f"{{'tool_call_result': {{'result': 'data', 'origin': {{...}}, 'error': false}}}}]"
@@ -367,7 +367,7 @@ class ChatMessage:
         :returns:
             The created object.
         """
-        if not "role" in data:
+        if not "role" in data and not "_role" in data:
             raise ValueError(
                 "The `role` field is required in the message dictionary. "
                 f"Expected a dictionary with 'role' field containing one of: {[role.value for role in ChatRole]}. "
@@ -376,14 +376,6 @@ class ChatMessage:
             )
 
         if "content" in data:
-            if not "role" in data:
-                raise ValueError(
-                    "The `role` field is required in the message dictionary. "
-                    f"Expected a dictionary with 'role' field containing one of: {[role.value for role in ChatRole]}. "
-                    f"Common roles are 'user' (for user messages) and 'assistant' (for AI responses). "
-                    f"Received dictionary with keys: {list(data.keys())}"
-                )
-
             init_params: Dict[str, Any] = {
                 "_role": ChatRole(data["role"]),
                 "_name": data.get("name"),

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -113,7 +113,14 @@ def _deserialize_content(serialized_content: List[Dict[str, Any]]) -> List[ChatM
             tcr = ToolCallResult(result=result, origin=origin, error=error)
             content.append(tcr)
         else:
-            raise ValueError(f"Unsupported part in serialized ChatMessage: `{part}`")
+            raise ValueError(
+                f"Invalid content in ChatMessage: {part}. "
+                "ChatMessage content must be a list of dictionaries, where each dictionary contains one of these keys: "
+                "'text', 'tool_call', or 'tool_call_result'. "
+                f"Valid formats: [{{'text': 'Hello'}}, "
+                f"{{'tool_call': {{'tool_name': 'search', 'arguments': {{}}, 'id': 'call_123'}}}}, "
+                f"{{'tool_call_result': {{'result': 'data', 'origin': {{...}}, 'error': false}}}}]"
+            )
 
     return content
 

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -115,8 +115,8 @@ def _deserialize_content(serialized_content: List[Dict[str, Any]]) -> List[ChatM
         else:
             raise ValueError(
                 f"Unsupported part in the serialized ChatMessage: {part}. "
-                "The serialized ChatMessage must be a list of dictionaries, where each dictionary contains one of these keys: "
-                "'text', 'tool_call', or 'tool_call_result'. "
+                "The serialized ChatMessage must be a list of dictionaries, where each dictionary contains "
+                "one of these keys: 'text', 'tool_call', or 'tool_call_result'. "
                 f"Valid formats: [{{'text': 'Hello'}}, "
                 f"{{'tool_call': {{'tool_name': 'search', 'arguments': {{}}, 'id': 'call_123'}}}}, "
                 f"{{'tool_call_result': {{'result': 'data', 'origin': {{...}}, 'error': false}}}}]"
@@ -367,6 +367,14 @@ class ChatMessage:
         :returns:
             The created object.
         """
+        if not "role" in data:
+            raise ValueError(
+                "The `role` field is required in the message dictionary. "
+                f"Expected a dictionary with 'role' field containing one of: {[role.value for role in ChatRole]}. "
+                f"Common roles are 'user' (for user messages) and 'assistant' (for AI responses). "
+                f"Received dictionary with keys: {list(data.keys())}"
+            )
+
         if "content" in data:
             if not "role" in data:
                 raise ValueError(

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -114,8 +114,8 @@ def _deserialize_content(serialized_content: List[Dict[str, Any]]) -> List[ChatM
             content.append(tcr)
         else:
             raise ValueError(
-                f"Invalid content in ChatMessage: {part}. "
-                "ChatMessage content must be a list of dictionaries, where each dictionary contains one of these keys: "
+                f"Unsupported part in the serialized ChatMessage: {part}. "
+                "The serialized ChatMessage must be a list of dictionaries, where each dictionary contains one of these keys: "
                 "'text', 'tool_call', or 'tool_call_result'. "
                 f"Valid formats: [{{'text': 'Hello'}}, "
                 f"{{'tool_call': {{'tool_name': 'search', 'arguments': {{}}, 'id': 'call_123'}}}}, "

--- a/releasenotes/notes/improve-chatmessage-error-messages-llm-agents-a1b2c3d4e5f6g7h8.yaml
+++ b/releasenotes/notes/improve-chatmessage-error-messages-llm-agents-a1b2c3d4e5f6g7h8.yaml
@@ -1,7 +1,7 @@
 enhancements:
   - |
     Improved error messages in ChatMessage deserialization to provide clearer guidance for LLM-agent use cases.
-    The ``_deserialize_content`` function now provides detailed error messages when ChatMessage content format
+    The `_deserialize_content` function now provides detailed error messages when ChatMessage content format
     is invalid, including the expected structure (list of dictionaries with 'text', 'tool_call', or
     'tool_call_result' keys) and concrete examples. This enhancement reduces debugging cycles and improves
     LLM self-correction capabilities when working with agent tools and structured message formats.

--- a/releasenotes/notes/improve-chatmessage-error-messages-llm-agents-a1b2c3d4e5f6g7h8.yaml
+++ b/releasenotes/notes/improve-chatmessage-error-messages-llm-agents-a1b2c3d4e5f6g7h8.yaml
@@ -1,0 +1,7 @@
+enhancements:
+  - |
+    Improved error messages in ChatMessage deserialization to provide clearer guidance for LLM-agent use cases.
+    The ``_deserialize_content`` function now provides detailed error messages when ChatMessage content format
+    is invalid, including the expected structure (list of dictionaries with 'text', 'tool_call', or
+    'tool_call_result' keys) and concrete examples. This enhancement reduces debugging cycles and improves
+    LLM self-correction capabilities when working with agent tools and structured message formats.

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -430,3 +430,23 @@ def test_from_openai_dict_format_unsupported_role():
 def test_from_openai_dict_format_assistant_missing_content_and_tool_calls():
     with pytest.raises(ValueError):
         ChatMessage.from_openai_dict_format({"role": "assistant", "irrelevant": "irrelevant"})
+
+
+def test_from_dict_with_invalid_content_improved_error():
+    """Test that _deserialize_content provides clear error messages for invalid content formats."""
+    # Test with completely invalid content structure
+    data = {"role": "user", "content": [{"invalid_key": "some_value"}]}
+
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid content in ChatMessage.*ChatMessage content must be a list of dictionaries.*'text', 'tool_call', or 'tool_call_result'",
+    ):
+        ChatMessage.from_dict(data)
+
+    # Test with mixed valid and invalid content
+    data = {"role": "assistant", "content": [{"text": "Valid text"}, {"wrong_field": "invalid"}]}
+
+    with pytest.raises(
+        ValueError, match=r"Invalid content in ChatMessage.*Valid formats.*text.*tool_call.*tool_call_result"
+    ):
+        ChatMessage.from_dict(data)

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -450,3 +450,19 @@ def test_from_dict_with_invalid_content_improved_error():
         ValueError, match=r"Invalid content in ChatMessage.*Valid formats.*text.*tool_call.*tool_call_result"
     ):
         ChatMessage.from_dict(data)
+
+
+def test_from_dict_with_missing_role_improved_error():
+    """Test that from_dict provides clear error messages when role field is missing."""
+    # Test with missing role field
+    data = {"content": [{"text": "Hello"}], "meta": {}}
+
+    with pytest.raises(
+        ValueError,
+        match=r"The `role` field is required.*Expected a dictionary with 'role' field containing one of.*\['user', 'system', 'assistant', 'tool'\].*Common roles are 'user'.*'assistant'",
+    ):
+        ChatMessage.from_dict(data)
+
+    # Test that the error message shows the received keys
+    with pytest.raises(ValueError, match=r"Received dictionary with keys: \['content', 'meta'\]"):
+        ChatMessage.from_dict(data)


### PR DESCRIPTION
## Why:
During execution of itinerary agent where we wrap daily itinerary Agent with ComponentTool - LLMs were encountering vague error messages when ChatMessage deserialization failed, leading to failed tool invocations, wasted debugging cycles, and unnecessary token costs. The original error `"Unsupported part in serialized ChatMessage: ..."` provided no guidance on the expected ChatMessage schema structure.

## What:
- **Core component**: Enhanced error message in `_deserialize_content()` function in `haystack/dataclasses/chat_message.py`
- **Key features**: 
  - Clear explanation of required ChatMessage content structure (list of dictionaries)
  - Concrete examples showing valid formats for 'text', 'tool_call', and 'tool_call_result'

## How can it be used:
```python
# Before: Vague error when content format is wrong
# "Unsupported part in serialized ChatMessage: `invalid_data`"

# After: Clear, actionable error message
# "Invalid content in ChatMessage: invalid_data. ChatMessage content must be a list of dictionaries, 
# where each dictionary contains exactly one of these keys: 'text', 'tool_call', or 'tool_call_result'. 
# Valid formats: [{'text': 'Hello'}, {'tool_call': {'tool_name': 'search', 'arguments': {}, 'id': 'call_123'}}, 
# {'tool_call_result': {'result': 'data', 'origin': {...}, 'error': false}}]"

# Now LLMs can self-correct based on the clear schema guidance
```

## How did you test it:
- **Error message validation**: Unit test added
- **Using itinerary agent**: Manual test with itinerary agent

## Notes for the reviewer:
- **Dependencies**: No new packages added
- **Scope**: Focused specifically on the ChatMessage `_deserialize_content` error case as requested
- **Future work**: This pattern could be applied to other "LLM-contact points" in the codebase for similar improvements