### PR TITLE
feat: Warn users if Agent is called with only system messages

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -237,6 +237,8 @@ class Agent:
             - "messages": List of all messages exchanged during the agent's run.
             - "last_message": The last message exchanged during the agent's run.
             - Any additional keys defined in the `state_schema`.
+        :raises RuntimeError: If the Agent component wasn't warmed up before calling `run()`.
+        :raises ValueError: If no messages were provided to the Agent.
         """
         if not self._is_warmed_up and hasattr(self.chat_generator, "warm_up"):
             raise RuntimeError("The component Agent wasn't warmed up. Run 'warm_up()' before calling 'run()'.")
@@ -341,6 +343,8 @@ class Agent:
             - "messages": List of all messages exchanged during the agent's run.
             - "last_message": The last message exchanged during the agent's run.
             - Any additional keys defined in the `state_schema`.
+        :raises RuntimeError: If the Agent component wasn't warmed up before calling `run_async()`.
+        :raises ValueError: If no messages were provided to the Agent.
         """
         if not self._is_warmed_up and hasattr(self.chat_generator, "warm_up"):
             raise RuntimeError("The component Agent wasn't warmed up. Run 'warm_up()' before calling 'run_async()'.")

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -69,7 +69,7 @@ class Agent:
         max_agent_steps: int = 100,
         raise_on_tool_invocation_failure: bool = False,
         streaming_callback: Optional[StreamingCallbackT] = None,
-    ):
+    ) -> None:
         """
         Initialize the agent component.
 
@@ -246,9 +246,6 @@ class Agent:
         if self.system_prompt is not None:
             messages = [ChatMessage.from_system(self.system_prompt)] + messages
 
-        if len(messages) == 0:
-            raise ValueError("No messages were provided to the Agent.")
-
         if all(m.is_from(ChatRole.SYSTEM) for m in messages):
             logger.warning(
                 "All messages provided to the Agent component are system messages. This is not recommended as the "
@@ -351,9 +348,6 @@ class Agent:
 
         if self.system_prompt is not None:
             messages = [ChatMessage.from_system(self.system_prompt)] + messages
-
-        if len(messages) == 0:
-            raise ValueError("No messages were provided to the Agent.")
 
         if all(m.is_from(ChatRole.SYSTEM) for m in messages):
             logger.warning(

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -12,7 +12,7 @@ from haystack.core.pipeline.async_pipeline import AsyncPipeline
 from haystack.core.pipeline.pipeline import Pipeline
 from haystack.core.pipeline.utils import _deepcopy_with_exceptions
 from haystack.core.serialization import component_to_dict
-from haystack.dataclasses import ChatMessage
+from haystack.dataclasses import ChatMessage, ChatRole
 from haystack.dataclasses.streaming_chunk import StreamingCallbackT, select_streaming_callback
 from haystack.tools import Tool, Toolset, deserialize_tools_or_toolset_inplace, serialize_tools_or_toolset
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
@@ -244,6 +244,15 @@ class Agent:
         if self.system_prompt is not None:
             messages = [ChatMessage.from_system(self.system_prompt)] + messages
 
+        if len(messages) == 0:
+            raise ValueError("No messages were provided to the Agent.")
+
+        if all(m.is_from(ChatRole.SYSTEM) for m in messages):
+            logger.warning(
+                "All messages provided to the Agent component are system messages. This is not recommended as the "
+                "Agent will not perform any actions specific to user input. Consider adding user messages to the input."
+            )
+
         state = State(schema=self.state_schema, data=kwargs)
         state.set("messages", messages)
         component_visits = dict.fromkeys(["chat_generator", "tool_invoker"], 0)
@@ -338,6 +347,15 @@ class Agent:
 
         if self.system_prompt is not None:
             messages = [ChatMessage.from_system(self.system_prompt)] + messages
+
+        if len(messages) == 0:
+            raise ValueError("No messages were provided to the Agent.")
+
+        if all(m.is_from(ChatRole.SYSTEM) for m in messages):
+            logger.warning(
+                "All messages provided to the Agent component are system messages. This is not recommended as the "
+                "Agent will not perform any actions specific to user input. Consider adding user messages to the input."
+            )
 
         state = State(schema=self.state_schema, data=kwargs)
         state.set("messages", messages)

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -238,7 +238,6 @@ class Agent:
             - "last_message": The last message exchanged during the agent's run.
             - Any additional keys defined in the `state_schema`.
         :raises RuntimeError: If the Agent component wasn't warmed up before calling `run()`.
-        :raises ValueError: If no messages were provided to the Agent.
         """
         if not self._is_warmed_up and hasattr(self.chat_generator, "warm_up"):
             raise RuntimeError("The component Agent wasn't warmed up. Run 'warm_up()' before calling 'run()'.")
@@ -341,7 +340,6 @@ class Agent:
             - "last_message": The last message exchanged during the agent's run.
             - Any additional keys defined in the `state_schema`.
         :raises RuntimeError: If the Agent component wasn't warmed up before calling `run_async()`.
-        :raises ValueError: If no messages were provided to the Agent.
         """
         if not self._is_warmed_up and hasattr(self.chat_generator, "warm_up"):
             raise RuntimeError("The component Agent wasn't warmed up. Run 'warm_up()' before calling 'run_async()'.")

--- a/releasenotes/notes/warning-or-error-missing-messages-agent-c9bb7f1fd3708df1.yaml
+++ b/releasenotes/notes/warning-or-error-missing-messages-agent-c9bb7f1fd3708df1.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    - Now if no messages are provided to the agent at runtime a ValueError is raised. Previously the Agent would return an empty list of messages as output.
+    - Now if only system messages are provided as input a warning will be logged to the user indicating that this likely not intended.

--- a/releasenotes/notes/warning-or-error-missing-messages-agent-c9bb7f1fd3708df1.yaml
+++ b/releasenotes/notes/warning-or-error-missing-messages-agent-c9bb7f1fd3708df1.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    - If only system messages are provided as input a warning will be logged to the user indicating that this likely not intended.
+    - If only system messages are provided as input a warning will be logged to the user indicating that this likely not intended and that they should probably also provide user messages.

--- a/releasenotes/notes/warning-or-error-missing-messages-agent-c9bb7f1fd3708df1.yaml
+++ b/releasenotes/notes/warning-or-error-missing-messages-agent-c9bb7f1fd3708df1.yaml
@@ -1,5 +1,4 @@
 ---
 enhancements:
   - |
-    - Now if no messages are provided to the agent at runtime a ValueError is raised. Previously the Agent would return an empty list of messages as output.
-    - Now if only system messages are provided as input a warning will be logged to the user indicating that this likely not intended.
+    - If only system messages are provided as input a warning will be logged to the user indicating that this likely not intended.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -719,6 +719,20 @@ class TestAgent:
         with pytest.raises(RuntimeError, match="The component Agent wasn't warmed up."):
             agent.run([ChatMessage.from_user("What is the weather in Berlin?")])
 
+    def test_run_no_messages(self):
+        chat_generator = MockChatGeneratorWithoutRunAsync()
+        agent = Agent(chat_generator=chat_generator, tools=[])
+        agent.warm_up()
+        with pytest.raises(ValueError, match="No messages were provided to the Agent."):
+            _ = agent.run([])
+
+    def test_run_only_system_prompt(self, caplog):
+        chat_generator = MockChatGeneratorWithoutRunAsync()
+        agent = Agent(chat_generator=chat_generator, tools=[], system_prompt="This is a system prompt.")
+        agent.warm_up()
+        _ = agent.run([])
+        assert "All messages provided to the Agent component are system messages." in caplog.text
+
     @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
     @pytest.mark.integration
     def test_run(self, weather_tool):

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -719,12 +719,13 @@ class TestAgent:
         with pytest.raises(RuntimeError, match="The component Agent wasn't warmed up."):
             agent.run([ChatMessage.from_user("What is the weather in Berlin?")])
 
-    def test_run_no_messages(self):
-        chat_generator = MockChatGeneratorWithoutRunAsync()
+    def test_run_no_messages(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        chat_generator = OpenAIChatGenerator()
         agent = Agent(chat_generator=chat_generator, tools=[])
         agent.warm_up()
-        with pytest.raises(ValueError, match="No messages were provided to the Agent."):
-            _ = agent.run([])
+        result = agent.run([])
+        assert result["messages"] == []
 
     def test_run_only_system_prompt(self, caplog):
         chat_generator = MockChatGeneratorWithoutRunAsync()


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9440

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Logs a warning message to users if only system messages are passed to the Agent at runtime causing potentially unexpected behavior.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
