### PR TITLE
fix: Fix serialization and deserialization of `ConditionalRouter` with multiple outputs

### DIFF
--- a/test/components/routers/test_conditional_router.py
+++ b/test/components/routers/test_conditional_router.py
@@ -616,3 +616,24 @@ class TestRouter:
                     }
                 ]
             )
+
+    def test_sede_multiple_outputs(self):
+        routes = [
+            {
+                "condition": "{{phone_num|get_area_code == 123}}",
+                "output": ["{{phone_num}}", "{{phone_num|get_area_code}}"],
+                "output_name": ["phone_num", "area_code"],
+                "output_type": [str, int],
+            },
+            {
+                "condition": "{{phone_num|get_area_code != 123}}",
+                "output": ["{{phone_num}}", "{{phone_num|get_area_code}}"],
+                "output_name": ["phone_num", "area_code"],
+                "output_type": [str, int],
+            },
+        ]
+
+        router = ConditionalRouter(routes, custom_filters={"get_area_code": custom_filter_to_sede})
+        reloaded_router = ConditionalRouter.from_dict(router.to_dict())
+        assert reloaded_router.custom_filters == router.custom_filters
+        assert reloaded_router.routes == router.routes


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9488

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Fix the `to_dict` and `from_dict` methods to properly handle the case when `output_type` is a List of types or a List of strings.

cc @bglearning @medsriha 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
