### PR TITLE
test: replace tool calling model in tests with Qwen2.5-72B-Instruct

### DIFF
--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -821,13 +821,13 @@ class TestHuggingFaceAPIChatGenerator:
         """
         We test the round trip: generate tool call, pass tool message, generate response.
 
-        The model used here (Hermes-3-Llama-3.1-8B) is not gated and kept in a warm state.
+        The model used here (Qwen/Qwen2.5-72B-Instruct) is not gated and kept in a warm state.
         """
 
         chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "NousResearch/Hermes-3-Llama-3.1-8B"},
+            api_params={"model": "Qwen/Qwen2.5-72B-Instruct", "provider": "hf-inference"},
             generation_kwargs={"temperature": 0.5},
         )
 
@@ -852,7 +852,7 @@ class TestHuggingFaceAPIChatGenerator:
         final_message = results["replies"][0]
         assert not final_message.tool_calls
         assert len(final_message.text) > 0
-        assert "paris" in final_message.text.lower()
+        assert "paris" in final_message.text.lower() and "22" in final_message.text
 
     @pytest.mark.asyncio
     async def test_run_async(self, mock_check_valid_model, mock_chat_completion_async, chat_messages):


### PR DESCRIPTION
### Related Issues

- nightly tests often failing due to errors in NousResearch/Hermes-3-Llama-3.1-8B (the model we use for testing tool calling in the HF API): https://github.com/deepset-ai/haystack/actions/runs/15479832631/job/43583453403

### Proposed Changes:
- replace the model with [Qwen/Qwen2.5-72B-Instruct](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct), served with HF inference API, which seems more reliable

### How did you test it?
CI

### Notes for the reviewer
This choice might change over time, depending on the availability of the models served on the HF API

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
