### PR TITLE
fix: fix `print_streaming_chunk` + add tests

### DIFF
--- a/haystack/components/generators/utils.py
+++ b/haystack/components/generators/utils.py
@@ -44,7 +44,7 @@ def print_streaming_chunk(chunk: StreamingChunk) -> None:
                 if chunk.index and tool_call.index > chunk.index:
                     print("\n\n", flush=True, end="")
 
-                print("[TOOL CALL]\nTool: {tool_call.tool_name} \nArguments: ", flush=True, end="")
+                print(f"[TOOL CALL]\nTool: {tool_call.tool_name} \nArguments: ", flush=True, end="")
 
             # print the tool arguments
             if tool_call.arguments:

--- a/releasenotes/notes/fix-print-streaming-chunk-501aaa208354d211.yaml
+++ b/releasenotes/notes/fix-print-streaming-chunk-501aaa208354d211.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fixed a bug in the `print_streaming_chunk` utility function that prevented tool call name from being printed.


### PR DESCRIPTION
### Related Issues

Reported by @bilgeyucel:

```
[TOOL CALL]
Tool: {tool_call.tool_name} -> supposed to print the tool name
Arguments: ...
```

### Proposed Changes:
- fix the tool name printing
- add tests for this utility function

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
