### PR TITLE
chore: Add DocusaurusRenderer and use description, title, id fields

### DIFF
--- a/docs/pydoc/config_docusaurus/agents_api.yml
+++ b/docs/pydoc/config_docusaurus/agents_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/agents]
+    modules: ["agent", "state"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Tool-using agents with provider-agnostic chat model support.
+  title: Agents
+  id: agents-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: agents_api.md

--- a/docs/pydoc/config_docusaurus/audio_api.yml
+++ b/docs/pydoc/config_docusaurus/audio_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/audio]
+    modules: ["whisper_local", "whisper_remote"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Transcribes audio files.
+  title: Audio
+  id: audio-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: audio_api.md

--- a/docs/pydoc/config_docusaurus/builders_api.yml
+++ b/docs/pydoc/config_docusaurus/builders_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/builders]
+    modules: ["answer_builder", "prompt_builder", "chat_prompt_builder"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Extract the output of a Generator to an Answer format, and build prompts.
+  title: Builders
+  id: builders-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: builders_api.md

--- a/docs/pydoc/config_docusaurus/caching_api.yml
+++ b/docs/pydoc/config_docusaurus/caching_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/caching]
+    modules: ["cache_checker"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Checks if any document coming from the given URL is already present in the store.
+  title: Caching
+  id: caching-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: cachings_api.md

--- a/docs/pydoc/config_docusaurus/classifiers_api.yml
+++ b/docs/pydoc/config_docusaurus/classifiers_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/classifiers]
+    modules: ["document_language_classifier", "zero_shot_document_classifier"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Classify documents based on the provided labels.
+  title: Classifiers
+  id: classifiers-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: classifiers_api.md

--- a/docs/pydoc/config_docusaurus/connectors.yml
+++ b/docs/pydoc/config_docusaurus/connectors.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/connectors]
+    modules: ["openapi_service", "openapi"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Various connectors to integrate with external services.
+  title: Connectors
+  id: connectors-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: connectors_api.md

--- a/docs/pydoc/config_docusaurus/converters_api.yml
+++ b/docs/pydoc/config_docusaurus/converters_api.yml
@@ -1,0 +1,43 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/converters]
+    modules:
+      [
+        "azure",
+        "csv",
+        "docx",
+        "html",
+        "json",
+        "markdown",
+        "msg",
+        "multi_file_converter",
+        "openapi_functions",
+        "output_adapter",
+        "pdfminer",
+        "pptx",
+        "pypdf",
+        "tika",
+        "txt",
+        "xlsx",
+      ]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Various converters to transform data from one format to another.
+  title: Converters
+  id: converters-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: converters_api.md

--- a/docs/pydoc/config_docusaurus/data_classess_api.yml
+++ b/docs/pydoc/config_docusaurus/data_classess_api.yml
@@ -1,0 +1,26 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/dataclasses]
+    modules:
+      ["answer", "byte_stream", "chat_message", "document", "sparse_embedding", "state", "streaming_chunk"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Core classes that carry data through the system.
+  title: Data Classes
+  id: data-classess-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: data_classess_api.md

--- a/docs/pydoc/config_docusaurus/document_stores_api.yml
+++ b/docs/pydoc/config_docusaurus/document_stores_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/document_stores/in_memory]
+    modules: ["document_store"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Stores your texts and meta data and provides them to the Retriever at query time.
+  title: Document Stores
+  id: document-stores-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: document_stores_api.md

--- a/docs/pydoc/config_docusaurus/document_writers_api.yml
+++ b/docs/pydoc/config_docusaurus/document_writers_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/writers]
+    modules: ["document_writer"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Writes Documents to a DocumentStore.
+  title: Document Writers
+  id: document-writers-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: document_writers_api.md

--- a/docs/pydoc/config_docusaurus/embedders_api.yml
+++ b/docs/pydoc/config_docusaurus/embedders_api.yml
@@ -1,0 +1,35 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/embedders]
+    modules:
+      [
+        "azure_document_embedder",
+        "azure_text_embedder",
+        "hugging_face_api_document_embedder",
+        "hugging_face_api_text_embedder",
+        "openai_document_embedder",
+        "openai_text_embedder",
+        "sentence_transformers_document_embedder",
+        "sentence_transformers_text_embedder",
+      ]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Transforms queries into vectors to look for similar or relevant Documents.
+  title: Embedders
+  id: embedders-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: embedders_api.md

--- a/docs/pydoc/config_docusaurus/evaluation_api.yml
+++ b/docs/pydoc/config_docusaurus/evaluation_api.yml
@@ -1,0 +1,28 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/evaluation]
+    modules:
+      [
+        "eval_run_result",
+      ]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Represents the results of evaluation.
+  title: Evaluation
+  id: evaluation-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: evaluation_api.md

--- a/docs/pydoc/config_docusaurus/evaluators_api.yml
+++ b/docs/pydoc/config_docusaurus/evaluators_api.yml
@@ -1,0 +1,36 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/evaluators]
+    modules:
+      [
+        "answer_exact_match",
+        "context_relevance",
+        "document_map",
+        "document_mrr",
+        "document_ndcg",
+        "document_recall",
+        "faithfulness",
+        "llm_evaluator",
+        "sas_evaluator",
+      ]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Evaluate your pipelines or individual components.
+  title: Evaluators
+  id: evaluators-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: evaluators_api.md

--- a/docs/pydoc/config_docusaurus/extractors_api.yml
+++ b/docs/pydoc/config_docusaurus/extractors_api.yml
@@ -1,0 +1,27 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/extractors]
+    modules: ["named_entity_extractor", "llm_metadata_extractor"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: filter
+    expression: "name not in ['_BackendEnumMeta', '_NerBackend', '_HfBackend', '_SpacyBackend']"
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Extracts predefined entities out of a piece of text.
+  title: Extractors
+  id: extractors-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: extractors_api.md

--- a/docs/pydoc/config_docusaurus/fetchers_api.yml
+++ b/docs/pydoc/config_docusaurus/fetchers_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/fetchers]
+    modules: ["link_content"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Fetches content from a list of URLs and returns a list of extracted content streams.
+  title: Fetchers
+  id: fetchers-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: fetchers_api.md

--- a/docs/pydoc/config_docusaurus/generators_api.yml
+++ b/docs/pydoc/config_docusaurus/generators_api.yml
@@ -1,0 +1,36 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/generators]
+    modules:
+      [
+        "azure",
+        "hugging_face_local",
+        "hugging_face_api",
+        "openai",
+        "openai_dalle",
+        "chat/azure",
+        "chat/hugging_face_local",
+        "chat/hugging_face_api",
+        "chat/openai",
+      ]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Enables text generation using LLMs.
+  title: Generators
+  id: generators-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: generators_api.md

--- a/docs/pydoc/config_docusaurus/joiners_api.yml
+++ b/docs/pydoc/config_docusaurus/joiners_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/joiners]
+    modules: ["answer_joiner", "branch", "document_joiner", "list_joiner", "string_joiner"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Components that join list of different objects
+  title: Joiners
+  id: joiners-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: joiners_api.md

--- a/docs/pydoc/config_docusaurus/pipeline_api.yml
+++ b/docs/pydoc/config_docusaurus/pipeline_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/core/pipeline]
+    modules: ["async_pipeline","pipeline"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Arranges components and integrations in flow.
+  title: Pipeline
+  id: pipeline-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: pipeline_api.md

--- a/docs/pydoc/config_docusaurus/preprocessors_api.yml
+++ b/docs/pydoc/config_docusaurus/preprocessors_api.yml
@@ -1,0 +1,33 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/preprocessors]
+    modules: [
+      "csv_document_cleaner",
+      "csv_document_splitter",
+      "document_cleaner",
+      "document_preprocessor",
+      "document_splitter",
+      "hierarchical_document_splitter",
+      "recursive_splitter",
+      "text_cleaner"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Preprocess your Documents and texts. Clean, split, and more.
+  title: PreProcessors
+  id: preprocessors-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: preprocessors_api.md

--- a/docs/pydoc/config_docusaurus/rankers_api.yml
+++ b/docs/pydoc/config_docusaurus/rankers_api.yml
@@ -1,0 +1,32 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/rankers]
+    modules: [
+      "hugging_face_tei",
+      "lost_in_the_middle",
+      "meta_field",
+      "meta_field_grouping_ranker",
+      "sentence_transformers_diversity",
+      "sentence_transformers_similarity",
+      "transformers_similarity"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Reorders a set of Documents based on their relevance to the query.
+  title: Rankers
+  id: rankers-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: rankers_api.md

--- a/docs/pydoc/config_docusaurus/readers_api.yml
+++ b/docs/pydoc/config_docusaurus/readers_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/readers]
+    modules: ["extractive"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Takes a query and a set of Documents as input and returns ExtractedAnswers by selecting a text span within the Documents.
+  title: Readers
+  id: readers-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: readers_api.md

--- a/docs/pydoc/config_docusaurus/retrievers_api.yml
+++ b/docs/pydoc/config_docusaurus/retrievers_api.yml
@@ -1,0 +1,32 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/retrievers]
+    modules:
+      [
+        "auto_merging_retriever",
+        "in_memory/bm25_retriever",
+        "in_memory/embedding_retriever",
+        "filter_retriever",
+        "sentence_window_retriever",
+      ]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Sweeps through a Document Store and returns a set of candidate Documents that are relevant to the query.
+  title: Retrievers
+  id: retrievers-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: retrievers_api.md

--- a/docs/pydoc/config_docusaurus/routers_api.yml
+++ b/docs/pydoc/config_docusaurus/routers_api.yml
@@ -1,0 +1,33 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/routers]
+    modules:
+      [
+        "conditional_router",
+        "file_type_router",
+        "metadata_router",
+        "text_language_router",
+        "transformers_text_router",
+        "zero_shot_text_router",
+      ]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Routers is a group of components that route queries or Documents to other components that can handle them best.
+  title: Routers
+  id: routers-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: routers_api.md

--- a/docs/pydoc/config_docusaurus/samplers_api.yml
+++ b/docs/pydoc/config_docusaurus/samplers_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/samplers]
+    modules: ["top_p"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Filters documents based on their similarity scores using top-p sampling.
+  title: Samplers
+  id: samplers-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: samplers_api.md

--- a/docs/pydoc/config_docusaurus/tool_components_api.yml
+++ b/docs/pydoc/config_docusaurus/tool_components_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/tools]
+    modules: ["tool_invoker"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Components related to Tool Calling.
+  title: Tool Components
+  id: tool-components-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: tool_components_api.md

--- a/docs/pydoc/config_docusaurus/tools_api.yml
+++ b/docs/pydoc/config_docusaurus/tools_api.yml
@@ -1,0 +1,26 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/tools]
+    modules:
+      ["tool", "from_function", "component_tool", "toolset"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Unified abstractions to represent tools across the framework.
+  title: Tools
+  id: tools-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: tools_api.md

--- a/docs/pydoc/config_docusaurus/utils_api.yml
+++ b/docs/pydoc/config_docusaurus/utils_api.yml
@@ -1,0 +1,26 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/utils]
+    ignore_when_discovered: ["__init__", "hf"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: filter
+    expression: "name not in ['TokenSecret', 'EnvVarSecret','_get_default_device', '_split_device_string', 'convert']"
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Utility functions and classes used across the library.
+  title: Utils
+  id: utils-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: utils_api.md

--- a/docs/pydoc/config_docusaurus/validators_api.yml
+++ b/docs/pydoc/config_docusaurus/validators_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/validators]
+    modules: ["json_schema"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Validators validate LLM outputs
+  title: Validators
+  id: validators-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: validators_api.md

--- a/docs/pydoc/config_docusaurus/websearch_api.yml
+++ b/docs/pydoc/config_docusaurus/websearch_api.yml
@@ -1,0 +1,25 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/websearch]
+    modules: ["serper_dev", "searchapi"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
+  description: Web search engine for Haystack.
+  title: Websearch
+  id: websearch-api
+  markdown:
+    descriptive_class_title: false
+    classdef_code_block: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: websearch_api.md


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/146
- fixes https://github.com/deepset-ai/haystack-private/issues/148

### Proposed Changes:

- Copy docs/pydoc/config to docs/pydoc/config_docusaurus/
- In the copies replace ReadmeCoreRenderer with DocusaurusRenderer
- Rename fields `excerpt` to `description`, `slug` to `id`
- Remove fields `order`, `category_slug`

### How did you test it?

Tested with docs/pydoc/config_docusaurus/agents_api.yml manually

### Notes for the reviewer

DocusaurusRenderer was added in https://github.com/deepset-ai/haystack-pydoc-tools/pull/7 and released in haystack-pydoc-tools 0.4.0 https://pypi.org/project/haystack-pydoc-tools/#history

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
