### PR TITLE
chore: remove deprecated `async_executor` param from `ToolIinvoker`

### DIFF
--- a/test/components/tools/test_tool_invoker.py
+++ b/test/components/tools/test_tool_invoker.py
@@ -100,11 +100,6 @@ def faulty_invoker(faulty_tool):
     return ToolInvoker(tools=[faulty_tool], raise_on_failure=True, convert_result_to_json_string=False)
 
 
-@pytest.fixture
-def thread_executor():
-    return ThreadPoolExecutor(thread_name_prefix=f"async-test-executor", max_workers=2)
-
-
 class TestToolInvoker:
     def test_init(self, weather_tool):
         invoker = ToolInvoker(tools=[weather_tool])
@@ -227,7 +222,7 @@ class TestToolInvoker:
         assert final_chunk.content == ""
 
     @pytest.mark.asyncio
-    async def test_run_async_with_streaming_callback(self, thread_executor, weather_tool):
+    async def test_run_async_with_streaming_callback(self, weather_tool):
         streaming_callback_called = False
 
         async def streaming_callback(chunk: StreamingChunk) -> None:
@@ -235,12 +230,7 @@ class TestToolInvoker:
             nonlocal streaming_callback_called
             streaming_callback_called = True
 
-        tool_invoker = ToolInvoker(
-            tools=[weather_tool],
-            raise_on_failure=True,
-            convert_result_to_json_string=False,
-            async_executor=thread_executor,
-        )
+        tool_invoker = ToolInvoker(tools=[weather_tool], raise_on_failure=True, convert_result_to_json_string=False)
 
         tool_calls = [
             ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"}),
@@ -269,18 +259,13 @@ class TestToolInvoker:
         assert streaming_callback_called
 
     @pytest.mark.asyncio
-    async def test_run_async_with_streaming_callback_finish_reason(self, thread_executor, weather_tool):
+    async def test_run_async_with_streaming_callback_finish_reason(self, weather_tool):
         streaming_chunks = []
 
         async def streaming_callback(chunk: StreamingChunk) -> None:
             streaming_chunks.append(chunk)
 
-        tool_invoker = ToolInvoker(
-            tools=[weather_tool],
-            raise_on_failure=True,
-            convert_result_to_json_string=False,
-            async_executor=thread_executor,
-        )
+        tool_invoker = ToolInvoker(tools=[weather_tool], raise_on_failure=True, convert_result_to_json_string=False)
 
         tool_call = ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})
         message = ChatMessage.from_assistant(tool_calls=[tool_call])
@@ -319,10 +304,8 @@ class TestToolInvoker:
         assert not tool_call_result.error
 
     @pytest.mark.asyncio
-    async def test_run_async_with_toolset(self, tool_set, thread_executor):
-        tool_invoker = ToolInvoker(
-            tools=tool_set, raise_on_failure=True, convert_result_to_json_string=False, async_executor=thread_executor
-        )
+    async def test_run_async_with_toolset(self, tool_set):
+        tool_invoker = ToolInvoker(tools=tool_set, raise_on_failure=True, convert_result_to_json_string=False)
         tool_calls = [
             ToolCall(tool_name="addition_tool", arguments={"num1": 5, "num2": 3}),
             ToolCall(tool_name="addition_tool", arguments={"num1": 5, "num2": 3}),


### PR DESCRIPTION
### Related Issues

- fixes #9548 

### Proposed Changes:

Remove the `async_executor` and associated logic.

### How did you test it?

Updated the tests
### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
