### PR TITLE
feat: add ImageContent dataclass to include images in ChatMessage + OpenAI support

### DIFF
--- a/docs/pydoc/config/data_classess_api.yml
+++ b/docs/pydoc/config/data_classess_api.yml
@@ -2,7 +2,7 @@ loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../../../haystack/dataclasses]
     modules:
-      ["answer", "byte_stream", "chat_message", "document", "sparse_embedding", "streaming_chunk"]
+      ["answer", "byte_stream", "chat_message", "document", "image_content", "sparse_embedding", "streaming_chunk"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter

--- a/docs/pydoc/config_docusaurus/data_classess_api.yml
+++ b/docs/pydoc/config_docusaurus/data_classess_api.yml
@@ -2,7 +2,7 @@ loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../../../haystack/dataclasses]
     modules:
-      ["answer", "byte_stream", "chat_message", "document", "sparse_embedding", "streaming_chunk"]
+      ["answer", "byte_stream", "chat_message", "document", "image_content", "sparse_embedding", "streaming_chunk"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter

--- a/haystack/dataclasses/__init__.py
+++ b/haystack/dataclasses/__init__.py
@@ -11,6 +11,7 @@ _import_structure = {
     "answer": ["Answer", "ExtractedAnswer", "GeneratedAnswer"],
     "byte_stream": ["ByteStream"],
     "chat_message": ["ChatMessage", "ChatRole", "TextContent", "ToolCall", "ToolCallResult"],
+    "image_content": ["ImageContent"],
     "document": ["Document"],
     "sparse_embedding": ["SparseEmbedding"],
     "state": ["State"],
@@ -37,6 +38,7 @@ if TYPE_CHECKING:
     from .chat_message import ToolCall as ToolCall
     from .chat_message import ToolCallResult as ToolCallResult
     from .document import Document as Document
+    from .image_content import ImageContent as ImageContent
     from .sparse_embedding import SparseEmbedding as SparseEmbedding
     from .streaming_chunk import AsyncStreamingCallbackT as AsyncStreamingCallbackT
     from .streaming_chunk import ComponentInfo as ComponentInfo

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 from haystack import logging
+from haystack.dataclasses.image_content import ImageContent
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +87,33 @@ class TextContent:
     text: str
 
 
-ChatMessageContentT = Union[TextContent, ToolCall, ToolCallResult]
+ChatMessageContentT = Union[TextContent, ToolCall, ToolCallResult, ImageContent]
+
+
+def _deserialize_content_part(part: Dict[str, Any]) -> ChatMessageContentT:
+    """
+    Deserialize a single content part of a serialized ChatMessage.
+
+    :param part:
+        A dictionary representing a single content part of a serialized ChatMessage.
+    :returns:
+        A ChatMessageContentT object.
+    :raises ValueError:
+        If the part is not a valid ChatMessageContentT object.
+    """
+    if "text" in part:
+        return TextContent(text=part["text"])
+    if "tool_call" in part:
+        return ToolCall(**part["tool_call"])
+    if "tool_call_result" in part:
+        result = part["tool_call_result"]["result"]
+        origin = ToolCall(**part["tool_call_result"]["origin"])
+        error = part["tool_call_result"]["error"]
+        tcr = ToolCallResult(result=result, origin=origin, error=error)
+        return tcr
+    if "image" in part:
+        return ImageContent(**part["image"])
+    raise ValueError(f"Unsupported content part in the serialized ChatMessage: `{part}`")
 
 
 def _deserialize_content(serialized_content: List[Dict[str, Any]]) -> List[ChatMessageContentT]:
@@ -99,30 +126,29 @@ def _deserialize_content(serialized_content: List[Dict[str, Any]]) -> List[ChatM
     :returns:
         Deserialized `content` field as a list of `ChatMessageContentT` objects.
     """
-    content: List[ChatMessageContentT] = []
+    return [_deserialize_content_part(part) for part in serialized_content]
 
-    for part in serialized_content:
-        if "text" in part:
-            content.append(TextContent(text=part["text"]))
-        elif "tool_call" in part:
-            content.append(ToolCall(**part["tool_call"]))
-        elif "tool_call_result" in part:
-            result = part["tool_call_result"]["result"]
-            origin = ToolCall(**part["tool_call_result"]["origin"])
-            error = part["tool_call_result"]["error"]
-            tcr = ToolCallResult(result=result, origin=origin, error=error)
-            content.append(tcr)
-        else:
-            raise ValueError(
-                f"Unsupported content part in the serialized ChatMessage: {part}. "
-                "The `content` field of the serialized ChatMessage must be a list of dictionaries, where each "
-                "dictionary contains one of these keys: 'text', 'tool_call', or 'tool_call_result'. "
-                f"Valid formats: [{{'text': 'Hello'}}, "
-                f"{{'tool_call': {{'tool_name': 'search', 'arguments': {{}}, 'id': 'call_123'}}}}, "
-                f"{{'tool_call_result': {{'result': 'data', 'origin': {{...}}, 'error': false}}}}]"
-            )
 
-    return content
+def _serialize_content_part(part: ChatMessageContentT) -> Dict[str, Any]:
+    """
+    Serialize a single content part of a ChatMessage.
+
+    :param part:
+        A ChatMessageContentT object.
+    :returns:
+        A dictionary representing the content part.
+    :raises TypeError:
+        If the part is not a valid ChatMessageContentT object.
+    """
+    if isinstance(part, TextContent):
+        return {"text": part.text}
+    elif isinstance(part, ToolCall):
+        return {"tool_call": asdict(part)}
+    elif isinstance(part, ToolCallResult):
+        return {"tool_call_result": asdict(part)}
+    elif isinstance(part, ImageContent):
+        return {"image": asdict(part)}
+    raise TypeError(f"Unsupported type in ChatMessage content: `{type(part).__name__}` for `{part}`.")
 
 
 @dataclass
@@ -252,6 +278,22 @@ class ChatMessage:
             return tool_call_results[0]
         return None
 
+    @property
+    def images(self) -> List[ImageContent]:
+        """
+        Returns the list of all images contained in the message.
+        """
+        return [content for content in self._content if isinstance(content, ImageContent)]
+
+    @property
+    def image(self) -> Optional[ImageContent]:
+        """
+        Returns the first image contained in the message.
+        """
+        if images := self.images:
+            return images[0]
+        return None
+
     def is_from(self, role: Union[ChatRole, str]) -> bool:
         """
         Check if the message is from a specific role.
@@ -264,16 +306,44 @@ class ChatMessage:
         return self._role == role
 
     @classmethod
-    def from_user(cls, text: str, meta: Optional[Dict[str, Any]] = None, name: Optional[str] = None) -> "ChatMessage":
+    def from_user(
+        cls,
+        text: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None,
+        name: Optional[str] = None,
+        *,
+        content_parts: Optional[Sequence[Union[TextContent, str, ImageContent]]] = None,
+    ) -> "ChatMessage":
         """
         Create a message from the user.
 
-        :param text: The text content of the message.
+        :param text: The text content of the message. Specify this or content_parts.
         :param meta: Additional metadata associated with the message.
         :param name: An optional name for the participant. This field is only supported by OpenAI.
+        :param content_parts: A list of content parts to include in the message. Specify this or text.
         :returns: A new ChatMessage instance.
         """
-        return cls(_role=ChatRole.USER, _content=[TextContent(text=text)], _meta=meta or {}, _name=name)
+        if not text and not content_parts:
+            raise ValueError("Either text or content_parts must be provided.")
+        if text and content_parts:
+            raise ValueError("Only one of text or content_parts can be provided.")
+
+        content: Sequence[Union[TextContent, ImageContent]] = []
+
+        if text is not None:
+            content = [TextContent(text=text)]
+        elif content_parts is not None:
+            content = [TextContent(el) if isinstance(el, str) else el for el in content_parts]
+            if not any(isinstance(el, TextContent) for el in content):
+                raise ValueError("The user message must contain at least one textual part.")
+
+            unsupported_parts = [el for el in content if not isinstance(el, (ImageContent, TextContent))]
+            if unsupported_parts:
+                raise ValueError(
+                    f"The user message must contain only text or image parts. Unsupported parts: {unsupported_parts}"
+                )
+
+        return cls(_role=ChatRole.USER, _content=content, _meta=meta or {}, _name=name)
 
     @classmethod
     def from_system(cls, text: str, meta: Optional[Dict[str, Any]] = None, name: Optional[str] = None) -> "ChatMessage":
@@ -343,18 +413,8 @@ class ChatMessage:
         serialized["role"] = self._role.value
         serialized["meta"] = self._meta
         serialized["name"] = self._name
-        content: List[Dict[str, Any]] = []
-        for part in self._content:
-            if isinstance(part, TextContent):
-                content.append({"text": part.text})
-            elif isinstance(part, ToolCall):
-                content.append({"tool_call": asdict(part)})
-            elif isinstance(part, ToolCallResult):
-                content.append({"tool_call_result": asdict(part)})
-            else:
-                raise TypeError(f"Unsupported type in ChatMessage content: `{type(part).__name__}` for `{part}`.")
 
-        serialized["content"] = content
+        serialized["content"] = [_serialize_content_part(part) for part in self._content]
         return serialized
 
     @classmethod
@@ -426,7 +486,9 @@ class ChatMessage:
                 "A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, or `ToolCallResult`."
             )
         if len(text_contents) + len(tool_call_results) > 1:
-            raise ValueError("A `ChatMessage` can only contain one `TextContent` or one `ToolCallResult`.")
+            raise ValueError(
+                "For OpenAI compatibility, a `ChatMessage` can only contain one `TextContent` or one `ToolCallResult`."
+            )
 
         openai_msg: Dict[str, Any] = {"role": self._role.value}
 
@@ -434,6 +496,31 @@ class ChatMessage:
         if self._name is not None:
             openai_msg["name"] = self._name
 
+        # user message
+        if openai_msg["role"] == "user":
+            if len(self._content) == 1:
+                openai_msg["content"] = self.text
+                return openai_msg
+
+            # if the user message contains a list of text and images, OpenAI expects a list of dictionaries
+            content = []
+            for part in self._content:
+                if isinstance(part, TextContent):
+                    content.append({"type": "text", "text": part.text})
+                elif isinstance(part, ImageContent):
+                    image_item: Dict[str, Any] = {
+                        "type": "image_url",
+                        # If no MIME type is provided, default to JPEG.
+                        # OpenAI API appears to tolerate MIME type mismatches.
+                        "image_url": {"url": f"data:{part.mime_type or 'image/jpeg'};base64,{part.base64_image}"},
+                    }
+                    if part.detail:
+                        image_item["image_url"]["detail"] = part.detail
+                    content.append(image_item)
+            openai_msg["content"] = content
+            return openai_msg
+
+        # tool message
         if tool_call_results:
             result = tool_call_results[0]
             openai_msg["content"] = result.result
@@ -441,15 +528,14 @@ class ChatMessage:
                 openai_msg["tool_call_id"] = result.origin.id
             elif require_tool_call_ids:
                 raise ValueError("`ToolCall` must have a non-null `id` attribute to be used with OpenAI.")
-
             # OpenAI does not provide a way to communicate errors in tool invocations, so we ignore the error field
             return openai_msg
 
+        # system and assistant messages
         if text_contents:
             openai_msg["content"] = text_contents[0]
         if tool_calls:
             openai_tool_calls = []
-
             for tc in tool_calls:
                 openai_tool_call = {
                     "type": "function",
@@ -461,7 +547,6 @@ class ChatMessage:
                 elif require_tool_call_ids:
                     raise ValueError("`ToolCall` must have a non-null `id` attribute to be used with OpenAI.")
                 openai_tool_calls.append(openai_tool_call)
-
             openai_msg["tool_calls"] = openai_tool_calls
         return openai_msg
 

--- a/haystack/dataclasses/image_content.py
+++ b/haystack/dataclasses/image_content.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+from dataclasses import dataclass, field
+from io import BytesIO
+from typing import Any, Dict, Literal, Optional
+
+import filetype
+
+from haystack import logging
+from haystack.lazy_imports import LazyImport
+from haystack.utils import is_in_jupyter
+
+with LazyImport("The 'show' method requires the 'PIL' library. Run 'pip install pillow'") as pillow_import:
+    from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+# NOTE: We have to rely on this since our util functions are using the bytestream object.
+#      We could change this to use the file path instead, where the file extension is used to determine the format.
+# This is a mapping of image formats to their MIME types.
+# from PIL import Image
+# Image.init()  # <- Must force all plugins to initialize to get this mapping
+# print(Image.MIME)
+FORMAT_TO_MIME = {
+    "BMP": "image/bmp",
+    "DIB": "image/bmp",
+    "PCX": "image/x-pcx",
+    "EPS": "application/postscript",
+    "GIF": "image/gif",
+    "PNG": "image/png",
+    "JPEG2000": "image/jp2",
+    "ICNS": "image/icns",
+    "ICO": "image/x-icon",
+    "JPEG": "image/jpeg",
+    "MPEG": "video/mpeg",
+    "TIFF": "image/tiff",
+    "MPO": "image/mpo",
+    "PALM": "image/palm",
+    "PDF": "application/pdf",
+    "PPM": "image/x-portable-anymap",
+    "PSD": "image/vnd.adobe.photoshop",
+    "SGI": "image/sgi",
+    "TGA": "image/x-tga",
+    "WEBP": "image/webp",
+    "XBM": "image/xbm",
+    "XPM": "image/xpm",
+}
+MIME_TO_FORMAT = {v: k for k, v in FORMAT_TO_MIME.items()}
+# Adding some common MIME types that are not in the PIL mapping
+MIME_TO_FORMAT["image/jpg"] = "JPEG"
+
+IMAGE_MIME_TYPES = set(MIME_TO_FORMAT.keys())
+
+
+@dataclass
+class ImageContent:
+    """
+    The image content of a chat message.
+
+    :param base64_image: A base64 string representing the image.
+    :param mime_type: The MIME type of the image (e.g. "image/png", "image/jpeg").
+        Providing this value is recommended, as most LLM providers require it.
+        If not provided, the MIME type is guessed from the base64 string, which can be slow and not always reliable.
+    :param detail: Optional detail level of the image (only supported by OpenAI). One of "auto", "high", or "low".
+    :param meta: Optional metadata for the image.
+    :param validation: If True (default), a validation process is performed:
+        - Check whether the base64 string is valid;
+        - Guess the MIME type if not provided;
+        - Check if the MIME type is a valid image MIME type.
+        Set to False to skip validation and speed up initialization.
+    """
+
+    base64_image: str
+    mime_type: Optional[str] = None
+    detail: Optional[Literal["auto", "high", "low"]] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
+    validation: bool = True
+
+    def __post_init__(self):
+        if not self.validation:
+            return
+
+        try:
+            decoded_image = base64.b64decode(self.base64_image, validate=True)
+        except Exception as e:
+            raise ValueError("The base64 string is not valid") from e
+
+        # mime_type is an important information, so we try to guess it if not provided
+        if not self.mime_type:
+            guess = filetype.guess(decoded_image)
+            if guess:
+                self.mime_type = guess.mime
+            else:
+                msg = (
+                    "Failed to guess the MIME type of the image. Omitting the MIME type may result in "
+                    "processing errors or incorrect handling of the image by LLM providers."
+                )
+                logger.warning(msg)
+
+        if self.mime_type and self.mime_type not in IMAGE_MIME_TYPES:
+            raise ValueError(f"{self.mime_type} is not a valid image MIME type.")
+
+    def __repr__(self) -> str:
+        """
+        Return a string representation of the ImageContent, truncating the base64_image to 100 bytes.
+        """
+        fields = []
+
+        truncated_data = self.base64_image[:100] + "..." if len(self.base64_image) > 100 else self.base64_image
+        fields.append(f"base64_image={truncated_data!r}")
+        fields.append(f"mime_type={self.mime_type!r}")
+        fields.append(f"detail={self.detail!r}")
+        fields.append(f"meta={self.meta!r}")
+        fields_str = ", ".join(fields)
+        return f"{self.__class__.__name__}({fields_str})"
+
+    def show(self) -> None:
+        """
+        Shows the image.
+        """
+        pillow_import.check()
+        image_bytes = BytesIO(base64.b64decode(self.base64_image))
+        image = Image.open(image_bytes)
+
+        if is_in_jupyter():
+            # ipython is not a core dependency so we cannot import it at the module level
+            from IPython.display import display
+
+            display(image)
+        else:
+            image.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
   "python-dateutil",
   "jsonschema",             # JsonSchemaValidator, Tool
   "docstring-parser",       # ComponentTool
+  "filetype",               # MIME type guessing for ImageContent
   "haystack-experimental",
 ]
 
@@ -95,6 +96,7 @@ dependencies = [
   "langdetect",                                       # TextLanguageRouter and DocumentLanguageClassifier
   "openai-whisper>=20231106",                         # LocalWhisperTranscriber
   "arrow>=1.3.0",                                     # Jinja2TimeExtension
+  "pillow",                                           # ImageContent
 
 
   # Converters

--- a/releasenotes/notes/multimodal-support-chatmessage-a4fa961db8af4e43.yaml
+++ b/releasenotes/notes/multimodal-support-chatmessage-a4fa961db8af4e43.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Chat Messages with the user role can now include images using the new `ImageContent` dataclass.
+
+    We've added image support to `OpenAIChatGenerator`, and plan to support more model providers over time.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 import logging
 import os
 from datetime import datetime
@@ -29,7 +30,7 @@ from haystack.components.generators.chat.openai import (
     _convert_chat_completion_chunk_to_streaming_chunk,
 )
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.dataclasses import ChatMessage, StreamingChunk, ToolCall, ToolCallDelta
+from haystack.dataclasses import ChatMessage, ChatRole, ImageContent, StreamingChunk, ToolCall, ToolCallDelta
 from haystack.tools import ComponentTool, Tool
 from haystack.tools.toolset import Toolset
 from haystack.utils.auth import Secret
@@ -745,6 +746,32 @@ class TestOpenAIChatGenerator:
         assert tool_call.tool_name == "weather"
         assert tool_call.arguments == {"city": "Paris"}
         assert message.meta["finish_reason"] == "tool_calls"
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run_multimodal(self, test_files_path):
+        image_path = test_files_path / "images" / "apple.jpg"
+        with open(image_path, "rb") as image_file:
+            base64_image = base64.b64encode(image_file.read()).decode("utf-8")
+
+        image_content = ImageContent(base64_image=base64_image, mime_type="image/jpeg", detail="low")
+        chat_messages = [ChatMessage.from_user(content_parts=["Describe the image in max 5 words", image_content])]
+
+        generator = OpenAIChatGenerator()
+        results = generator.run(chat_messages)
+
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+
+        assert message.text
+        assert "apple" in message.text.lower()
+
+        assert message.is_from(ChatRole.ASSISTANT)
+        assert not message.tool_calls
+        assert not message.tool_call_results
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -80,3 +80,8 @@ def spying_tracer() -> Generator[SpyingTracer, None, None]:
 
     # Make sure to disable tracing after the test to avoid affecting other tests
     tracing.disable_tracing()
+
+
+@pytest.fixture()
+def base64_image_string():
+    return "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII="

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from haystack.dataclasses.chat_message import ChatMessage, ChatRole, TextContent, ToolCall, ToolCallResult
+from haystack.dataclasses.image_content import ImageContent
 
 
 def test_tool_call_init():
@@ -43,6 +44,8 @@ def test_from_assistant_with_valid_content():
     assert not message.tool_call
     assert not message.tool_call_results
     assert not message.tool_call_result
+    assert not message.images
+    assert not message.image
 
 
 def test_from_assistant_with_tool_calls():
@@ -63,6 +66,8 @@ def test_from_assistant_with_tool_calls():
     assert not message.text
     assert not message.tool_call_results
     assert not message.tool_call_result
+    assert not message.images
+    assert not message.image
 
 
 def test_from_user_with_valid_content():
@@ -80,6 +85,8 @@ def test_from_user_with_valid_content():
     assert not message.tool_call
     assert not message.tool_call_results
     assert not message.tool_call_result
+    assert not message.images
+    assert not message.image
 
 
 def test_from_user_with_name():
@@ -89,6 +96,40 @@ def test_from_user_with_name():
     assert message.name == "John"
     assert message.role == ChatRole.USER
     assert message._content == [TextContent(text)]
+
+
+def test_from_user_fails_if_no_text_or_content_parts():
+    with pytest.raises(ValueError):
+        ChatMessage.from_user()
+
+
+def test_from_user_fails_if_text_and_content_parts():
+    with pytest.raises(ValueError):
+        ChatMessage.from_user(text="text", content_parts=[TextContent(text="text")])
+
+
+def test_from_user_with_content_parts(base64_image_string):
+    content_parts = [TextContent(text="text"), ImageContent(base64_image=base64_image_string)]
+    message = ChatMessage.from_user(content_parts=content_parts)
+
+    assert message.role == ChatRole.USER
+    assert message._content == content_parts
+
+    content_parts = ["text", ImageContent(base64_image=base64_image_string)]
+    message = ChatMessage.from_user(content_parts=content_parts)
+
+    assert message.role == ChatRole.USER
+    assert message._content == [TextContent(text="text"), ImageContent(base64_image=base64_image_string)]
+
+
+def test_from_user_with_content_parts_fails_if_no_textual_parts(base64_image_string):
+    with pytest.raises(ValueError):
+        ChatMessage.from_user(content_parts=[ImageContent(base64_image=base64_image_string)])
+
+
+def test_from_user_with_content_parts_fails_unsupported_parts():
+    with pytest.raises(ValueError):
+        ChatMessage.from_user(content_parts=["text part", ToolCall(id="123", tool_name="mytool", arguments={"a": 1})])
 
 
 def test_from_system_with_valid_content():
@@ -105,6 +146,8 @@ def test_from_system_with_valid_content():
     assert not message.tool_call
     assert not message.tool_call_results
     assert not message.tool_call_result
+    assert not message.images
+    assert not message.image
 
 
 def test_from_tool_with_valid_content():
@@ -124,6 +167,8 @@ def test_from_tool_with_valid_content():
     assert not message.tool_call
     assert not message.texts
     assert not message.text
+    assert not message.images
+    assert not message.image
 
 
 def test_multiple_text_segments():
@@ -157,7 +202,7 @@ def test_from_function_class_method_removed():
         ChatMessage.from_function("Result of function invocation", "my_function")
 
 
-def test_serde():
+def test_serde(base64_image_string):
     # the following message is created just for testing purposes and does not make sense in a real use case
 
     role = ChatRole.ASSISTANT
@@ -165,9 +210,12 @@ def test_serde():
     text_content = TextContent(text="Hello")
     tool_call = ToolCall(id="123", tool_name="mytool", arguments={"a": 1})
     tool_call_result = ToolCallResult(result="result", origin=tool_call, error=False)
+    image_content = ImageContent(
+        base64_image=base64_image_string, mime_type="image/png", detail="auto", meta={"key": "value"}, validation=True
+    )
     meta = {"some": "info"}
 
-    message = ChatMessage(_role=role, _content=[text_content, tool_call, tool_call_result], _meta=meta)
+    message = ChatMessage(_role=role, _content=[text_content, tool_call, tool_call_result, image_content], _meta=meta)
 
     serialized_message = message.to_dict()
     assert serialized_message == {
@@ -179,6 +227,15 @@ def test_serde():
                     "result": "result",
                     "error": False,
                     "origin": {"id": "123", "tool_name": "mytool", "arguments": {"a": 1}},
+                }
+            },
+            {
+                "image": {
+                    "base64_image": base64_image_string,
+                    "mime_type": "image/png",
+                    "detail": "auto",
+                    "meta": {"key": "value"},
+                    "validation": True,
                 }
             },
         ],
@@ -340,6 +397,60 @@ def test_to_openai_dict_format():
     assert message.to_openai_dict_format() == {"role": "assistant", "content": "I have an answer", "name": "Assistant1"}
 
 
+def test_to_openai_dict_format_system_message():
+    message = ChatMessage.from_system("You are good assistant")
+    assert message.to_openai_dict_format() == {"role": "system", "content": "You are good assistant"}
+
+
+def test_to_openai_dict_format_user_message():
+    message = ChatMessage.from_user("I have a question")
+    assert message.to_openai_dict_format() == {"role": "user", "content": "I have a question"}
+
+
+def test_to_openai_dict_format_multimodal_user_message(base64_image_string):
+    message = ChatMessage.from_user(
+        content_parts=[TextContent("I have a question"), ImageContent(base64_image=base64_image_string)]
+    )
+    assert message.to_openai_dict_format() == {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "I have a question"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{base64_image_string}"}},
+        ],
+    }
+
+
+def test_to_openai_dict_format_assistant_message():
+    message = ChatMessage.from_assistant(text="I have an answer", meta={"finish_reason": "stop"})
+    assert message.to_openai_dict_format() == {"role": "assistant", "content": "I have an answer"}
+
+    message = ChatMessage.from_assistant(
+        tool_calls=[ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})]
+    )
+    assert message.to_openai_dict_format() == {
+        "role": "assistant",
+        "tool_calls": [
+            {"id": "123", "type": "function", "function": {"name": "weather", "arguments": '{"city": "Paris"}'}}
+        ],
+    }
+
+
+def test_to_openai_dict_format_tool_message():
+    tool_result = json.dumps({"weather": "sunny", "temperature": "25"})
+    message = ChatMessage.from_tool(
+        tool_result=tool_result, origin=ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"})
+    )
+    assert message.to_openai_dict_format() == {"role": "tool", "content": tool_result, "tool_call_id": "123"}
+
+
+def test_to_openai_dict_format_with_name():
+    message = ChatMessage.from_user(text="I have a question", name="John")
+    assert message.to_openai_dict_format() == {"role": "user", "content": "I have a question", "name": "John"}
+
+    message = ChatMessage.from_assistant(text="I have an answer", name="Assistant1")
+    assert message.to_openai_dict_format() == {"role": "assistant", "content": "I have an answer", "name": "Assistant1"}
+
+
 def test_to_openai_dict_format_invalid():
     message = ChatMessage(_role=ChatRole.ASSISTANT, _content=[])
     with pytest.raises(ValueError):
@@ -349,6 +460,15 @@ def test_to_openai_dict_format_invalid():
         _role=ChatRole.ASSISTANT,
         _content=[TextContent(text="I have an answer"), TextContent(text="I have another answer")],
     )
+    with pytest.raises(ValueError):
+        message.to_openai_dict_format()
+
+    tool_call_null_id = ToolCall(id=None, tool_name="weather", arguments={"city": "Paris"})
+    message = ChatMessage.from_assistant(tool_calls=[tool_call_null_id])
+    with pytest.raises(ValueError):
+        message.to_openai_dict_format()
+
+    message = ChatMessage.from_tool(tool_result="result", origin=tool_call_null_id)
     with pytest.raises(ValueError):
         message.to_openai_dict_format()
 

--- a/test/dataclasses/test_image_content.py
+++ b/test/dataclasses/test_image_content.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from haystack.dataclasses.image_content import ImageContent
+
+
+def test_image_content_init(base64_image_string):
+    image_content = ImageContent(
+        base64_image=base64_image_string, mime_type="image/png", detail="auto", meta={"key": "value"}
+    )
+    assert image_content.base64_image == base64_image_string
+    assert image_content.mime_type == "image/png"
+    assert image_content.detail == "auto"
+    assert image_content.meta == {"key": "value"}
+    assert image_content.validation
+
+
+def test_image_content_init_with_invalid_base64_string():
+    with pytest.raises(ValueError):
+        ImageContent(base64_image="invalid_base64_string")
+
+
+def test_image_content_init_with_invalid_base64_string_and_validation_false():
+    image_content = ImageContent(base64_image="invalid_base64_string", validation=False)
+    assert image_content.base64_image == "invalid_base64_string"
+    assert image_content.mime_type is None
+    assert image_content.detail is None
+    assert image_content.meta == {}
+    assert not image_content.validation
+
+
+def test_image_content_init_with_invalid_mime_type(test_files_path, base64_image_string):
+    with pytest.raises(ValueError):
+        ImageContent(base64_image=base64_image_string, mime_type="text/xml")
+
+    with open(test_files_path / "docx" / "sample_docx.docx", "rb") as docx_file:
+        docx_base64 = base64.b64encode(docx_file.read()).decode("utf-8")
+    with pytest.raises(ValueError):
+        ImageContent(base64_image=docx_base64)
+
+
+def test_image_content_init_with_invalid_mime_type_and_validation_false(test_files_path, base64_image_string):
+    image_content = ImageContent(base64_image=base64_image_string, mime_type="text/xml", validation=False)
+    assert image_content.base64_image == base64_image_string
+    assert image_content.mime_type == "text/xml"
+    assert image_content.detail is None
+    assert image_content.meta == {}
+    assert not image_content.validation
+
+    with open(test_files_path / "docx" / "sample_docx.docx", "rb") as docx_file:
+        docx_base64 = base64.b64encode(docx_file.read()).decode("utf-8")
+    image_content = ImageContent(base64_image=docx_base64, validation=False)
+    assert image_content.base64_image == docx_base64
+    assert image_content.mime_type is None
+    assert image_content.detail is None
+    assert image_content.meta == {}
+    assert not image_content.validation
+
+
+def test_image_content_mime_type_guessing(test_files_path):
+    image_path = test_files_path / "images" / "apple.jpg"
+    with open(image_path, "rb") as image_file:
+        base64_image = base64.b64encode(image_file.read()).decode("utf-8")
+    image_content = ImageContent(base64_image=base64_image)
+    assert image_content.mime_type == "image/jpeg"
+
+    # do not guess mime type if mime type is provided
+    image_content = ImageContent(base64_image=base64_image, mime_type="image/png")
+    assert image_content.mime_type == "image/png"
+
+
+def test_image_content_show_in_jupyter(test_files_path):
+    image_path = test_files_path / "images" / "apple.jpg"
+    with open(image_path, "rb") as image_file:
+        base64_image = base64.b64encode(image_file.read()).decode("utf-8")
+    image_content = ImageContent(base64_image=base64_image)
+
+    with (
+        patch("haystack.dataclasses.image_content.is_in_jupyter", return_value=True),
+        patch("IPython.display.display") as mock_display,
+    ):
+        image_content.show()
+
+        mock_display.assert_called_once()
+        displayed_image = mock_display.call_args[0][0]
+        assert isinstance(displayed_image, Image.Image)
+
+
+def test_image_content_show_outside_jupyter(test_files_path):
+    image_path = test_files_path / "images" / "apple.jpg"
+    with open(image_path, "rb") as image_file:
+        base64_image = base64.b64encode(image_file.read()).decode("utf-8")
+    image_content = ImageContent(base64_image=base64_image)
+
+    # mocking is_in_jupyter is not needed because we don't test in a Jupyter notebook
+    with patch.object(Image.Image, "show") as mock_show:
+        image_content.show()
+        mock_show.assert_called_once()

--- a/test/tools/test_parameters_schema_utils.py
+++ b/test/tools/test_parameters_schema_utils.py
@@ -125,6 +125,44 @@ TOOL_CALL_RESULT_SCHEMA = {
     "required": ["result", "origin", "error"],
 }
 
+IMAGE_CONTENT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "base64_image": {"type": "string", "description": "A base64 string representing the image."},
+        "meta": {
+            "type": "object",
+            "default": {},
+            "description": "Optional metadata for the image.",
+            "additionalProperties": True,
+        },
+        "mime_type": {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "default": None,
+            "description": 'The MIME type of the image (e.g. "image/png", "image/jpeg").\n'
+            "Providing this value is recommended, as most LLM providers require it.\n"
+            "If not provided, the MIME type is guessed from the base64 string, "
+            "which can be slow and not always reliable.",
+        },
+        "validation": {
+            "type": "boolean",
+            "default": True,
+            "description": "If True (default), a validation process is performed:\n"
+            "- Check whether the base64 string is valid;\n"
+            "- Guess the MIME type if not provided;\n"
+            "- Check if the MIME type is a valid image MIME type.\n"
+            "Set to False to skip validation and speed up initialization.",
+        },
+        "detail": {
+            "anyOf": [{"enum": ["auto", "high", "low"], "type": "string"}, {"type": "null"}],
+            "default": None,
+            "description": (
+                'Optional detail level of the image (only supported by OpenAI). One of "auto", "high", or "low".'
+            ),
+        },
+    },
+    "required": ["base64_image"],
+}
+
 CHAT_ROLE_SCHEMA = {
     "description": "Enumeration representing the roles within a chat.",
     "enum": ["user", "system", "assistant", "tool"],
@@ -143,6 +181,7 @@ CHAT_MESSAGE_SCHEMA = {
                     {"$ref": "#/$defs/TextContent"},
                     {"$ref": "#/$defs/ToolCall"},
                     {"$ref": "#/$defs/ToolCallResult"},
+                    {"$ref": "#/$defs/ImageContent"},
                 ]
             },
         },
@@ -205,6 +244,7 @@ CHAT_MESSAGE_SCHEMA = {
                 "ToolCall": TOOL_CALL_SCHEMA,
                 "ToolCallResult": TOOL_CALL_RESULT_SCHEMA,
                 "ChatRole": CHAT_ROLE_SCHEMA,
+                "ImageContent": IMAGE_CONTENT_SCHEMA,
             },
         ),
         (
@@ -223,6 +263,7 @@ CHAT_MESSAGE_SCHEMA = {
                 "ToolCall": TOOL_CALL_SCHEMA,
                 "ToolCallResult": TOOL_CALL_RESULT_SCHEMA,
                 "ChatRole": CHAT_ROLE_SCHEMA,
+                "ImageContent": IMAGE_CONTENT_SCHEMA,
             },
         ),
     ],


### PR DESCRIPTION
### Related Issues

- part of #9624

### Proposed Changes:
- start moving features from experimental:
  - `ImageContent` dataclass
  - `ChatMessage` adaptations
  - (OpenAI multimodal support derives from the previous points)

### How did you test it?
CI, new tests

### Notes for the reviewer
- I did not add `from_file_path` and `from_url` class methods, that internally use the image converters, to be added in a future PR.
- I renamed `ImageContent` `validate` attribute to `validation` since running tests I saw a warning that it shadows a Pydantic field (when used with `ComponentTool`), so I prefer to be on the safe side

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
