### PR TITLE
chore: `HuggingFaceAPIChatGenerator` - check if `ChatCompletionOutput.choices` is `None`

### DIFF
--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -526,7 +526,7 @@ class HuggingFaceAPIChatGenerator:
             messages=messages, tools=tools, **generation_kwargs
         )
 
-        if len(api_chat_output.choices) == 0:
+        if api_chat_output.choices is None or len(api_chat_output.choices) == 0:
             return {"replies": []}
 
         # n is unused, so the API always returns only one choice
@@ -593,7 +593,7 @@ class HuggingFaceAPIChatGenerator:
             messages=messages, tools=tools, **generation_kwargs
         )
 
-        if len(api_chat_output.choices) == 0:
+        if api_chat_output.choices is None or len(api_chat_output.choices) == 0:
             return {"replies": []}
 
         choice = api_chat_output.choices[0]


### PR DESCRIPTION
### Related Issues

- failing tutorial test: https://github.com/deepset-ai/haystack-tutorials/actions/runs/16431007196/job/46432251109#step:7:30
- the problem is that `ChatCompletionOutput.choices` is declared as `List[ChatCompletionOutputComplete]` in the spec but can sometimes be `None`

### Proposed Changes:
- check if `ChatCompletionOutput.choices` is `None` and return empty `replies` instead of raising an error

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
