### PR TITLE
docs: fix curly brackets

### DIFF
--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -103,6 +103,7 @@ class FaithfulnessEvaluator(LLMEvaluator):
             "inputs" must be a dictionary with keys "questions", "contexts", and "predicted_answers".
             "outputs" must be a dictionary with "statements" and "statement_scores".
             Expected format:
+            ```python
             [{
                 "inputs": {
                     "questions": "What is the capital of Italy?", "contexts": ["Rome is the capital of Italy."],
@@ -113,6 +114,7 @@ class FaithfulnessEvaluator(LLMEvaluator):
                     "statement_scores": [1, 0],
                 },
             }]
+            ```
         :param progress_bar:
             Whether to show a progress bar during the evaluation.
         :param raise_on_failure:

--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -107,22 +107,31 @@ class ComponentTool(Tool):
             Optional dictionary defining how a tool outputs should be converted into a string.
             If the source is provided only the specified output key is sent to the handler.
             If the source is omitted the whole tool result is sent to the handler.
-            Example: {
+            Example:
+            ```python
+            {
                 "source": "docs", "handler": format_documents
             }
+            ```
         :param inputs_from_state:
             Optional dictionary mapping state keys to tool parameter names.
-            Example: {"repository": "repo"} maps state's "repository" to tool's "repo" parameter.
+            Example: `{"repository": "repo"}` maps state's "repository" to tool's "repo" parameter.
         :param outputs_to_state:
             Optional dictionary defining how tool outputs map to keys within state as well as optional handlers.
             If the source is provided only the specified output key is sent to the handler.
-            Example: {
+            Example:
+            ```python
+            {
                 "documents": {"source": "docs", "handler": custom_handler}
             }
+            ```
             If the source is omitted the whole tool result is sent to the handler.
-            Example: {
+            Example:
+            ```python
+            {
                 "documents": {"handler": custom_handler}
             }
+            ```
         :raises ValueError: If the component is invalid or schema generation fails.
         """
         if not isinstance(component, Component):

--- a/haystack/tools/from_function.py
+++ b/haystack/tools/from_function.py
@@ -68,13 +68,16 @@ def create_tool_from_function(
         To intentionally leave the description empty, pass an empty string.
     :param inputs_from_state:
         Optional dictionary mapping state keys to tool parameter names.
-        Example: {"repository": "repo"} maps state's "repository" to tool's "repo" parameter.
+        Example: `{"repository": "repo"}` maps state's "repository" to tool's "repo" parameter.
     :param outputs_to_state:
         Optional dictionary defining how tool outputs map to state and message handling.
-        Example: {
+        Example:
+        ```python
+        {
             "documents": {"source": "docs", "handler": custom_handler},
             "message": {"source": "summary", "handler": format_summary}
         }
+        ```
     :returns:
         The Tool created from the function.
 

--- a/haystack/tools/tool.py
+++ b/haystack/tools/tool.py
@@ -41,7 +41,7 @@ class Tool:
         ```
     :param inputs_from_state:
         Optional dictionary mapping state keys to tool parameter names.
-        Example: {"repository": "repo"} maps state's "repository" to tool's "repo" parameter.
+        Example: `{"repository": "repo"}` maps state's "repository" to tool's "repo" parameter.
     :param outputs_to_state:
         Optional dictionary defining how tool outputs map to keys within state as well as optional handlers.
         If the source is provided only the specified output key is sent to the handler.


### PR DESCRIPTION
### Related Issues

- The build process using yarn for docusaurus on the generated pydocs markdown files failed because of errors

### Proposed Changes:

fix code examples in docstrings

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
