### PR TITLE
feat: Make `PipelineBase().validate_input` public

### DIFF
--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -198,7 +198,7 @@ class AsyncPipeline(PipelineBase):
         prepared_data = self._prepare_component_input_data(data)
 
         # raises ValueError if input is malformed in some way
-        self._validate_input(prepared_data)
+        self.validate_input(prepared_data)
         inputs_state = self._convert_to_internal_format(prepared_data)
 
         # For quick lookup of downstream receivers

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -899,7 +899,7 @@ class PipelineBase:
             parent_span=parent_span,
         )
 
-    def _validate_input(self, data: Dict[str, Any]) -> None:
+    def validate_input(self, data: Dict[str, Any]) -> None:
         """
         Validates pipeline input data.
 

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -172,7 +172,7 @@ class Pipeline(PipelineBase):
         data = self._prepare_component_input_data(data)
 
         # Raise ValueError if input is malformed in some way
-        self._validate_input(data)
+        self.validate_input(data)
 
         if include_outputs_from is None:
             include_outputs_from = set()

--- a/releasenotes/notes/make-validate-input-public-e547ef5b75069bd7.yaml
+++ b/releasenotes/notes/make-validate-input-public-e547ef5b75069bd7.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Make the PipelineBase().validate_input method public so users can use it with the confidence that it won't receive breaking changes without warning.
+    This method is useful for checking that all required connections in a pipeline have a connection and is automatically called in the run method of Pipeline.
+    It is being exposed as public for users who would like to call this method before runtime to validate the pipeline.


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/142

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Make PipelineBase._validate_input public so users can use it to validate pipelines before runtime. Currently Haystack only calls this internally at runtime.

Making it public signals to users they can use with the confidence it won't receive breaking changes without following our breaking change policy.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
