### PR TITLE
feat: extend ChatPromptBuilder to support string templates

### DIFF
--- a/haystack/components/builders/chat_prompt_builder.py
+++ b/haystack/components/builders/chat_prompt_builder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from copy import deepcopy
 from typing import Any, Dict, List, Literal, Optional, Set, Union
 
@@ -10,15 +11,30 @@ from jinja2.sandbox import SandboxedEnvironment
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses.chat_message import ChatMessage, ChatRole, TextContent
+from haystack.lazy_imports import LazyImport
 from haystack.utils import Jinja2TimeExtension
+from haystack.utils.jinja2_chat_extension import ChatMessageExtension, templatize_part
 
 logger = logging.getLogger(__name__)
+
+with LazyImport("Run 'pip install \"arrow>=1.3.0\"'") as arrow_import:
+    import arrow  # pylint: disable=unused-import
+
+NO_TEXT_ERROR_MESSAGE = "ChatMessages from {role} role must contain text. Received ChatMessage with no text: {message}"
+
+FILTER_NOT_ALLOWED_ERROR_MESSAGE = (
+    "The templatize_part filter cannot be used with a template containing a list of"
+    "ChatMessage objects. Use a string template or remove the templatize_part filter "
+    "from the template."
+)
 
 
 @component
 class ChatPromptBuilder:
     """
-    Renders a chat prompt from a template string using Jinja2 syntax.
+    Renders a chat prompt from a template using Jinja2 syntax.
+
+    A template can be a list of `ChatMessage` objects, or a special string, as shown in the usage examples.
 
     It constructs prompts using static or dynamic templates, which you can update for each pipeline run.
 
@@ -28,7 +44,7 @@ class ChatPromptBuilder:
 
     ### Usage examples
 
-    #### With static prompt template
+    #### Static ChatMessage prompt template
 
     ```python
     template = [ChatMessage.from_user("Translate to {{ target_language }}. Context: {{ snippet }}; Translation:")]
@@ -36,7 +52,7 @@ class ChatPromptBuilder:
     builder.run(target_language="spanish", snippet="I can't speak spanish.")
     ```
 
-    #### Overriding static template at runtime
+    #### Overriding static ChatMessage template at runtime
 
     ```python
     template = [ChatMessage.from_user("Translate to {{ target_language }}. Context: {{ snippet }}; Translation:")]
@@ -48,7 +64,7 @@ class ChatPromptBuilder:
     builder.run(target_language="spanish", snippet="I can't speak spanish.", template=summary_template)
     ```
 
-    #### With dynamic prompt template
+    #### Dynamic ChatMessage prompt template
 
     ```python
     from haystack.components.builders import ChatPromptBuilder
@@ -97,11 +113,34 @@ class ChatPromptBuilder:
     'total_tokens': 238}})]}}
     ```
 
+    #### String prompt template
+    ```python
+    from haystack.components.builders import ChatPromptBuilder
+    from haystack.dataclasses.image_content import ImageContent
+
+    template = \"\"\"
+    {% message role="system" %}
+    You are a helpful assistant.
+    {% endmessage %}
+
+    {% message role="user" %}
+    Hello! I am {{user_name}}. What's the difference between the following images?
+    {% for image in images %}
+    {{ image | templatize_part }}
+    {% endfor %}
+    {% endmessage %}
+    \"\"\"
+
+    images = [ImageContent.from_file_path("apple.jpg"), ImageContent.from_file_path("orange.jpg")]
+
+    builder = ChatPromptBuilder(template=template)
+    builder.run(user_name="John", images=images)
+    ```
     """
 
     def __init__(
         self,
-        template: Optional[List[ChatMessage]] = None,
+        template: Optional[Union[List[ChatMessage], str]] = None,
         required_variables: Optional[Union[List[str], Literal["*"]]] = None,
         variables: Optional[List[str]] = None,
     ):
@@ -109,7 +148,7 @@ class ChatPromptBuilder:
         Constructs a ChatPromptBuilder component.
 
         :param template:
-            A list of `ChatMessage` objects. The component looks for Jinja2 template syntax and
+            A list of `ChatMessage` objects or a string template. The component looks for Jinja2 template syntax and
             renders the prompt with the provided variables. Provide the template in either
             the `init` method` or the `run` method.
         :param required_variables:
@@ -123,26 +162,32 @@ class ChatPromptBuilder:
         """
         self._variables = variables
         self._required_variables = required_variables
-        self.required_variables = required_variables or []
         self.template = template
-        variables = variables or []
-        try:
-            # The Jinja2TimeExtension needs an optional dependency to be installed.
-            # If it's not available we can do without it and use the ChatPromptBuilder as is.
-            self._env = SandboxedEnvironment(extensions=[Jinja2TimeExtension])
-        except ImportError:
-            self._env = SandboxedEnvironment()
 
+        self._env = SandboxedEnvironment(extensions=[ChatMessageExtension])
+        self._env.filters["templatize_part"] = templatize_part
+        if arrow_import.is_successful():
+            self._env.add_extension(Jinja2TimeExtension)
+
+        extracted_variables = []
         if template and not variables:
-            for message in template:
-                if message.is_from(ChatRole.USER) or message.is_from(ChatRole.SYSTEM):
-                    # infer variables from template
-                    if message.text is None:
-                        raise ValueError(f"The provided ChatMessage has no text. ChatMessage: {message}")
-                    ast = self._env.parse(message.text)
-                    template_variables = meta.find_undeclared_variables(ast)
-                    variables += list(template_variables)
-        self.variables = variables
+            if isinstance(template, list):
+                for message in template:
+                    if message.is_from(ChatRole.USER) or message.is_from(ChatRole.SYSTEM):
+                        # infer variables from template
+                        if message.text is None:
+                            raise ValueError(NO_TEXT_ERROR_MESSAGE.format(role=message.role.value, message=message))
+                        if message.text and "templatize_part" in message.text:
+                            raise ValueError(FILTER_NOT_ALLOWED_ERROR_MESSAGE)
+                        ast = self._env.parse(message.text)
+                        template_variables = meta.find_undeclared_variables(ast)
+                        extracted_variables += list(template_variables)
+            elif isinstance(template, str):
+                ast = self._env.parse(template)
+                extracted_variables = list(meta.find_undeclared_variables(ast))
+
+        self.variables = variables or extracted_variables
+        self.required_variables = required_variables or []
 
         if len(self.variables) > 0 and required_variables is None:
             logger.warning(
@@ -163,7 +208,7 @@ class ChatPromptBuilder:
     @component.output_types(prompt=List[ChatMessage])
     def run(
         self,
-        template: Optional[List[ChatMessage]] = None,
+        template: Optional[Union[List[ChatMessage], str]] = None,
         template_variables: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
@@ -175,7 +220,8 @@ class ChatPromptBuilder:
         To overwrite pipeline kwargs, you can set the `template_variables` parameter.
 
         :param template:
-            An optional list of `ChatMessage` objects to overwrite ChatPromptBuilder's default template.
+            An optional list of `ChatMessage` objects or string template to overwrite ChatPromptBuilder's default
+            template.
             If `None`, the default template provided at initialization is used.
         :param template_variables:
             An optional dictionary of template variables to overwrite the pipeline variables.
@@ -200,7 +246,7 @@ class ChatPromptBuilder:
                 f"Please provide a valid list of ChatMessage instances to render the prompt."
             )
 
-        if not all(isinstance(message, ChatMessage) for message in template):
+        if isinstance(template, list) and not all(isinstance(message, ChatMessage) for message in template):
             raise ValueError(
                 f"The {self.__class__.__name__} expects a list containing only ChatMessage instances. "
                 f"The provided list contains other types. Please ensure that all elements in the list "
@@ -208,21 +254,47 @@ class ChatPromptBuilder:
             )
 
         processed_messages = []
-        for message in template:
-            if message.is_from(ChatRole.USER) or message.is_from(ChatRole.SYSTEM):
-                self._validate_variables(set(template_variables_combined.keys()))
-                if message.text is None:
-                    raise ValueError(f"The provided ChatMessage has no text. ChatMessage: {message}")
-                compiled_template = self._env.from_string(message.text)
-                rendered_text = compiled_template.render(template_variables_combined)
-                # deep copy the message to avoid modifying the original message
-                rendered_message: ChatMessage = deepcopy(message)
-                rendered_message._content = [TextContent(text=rendered_text)]
-                processed_messages.append(rendered_message)
-            else:
-                processed_messages.append(message)
+        if isinstance(template, list):
+            for message in template:
+                if message.is_from(ChatRole.USER) or message.is_from(ChatRole.SYSTEM):
+                    self._validate_variables(set(template_variables_combined.keys()))
+                    if message.text is None:
+                        raise ValueError(NO_TEXT_ERROR_MESSAGE.format(role=message.role.value, message=message))
+                    if message.text and "templatize_part" in message.text:
+                        raise ValueError(FILTER_NOT_ALLOWED_ERROR_MESSAGE)
+                    compiled_template = self._env.from_string(message.text)
+                    rendered_text = compiled_template.render(template_variables_combined)
+                    # deep copy the message to avoid modifying the original message
+                    rendered_message: ChatMessage = deepcopy(message)
+                    rendered_message._content = [TextContent(text=rendered_text)]
+                    processed_messages.append(rendered_message)
+                else:
+                    processed_messages.append(message)
+        elif isinstance(template, str):
+            self._validate_variables(set(template_variables_combined.keys()))
+            processed_messages = self._render_chat_messages_from_str_template(template, template_variables_combined)
 
         return {"prompt": processed_messages}
+
+    def _render_chat_messages_from_str_template(
+        self, template: str, template_variables: Dict[str, Any]
+    ) -> List[ChatMessage]:
+        """
+        Renders a chat message from a string template.
+
+        This must be used in conjunction with the `ChatMessageExtension` Jinja2 extension
+        and the `templatize_part` filter.
+        """
+        compiled_template = self._env.from_string(template)
+        rendered = compiled_template.render(template_variables)
+
+        messages = []
+        for line in rendered.strip().split("\n"):
+            line = line.strip()
+            if line:
+                messages.append(ChatMessage.from_dict(json.loads(line)))
+
+        return messages
 
     def _validate_variables(self, provided_variables: Set[str]):
         """
@@ -252,10 +324,11 @@ class ChatPromptBuilder:
         :returns:
             Serialized dictionary representation of the component.
         """
-        if self.template is not None:
+        template: Optional[Union[List[Dict[str, Any]], str]] = None
+        if isinstance(self.template, list):
             template = [m.to_dict() for m in self.template]
-        else:
-            template = None
+        elif isinstance(self.template, str):
+            template = self.template
 
         return default_to_dict(
             self, template=template, variables=self._variables, required_variables=self._required_variables
@@ -275,6 +348,9 @@ class ChatPromptBuilder:
         init_parameters = data["init_parameters"]
         template = init_parameters.get("template")
         if template:
-            init_parameters["template"] = [ChatMessage.from_dict(d) for d in template]
+            if isinstance(template, list):
+                init_parameters["template"] = [ChatMessage.from_dict(d) for d in template]
+            elif isinstance(template, str):
+                init_parameters["template"] = template
 
         return default_from_dict(cls, data)

--- a/haystack/utils/jinja2_chat_extension.py
+++ b/haystack/utils/jinja2_chat_extension.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from typing import Any, Callable, List, Optional, Union, get_args
+
+from jinja2 import TemplateSyntaxError, nodes
+from jinja2.ext import Extension
+
+from haystack import logging
+from haystack.dataclasses.chat_message import (
+    ChatMessage,
+    ChatMessageContentT,
+    ChatRole,
+    ImageContent,
+    TextContent,
+    ToolCall,
+    ToolCallResult,
+    _deserialize_content_part,
+    _serialize_content_part,
+)
+
+logger = logging.getLogger(__name__)
+
+START_TAG = "<haystack_content_part>"
+END_TAG = "</haystack_content_part>"
+
+
+class ChatMessageExtension(Extension):
+    """
+    A Jinja2 extension for creating structured chat messages with mixed content types.
+
+    This extension provides a custom {% message %} tag that allows creating chat messages
+    with different attributes (role, name, meta) and mixed content types (text, images, etc.).
+
+    Inspired by [Banks](https://github.com/masci/banks).
+
+    Example:
+    {% message role="system" %}
+    You are a helpful assistant. You like to talk with {{user_name}}.
+    {% endmessage %}
+
+    {% message role="user" %}
+    Hello! I am {{user_name}}. Please describe the images.
+    {% for image in images %}
+    {{ image | templatize_part }}
+    {% endfor %}
+    {% endmessage %}
+
+    ### How it works
+    1. The {% message %} tag is used to define a chat message.
+    2. The message can contain text and other structured content parts.
+    3. To include a structured content part in the message, the `| templatize_part` filter is used.
+       The filter serializes the content part into a JSON string and wraps it in a `<haystack_content_part>` tag.
+    4. The `_build_chat_message_json` method of the extension parses the message content parts,
+       converts them into a ChatMessage object and serializes it to a JSON string.
+    5. The obtained JSON string is usable in the ChatPromptBuilder component, where templates are rendered to actual
+       ChatMessage objects.
+    """
+
+    SUPPORTED_ROLES = [role.value for role in ChatRole]
+
+    tags = {"message"}
+
+    def parse(self, parser: Any) -> Union[nodes.Node, List[nodes.Node]]:
+        """
+        Parse the message tag and its attributes in the Jinja2 template.
+
+        This method handles the parsing of role (mandatory), name (optional), meta (optional) and message body content.
+
+        :param parser: The Jinja2 parser instance
+        :return: A CallBlock node containing the parsed message configuration
+        :raises TemplateSyntaxError: If an invalid role is provided
+        """
+        lineno = next(parser.stream).lineno
+
+        # Parse role attribute (mandatory)
+        parser.stream.expect("name:role")
+        parser.stream.expect("assign")
+        role_expr = parser.parse_expression()
+
+        if isinstance(role_expr, nodes.Const):
+            role = role_expr.value
+            if role not in self.SUPPORTED_ROLES:
+                raise TemplateSyntaxError(f"Role must be one of: {', '.join(self.SUPPORTED_ROLES)}", lineno)
+
+        # Parse optional name attribute
+        name_expr = None
+        if parser.stream.current.test("name:name"):
+            parser.stream.skip()
+            parser.stream.expect("assign")
+            name_expr = parser.parse_expression()
+            if not isinstance(name_expr.value, str):
+                raise TemplateSyntaxError("name must be a string", lineno)
+
+        # Parse optional meta attribute
+        meta_expr = None
+        if parser.stream.current.test("name:meta"):
+            parser.stream.skip()
+            parser.stream.expect("assign")
+            meta_expr = parser.parse_expression()
+            if not isinstance(meta_expr, nodes.Dict):
+                raise TemplateSyntaxError("meta must be a dictionary", lineno)
+
+        # Parse message body
+        body = parser.parse_statements(("name:endmessage",), drop_needle=True)
+
+        # Build message node with all parameters
+        return nodes.CallBlock(
+            self.call_method(
+                name="_build_chat_message_json",
+                args=[role_expr, name_expr or nodes.Const(None), meta_expr or nodes.Dict([])],
+            ),
+            [],
+            [],
+            body,
+        ).set_lineno(lineno)
+
+    def _build_chat_message_json(self, role: str, name: Optional[str], meta: dict, caller: Callable[[], str]) -> str:
+        """
+        Build a ChatMessage object from template content and serialize it to a JSON string.
+
+        This method is called by Jinja2 when processing a {% message %} tag.
+        It takes the rendered content from the template, converts XML blocks into ChatMessageContentT objects,
+        creates a ChatMessage object and serializes it to a JSON string.
+
+        :param role: The role of the message
+        :param name: Optional name for the message sender
+        :param meta: Optional metadata dictionary
+        :param caller: Callable that returns the rendered content
+        :return: A JSON string representation of the ChatMessage object
+        """
+
+        content = caller()
+        parts = self._parse_content_parts(content)
+        if not parts:
+            raise ValueError(
+                f"Message template produced content that couldn't be parsed into any message parts. "
+                f"Content: '{content!r}'"
+            )
+
+        chat_message = self._validate_build_chat_message(parts=parts, role=role, meta=meta, name=name)
+
+        return json.dumps(chat_message.to_dict()) + "\n"
+
+    @staticmethod
+    def _parse_content_parts(content: str) -> List[ChatMessageContentT]:
+        """
+        Parse a string into a sequence of ChatMessageContentT objects.
+
+        This method handles:
+        - Plain text content, converted to TextContent objects
+        - Structured content parts wrapped in <haystack_content_part> tags, converted to ChatMessageContentT objects
+
+        :param content: Input string containing mixed text and content parts
+        :return: A list of ChatMessageContentT objects
+        :raises ValueError: If the content is empty or contains only whitespace characters or if a
+                            <haystack_content_part> tag is found without a matching closing tag.
+        """
+        if not content.strip():
+            raise ValueError(
+                f"Message content in template is empty or contains only whitespace characters. Content: {content!r}"
+            )
+
+        parts: List[ChatMessageContentT] = []
+        cursor = 0
+        total_length = len(content)
+
+        while cursor < total_length:
+            tag_start = content.find(START_TAG, cursor)
+
+            if tag_start == -1:
+                # No more tags, add remaining text if any
+                remaining_text = content[cursor:].strip()
+                if remaining_text:
+                    parts.append(TextContent(text=remaining_text))
+                break
+
+            # Add text before tag if any
+            if tag_start > cursor:
+                plain_text = content[cursor:tag_start].strip()
+                if plain_text:
+                    parts.append(TextContent(text=plain_text))
+
+            content_start = tag_start + len(START_TAG)
+            tag_end = content.find(END_TAG, content_start)
+
+            if tag_end == -1:
+                raise ValueError(
+                    f"Found unclosed <haystack_content_part> tag at position {tag_start}. "
+                    f"Content: '{content[tag_start : tag_start + 50]}...'"
+                )
+
+            json_content = content[content_start:tag_end]
+            data = json.loads(json_content)
+            parts.append(_deserialize_content_part(data))
+
+            cursor = tag_end + len(END_TAG)
+
+        return parts
+
+    @staticmethod
+    def _validate_build_chat_message(
+        parts: List[ChatMessageContentT], role: str, meta: dict, name: Optional[str] = None
+    ) -> ChatMessage:
+        """
+        Validate the parts of a chat message and build a ChatMessage object.
+
+        :param parts: Content parts of the message
+        :param role: The role of the message
+        :param meta: The metadata of the message
+        :param name: The optional name of the message
+        :return: A ChatMessage object
+
+        :raises ValueError: If content parts don't allow to build a valid ChatMessage object or the role is not
+                            supported
+        """
+
+        if role == "user":
+            valid_parts = [part for part in parts if isinstance(part, (TextContent, str, ImageContent))]
+            if len(parts) != len(valid_parts):
+                raise ValueError("User message must contain only TextContent, string or ImageContent parts.")
+            return ChatMessage.from_user(meta=meta, name=name, content_parts=valid_parts)
+
+        if role == "system":
+            if not isinstance(parts[0], TextContent):
+                raise ValueError("System message must contain a text part.")
+            text = parts[0].text
+            if len(parts) > 1:
+                raise ValueError("System message must contain only one text part.")
+            return ChatMessage.from_system(meta=meta, name=name, text=text)
+
+        if role == "assistant":
+            texts = [part.text for part in parts if isinstance(part, TextContent)]
+            tool_calls = [part for part in parts if isinstance(part, ToolCall)]
+            if len(texts) > 1:
+                raise ValueError("Assistant message must contain one text part at most.")
+            if len(texts) == 0 and len(tool_calls) == 0:
+                raise ValueError("Assistant message must contain at least one text or tool call part.")
+            if len(parts) > len(texts) + len(tool_calls):
+                raise ValueError("Assistant message must contain only text or tool call parts.")
+            return ChatMessage.from_assistant(
+                meta=meta, name=name, text=texts[0] if texts else None, tool_calls=tool_calls or None
+            )
+
+        if role == "tool":
+            tool_call_results = [part for part in parts if isinstance(part, ToolCallResult)]
+            if len(tool_call_results) == 0 or len(tool_call_results) > 1 or len(parts) > len(tool_call_results):
+                raise ValueError("Tool message must contain only one tool call result.")
+
+            tool_result = tool_call_results[0].result
+            origin = tool_call_results[0].origin
+            error = tool_call_results[0].error
+
+            return ChatMessage.from_tool(meta=meta, tool_result=tool_result, origin=origin, error=error)
+
+        raise ValueError(f"Unsupported role: {role}")
+
+
+def templatize_part(value: ChatMessageContentT) -> str:
+    """
+    Jinja filter to convert an ChatMessageContentT object into JSON string wrapped in special XML content tags.
+
+    :param value: The ChatMessageContentT object to convert
+    :return: A JSON string wrapped in special XML content tags
+    :raises ValueError: If the value is not an instance of ChatMessageContentT
+    """
+    chat_message_content_types = get_args(ChatMessageContentT)
+    if not isinstance(value, chat_message_content_types):
+        chat_message_content_types_str = ", ".join([t.__name__ for t in chat_message_content_types])
+        raise ValueError(
+            f"Value must be an instance of one of the following types: {chat_message_content_types_str}. "
+            f"Got: {type(value).__name__}"
+        )
+    return f"{START_TAG}{json.dumps(_serialize_content_part(value))}{END_TAG}"

--- a/releasenotes/notes/chat-prompt-builder-string-template-2405242a8aad2967.yaml
+++ b/releasenotes/notes/chat-prompt-builder-string-template-2405242a8aad2967.yaml
@@ -1,0 +1,27 @@
+---
+features:
+  - |
+    `ChatPromptBuilder` now supports special string templates in addition to a list of `ChatMessage` objects.
+
+    This new format is more flexible and allows to include structured parts like images in the templatized
+    `ChatMessage`.
+
+    ```python
+    from haystack.components.builders import ChatPromptBuilder
+    from haystack.dataclasses.chat_message import ImageContent
+
+    template = """
+    {% message role="user" %}
+    Hello! I am {{user_name}}. What's the difference between the following images?
+    {% for image in images %}
+    {{ image | templatize_part }}
+    {% endfor %}
+    {% endmessage %}
+    """
+
+    images=[ImageContent.from_file_path("apple-fruit.jpg"),
+            ImageContent.from_file_path("apple-logo.jpg")]
+
+    builder = ChatPromptBuilder(template=template)
+    builder.run(user_name="John", images=images)
+    ```

--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import arrow
 import pytest
@@ -12,7 +12,7 @@ from jinja2 import TemplateSyntaxError
 from haystack import component
 from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
 from haystack.core.pipeline.pipeline import Pipeline
-from haystack.dataclasses.chat_message import ChatMessage
+from haystack.dataclasses.chat_message import ChatMessage, ImageContent
 from haystack.dataclasses.document import Document
 
 
@@ -33,7 +33,7 @@ class TestChatPromptBuilder:
         # we have inputs that contain: template, template_variables + inferred variables
         inputs = builder.__haystack_input__._sockets_dict
         assert set(inputs.keys()) == {"template", "template_variables", "variable", "variable2"}
-        assert inputs["template"].type == Optional[List[ChatMessage]]
+        assert inputs["template"].type == Optional[Union[List[ChatMessage], str]]
         assert inputs["template_variables"].type == Optional[Dict[str, Any]]
         assert inputs["variable"].type == Any
         assert inputs["variable2"].type == Any
@@ -54,7 +54,7 @@ class TestChatPromptBuilder:
         # we have inputs that contain: template, template_variables + variables
         inputs = builder.__haystack_input__._sockets_dict
         assert set(inputs.keys()) == {"template", "template_variables", "var1", "var2"}
-        assert inputs["template"].type == Optional[List[ChatMessage]]
+        assert inputs["template"].type == Optional[Union[List[ChatMessage], str]]
         assert inputs["template_variables"].type == Optional[Dict[str, Any]]
         assert inputs["var1"].type == Any
         assert inputs["var2"].type == Any
@@ -76,7 +76,7 @@ class TestChatPromptBuilder:
         # we have inputs that contain: template, template_variables + inferred variables
         inputs = builder.__haystack_input__._sockets_dict
         assert set(inputs.keys()) == {"template", "template_variables", "variable"}
-        assert inputs["template"].type == Optional[List[ChatMessage]]
+        assert inputs["template"].type == Optional[Union[List[ChatMessage], str]]
         assert inputs["template_variables"].type == Optional[Dict[str, Any]]
         assert inputs["variable"].type == Any
 
@@ -97,7 +97,7 @@ class TestChatPromptBuilder:
         # we have inputs that contain: template, template_variables + variables
         inputs = builder.__haystack_input__._sockets_dict
         assert set(inputs.keys()) == {"template", "template_variables", "var1", "var2", "var3"}
-        assert inputs["template"].type == Optional[List[ChatMessage]]
+        assert inputs["template"].type == Optional[Union[List[ChatMessage], str]]
         assert inputs["template_variables"].type == Optional[Dict[str, Any]]
         assert inputs["var1"].type == Any
         assert inputs["var2"].type == Any
@@ -675,3 +675,265 @@ class TestChatPromptBuilderDynamic:
         assert comp.template is None
         assert comp._variables is None
         assert comp._required_variables is None
+
+    def test_chat_message_list_with_templatize_part_init_raises_error(self):
+        template = [ChatMessage.from_user("This is a {{ variable | templatize_part }}")]
+        with pytest.raises(ValueError, match="templatize_part filter cannot be used"):
+            ChatPromptBuilder(template=template)
+
+    def test_chat_message_list_with_templatize_part_run_raises_error(self):
+        builder = ChatPromptBuilder()
+        template = [ChatMessage.from_user("This is a {{ variable | templatize_part }}")]
+        with pytest.raises(ValueError, match="templatize_part filter cannot be used"):
+            builder.run(template=template, variable="test")
+
+
+class TestChatPromptBuilderWithStrTemplate:
+    def test_init(self):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template)
+
+        assert builder.template == template
+        assert builder._variables is None
+        assert builder._required_variables is None
+        assert builder.variables == ["name"]
+
+    def test_init_with_invalid_template(self):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}!
+        {% endmessage %}
+        """
+        with pytest.raises(TemplateSyntaxError):
+            ChatPromptBuilder(template=template)
+
+    def test_run(self):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template)
+        result = builder.run(name="John")
+        assert result["prompt"] == [ChatMessage.from_user("Hello, my name is John!")]
+
+    def test_run_template_variable(self):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template)
+        result = builder.run(template_variables={"name": "John"})
+        assert result["prompt"] == [ChatMessage.from_user("Hello, my name is John!")]
+
+    def test_run_template_variable_overrides_variable(self):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template)
+        result = builder.run(name="John", template_variables={"name": "Jane"})
+        assert result["prompt"] == [ChatMessage.from_user("Hello, my name is Jane!")]
+
+    def test_run_without_input(self):
+        template = """
+        {% message role="user" %}
+        Hello, my name is Lukas!
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template)
+        result = builder.run()
+        assert result["prompt"] == [ChatMessage.from_user("Hello, my name is Lukas!")]
+
+    def test_run_with_missing_input(self):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template)
+        result = builder.run()
+        assert result["prompt"] == [ChatMessage.from_user("Hello, my name is !")]
+
+    def test_run_with_missing_required_input(self):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template, required_variables=["name"])
+        with pytest.raises(ValueError):
+            builder.run()
+
+    def test_run_with_missing_required_input_using_star(self):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template, required_variables="*")
+        with pytest.raises(ValueError):
+            builder.run()
+
+    def test_run_with_variables_and_runtime_template(self):
+        variables = ["name"]
+
+        builder = ChatPromptBuilder(variables=variables)
+
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+        """
+        template_variables = {"name": "John"}
+
+        expected_result = {"prompt": [ChatMessage.from_user("Hello, my name is John!")]}
+
+        assert builder.run(template_variables=template_variables, template=template) == expected_result
+
+    def test_run_overwriting_default_template(self):
+        initial_template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=initial_template)
+
+        runtime_template = """
+        {% message role="user" %}
+        Hello, I come from {{country}}!
+        {% endmessage %}
+        """
+        result = builder.run(template_variables={"country": "Italy"}, template=runtime_template)
+        assert result["prompt"] == [ChatMessage.from_user("Hello, I come from Italy!")]
+
+    def test_run_with_name_and_meta(self):
+        template = """
+        {% message role="user" name="John" meta={"key": "value"} %}
+        Hello from {{country}}!
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template)
+        result = builder.run(country="Italy")
+        assert result["prompt"] == [ChatMessage.from_user("Hello from Italy!", name="John", meta={"key": "value"})]
+
+    def test_multiline_template(self):
+        template = """
+{% message role="user" %}
+Hello, my name is {{name}}!
+Second line.
+Third line.
+{% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template)
+        result = builder.run(name="John")
+        assert result["prompt"] == [ChatMessage.from_user("Hello, my name is John!\nSecond line.\nThird line.")]
+
+    def test_with_now_filter(self):
+        template = """
+        {% message role="user" %}
+        Hello, the date is {% now 'UTC', '%Y-%m-%d'%}!
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template)
+        result = builder.run()
+
+        expected_date = arrow.now("UTC").strftime("%Y-%m-%d")
+        assert result["prompt"] == [ChatMessage.from_user(f"Hello, the date is {expected_date}!")]
+
+    def test_run_multiple_messages(self):
+        template = """
+        {% message role="system" %}
+        You are a {{adjective}} assistant.
+        {% endmessage %}
+
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+
+        {% message role="assistant" %}
+        Hello, {{name}}! How can I help you today?
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template)
+        result = builder.run(name="John", adjective="helpful")
+        assert result["prompt"] == [
+            ChatMessage.from_system("You are a helpful assistant."),
+            ChatMessage.from_user("Hello, my name is John!"),
+            ChatMessage.from_assistant("Hello, John! How can I help you today?"),
+        ]
+
+    def test_run_multiple_images(self, base64_image_string):
+        template = """
+        {% message role="user" %}
+        Hello! I am {{user_name}}. What's the difference between the following images?
+        {% for image in images %}
+        {{ image | templatize_part }}
+        {% endfor %}
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(template=template)
+        images = [
+            ImageContent(base64_image=base64_image_string, mime_type="image/png"),
+            ImageContent(base64_image=base64_image_string, mime_type="image/png"),
+        ]
+        result = builder.run(user_name="John", images=images)
+
+        assert result["prompt"] == [
+            ChatMessage.from_user(
+                content_parts=["Hello! I am John. What's the difference between the following images?", *images]
+            )
+        ]
+
+    def test_to_dict(self):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+
+        {% message role="assistant" %}
+        Hello, I am {{assistant_name}}! How can I help you today?
+        {% endmessage %}
+        """
+        builder = ChatPromptBuilder(
+            template=template, variables=["name", "assistant_name"], required_variables=["name"]
+        )
+
+        assert builder.to_dict() == {
+            "type": "haystack.components.builders.chat_prompt_builder.ChatPromptBuilder",
+            "init_parameters": {
+                "template": template,
+                "variables": ["name", "assistant_name"],
+                "required_variables": ["name"],
+            },
+        }
+
+    def test_from_dict(self):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+
+        {% message role="assistant" %}
+        Hello, I am {{assistant_name}}! How can I help you today?
+        {% endmessage %}
+        """
+
+        data = {
+            "type": "haystack.components.builders.chat_prompt_builder.ChatPromptBuilder",
+            "init_parameters": {
+                "template": template,
+                "variables": ["name", "assistant_name"],
+                "required_variables": ["name"],
+            },
+        }
+        builder = ChatPromptBuilder.from_dict(data)
+        assert builder.template == template
+        assert builder.variables == ["name", "assistant_name"]
+        assert builder.required_variables == ["name"]

--- a/test/utils/test_jinja2_chat_extension.py
+++ b/test/utils/test_jinja2_chat_extension.py
@@ -1,0 +1,469 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from unittest.mock import patch
+
+import pytest
+from jinja2 import TemplateSyntaxError
+from jinja2.sandbox import SandboxedEnvironment
+
+from haystack.dataclasses.chat_message import ImageContent, ToolCall, ToolCallResult
+from haystack.utils.jinja2_chat_extension import ChatMessageExtension, templatize_part
+
+
+class TestChatMessageExtension:
+    @pytest.fixture
+    def jinja_env(self) -> SandboxedEnvironment:
+        # we use a SandboxedEnvironment here to replicate the conditions of the ChatPromptBuilder component
+        env = SandboxedEnvironment(extensions=[ChatMessageExtension])
+        env.filters["templatize_part"] = templatize_part
+        return env
+
+    def test_message_with_name_and_meta(self, jinja_env):
+        template = """
+        {% message role="user" name="Bob" meta={"language": "en"} %}
+        Hello!
+        {% endmessage %}
+        """
+        rendered = jinja_env.from_string(template).render()
+        output = json.loads(rendered.strip())
+        expected = {"role": "user", "name": "Bob", "content": [{"text": "Hello!"}], "meta": {"language": "en"}}
+        assert output == expected
+
+    def test_message_no_endmessage_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        Hello!
+        """
+        with pytest.raises(TemplateSyntaxError, match="Jinja was looking for the following tags: 'endmessage'"):
+            jinja_env.from_string(template).render()
+
+    def test_message_no_role_raises_error(self, jinja_env):
+        template = """
+        {% message %}
+        You are a helpful assistant.
+        {% endmessage %}
+        """
+        with pytest.raises(TemplateSyntaxError, match="expected token 'role'"):
+            jinja_env.from_string(template).render()
+
+    def test_message_meta_not_dict_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" meta="not a dict" %}
+        Hello!
+        {% endmessage %}
+        """
+        with pytest.raises(TemplateSyntaxError, match="meta must be a dictionary"):
+            jinja_env.from_string(template).render()
+
+    def test_message_meta_invalid_dict_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" meta={"key": "unclosed_value} %}
+        Hello!
+        {% endmessage %}
+        """
+        with pytest.raises(TemplateSyntaxError):
+            jinja_env.from_string(template).render()
+
+    def test_message_name_not_str_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" name=123 %}
+        Hello!
+        {% endmessage %}
+        """
+        with pytest.raises(TemplateSyntaxError, match="name must be a string"):
+            jinja_env.from_string(template).render()
+
+    def test_system_message(self, jinja_env):
+        template = """
+        {% message role="system" %}
+        You are a helpful assistant.
+        {% endmessage %}
+        """
+        rendered = jinja_env.from_string(template).render()
+        output = json.loads(rendered.strip())
+        expected = {"role": "system", "content": [{"text": "You are a helpful assistant."}], "name": None, "meta": {}}
+        assert output == expected
+
+    def test_user_message_with_variable(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        Hello, my name is {{name}}!
+        {% endmessage %}
+        """
+        rendered = jinja_env.from_string(template).render(name="Alice")
+        output = json.loads(rendered.strip())
+        expected = {"role": "user", "content": [{"text": "Hello, my name is Alice!"}], "name": None, "meta": {}}
+        assert output == expected
+
+    def test_assistant_message_with_tool_call(self, jinja_env):
+        template = """
+        {% message role="assistant" %}
+        Let me search for that information.
+        {{ tool_call | templatize_part }}
+        {% endmessage %}
+        """
+        tool_call = ToolCall(tool_name="search", arguments={"query": "an interesting question"}, id="search_1")
+        rendered = jinja_env.from_string(template).render(tool_call=tool_call)
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "assistant",
+            "content": [
+                {"text": "Let me search for that information."},
+                {
+                    "tool_call": {
+                        "tool_name": "search",
+                        "arguments": {"query": "an interesting question"},
+                        "id": "search_1",
+                    }
+                },
+            ],
+            "name": None,
+            "meta": {},
+        }
+        assert output == expected
+
+    def test_tool_message(self, jinja_env):
+        template = """
+        {% message role="tool" %}
+        {{ tool_result | templatize_part }}
+        {% endmessage %}
+        """
+        tool_call = ToolCall(tool_name="search", arguments={"query": "test"}, id="search_1")
+        tool_result = ToolCallResult(result="Here are the search results", origin=tool_call, error=False)
+        rendered = jinja_env.from_string(template).render(tool_result=tool_result)
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "tool",
+            "content": [
+                {
+                    "tool_call_result": {
+                        "result": "Here are the search results",
+                        "error": False,
+                        "origin": {"tool_name": "search", "arguments": {"query": "test"}, "id": "search_1"},
+                    }
+                }
+            ],
+            "name": None,
+            "meta": {},
+        }
+        assert output == expected
+
+    def test_user_message_with_image(self, jinja_env, base64_image_string):
+        template = """
+        {% message role="user" %}
+        Please describe this image:
+        {{ image | templatize_part }}
+        {% endmessage %}
+        """
+        image = ImageContent(base64_image=base64_image_string, mime_type="image/png")
+        rendered = jinja_env.from_string(template).render(image=image)
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "user",
+            "content": [
+                {"text": "Please describe this image:"},
+                {
+                    "image": {
+                        "base64_image": base64_image_string,
+                        "mime_type": "image/png",
+                        "detail": None,
+                        "meta": {},
+                        "validation": True,
+                    }
+                },
+            ],
+            "name": None,
+            "meta": {},
+        }
+        assert output == expected
+
+    def test_user_message_with_multiple_images(self, jinja_env, base64_image_string):
+        template = """
+        {% message role="user" %}
+        Compare these images:
+        {% for img in images %}
+        {{ img | templatize_part }}
+        {% endfor %}
+        {% endmessage %}
+        """
+        images = [
+            ImageContent(base64_image=base64_image_string, mime_type="image/png"),
+            ImageContent(base64_image=base64_image_string, mime_type="image/png"),
+        ]
+        rendered = jinja_env.from_string(template).render(images=images)
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "user",
+            "content": [
+                {"text": "Compare these images:"},
+                {
+                    "image": {
+                        "base64_image": base64_image_string,
+                        "mime_type": "image/png",
+                        "detail": None,
+                        "meta": {},
+                        "validation": True,
+                    }
+                },
+                {
+                    "image": {
+                        "base64_image": base64_image_string,
+                        "mime_type": "image/png",
+                        "detail": None,
+                        "meta": {},
+                        "validation": True,
+                    }
+                },
+            ],
+            "name": None,
+            "meta": {},
+        }
+        assert output == expected
+
+    def test_user_message_with_multiple_images_and_interleaved_text(self, jinja_env, base64_image_string):
+        """
+        Tests that messages with multiple images and interleaved text are rendered correctly.
+        This format is used by Anthropic models:
+        https://docs.anthropic.com/en/docs/build-with-claude/vision#example-multiple-images
+        """
+        template = """
+        {% message role="user" %}
+        {% for image in images %}
+        Image {{ loop.index }}:
+        {{ image | templatize_part }}
+        {% endfor %}
+        What's the difference between the two images?
+        {% endmessage %}
+        """
+        image = ImageContent(base64_image=base64_image_string, mime_type="image/png")
+        rendered = jinja_env.from_string(template).render(images=[image, image])
+        output = json.loads(rendered.strip())
+
+        expected = {
+            "role": "user",
+            "content": [
+                {"text": "Image 1:"},
+                {
+                    "image": {
+                        "base64_image": base64_image_string,
+                        "mime_type": "image/png",
+                        "detail": None,
+                        "meta": {},
+                        "validation": True,
+                    }
+                },
+                {"text": "Image 2:"},
+                {
+                    "image": {
+                        "base64_image": base64_image_string,
+                        "mime_type": "image/png",
+                        "detail": None,
+                        "meta": {},
+                        "validation": True,
+                    }
+                },
+                {"text": "What's the difference between the two images?"},
+            ],
+            "name": None,
+            "meta": {},
+        }
+        assert output == expected
+
+    def test_user_message_multiple_lines(self, jinja_env):
+        template = """
+{% message role="user" %}
+What do you think of NLP?
+It's an interesting domain, if you ask me.
+But my favorite subject is Small Language Models.
+{% endmessage %}
+        """
+        rendered = jinja_env.from_string(template).render()
+        output = json.loads(rendered.strip())
+        expected = {
+            "role": "user",
+            "content": [
+                {
+                    "text": (
+                        "What do you think of NLP?\nIt's an interesting domain, if you ask me.\n"
+                        "But my favorite subject is Small Language Models."
+                    )
+                }
+            ],
+            "name": None,
+            "meta": {},
+        }
+        assert output == expected
+
+    def test_invalid_role(self, jinja_env):
+        template = """
+        {% message role="invalid_role" %}
+        This should fail
+        {% endmessage %}
+        """
+        with pytest.raises(TemplateSyntaxError, match="Role must be one of"):
+            jinja_env.from_string(template).render()
+
+    def test_templatize_part_filter_with_invalid_type(self):
+        with pytest.raises(ValueError, match="Value must be an instance of one of the following types"):
+            templatize_part(123)
+
+    def test_empty_message_content_raises_error(self, jinja_env):
+        error_message = "Message content in template is empty or contains only whitespace characters."
+
+        template = "{% message role='user' %}{% endmessage %}"
+        with pytest.raises(ValueError, match=error_message):
+            jinja_env.from_string(template).render()
+
+        template = "{% message role='user' %}  \n\t\n\t  {% endmessage %}"
+        with pytest.raises(ValueError, match=error_message):
+            jinja_env.from_string(template).render()
+
+        template = """
+        {% message role="user" %}
+        {% if some_condition %}
+        {% else %}
+        {% endif %}
+        {% endmessage %}
+        """
+        with pytest.raises(ValueError, match=error_message):
+            jinja_env.from_string(template).render()
+
+        template = """
+        {% message role="user" %}
+        {{ variable_that_doesnt_exist }}
+        {% endmessage %}
+        """
+        with pytest.raises(ValueError, match=error_message):
+            jinja_env.from_string(template).render()
+
+    def test_message_no_parts_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        Something
+        {% endmessage %}
+        """
+
+        # I am patching the _parse_content_parts method to return an empty list
+        # because I could not find a template that raises a similar error
+        with patch("haystack.utils.jinja2_chat_extension.ChatMessageExtension._parse_content_parts", return_value=[]):
+            with pytest.raises(ValueError, match="message parts"):
+                jinja_env.from_string(template).render()
+
+    def test_message_with_whitespace_handling(self, jinja_env):
+        # the following templates should all be equivalent
+        templates = [
+            """{% message role="user" %}String{% endmessage %}""",
+            """{% message role="user" %}    String    {% endmessage %}""",
+            """{% message role="user" %}
+            String
+            {% endmessage %}""",
+            """{% message role="user" %}\tString\t{% endmessage %}""",
+        ]
+        expected = {"role": "user", "content": [{"text": "String"}], "name": None, "meta": {}}
+        for template in templates:
+            rendered = jinja_env.from_string(template).render()
+            output = json.loads(rendered.strip())
+            assert output == expected
+
+    def test_unclosed_content_tag_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        <haystack_content_part>{"type": "text", "text": "Hello"}
+        {% endmessage %}
+        """
+        with pytest.raises(ValueError, match="Found unclosed <haystack_content_part> tag"):
+            jinja_env.from_string(template).render()
+
+    def test_invalid_json_in_content_part_raises_error(self, jinja_env):
+        template = """
+        {% message role="user" %}
+        Normal text before.
+        <haystack_content_part>{"this is": "invalid" json}</haystack_content_part>
+        <haystack_content_part>not even trying to be json</haystack_content_part>
+        <haystack_content_part>{]</haystack_content_part>
+        Normal text after.
+        {% endmessage %}
+        """
+        with pytest.raises(json.JSONDecodeError):
+            jinja_env.from_string(template).render()
+
+    def test_invalid_system_message_raises_error(self, jinja_env, base64_image_string):
+        template = """
+        {% message role="system" %}
+        {{ image | templatize_part }}
+        {% endmessage %}
+        """
+        image = ImageContent(base64_image=base64_image_string, mime_type="image/png")
+        with pytest.raises(ValueError):
+            jinja_env.from_string(template).render(image=image)
+
+        template = """
+        {% message role="system" %}
+        Some text.
+        {{ image | templatize_part }}
+        {% endmessage %}
+        """
+        with pytest.raises(ValueError):
+            jinja_env.from_string(template).render(image=image)
+
+    def test_invalid_assistant_message_raises_error(self, jinja_env, base64_image_string):
+        template = """
+        {% message role="assistant" %}
+        text 1
+        {{ image | templatize_part }}
+        text 2
+        {% endmessage %}
+        """
+        image = ImageContent(base64_image=base64_image_string, mime_type="image/png")
+        with pytest.raises(ValueError):
+            jinja_env.from_string(template).render(image=image)
+
+        template = """
+        {% message role="assistant" %}
+        {{ image | templatize_part }}
+        {% endmessage %}
+        """
+        with pytest.raises(ValueError):
+            jinja_env.from_string(template).render(image=image)
+
+        template = """
+        {% message role="assistant" %}
+        text 1
+        {{ image | templatize_part }}
+        {% endmessage %}
+        """
+        with pytest.raises(ValueError):
+            jinja_env.from_string(template).render(image=image)
+
+    def test_invalid_tool_message_raises_error(self, jinja_env, base64_image_string):
+        template = """
+        {% message role="tool" %}
+        {{ image | templatize_part }}
+        {% endmessage %}
+        """
+        image = ImageContent(base64_image=base64_image_string, mime_type="image/png")
+        with pytest.raises(ValueError):
+            jinja_env.from_string(template).render(image=image)
+
+        template = """
+        {% message role="tool" %}
+        {{ tool_result | templatize_part }}
+        {{ tool_result | templatize_part }}
+        {% endmessage %}
+        """
+        tool_call = ToolCall(tool_name="search", arguments={"query": "test"}, id="search_1")
+        tool_result = ToolCallResult(result="Here are the search results", origin=tool_call, error=False)
+        with pytest.raises(ValueError):
+            jinja_env.from_string(template).render(tool_result=tool_result)
+
+        template = """
+        {% message role="tool" %}
+        {{ tool_result | templatize_part }}
+        {{ image | templatize_part }}
+        {% endmessage %}
+        """
+        with pytest.raises(ValueError):
+            jinja_env.from_string(template).render(image=image)


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
