### PR TITLE
feat: Raise `PipelineComponentBlockedError` if the pipeline is unable to continue running due to a blocked component

### DIFF
--- a/haystack/core/errors.py
+++ b/haystack/core/errors.py
@@ -43,6 +43,18 @@ class PipelineRuntimeError(Exception):
         return cls(component_name, component_type, message)
 
 
+class PipelineComponentBlockedError(PipelineRuntimeError):
+    def __init__(self, component_name: str, component_type: Type) -> None:
+        message = (
+            "Cannot run pipeline - the next component that is meant to run is blocked.\n"
+            f"Component name: '{component_name}'\n"
+            f"Component type: '{component_type.__name__}'\n"
+            "This typically happens when the component is unable to receive all of its required inputs.\n"
+            "Check the connections to this component and ensure all required inputs are provided."
+        )
+        super().__init__(component_name, component_type, message)
+
+
 class PipelineComponentsBlockedError(PipelineRuntimeError):
     def __init__(self) -> None:
         message = (

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -15,6 +15,7 @@ from haystack import logging, tracing
 from haystack.core.component import Component, InputSocket, OutputSocket, component
 from haystack.core.errors import (
     DeserializationError,
+    PipelineComponentBlockedError,
     PipelineComponentsBlockedError,
     PipelineConnectError,
     PipelineDrawingError,
@@ -1177,18 +1178,20 @@ class PipelineBase:  # noqa: PLW1641
             None if (item := priority_queue.get()) is None else (ComponentPriority(item[0]), str(item[1]))
         )
 
-        if priority_and_component_name is not None and priority_and_component_name[0] != ComponentPriority.BLOCKED:
-            priority, component_name = priority_and_component_name
-            component = self._get_component_with_graph_metadata_and_visits(
-                component_name, component_visits[component_name]
-            )
-            if component["visits"] > self._max_runs_per_component:
+        if priority_and_component_name is None:
+            return None
+
+        priority, component_name = priority_and_component_name
+        comp = self._get_component_with_graph_metadata_and_visits(component_name, component_visits[component_name])
+        if priority_and_component_name[0] != ComponentPriority.BLOCKED:
+            if comp["visits"] > self._max_runs_per_component:
                 msg = f"Maximum run count {self._max_runs_per_component} reached for component '{component_name}'"
                 raise PipelineMaxComponentRuns(msg)
-
-            return priority, component_name, component
-
-        return None
+            return priority, component_name, comp
+        else:
+            raise PipelineComponentBlockedError(
+                component_name=component_name, component_type=comp["instance"].__class__
+            )
 
     @staticmethod
     def _add_missing_input_defaults(

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -208,6 +208,8 @@ class Pipeline(PipelineBase):
 
             while True:
                 candidate = self._get_next_runnable_component(priority_queue, component_visits)
+
+                # If there are no runnable components left, we can exit the loop
                 if candidate is None:
                     break
 


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/7371

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Update `_get_next_runnable_component` to raise the new `PipelineComponentBlockedError` error if the next runnable component is blocked. 

I'm not entirely sure if this is the right course of action since in some cases it's expected that components are blocked such as when we have two branches in a pipeline and only one branch is activated based on a condition (e.g. using a ConditionalRouter).

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Running integration tests via CI to see if this affects existing tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
