### PR TITLE
fix: In `set_output_types` check that the decorator `@component.output_types` is not present on the `run_async` method

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -512,13 +512,18 @@ class _Component:
             # no decorators here
             def run(self, value: int):
                 return {"output_1": 1, "output_2": "2"}
+
+            # also no decorators here
+            async def run_async(self, value: int):
+                return {"output_1": 1, "output_2": "2"}
         ```
         """
-        has_decorator = hasattr(instance.run, "_output_types_cache")
-        if has_decorator:
+        has_run_decorator = hasattr(instance.run, "_output_types_cache")
+        has_run_async_decorator = hasattr(instance, "run_async") and hasattr(instance.run_async, "_output_types_cache")
+        if has_run_decorator or has_run_async_decorator:
             raise ComponentError(
-                "Cannot call `set_output_types` on a component that already has "
-                "the 'output_types' decorator on its `run` method"
+                "Cannot call `set_output_types` on a component that already has the 'output_types' decorator on its "
+                "`run` or `run_async` methods."
             )
 
         instance.__haystack_output__ = Sockets(

--- a/releasenotes/notes/fix-set-output-types-async-check-2e5d578a3ccdcc59.yaml
+++ b/releasenotes/notes/fix-set-output-types-async-check-2e5d578a3ccdcc59.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    When calling `set_output_types` we now also check that the decorator @component.output_types is not present on the `run_async` method of a Component. Previously we only checked that the Component.run method did not possess the decorator.

--- a/test/core/component/test_component.py
+++ b/test/core/component/test_component.py
@@ -328,6 +328,23 @@ def test_output_types_decorator_and_set_output_types():
         _ = MockComponent()
 
 
+def test_output_types_decorator_and_set_output_types_async():
+    @component
+    class MockComponent:
+        def __init__(self) -> None:
+            component.set_output_types(self, value=int)
+
+        def run(self, value: int):
+            return {"value": 1}
+
+        @component.output_types(value=int)
+        async def run_async(self, value: int):
+            return {"value": 1}
+
+    with pytest.raises(ComponentError, match="Cannot call `set_output_types`"):
+        _ = MockComponent()
+
+
 def test_output_types_decorator_mismatch_run_async_run():
     @component
     class MockComponent:


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
When calling `set_output_types` we now also check that the decorator @component.output_types is not present on the `run_async` method of a Component. Previously we only checked that the Component.run method did not possess the decorator.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added a unit test 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
