### PR TITLE
chore: update linter configuration for compatibility with latest ruff release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
   "pandas",                                    # AzureOCRDocumentConverter, CSVDocumentCleaner, CSVDocumentSplitter,
                                                # EvaluationRunResult, XLSXToDocument, and pipeline tests
 
-  "transformers[torch,sentencepiece]>=4.51.1,<4.52", # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
+  "transformers[torch, sentencepiece]>=4.51.1,<4.52", # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
   "huggingface_hub>=0.27.0",                   # Hugging Face API Generators and Embedders
   "sentence-transformers>=4.1.0",              # Sentence Transformers Embedders, Rankers, and SASEvaluator
   "langdetect",                                # TextLanguageRouter and DocumentLanguageClassifier
@@ -333,7 +333,9 @@ ignore = [
   "SIM118",  # in-dict-keys
   # we re-export symbols for correct type checking
   # https://typing.python.org/en/latest/spec/distributing.html#import-conventions
-  "PLC0414", # useless-import-alias
+  "PLC0414", # useless-import-alias,
+  "PLC0415", # useless-import-alias,
+  "PLW1641", # use-f-string
 ]
 
 [tool.ruff.lint.mccabe]


### PR DESCRIPTION
### Related Issues

- Fixes failing lint tests caused by updated ruff rules

### Proposed Changes:

- Update `pyproject.toml` to ignore new rules introduced in the latest ruff release

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
