### PR TITLE
chore: fix deepset_sync.py for pylint + general linting improvements

### DIFF
--- a/.github/utils/check_imports.py
+++ b/.github/utils/check_imports.py
@@ -1,14 +1,17 @@
+import importlib
 import os
 import sys
-import importlib
 import traceback
 from pathlib import Path
 from typing import List, Optional
+
 from haystack import logging  # pylint: disable=unused-import  # this is needed to avoid circular imports
+
 
 def validate_module_imports(root_dir: str, exclude_subdirs: Optional[List[str]] = None) -> tuple[list, list]:
     """
     Recursively search for all Python modules and attempt to import them.
+
     This includes both packages (directories with __init__.py) and individual Python files.
     """
     imported = []
@@ -25,7 +28,7 @@ def validate_module_imports(root_dir: str, exclude_subdirs: Optional[List[str]] 
 
         # Convert path to module format
         module_path = ".".join(Path(root).relative_to(base_path.parent).parts)
-        python_files = [f for f in files if f.endswith('.py')]
+        python_files = [f for f in files if f.endswith(".py")]
 
         # Try importing package and individual files
         for file in python_files:
@@ -39,16 +42,15 @@ def validate_module_imports(root_dir: str, exclude_subdirs: Optional[List[str]] 
                 importlib.import_module(module_to_import)
                 imported.append(module_to_import)
             except:
-                failed.append({
-                    'module': module_to_import,
-                    'traceback': traceback.format_exc()
-                })
+                failed.append({"module": module_to_import, "traceback": traceback.format_exc()})
 
     return imported, failed
+
 
 def main():
     """
     This script checks that all Haystack modules can be imported successfully.
+
     This includes both packages and individual Python files.
     This can detect several issues, such as:
     - Syntax errors in Python files
@@ -80,5 +82,5 @@ def main():
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.github/utils/create_unstable_docs.py
+++ b/.github/utils/create_unstable_docs.py
@@ -1,14 +1,16 @@
+import argparse
 import re
 import sys
-import argparse
 
-from readme_api import get_versions, create_new_unstable
-
+from readme_api import create_new_unstable, get_versions
 
 VERSION_VALIDATOR = re.compile(r"^[0-9]+\.[0-9]+$")
 
 
 def calculate_new_unstable(version: str):
+    """
+    Calculate the new unstable version based on the given version.
+    """
     # version must be formatted like so <major>.<minor>
     major, minor = version.split(".")
     return f"{major}.{int(minor) + 1}-unstable"

--- a/.github/utils/deepset_sync.py
+++ b/.github/utils/deepset_sync.py
@@ -8,8 +8,10 @@ import os
 import sys
 import json
 import argparse
-import requests
+from typing import Optional
 from pathlib import Path
+
+import requests
 
 
 def transform_filename(filepath: Path) -> str:
@@ -56,7 +58,7 @@ def upload_file_to_deepset(filepath: Path, api_key: str, workspace: str) -> bool
     }
 
     try:
-        response = requests.post(url, params=params, headers=headers, files=files)
+        response = requests.post(url, params=params, headers=headers, files=files, timeout=300)
         response.raise_for_status()
         print(f"Successfully uploaded: {filepath} as {transformed_name}")
         return True
@@ -93,7 +95,7 @@ def delete_files_from_deepset(
     data: dict[str, list[str]] = {"names": transformed_names}
 
     try:
-        response = requests.delete(url, headers=headers, json=data)
+        response = requests.delete(url, headers=headers, json=data, timeout=300)
         response.raise_for_status()
         print(f"Successfully deleted {len(transformed_names)} file(s):")
         for original, transformed in zip(filepaths, transformed_names):
@@ -123,7 +125,7 @@ def main() -> None:
     args = parser.parse_args()
 
     # Get environment variables
-    api_key: str | None = os.environ.get("DEEPSET_API_KEY")
+    api_key: Optional[str] = os.environ.get("DEEPSET_API_KEY")
     workspace: str = os.environ.get("DEEPSET_WORKSPACE")
 
     if not api_key:

--- a/.github/utils/deepset_sync.py
+++ b/.github/utils/deepset_sync.py
@@ -4,12 +4,12 @@
 # ]
 # ///
 
+import argparse
+import json
 import os
 import sys
-import json
-import argparse
-from typing import Optional
 from pathlib import Path
+from typing import Optional
 
 import requests
 
@@ -17,6 +17,7 @@ import requests
 def transform_filename(filepath: Path) -> str:
     """
     Transform a file path to the required format:
+
     - Replace path separators with underscores
     """
     # Convert to string and replace path separators with underscores
@@ -46,10 +47,7 @@ def upload_file_to_deepset(filepath: Path, api_key: str, workspace: str) -> bool
     url = f"https://api.cloud.deepset.ai/api/v1/workspaces/{workspace}/files"
     params: dict[str, str] = {"file_name": transformed_name, "write_mode": "OVERWRITE"}
 
-    headers: dict[str, str] = {
-        "accept": "application/json",
-        "authorization": f"Bearer {api_key}",
-    }
+    headers: dict[str, str] = {"accept": "application/json", "authorization": f"Bearer {api_key}"}
 
     # Prepare multipart form data
     files: dict[str, tuple[None, str, str]] = {
@@ -71,9 +69,7 @@ def upload_file_to_deepset(filepath: Path, api_key: str, workspace: str) -> bool
         return False
 
 
-def delete_files_from_deepset(
-    filepaths: list[Path], api_key: str, workspace: str
-) -> bool:
+def delete_files_from_deepset(filepaths: list[Path], api_key: str, workspace: str) -> bool:
     """
     Delete multiple files from Deepset API.
     """
@@ -115,12 +111,8 @@ def main() -> None:
     Main function to process and upload/delete files.
     """
     # Parse command line arguments
-    parser = argparse.ArgumentParser(
-        description="Upload/delete Python files to/from Deepset"
-    )
-    parser.add_argument(
-        "--changed", nargs="*", default=[], help="Changed or added files"
-    )
+    parser = argparse.ArgumentParser(description="Upload/delete Python files to/from Deepset")
+    parser.add_argument("--changed", nargs="*", default=[], help="Changed or added files")
     parser.add_argument("--deleted", nargs="*", default=[], help="Deleted files")
     args = parser.parse_args()
 
@@ -169,13 +161,9 @@ def main() -> None:
     print("-" * 50)
     print("Processing Summary:")
     if changed_files:
-        print(
-            f"   Uploads - Successful: {upload_success}, Failed: {len(upload_failed)}"
-        )
+        print(f"   Uploads - Successful: {upload_success}, Failed: {len(upload_failed)}")
     if deleted_files:
-        print(
-            f"   Deletions - {'Successful' if delete_success else 'Failed'}: {len(deleted_files)} file(s)"
-        )
+        print(f"   Deletions - {'Successful' if delete_success else 'Failed'}: {len(deleted_files)} file(s)")
 
     if upload_failed:
         print("\nFailed uploads:")

--- a/.github/utils/delete_outdated_docs.py
+++ b/.github/utils/delete_outdated_docs.py
@@ -12,6 +12,9 @@ VERSION_VALIDATOR = re.compile(r"^[0-9]+\.[0-9]+$")
 
 
 def readme_token():
+    """
+    Get the Readme API token from the environment variable and encode it in base64.
+    """
     api_key = os.getenv("README_API_KEY", None)
     if not api_key:
         raise Exception("README_API_KEY env var is not set")
@@ -21,6 +24,9 @@ def readme_token():
 
 
 def create_headers(version: str):
+    """
+    Create headers for the Readme API.
+    """
     return {"authorization": f"Basic {readme_token()}", "x-readme-version": version}
 
 
@@ -35,6 +41,9 @@ def get_docs_in_category(category_slug: str, version: str) -> List[str]:
 
 
 def delete_doc(slug: str, version: str):
+    """
+    Delete a document from Readme, based on the slug and version.
+    """
     url = f"https://dash.readme.com/api/v1/docs/{slug}"
     headers = create_headers(version)
     res = requests.delete(url, headers=headers, timeout=10)

--- a/.github/utils/docstrings_checksum.py
+++ b/.github/utils/docstrings_checksum.py
@@ -1,11 +1,13 @@
+import ast
+import hashlib
 from pathlib import Path
 from typing import Iterator
 
-import ast
-import hashlib
-
 
 def docstrings_checksum(python_files: Iterator[Path]):
+    """
+    Calculate the checksum of the docstrings in the given Python files.
+    """
     files_content = (f.read_text() for f in python_files)
     trees = (ast.parse(c) for c in files_content)
 

--- a/.github/utils/promote_unstable_docs.py
+++ b/.github/utils/promote_unstable_docs.py
@@ -1,6 +1,6 @@
+import argparse
 import re
 import sys
-import argparse
 
 from readme_api import get_versions, promote_unstable_to_stable
 
@@ -8,9 +8,7 @@ VERSION_VALIDATOR = re.compile(r"^[0-9]+\.[0-9]+$")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-v", "--version", help="The version to promote to stable (e.g. 2.1).", required=True
-    )
+    parser.add_argument("-v", "--version", help="The version to promote to stable (e.g. 2.1).", required=True)
     args = parser.parse_args()
 
     if VERSION_VALIDATOR.match(args.version) is None:

--- a/.github/utils/pyproject_to_requirements.py
+++ b/.github/utils/pyproject_to_requirements.py
@@ -3,7 +3,8 @@ import re
 import sys
 from pathlib import Path
 
-import toml
+# toml is available in the default environment but not in the test environment, so pylinyt complains
+import toml  # pylint: disable=import-error
 
 matcher = re.compile(r"farm-haystack\[(.+)\]")
 parser = argparse.ArgumentParser(

--- a/.github/utils/pyproject_to_requirements.py
+++ b/.github/utils/pyproject_to_requirements.py
@@ -14,6 +14,9 @@ parser.add_argument("--extra", default="")
 
 
 def resolve(target: str, extras: dict, results: set):
+    """
+    Resolve the dependencies for a given target.
+    """
     if target not in extras:
         results.add(target)
         return
@@ -28,6 +31,9 @@ def resolve(target: str, extras: dict, results: set):
 
 
 def main(pyproject_path: Path, extra: str = ""):
+    """
+    Convert a pyproject.toml file to a requirements.txt file.
+    """
     content = toml.load(pyproject_path)
     # basic set of dependencies
     deps = set(content["project"]["dependencies"])

--- a/.github/utils/pyproject_to_requirements.py
+++ b/.github/utils/pyproject_to_requirements.py
@@ -3,7 +3,7 @@ import re
 import sys
 from pathlib import Path
 
-# toml is available in the default environment but not in the test environment, so pylinyt complains
+# toml is available in the default environment but not in the test environment, so pylint complains
 import toml  # pylint: disable=import-error
 
 matcher = re.compile(r"farm-haystack\[(.+)\]")

--- a/.github/utils/readme_api.py
+++ b/.github/utils/readme_api.py
@@ -1,16 +1,23 @@
-import os
 import base64
+import os
+
 import requests
 
 
-
 class ReadmeAuth(requests.auth.AuthBase):
-    def __call__(self, r):
+    """
+    Custom authentication class for Readme API.
+    """
+
+    def __call__(self, r):  # noqa: D102
         r.headers["authorization"] = f"Basic {readme_token()}"
         return r
 
 
 def readme_token():
+    """
+    Get the Readme API token from the environment variable and encode it in base64.
+    """
     api_key = os.getenv("RDME_API_KEY", None)
     if not api_key:
         raise Exception("RDME_API_KEY env var is not set")

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ on:
       - "haystack/core/pipeline/predefined/*"
       - "test/**/*.py"
       - "pyproject.toml"
-      - ".github/utils/check_imports.py"
+      - ".github/utils/*.py"
 
 env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/tests_skipper_trigger.yml
+++ b/.github/workflows/tests_skipper_trigger.yml
@@ -16,7 +16,7 @@ on:
       - "haystack/core/pipeline/predefined/*"
       - "test/**/*.py"
       - "pyproject.toml"
-      - ".github/utils/check_imports.py"
+      - ".github/utils/*.py"
 
 jobs:
   check_if_changed:
@@ -39,7 +39,7 @@ jobs:
               - "haystack/core/pipeline/predefined/*"
               - "test/**/*.py"
               - "pyproject.toml"
-              - ".github/utils/check_imports.py"
+              - ".github/utils/*.py"
 
   trigger-catch-all:
     name: Tests completed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,7 +283,7 @@ disallow_incomplete_defs = false
 
 [tool.ruff]
 line-length = 120
-exclude = [".github", "proposals"]
+exclude = ["proposals"]
 
 [tool.ruff.format]
 skip-magic-trailing-comma = true


### PR DESCRIPTION
### Related Issues

- pylint failing on main: https://github.com/deepset-ai/haystack/actions/runs/15919213367/job/44902536363
- pylint did not run on the original PR: #9555
- ruff and pylint settings for checking .github/ are not aligned

### Proposed Changes:

- fix linting of the offending file
- make sure that pylint is executed for ./github/utils/*.py files
- have ruff check those files as well (and fix format)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
