### PR TITLE
fix: Update `LLMMetadataExtractor` to not modify documents in place

### DIFF
--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -5,6 +5,7 @@
 import copy
 import json
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from typing import Any, Dict, List, Optional, Union
 
 from jinja2 import meta
@@ -319,23 +320,31 @@ class LLMMetadataExtractor:
         failed_documents = []
         for document, result in zip(documents, results):
             if "error" in result:
-                document.meta["metadata_extraction_error"] = result["error"]
-                document.meta["metadata_extraction_response"] = None
-                failed_documents.append(document)
+                new_meta = {
+                    **document.meta,
+                    "metadata_extraction_error": result["error"],
+                    "metadata_extraction_response": None,
+                }
+                # We set id to an empty string to retrigger new id creation
+                failed_documents.append(replace(document, meta=new_meta, id=""))
                 continue
 
             parsed_metadata = self._extract_metadata(result["replies"][0].text)
             if "error" in parsed_metadata:
-                document.meta["metadata_extraction_error"] = parsed_metadata["error"]
-                document.meta["metadata_extraction_response"] = result["replies"][0]
-                failed_documents.append(document)
+                new_meta = {
+                    **document.meta,
+                    "metadata_extraction_error": parsed_metadata["error"],
+                    "metadata_extraction_response": result["replies"][0],
+                }
+                # We set id to an empty string to retrigger new id creation
+                failed_documents.append(replace(document, meta=new_meta, id=""))
                 continue
 
-            for key in parsed_metadata:
-                document.meta[key] = parsed_metadata[key]
-                # Remove metadata_extraction_error and metadata_extraction_response if present from previous runs
-                document.meta.pop("metadata_extraction_error", None)
-                document.meta.pop("metadata_extraction_response", None)
-            successful_documents.append(document)
+            new_meta = {**document.meta, **parsed_metadata}
+            # Remove metadata_extraction_error and metadata_extraction_response if present from previous runs
+            new_meta.pop("metadata_extraction_error", None)
+            new_meta.pop("metadata_extraction_response", None)
+            # We set id to an empty string to retrigger new id creation
+            successful_documents.append(replace(document, meta=new_meta, id=""))
 
         return {"documents": successful_documents, "failed_documents": failed_documents}

--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -325,8 +325,8 @@ class LLMMetadataExtractor:
                     "metadata_extraction_error": result["error"],
                     "metadata_extraction_response": None,
                 }
-                # We set id to an empty string to retrigger new id creation
-                failed_documents.append(replace(document, meta=new_meta, id=""))
+                # We use replace to ensure we don't modify the original document
+                failed_documents.append(replace(document, meta=new_meta))
                 continue
 
             parsed_metadata = self._extract_metadata(result["replies"][0].text)
@@ -336,15 +336,15 @@ class LLMMetadataExtractor:
                     "metadata_extraction_error": parsed_metadata["error"],
                     "metadata_extraction_response": result["replies"][0],
                 }
-                # We set id to an empty string to retrigger new id creation
-                failed_documents.append(replace(document, meta=new_meta, id=""))
+                # We use replace to ensure we don't modify the original document
+                failed_documents.append(replace(document, meta=new_meta))
                 continue
 
             new_meta = {**document.meta, **parsed_metadata}
             # Remove metadata_extraction_error and metadata_extraction_response if present from previous runs
             new_meta.pop("metadata_extraction_error", None)
             new_meta.pop("metadata_extraction_response", None)
-            # We set id to an empty string to retrigger new id creation
-            successful_documents.append(replace(document, meta=new_meta, id=""))
+            # We use replace to ensure we don't modify the original document
+            successful_documents.append(replace(document, meta=new_meta))
 
         return {"documents": successful_documents, "failed_documents": failed_documents}

--- a/releasenotes/notes/create-new-doc-id-llm-metadata-extractor-ca5edc1177a71e75.yaml
+++ b/releasenotes/notes/create-new-doc-id-llm-metadata-extractor-ca5edc1177a71e75.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Returned documents from the `LLMMetadataExtractor` create new IDs based on the extracted metadata. This makes it easier to distinguish the parent documents and the new documents.

--- a/releasenotes/notes/create-new-doc-id-llm-metadata-extractor-ca5edc1177a71e75.yaml
+++ b/releasenotes/notes/create-new-doc-id-llm-metadata-extractor-ca5edc1177a71e75.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Returned documents from the `LLMMetadataExtractor` create new IDs based on the extracted metadata. This makes it easier to distinguish the parent documents and the new documents.

--- a/test/components/extractors/test_llm_metadata_extractor.py
+++ b/test/components/extractors/test_llm_metadata_extractor.py
@@ -244,11 +244,13 @@ class TestLLMMetadataExtractor:
         assert len(result["failed_documents"]) == 2
 
         failed_doc_none = result["failed_documents"][0]
+        assert failed_doc_none.id
         assert failed_doc_none.id != doc_with_none_content.id
         assert "metadata_extraction_error" in failed_doc_none.meta
         assert failed_doc_none.meta["metadata_extraction_error"] == "Document has no content, skipping LLM call."
 
         failed_doc_empty = result["failed_documents"][1]
+        assert failed_doc_empty.id
         assert failed_doc_empty.id != doc_with_empty_content.id
         assert "metadata_extraction_error" in failed_doc_empty.meta
         assert failed_doc_empty.meta["metadata_extraction_error"] == "Document has no content, skipping LLM call."
@@ -325,5 +327,6 @@ output:
 
         # Check that IDs of documents in doc store are different from the original documents
         doc_store_doc_ids = {doc.id for doc in doc_store_docs}
+        assert len(doc_store_doc_ids) == 2
         original_doc_ids = {doc.id for doc in docs}
         assert doc_store_doc_ids != original_doc_ids

--- a/test/components/extractors/test_llm_metadata_extractor.py
+++ b/test/components/extractors/test_llm_metadata_extractor.py
@@ -325,7 +325,7 @@ output:
         assert "entities" in doc_store_docs[0].meta
         assert "entities" in doc_store_docs[1].meta
 
-        # Check that IDs of documents in doc store are different from the original documents
+        # Check that IDs of documents in doc store are the same as the original documents
         doc_store_doc_ids = {doc.id for doc in doc_store_docs}
         assert len(doc_store_doc_ids) == 2
         original_doc_ids = {doc.id for doc in docs}

--- a/test/components/extractors/test_llm_metadata_extractor.py
+++ b/test/components/extractors/test_llm_metadata_extractor.py
@@ -244,12 +244,12 @@ class TestLLMMetadataExtractor:
         assert len(result["failed_documents"]) == 2
 
         failed_doc_none = result["failed_documents"][0]
-        assert failed_doc_none.id == doc_with_none_content.id
+        assert failed_doc_none.id != doc_with_none_content.id
         assert "metadata_extraction_error" in failed_doc_none.meta
         assert failed_doc_none.meta["metadata_extraction_error"] == "Document has no content, skipping LLM call."
 
         failed_doc_empty = result["failed_documents"][1]
-        assert failed_doc_empty.id == doc_with_empty_content.id
+        assert failed_doc_empty.id != doc_with_empty_content.id
         assert "metadata_extraction_error" in failed_doc_empty.meta
         assert failed_doc_empty.meta["metadata_extraction_error"] == "Document has no content, skipping LLM call."
 
@@ -322,3 +322,8 @@ output:
         assert len(doc_store_docs) == 2
         assert "entities" in doc_store_docs[0].meta
         assert "entities" in doc_store_docs[1].meta
+
+        # Check that IDs of documents in doc store are different from the original documents
+        doc_store_doc_ids = {doc.id for doc in doc_store_docs}
+        original_doc_ids = {doc.id for doc in docs}
+        assert doc_store_doc_ids != original_doc_ids

--- a/test/components/extractors/test_llm_metadata_extractor.py
+++ b/test/components/extractors/test_llm_metadata_extractor.py
@@ -245,13 +245,13 @@ class TestLLMMetadataExtractor:
 
         failed_doc_none = result["failed_documents"][0]
         assert failed_doc_none.id
-        assert failed_doc_none.id != doc_with_none_content.id
+        assert failed_doc_none.id == doc_with_none_content.id
         assert "metadata_extraction_error" in failed_doc_none.meta
         assert failed_doc_none.meta["metadata_extraction_error"] == "Document has no content, skipping LLM call."
 
         failed_doc_empty = result["failed_documents"][1]
         assert failed_doc_empty.id
-        assert failed_doc_empty.id != doc_with_empty_content.id
+        assert failed_doc_empty.id == doc_with_empty_content.id
         assert "metadata_extraction_error" in failed_doc_empty.meta
         assert failed_doc_empty.meta["metadata_extraction_error"] == "Document has no content, skipping LLM call."
 
@@ -329,4 +329,4 @@ output:
         doc_store_doc_ids = {doc.id for doc in doc_store_docs}
         assert len(doc_store_doc_ids) == 2
         original_doc_ids = {doc.id for doc in docs}
-        assert doc_store_doc_ids != original_doc_ids
+        assert doc_store_doc_ids == original_doc_ids


### PR DESCRIPTION
### Related Issues

- an idea to address https://github.com/deepset-ai/haystack/issues/9505

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Update `LLMMetadataExtractor` to not modify Document objects in place. 

I've opted to use the `replace` function from `dataclasses` to do this since it does create a new dataclass object and doesn't modify the old one in place. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
