### PR TITLE
Fixes incorrect ID generation for identical chunks in RecursiveDocumentSplitter

### DIFF
--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -427,9 +427,8 @@ class RecursiveDocumentSplitter:
             meta["parent_id"] = doc.id
             meta["split_id"] = split_nr
             meta["split_idx_start"] = current_position
+            meta["_split_overlap"] = [] if self.split_overlap > 0 else None
             new_doc = Document(content=chunk, meta=meta)
-            new_doc.meta["split_idx_start"] = current_position
-            new_doc.meta["_split_overlap"] = [] if self.split_overlap > 0 else None
 
             # add overlap information to the previous and current doc
             if split_nr > 0 and self.split_overlap > 0:

--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -423,8 +423,11 @@ class RecursiveDocumentSplitter:
         new_docs: List[Document] = []
 
         for split_nr, chunk in enumerate(chunks):
-            new_doc = Document(content=chunk, meta=deepcopy(doc.meta))
-            new_doc.meta["split_id"] = split_nr
+            meta = deepcopy(doc.meta)
+            meta["parent_id"] = doc.id
+            meta["split_id"] = split_nr
+            meta["split_idx_start"] = current_position
+            new_doc = Document(content=chunk, meta=meta)
             new_doc.meta["split_idx_start"] = current_position
             new_doc.meta["_split_overlap"] = [] if self.split_overlap > 0 else None
 

--- a/releasenotes/notes/fix-recursive-splitter-unique-ids-5ae9901b81131302.yaml
+++ b/releasenotes/notes/fix-recursive-splitter-unique-ids-5ae9901b81131302.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **RecursiveDocumentSplitter** now generates a unique `Document.id` for every chunk. The meta fields (`split_id`, `parent_id`, etc.) are populated _before_ `Document` creation, so the hash used for `id` generation is always unique.

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -990,3 +990,29 @@ def test_run_complex_text_with_multiple_separators():
     assert len(chunks[3].content) == 152
     assert chunks[3].content.startswith("C")
     assert chunks[3].content.endswith("D" * 50)
+
+
+def test_recursive_splitter_generates_unique_ids_and_correct_meta():
+    """
+    • Every produced chunk must have a unique `id`.
+    • Each chunk must carry `parent_id` = original doc’s ID.
+    • `split_id` values must be 0, 1, 2, …
+    """
+    from haystack import Document
+    from haystack.components.preprocessors.recursive_splitter import RecursiveDocumentSplitter
+
+    text = "Haystack is awesome. " * 5
+    source_doc = Document(content=text)
+
+    splitter = RecursiveDocumentSplitter(split_length=3)
+    splitter.warm_up()
+
+    chunks = splitter.run([source_doc])["documents"]
+
+    # IDs must be unique
+    assert len({c.id for c in chunks}) == len(chunks)
+
+    # parent_id and split_id checks
+    for idx, chunk in enumerate(chunks):
+        assert chunk.meta["parent_id"] == source_doc.id
+        assert chunk.meta["split_id"] == idx

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -993,14 +993,6 @@ def test_run_complex_text_with_multiple_separators():
 
 
 def test_recursive_splitter_generates_unique_ids_and_correct_meta():
-    """
-    • Every produced chunk must have a unique `id`.
-    • Each chunk must carry `parent_id` = original doc’s ID.
-    • `split_id` values must be 0, 1, 2, …
-    """
-    from haystack import Document
-    from haystack.components.preprocessors.recursive_splitter import RecursiveDocumentSplitter
-
     text = "Haystack is awesome. " * 5
     source_doc = Document(content=text)
 


### PR DESCRIPTION


### Related Issues

- fixes #9508 

### Proposed Changes:
The issue occurred because `Document.id` is generated based on the `content` and `meta` at creation time.  

However, meta fields like `split_id` and `parent_id` were added **after** the `Document` was instantiated, causing chunks with identical content and meta to produce identical `id`s.

- Includes a unit test that verifies uniqueness of IDs and correct metadata assignment


### How did you test it?

- Added a unit test: `test_recursive_splitter_generates_unique_ids_and_correct_meta`

### Notes for the reviewer


### Checklist

-  [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
-   [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
-   [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
