### PR TITLE
fix: fix SuperComponent class serialization/deserialization for async Pipelines

### DIFF
--- a/haystack/core/super_component/super_component.py
+++ b/haystack/core/super_component/super_component.py
@@ -367,11 +367,13 @@ class _SuperComponent:
         :return: Dictionary containing serialized SuperComponent data
         """
         serialized_pipeline = self.pipeline.to_dict()
+        is_pipeline_async = isinstance(self.pipeline, AsyncPipeline)
         serialized = default_to_dict(
             self,
             pipeline=serialized_pipeline,
             input_mapping=self._original_input_mapping,
             output_mapping=self._original_output_mapping,
+            is_pipeline_async=is_pipeline_async,
         )
         serialized["type"] = generate_qualified_class_name(SuperComponent)
         return serialized
@@ -462,7 +464,9 @@ class SuperComponent(_SuperComponent):
         :returns:
             The deserialized SuperComponent.
         """
-        pipeline = Pipeline.from_dict(data["init_parameters"]["pipeline"])
+        is_pipeline_async = data["init_parameters"].pop("is_pipeline_async", False)
+        pipeline_class = AsyncPipeline if is_pipeline_async else Pipeline
+        pipeline = pipeline_class.from_dict(data["init_parameters"]["pipeline"])
         data["init_parameters"]["pipeline"] = pipeline
         return default_from_dict(cls, data)
 

--- a/releasenotes/notes/supercomponent-class-async-serde-4bfc357570b252db.yaml
+++ b/releasenotes/notes/supercomponent-class-async-serde-4bfc357570b252db.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+     The SuperComponent class can now correctly serialize and deserialize a SuperComponent based on an async pipeline.
+     Previously, the SuperComponent class always assumed the underlying pipeline was synchronous.

--- a/test/core/super_component/test_super_component.py
+++ b/test/core/super_component/test_super_component.py
@@ -266,6 +266,7 @@ class TestSuperComponent:
         assert "type" in serialized
         assert "init_parameters" in serialized
         assert "pipeline" in serialized["init_parameters"]
+        assert serialized["init_parameters"]["is_pipeline_async"] is False
 
         # Test deserialization
         deserialized = SuperComponent.from_dict(serialized)
@@ -457,7 +458,6 @@ class TestSuperComponent:
 
         async_super_component = SuperComponent(pipeline=pipeline)
         serialized_super_component = async_super_component.to_dict()
-        print(serialized_super_component)
         assert serialized_super_component["init_parameters"]["is_pipeline_async"] is True
 
         deserialized_super_component = SuperComponent.from_dict(serialized_super_component)

--- a/test/core/super_component/test_super_component.py
+++ b/test/core/super_component/test_super_component.py
@@ -437,8 +437,13 @@ class TestSuperComponent:
 
     @pytest.mark.asyncio
     async def test_super_component_async_serialization_deserialization(self):
+        """
+        Test that when using the SuperComponent class, a SuperComponent based on an async pipeline can be serialized and
+        deserialized correctly.
+        """
+
         @component
-        class HelloWorldComponent:
+        class AsyncComponent:
             @component.output_types(output=str)
             def run(self):
                 return {"output": "irrelevant"}
@@ -448,11 +453,12 @@ class TestSuperComponent:
                 return {"output": "Hello world"}
 
         pipeline = AsyncPipeline()
-        pipeline.add_component("hello", HelloWorldComponent())
+        pipeline.add_component("hello", AsyncComponent())
 
-        my_super_component = SuperComponent(pipeline=pipeline)
-        serialized_super_component = my_super_component.to_dict()
-        assert serialized_super_component["init_parameters"]["is_pipeline_async"] == True
+        async_super_component = SuperComponent(pipeline=pipeline)
+        serialized_super_component = async_super_component.to_dict()
+        print(serialized_super_component)
+        assert serialized_super_component["init_parameters"]["is_pipeline_async"] is True
 
         deserialized_super_component = SuperComponent.from_dict(serialized_super_component)
         assert isinstance(deserialized_super_component.pipeline, AsyncPipeline)


### PR DESCRIPTION
### Related Issues

- fixes #9509

### Proposed Changes:
- added a new serialization parameter `is_pipeline_async` to the serialized dictionary of SuperComponent to store this information
- use this parameter to choose the appropriate pipeline class during deserialization

### How did you test it?
CI, new unit test

### Notes for the reviewer
In case this information is missing, we default to sync Pipeline: this should make sure that deserialization does not break for SuperComponents serialized before we release this change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
