### PR TITLE
feat: Update sentence window retriever to add `source_id_meta_field`, `split_id_meta_field `, and `raise_on_missing_meta_fields `

### DIFF
--- a/releasenotes/notes/update-sentence-window-retriever-61435bc3d1c5f66b.yaml
+++ b/releasenotes/notes/update-sentence-window-retriever-61435bc3d1c5f66b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added `source_id_meta_field` and `split_id_meta_field` to `SentenceWindowRetriever` for customizable metadata field names.

--- a/releasenotes/notes/update-sentence-window-retriever-61435bc3d1c5f66b.yaml
+++ b/releasenotes/notes/update-sentence-window-retriever-61435bc3d1c5f66b.yaml
@@ -2,3 +2,4 @@
 features:
   - |
     Added `source_id_meta_field` and `split_id_meta_field` to `SentenceWindowRetriever` for customizable metadata field names.
+    Added `raise_on_missing_meta_fields` to control whether a ValueError is raised if any of the documents at runtime are missing the required meta fields (set to True by default). If False, then the documents missing the meta field will be skipped when retrieving their windows, but the original document will still be included in the results.

--- a/test/components/retrievers/test_sentence_window_retriever.py
+++ b/test/components/retrievers/test_sentence_window_retriever.py
@@ -81,6 +81,7 @@ class TestSentenceWindowRetriever:
                 "window_size": 3,
                 "source_id_meta_field": "source_id",
                 "split_id_meta_field": "split_id",
+                "raise_on_missing_meta_fields": True,
             },
         }
 
@@ -95,6 +96,7 @@ class TestSentenceWindowRetriever:
                 "window_size": 5,
                 "source_id_meta_field": "source_id_test",
                 "split_id_meta_field": "split_id_test",
+                "raise_on_missing_meta_fields": False,
             },
         }
         component = SentenceWindowRetriever.from_dict(data)
@@ -102,6 +104,7 @@ class TestSentenceWindowRetriever:
         assert component.window_size == 5
         assert component.source_id_meta_field == "source_id_test"
         assert component.split_id_meta_field == "split_id_test"
+        assert not component.raise_on_missing_meta_fields
 
     def test_from_dict_without_docstore(self):
         data = {"type": "SentenceWindowRetriever", "init_parameters": {}}

--- a/test/components/retrievers/test_sentence_window_retriever.py
+++ b/test/components/retrievers/test_sentence_window_retriever.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import random
 from unittest.mock import ANY
 
 import pytest
@@ -92,15 +93,15 @@ class TestSentenceWindowRetriever:
                     "init_parameters": {},
                 },
                 "window_size": 5,
-                "source_id_meta_field": "source_id",
-                "split_id_meta_field": "split_id",
+                "source_id_meta_field": "source_id_test",
+                "split_id_meta_field": "split_id_test",
             },
         }
         component = SentenceWindowRetriever.from_dict(data)
         assert isinstance(component.document_store, InMemoryDocumentStore)
         assert component.window_size == 5
-        assert component.source_id_meta_field == "source_id"
-        assert component.split_id_meta_field == "split_id"
+        assert component.source_id_meta_field == "source_id_test"
+        assert component.split_id_meta_field == "split_id_test"
 
     def test_from_dict_without_docstore(self):
         data = {"type": "SentenceWindowRetriever", "init_parameters": {}}
@@ -125,8 +126,10 @@ class TestSentenceWindowRetriever:
             Document(content="This is a text with some words. There is a ", meta={"id": "doc_0"}),
             Document(content="some words. There is a second sentence. And there is ", meta={"id": "doc_1"}),
         ]
-        with pytest.raises(ValueError):
-            retriever = SentenceWindowRetriever(document_store=InMemoryDocumentStore(), window_size=3)
+        with pytest.raises(ValueError, match="The retrieved documents must have 'split_id_test' in their metadata."):
+            retriever = SentenceWindowRetriever(
+                document_store=InMemoryDocumentStore(), window_size=3, split_id_meta_field="split_id_test"
+            )
             retriever.run(retrieved_documents=docs)
 
     def test_document_without_source_id(self):
@@ -136,8 +139,10 @@ class TestSentenceWindowRetriever:
                 content="some words. There is a second sentence. And there is ", meta={"id": "doc_1", "split_id": 1}
             ),
         ]
-        with pytest.raises(ValueError):
-            retriever = SentenceWindowRetriever(document_store=InMemoryDocumentStore(), window_size=3)
+        with pytest.raises(ValueError, match="The retrieved documents must have 'source_id_test' in their metadata."):
+            retriever = SentenceWindowRetriever(
+                document_store=InMemoryDocumentStore(), window_size=3, source_id_meta_field="source_id_test"
+            )
             retriever.run(retrieved_documents=docs)
 
     def test_run_invalid_window_size(self):
@@ -181,8 +186,6 @@ class TestSentenceWindowRetriever:
             )
             accumulated_length += len(content)
 
-        import random
-
         random.shuffle(docs)
 
         doc_store = InMemoryDocumentStore()
@@ -195,6 +198,39 @@ class TestSentenceWindowRetriever:
         # assert that the context documents are in the correct order
         assert len(result["context_documents"]) == 7
         assert [doc.meta["split_idx_start"] for doc in result["context_documents"]] == [11, 22, 33, 44, 55, 66, 77]
+
+    def test_run_custom_fields(self):
+        docs = []
+        accumulated_length = 0
+        for sent in range(10):
+            content = f"Sentence {sent}."
+            docs.append(
+                Document(
+                    content=content,
+                    meta={
+                        "id": f"doc_{sent}",
+                        # Missing split_idx_start
+                        "source_id_test": "source1",
+                        "split_id_test": sent,
+                    },
+                )
+            )
+            accumulated_length += len(content)
+
+        random.shuffle(docs)
+
+        doc_store = InMemoryDocumentStore()
+        doc_store.write_documents(docs)
+        retriever = SentenceWindowRetriever(
+            document_store=doc_store,
+            window_size=3,
+            source_id_meta_field="source_id_test",
+            split_id_meta_field="split_id_test",
+        )
+
+        # run the retriever with a document whose content = "Sentence 4."
+        result = retriever.run(retrieved_documents=[doc for doc in docs if doc.content == "Sentence 4."])
+        assert len(result["context_documents"]) == 7
 
     @pytest.mark.integration
     def test_run_with_pipeline(self):

--- a/test/components/retrievers/test_sentence_window_retriever.py
+++ b/test/components/retrievers/test_sentence_window_retriever.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import ANY
+
 import pytest
 
 from haystack import DeserializationError, Document, Pipeline
@@ -62,12 +64,24 @@ class TestSentenceWindowRetriever:
         window_retriever = SentenceWindowRetriever(InMemoryDocumentStore())
         data = window_retriever.to_dict()
 
-        assert data["type"] == "haystack.components.retrievers.sentence_window_retriever.SentenceWindowRetriever"
-        assert data["init_parameters"]["window_size"] == 3
-        assert (
-            data["init_parameters"]["document_store"]["type"]
-            == "haystack.document_stores.in_memory.document_store.InMemoryDocumentStore"
-        )
+        assert data == {
+            "type": "haystack.components.retrievers.sentence_window_retriever.SentenceWindowRetriever",
+            "init_parameters": {
+                "document_store": {
+                    "type": "haystack.document_stores.in_memory.document_store.InMemoryDocumentStore",
+                    "init_parameters": {
+                        "bm25_algorithm": "BM25L",
+                        "bm25_parameters": {},
+                        "bm25_tokenization_regex": "(?u)\\b\\w\\w+\\b",
+                        "embedding_similarity_function": "dot_product",
+                        "index": ANY,
+                    },
+                },
+                "window_size": 3,
+                "source_id_meta_field": "source_id",
+                "split_id_meta_field": "split_id",
+            },
+        }
 
     def test_from_dict(self):
         data = {
@@ -78,11 +92,15 @@ class TestSentenceWindowRetriever:
                     "init_parameters": {},
                 },
                 "window_size": 5,
+                "source_id_meta_field": "source_id",
+                "split_id_meta_field": "split_id",
             },
         }
         component = SentenceWindowRetriever.from_dict(data)
         assert isinstance(component.document_store, InMemoryDocumentStore)
         assert component.window_size == 5
+        assert component.source_id_meta_field == "source_id"
+        assert component.split_id_meta_field == "split_id"
 
     def test_from_dict_without_docstore(self):
         data = {"type": "SentenceWindowRetriever", "init_parameters": {}}


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9592

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Added `source_id_meta_field` and `split_id_meta_field` to `SentenceWindowRetriever` for customizable metadata field names.
- Added `raise_on_missing_meta_fields` to control whether a ValueError is raised if any of the documents at runtime are missing the required meta fields (set to True by default). If False, then the documents missing the meta field will be skipped when retrieving their windows, but the original document will still be included in the results. This was added based on feedback from @ju-gu since it's hard to guarantee all docs will definitely have these meta fields when working with 60 million + documents. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Updated tests
- Added tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
cc @ju-gu 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
