### PR TITLE
fix: Fix Tool and ComponentTool serialization when specifying `outputs_to_string`

### DIFF
--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -206,14 +206,15 @@ class ComponentTool(Tool):
         """
         serialized_component = component_to_dict(obj=self._component, name=self.name)
 
-        serialized = {
+        serialized: Dict[str, Any] = {
             "component": serialized_component,
             "name": self.name,
             "description": self.description,
             "parameters": self._unresolved_parameters,
-            "outputs_to_string": self.outputs_to_string,
             "inputs_from_state": self.inputs_from_state,
-            "outputs_to_state": self.outputs_to_state,
+            # These are soft-copied as to not modify the attributes in place
+            "outputs_to_string": self.outputs_to_string.copy() if self.outputs_to_string else None,
+            "outputs_to_state": self.outputs_to_state.copy() if self.outputs_to_state else None,
         }
 
         if self.outputs_to_state is not None:
@@ -225,10 +226,8 @@ class ComponentTool(Tool):
                 serialized_outputs[key] = serialized_config
             serialized["outputs_to_state"] = serialized_outputs
 
-        if self.outputs_to_string is not None:
-            serialized["outputs_to_string"] = self.outputs_to_string.copy()
-            if self.outputs_to_string.get("handler") is not None:
-                serialized["outputs_to_string"]["handler"] = serialize_callable(self.outputs_to_string["handler"])
+        if self.outputs_to_string is not None and self.outputs_to_string.get("handler") is not None:
+            serialized["outputs_to_string"]["handler"] = serialize_callable(self.outputs_to_string["handler"])
 
         return {"type": generate_qualified_class_name(type(self)), "data": serialized}
 

--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -212,8 +212,7 @@ class ComponentTool(Tool):
             "description": self.description,
             "parameters": self._unresolved_parameters,
             "inputs_from_state": self.inputs_from_state,
-            # These are soft-copied as to not modify the attributes in place
-            "outputs_to_string": self.outputs_to_string.copy() if self.outputs_to_string else None,
+            # This is soft-copied as to not modify the attributes in place
             "outputs_to_state": self.outputs_to_state.copy() if self.outputs_to_state else None,
         }
 
@@ -227,6 +226,8 @@ class ComponentTool(Tool):
             serialized["outputs_to_state"] = serialized_outputs
 
         if self.outputs_to_string is not None and self.outputs_to_string.get("handler") is not None:
+            # This is soft-copied as to not modify the attributes in place
+            serialized["outputs_to_string"] = self.outputs_to_string.copy()
             serialized["outputs_to_string"]["handler"] = serialize_callable(self.outputs_to_string["handler"])
 
         return {"type": generate_qualified_class_name(type(self)), "data": serialized}

--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -229,6 +229,8 @@ class ComponentTool(Tool):
             # This is soft-copied as to not modify the attributes in place
             serialized["outputs_to_string"] = self.outputs_to_string.copy()
             serialized["outputs_to_string"]["handler"] = serialize_callable(self.outputs_to_string["handler"])
+        else:
+            serialized["outputs_to_string"] = None
 
         return {"type": generate_qualified_class_name(type(self)), "data": serialized}
 

--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -225,8 +225,10 @@ class ComponentTool(Tool):
                 serialized_outputs[key] = serialized_config
             serialized["outputs_to_state"] = serialized_outputs
 
-        if self.outputs_to_string is not None and self.outputs_to_string.get("handler") is not None:
-            serialized["outputs_to_string"] = serialize_callable(self.outputs_to_string["handler"])
+        if self.outputs_to_string is not None:
+            serialized["outputs_to_string"] = self.outputs_to_string.copy()
+            if self.outputs_to_string.get("handler") is not None:
+                serialized["outputs_to_string"]["handler"] = serialize_callable(self.outputs_to_string["handler"])
 
         return {"type": generate_qualified_class_name(type(self)), "data": serialized}
 

--- a/haystack/tools/tool.py
+++ b/haystack/tools/tool.py
@@ -121,10 +121,8 @@ class Tool:
                 serialized_outputs[key] = serialized_config
             data["outputs_to_state"] = serialized_outputs
 
-        if self.outputs_to_string is not None:
-            data["outputs_to_string"] = self.outputs_to_string.copy()
-            if self.outputs_to_string.get("handler") is not None:
-                data["outputs_to_string"]["handler"] = serialize_callable(self.outputs_to_string["handler"])
+        if self.outputs_to_string is not None and self.outputs_to_string.get("handler") is not None:
+            data["outputs_to_string"]["handler"] = serialize_callable(self.outputs_to_string["handler"])
 
         return {"type": generate_qualified_class_name(type(self)), "data": data}
 

--- a/haystack/tools/tool.py
+++ b/haystack/tools/tool.py
@@ -121,8 +121,10 @@ class Tool:
                 serialized_outputs[key] = serialized_config
             data["outputs_to_state"] = serialized_outputs
 
-        if self.outputs_to_string is not None and self.outputs_to_string.get("handler") is not None:
-            data["outputs_to_string"] = serialize_callable(self.outputs_to_string["handler"])
+        if self.outputs_to_string is not None:
+            data["outputs_to_string"] = self.outputs_to_string.copy()
+            if self.outputs_to_string.get("handler") is not None:
+                data["outputs_to_string"]["handler"] = serialize_callable(self.outputs_to_string["handler"])
 
         return {"type": generate_qualified_class_name(type(self)), "data": data}
 

--- a/releasenotes/notes/fix-serialization-tool-and-comp-tool-017caac6bb56e744.yaml
+++ b/releasenotes/notes/fix-serialization-tool-and-comp-tool-017caac6bb56e744.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the serialization of ComponentTool and Tool when specifying outputs_to_string. Previously an error occurred on deserialization right after serializing if outputs_to_string is not None.

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -13,6 +13,10 @@ def get_weather_report(city: str) -> str:
     return f"Weather report for {city}: 20°C, sunny"
 
 
+def format_string(text: str) -> str:
+    return f"Formatted: {text}"
+
+
 parameters = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
 
 
@@ -84,6 +88,8 @@ class TestTool:
             description="Get weather report",
             parameters=parameters,
             function=get_weather_report,
+            outputs_to_string={"handler": format_string},
+            inputs_from_state={"state_key": "tool_input_key"},
             outputs_to_state={"documents": {"handler": get_weather_report, "source": "docs"}},
         )
 
@@ -94,8 +100,8 @@ class TestTool:
                 "description": "Get weather report",
                 "parameters": parameters,
                 "function": "test_tool.get_weather_report",
-                "outputs_to_string": None,
-                "inputs_from_state": None,
+                "outputs_to_string": {"handler": "test_tool.format_string"},
+                "inputs_from_state": {"state_key": "tool_input_key"},
                 "outputs_to_state": {"documents": {"source": "docs", "handler": "test_tool.get_weather_report"}},
             },
         }
@@ -108,6 +114,8 @@ class TestTool:
                 "description": "Get weather report",
                 "parameters": parameters,
                 "function": "test_tool.get_weather_report",
+                "outputs_to_string": {"handler": "test_tool.format_string"},
+                "inputs_from_state": {"state_key": "tool_input_key"},
                 "outputs_to_state": {"documents": {"source": "docs", "handler": "test_tool.get_weather_report"}},
             },
         }
@@ -118,8 +126,9 @@ class TestTool:
         assert tool.description == "Get weather report"
         assert tool.parameters == parameters
         assert tool.function == get_weather_report
-        assert tool.outputs_to_state["documents"]["source"] == "docs"
-        assert tool.outputs_to_state["documents"]["handler"] == get_weather_report
+        assert tool.outputs_to_string == {"handler": format_string}
+        assert tool.inputs_from_state == {"state_key": "tool_input_key"}
+        assert tool.outputs_to_state == {"documents": {"source": "docs", "handler": get_weather_report}}
 
 
 def test_check_duplicate_tool_names():


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9523

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Update `to_dict` method of `ComponentTool` and `Tool` to properly serialize `outputs_to_string`. Added unit tests.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added unit tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
