### PR TITLE
feat: add `ImageContent` class methods

### DIFF
--- a/releasenotes/notes/image-content-class-methods-e8333e78a0fb14a2.yaml
+++ b/releasenotes/notes/image-content-class-methods-e8333e78a0fb14a2.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added convenience class methods to the `ImageContent` dataclass to create `ImageContent` objects from
+    file paths and URLs.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -754,13 +754,13 @@ class TestOpenAIChatGenerator:
     @pytest.mark.integration
     def test_live_run_multimodal(self, test_files_path):
         image_path = test_files_path / "images" / "apple.jpg"
-        with open(image_path, "rb") as image_file:
-            base64_image = base64.b64encode(image_file.read()).decode("utf-8")
 
-        image_content = ImageContent(base64_image=base64_image, mime_type="image/jpeg", detail="low")
-        chat_messages = [ChatMessage.from_user(content_parts=["Describe the image in max 5 words", image_content])]
+        # we resize the image to keep this test fast (around 1s) - increase the size in case of errors
+        image_content = ImageContent.from_file_path(file_path=image_path, size=(50, 50), detail="low")
 
-        generator = OpenAIChatGenerator()
+        chat_messages = [ChatMessage.from_user(content_parts=["What does this image show? Max 5 words", image_content])]
+
+        generator = OpenAIChatGenerator(model="gpt-4.1-nano")
         results = generator.run(chat_messages)
 
         assert len(results["replies"]) == 1


### PR DESCRIPTION
### Related Issues

- part of #9624

### Proposed Changes:

- add `ImageContent` class methods to convert file paths and URLs to `ImageContent` objects (moved from experimental)

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
