### PR TITLE
chore: cleanup - lint and tests

### DIFF
--- a/haystack/components/classifiers/document_language_classifier.py
+++ b/haystack/components/classifiers/document_language_classifier.py
@@ -99,11 +99,11 @@ class DocumentLanguageClassifier:
         return {"documents": documents}
 
     def _detect_language(self, document: Document) -> Optional[str]:
+        language = None
         try:
             language = langdetect.detect(document.content)
         except langdetect.LangDetectException:
             logger.warning(
                 "Langdetect cannot detect the language of Document with id: {document_id}", document_id=document.id
             )
-            language = None
         return language

--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -377,9 +377,8 @@ class OpenAPIServiceConnector:
             param_value = invocation_arguments.get(param_name)
             if param_value:
                 method_call_params["parameters"][param_name] = param_value
-            else:
-                if param.get("required", False):
-                    raise ValueError(f"Missing parameter: '{param_name}' required for the '{name}' operation.")
+            elif param.get("required", False):
+                raise ValueError(f"Missing parameter: '{param_name}' required for the '{name}' operation.")
 
         # Pack request body parameters under "data" key
         if request_body:
@@ -389,10 +388,9 @@ class OpenAPIServiceConnector:
                 param_value = invocation_arguments.get(param_name)
                 if param_value:
                     method_call_params["data"][param_name] = param_value
-                else:
-                    if param_name in required_params:
-                        raise ValueError(
-                            f"Missing requestBody parameter: '{param_name}' required for the '{name}' operation."
-                        )
+                elif param_name in required_params:
+                    raise ValueError(
+                        f"Missing requestBody parameter: '{param_name}' required for the '{name}' operation."
+                    )
         # call the underlying service REST API with the parameters
         return method_to_call(**method_call_params, raw_response=True)

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -322,7 +322,7 @@ class LLMEvaluator:
             If the received inputs are not lists or have different lengths
         """
         # Validate that all expected inputs are present in the received inputs
-        for param in expected.keys():
+        for param in expected:
             if param not in received:
                 msg = f"LLM evaluator expected input parameter '{param}' but received only {received.keys()}."
                 raise ValueError(msg)

--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -205,6 +205,8 @@ class LLMMetadataExtractor:
         return default_from_dict(cls, data)
 
     def _extract_metadata(self, llm_answer: str) -> Dict[str, Any]:
+        parsed_metadata: Dict[str, Any] = {}
+
         try:
             parsed_metadata = json.loads(llm_answer)
         except json.JSONDecodeError as e:

--- a/haystack/components/routers/text_language_router.py
+++ b/haystack/components/routers/text_language_router.py
@@ -92,11 +92,11 @@ class TextLanguageRouter:
         return output
 
     def _detect_language(self, text: str) -> Optional[str]:
+        language = None
         try:
             language = langdetect.detect(text)
         except langdetect.LangDetectException as exception:
             logger.warning("Langdetect cannot detect the language of text. Error: {error}", error=exception)
             # Only log the text in debug mode, as it might contain sensitive information
             logger.debug("Langdetect cannot detect the language of text: {text}", text=text)
-            language = None
         return language

--- a/haystack/core/serialization.py
+++ b/haystack/core/serialization.py
@@ -5,7 +5,7 @@
 import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Optional, Type
+from typing import Any, Dict, Iterable, Optional, Type, TypeVar
 
 from haystack import logging
 from haystack.core.component.component import _hook_component_init
@@ -13,6 +13,8 @@ from haystack.core.errors import DeserializationError, SerializationError
 from haystack.utils.type_serialization import thread_safe_import
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
 
 
 @dataclass(frozen=True)
@@ -100,7 +102,7 @@ def _validate_component_to_dict_output(component: Any, name: str, data: Dict[str
                 check_dict(v)
 
     def check_dict(d: Dict[str, Any]) -> None:
-        if any(not isinstance(k, str) for k in data.keys()):
+        if any(not isinstance(k, str) for k in data):
             raise SerializationError(
                 f"Component '{name}' of type '{type(component).__name__}' has a non-string key in the serialized data."
             )
@@ -210,7 +212,7 @@ def default_to_dict(obj: Any, **init_parameters: Any) -> Dict[str, Any]:
     return {"type": generate_qualified_class_name(type(obj)), "init_parameters": init_parameters}
 
 
-def default_from_dict(cls: Type[object], data: Dict[str, Any]) -> Any:
+def default_from_dict(cls: Type[T], data: Dict[str, Any]) -> T:
     """
     Utility function to deserialize a dictionary to an object.
 

--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -291,6 +291,7 @@ class ComponentTool(Tool):
             resolved_type = _resolve_type(input_type)
             fields[input_name] = (resolved_type, Field(default=default, description=description))
 
+        parameters_schema: Dict[str, Any] = {}
         try:
             model = create_model(component.run.__name__, __doc__=component_run_description, **fields)
             parameters_schema = model.model_json_schema()

--- a/haystack/utils/auth.py
+++ b/haystack/utils/auth.py
@@ -82,7 +82,7 @@ class Secret(ABC):
         """
         out = {"type": self.type.value}
         inner = self._to_dict()
-        assert all(k not in inner for k in out.keys())
+        assert all(k not in inner for k in out)
         out.update(inner)
         return out
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,13 +255,13 @@ disable = [
   "deprecated-method",
 ]
 [tool.pylint.'DESIGN']
-max-args = 38           # Default is 5
-max-attributes = 28     # Default is 7
-max-branches = 34       # Default is 12
-max-locals = 45         # Default is 15
-max-module-lines = 2468 # Default is 1000
-max-nested-blocks = 9   # Default is 5
-max-statements = 206    # Default is 50
+max-args = 20           # Default is 5
+max-attributes = 22     # Default is 7
+max-branches = 22       # Default is 12
+max-locals = 39         # Default is 15
+max-module-lines = 1500 # Default is 1000
+max-nested-blocks = 6   # Default is 5
+max-statements = 102    # Default is 50
 
 [tool.pylint.'SIMILARITIES']
 min-similarity-lines = 6
@@ -285,7 +285,6 @@ asyncio_default_fixture_loop_scope = "class"
 python_version = "3.9"
 disallow_incomplete_defs = true
 warn_return_any = false
-warn_unused_configs = true
 ignore_missing_imports = true
 check_untyped_defs = true
 
@@ -340,26 +339,23 @@ ignore = [
   "PERF203", # `try`-`except` within a loop incurs performance overhead
   "PERF401", # Use a list comprehension to create a transformed list
   "PLR1714", # repeated-equality-comparison
-  "PLR5501", # collapsible-else-if
   "PLW0603", # global-statement
-  "PLW1510", # subprocess-run-without-check
   "PLW2901", # redefined-loop-name
   "SIM108",  # if-else-block-instead-of-if-exp
-  "SIM115",  # open-file-with-context-handler
   "SIM118",  # in-dict-keys
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 28
+max-complexity = 20
 
 
 [tool.ruff.lint.pylint]
 allow-magic-value-types = ["float", "int", "str"]
-max-args = 14                                     # Default is 5
+max-args = 13                                     # Default is 5
 max-branches = 21                                 # Default is 12
 max-public-methods = 20                           # Default is 20
 max-returns = 7                                   # Default is 6
-max-statements = 60                               # Default is 50
+max-statements = 56                               # Default is 50
 
 [tool.coverage.run]
 omit = ["haystack/testing/*"]

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -27,8 +27,10 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
             yield tmp_dir
 
     @pytest.fixture
-    def document_store(self) -> InMemoryDocumentStore:
-        return InMemoryDocumentStore(bm25_algorithm="BM25L")
+    def document_store(self):
+        store = InMemoryDocumentStore(bm25_algorithm="BM25L")
+        yield store
+        store.shutdown()
 
     def test_to_dict(self):
         store = InMemoryDocumentStore()


### PR DESCRIPTION
### Proposed Changes:
- review pylint/ruff settings to increase strictness where possible
- minor type/format fixes
- make sure that `document_store` fixture is correctly shutdown in `InMemoryDocumentStore` tests (similar to #9448)
- avoid that Pipeline tests permanently write files on disk (using temp files)
- mark 2 slow unit tests (5s in my macOS) as integration tests -> this is the reason why coverage decreases

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
