### PR TITLE
docs: fix < > tags in LLMEvaluator

### DIFF
--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -230,17 +230,17 @@ class LLMEvaluator:
 
         Combine instructions, inputs, outputs, and examples into one prompt template with the following format:
         Instructions:
-        <instructions>
+        `<instructions>`
 
         Generate the response in JSON format with the following keys:
-        <list of output keys>
+        `<list of output keys>`
         Consider the instructions and the examples below to determine those values.
 
         Examples:
-        <examples>
+        `<examples>`
 
         Inputs:
-        <inputs>
+        `<inputs>`
         Outputs:
 
         :returns:


### PR DESCRIPTION
### Related Issues

- fixes an issue with xml tags not rendered correctly in LLMEvaluator docs

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
