### PR TITLE
fix: files should not be passed as single string

### DIFF
--- a/.github/workflows/sync_code_to_deepset.yml
+++ b/.github/workflows/sync_code_to_deepset.yml
@@ -35,7 +35,6 @@ jobs:
       env:
         DEEPSET_API_KEY: ${{ secrets.DEEPSET_API_KEY }}
         DEEPSET_WORKSPACE: haystack-code
-      # shellcheck disable=SC2086
       run: |
         # Combine added and modified files for upload
         CHANGED_FILES=""
@@ -51,6 +50,7 @@ jobs:
         fi
         
         # Run the script with changed and deleted files
+        # shellcheck disable=SC2086
         uv run --no-project --no-config --no-cache .github/utils/deepset_sync.py \
           --changed $CHANGED_FILES \
           --deleted ${{ steps.changed-files.outputs.deleted_files }}


### PR DESCRIPTION
### Related Issues


### Proposed Changes:

Quoting changed and deleted files causes the script to run with multiple files interpreted as a single file path.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
