### PR TITLE
feat: Update MetadataRouter to also support routing of ByteStreams based on metadata

### DIFF
--- a/haystack/components/routers/metadata_router.py
+++ b/haystack/components/routers/metadata_router.py
@@ -2,9 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, Generic, List, Type, TypeVar, Union, cast
-
-from typing_extensions import TypeAlias
+from typing import Any, Dict, Generic, List, Type, TypeVar, cast
 
 from haystack import Document, component
 from haystack.dataclasses.byte_stream import ByteStream

--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -4,11 +4,12 @@
 
 from dataclasses import fields
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dateutil.parser
 
 from haystack.dataclasses import Document
+from haystack.dataclasses.byte_stream import ByteStream
 from haystack.errors import FilterError
 
 
@@ -21,7 +22,7 @@ def raise_on_invalid_filter_syntax(filters: Optional[Dict[str, Any]] = None) -> 
         raise FilterError(msg)
 
 
-def document_matches_filter(filters: Dict[str, Any], document: Document) -> bool:
+def document_matches_filter(filters: Dict[str, Any], document: Union[ByteStream, Document]) -> bool:
     """
     Return whether `filters` match the Document.
 
@@ -158,7 +159,7 @@ COMPARISON_OPERATORS = {
 }
 
 
-def _logic_condition(condition: Dict[str, Any], document: Document) -> bool:
+def _logic_condition(condition: Dict[str, Any], document: Union[ByteStream, Document]) -> bool:
     if "operator" not in condition:
         msg = f"'operator' key missing in {condition}"
         raise FilterError(msg)
@@ -170,7 +171,7 @@ def _logic_condition(condition: Dict[str, Any], document: Document) -> bool:
     return LOGICAL_OPERATORS[operator](document, conditions)
 
 
-def _comparison_condition(condition: Dict[str, Any], document: Document) -> bool:
+def _comparison_condition(condition: Dict[str, Any], document: Union[ByteStream, Document]) -> bool:
     if "field" not in condition:
         # 'field' key is only found in comparison dictionaries.
         # We assume this is a logic dictionary since it's not present.

--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -34,15 +34,15 @@ def document_matches_filter(filters: Dict[str, Any], document: Union[ByteStream,
     return _logic_condition(filters, document)
 
 
-def _and(document: Document, conditions: List[Dict[str, Any]]) -> bool:
+def _and(document: Union[ByteStream, Document], conditions: List[Dict[str, Any]]) -> bool:
     return all(_comparison_condition(condition, document) for condition in conditions)
 
 
-def _or(document: Document, conditions: List[Dict[str, Any]]) -> bool:
+def _or(document: Union[ByteStream, Document], conditions: List[Dict[str, Any]]) -> bool:
     return any(_comparison_condition(condition, document) for condition in conditions)
 
 
-def _not(document: Document, conditions: List[Dict[str, Any]]) -> bool:
+def _not(document: Union[ByteStream, Document], conditions: List[Dict[str, Any]]) -> bool:
     return not _and(document, conditions)
 
 


### PR DESCRIPTION
### Related Issues

- fixes #9612 

### Proposed Changes:

- Adds support for `ByteStream` to `MetadataRouter`

### How did you test it?

Added tests routing `ByteStream` inputs via `MetadataRouter`

### Notes for the reviewer

I am a bit unsure if this really is the best solution here. I appreciate any feedback and I'm happy to change my approach

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
