### PR TITLE
feat: Add DocumentTypeRouter

### DIFF
--- a/docs/pydoc/config/routers_api.yml
+++ b/docs/pydoc/config/routers_api.yml
@@ -4,6 +4,7 @@ loaders:
     modules:
       [
         "conditional_router",
+        "document_type_router",
         "file_type_router",
         "llm_messages_router",
         "metadata_router",

--- a/docs/pydoc/config_docusaurus/routers_api.yml
+++ b/docs/pydoc/config_docusaurus/routers_api.yml
@@ -4,7 +4,9 @@ loaders:
     modules:
       [
         "conditional_router",
+        "document_type_router",
         "file_type_router",
+        "llm_messages_router",
         "metadata_router",
         "text_language_router",
         "transformers_text_router",

--- a/haystack/components/routers/__init__.py
+++ b/haystack/components/routers/__init__.py
@@ -9,6 +9,7 @@ from lazy_imports import LazyImporter
 
 _import_structure = {
     "conditional_router": ["ConditionalRouter"],
+    "document_type_router": ["DocumentTypeRouter"],
     "file_type_router": ["FileTypeRouter"],
     "llm_messages_router": ["LLMMessagesRouter"],
     "metadata_router": ["MetadataRouter"],
@@ -19,6 +20,7 @@ _import_structure = {
 
 if TYPE_CHECKING:
     from .conditional_router import ConditionalRouter as ConditionalRouter
+    from .document_type_router import DocumentTypeRouter as DocumentTypeRouter
     from .file_type_router import FileTypeRouter as FileTypeRouter
     from .llm_messages_router import LLMMessagesRouter as LLMMessagesRouter
     from .metadata_router import MetadataRouter as MetadataRouter

--- a/haystack/components/routers/document_type_router.py
+++ b/haystack/components/routers/document_type_router.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import mimetypes
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from haystack import component
+from haystack.components.routers.file_type_router import CUSTOM_MIMETYPES
+from haystack.dataclasses import Document
+
+
+@component
+class DocumentTypeRouter:
+    """
+    Routes documents by their MIME types.
+
+    DocumentTypeRouter is used to dynamically route documents within a pipeline based on their MIME types.
+    It supports exact MIME type matches and regex patterns.
+
+    MIME types can be extracted directly from document metadata or inferred from file paths using standard or
+    user-supplied MIME type mappings.
+
+    ### Usage example
+
+    ```python
+    from haystack.components.routers import DocumentTypeRouter
+    from haystack.dataclasses import Document
+
+    docs = [
+        Document(content="Example text", meta={"file_path": "example.txt"}),
+        Document(content="Another document", meta={"mime_type": "application/pdf"}),
+        Document(content="Unknown type")
+    ]
+
+    router = DocumentTypeRouter(
+        mime_type_meta_field="mime_type",
+        file_path_meta_field="file_path",
+        mime_types=["text/plain", "application/pdf"]
+    )
+
+    result = router.run(documents=docs)
+    print(result)
+    ```
+
+    Expected output:
+    ```python
+    {
+        "text/plain": [Document(...)],
+        "application/pdf": [Document(...)],
+        "unclassified": [Document(...)]
+    }
+    ```
+    """
+
+    def __init__(
+        self,
+        *,
+        mime_types: List[str],
+        mime_type_meta_field: Optional[str] = None,
+        file_path_meta_field: Optional[str] = None,
+        additional_mimetypes: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        Initialize the DocumentTypeRouter component.
+
+        :param mime_types:
+            A list of MIME types or regex patterns to classify the input documents.
+            (for example: `["text/plain", "audio/x-wav", "image/jpeg"]`).
+        :param mime_type_meta_field:
+            Optional name of the metadata field that holds the MIME type.
+        :param file_path_meta_field:
+            Optional name of the metadata field that holds the file path. Used to infer the MIME type if
+            `mime_type_meta_field` is not provided or missing in a document.
+        :param additional_mimetypes:
+            Optional dictionary mapping MIME types to file extensions to enhance or override the standard
+            `mimetypes` module. Useful when working with uncommon or custom file types.
+            For example: `{"application/vnd.custom-type": ".custom"}`.
+
+        :raises ValueError: If `mime_types` is empty or if both `mime_type_meta_field` and `file_path_meta_field` are
+            not provided.
+        """
+        if not mime_types:
+            raise ValueError("The list of mime types cannot be empty.")
+
+        if mime_type_meta_field is None and file_path_meta_field is None:
+            raise ValueError(
+                "At least one of 'mime_type_meta_field' or 'file_path_meta_field' must be provided to determine MIME "
+                "types."
+            )
+        self.mime_type_meta_field = mime_type_meta_field
+        self.file_path_meta_field = file_path_meta_field
+
+        if additional_mimetypes:
+            for mime, ext in additional_mimetypes.items():
+                mimetypes.add_type(mime, ext)
+
+        self._mime_type_patterns = []
+        for mime_type in mime_types:
+            try:
+                pattern = re.compile(mime_type)
+            except re.error:
+                raise ValueError(f"Invalid regex pattern '{mime_type}'.")
+            self._mime_type_patterns.append(pattern)
+
+        component.set_output_types(self, unclassified=List[Document], **dict.fromkeys(mime_types, List[Document]))
+        self.mime_types = mime_types
+        self.additional_mimetypes = additional_mimetypes
+
+    def run(self, documents: List[Document]) -> Dict[str, List[Document]]:
+        """
+        Categorize input documents into groups based on their MIME type.
+
+        MIME types can either be directly available in document metadata or derived from file paths using the
+        standard Python `mimetypes` module and custom mappings.
+
+        :param documents:
+            A list of documents to be categorized.
+
+        :returns:
+            A dictionary where the keys are MIME types (or `"unclassified"`) and the values are lists of documents.
+        """
+        mime_types = defaultdict(list)
+
+        for doc in documents:
+            mime_type = doc.meta.get(self.mime_type_meta_field) if self.mime_type_meta_field else None
+            file_path = doc.meta.get(self.file_path_meta_field) if self.file_path_meta_field else None
+
+            if mime_type is None and file_path:
+                # if mime_type is not provided, try to guess it from the file path
+                mime_type = self._get_mime_type(Path(file_path))
+
+            matched = False
+            if mime_type:
+                for pattern in self._mime_type_patterns:
+                    if pattern.fullmatch(mime_type):
+                        mime_types[pattern.pattern].append(doc)
+                        matched = True
+                        break
+            if not matched:
+                mime_types["unclassified"].append(doc)
+
+        return dict(mime_types)
+
+    def _get_mime_type(self, path: Path) -> Optional[str]:
+        """
+        Get the MIME type of the provided file path.
+
+        :param path: The file path to get the MIME type for.
+
+        :returns: The MIME type of the provided file path, or `None` if the MIME type cannot be determined.
+        """
+        extension = path.suffix.lower()
+        mime_type = mimetypes.guess_type(path.as_posix())[0]
+        # lookup custom mappings if the mime type is not found
+        return CUSTOM_MIMETYPES.get(extension, mime_type)

--- a/haystack/components/routers/document_type_router.py
+++ b/haystack/components/routers/document_type_router.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from haystack import component
-from haystack.components.routers.file_type_router import CUSTOM_MIMETYPES
 from haystack.dataclasses import Document
+from haystack.utils.misc import _guess_mime_type
 
 
 @component
@@ -131,7 +131,7 @@ class DocumentTypeRouter:
 
             if mime_type is None and file_path:
                 # if mime_type is not provided, try to guess it from the file path
-                mime_type = self._get_mime_type(Path(file_path))
+                mime_type = _guess_mime_type(Path(file_path))
 
             matched = False
             if mime_type:
@@ -144,16 +144,3 @@ class DocumentTypeRouter:
                 mime_types["unclassified"].append(doc)
 
         return dict(mime_types)
-
-    def _get_mime_type(self, path: Path) -> Optional[str]:
-        """
-        Get the MIME type of the provided file path.
-
-        :param path: The file path to get the MIME type for.
-
-        :returns: The MIME type of the provided file path, or `None` if the MIME type cannot be determined.
-        """
-        extension = path.suffix.lower()
-        mime_type = mimetypes.guess_type(path.as_posix())[0]
-        # lookup custom mappings if the mime type is not found
-        return CUSTOM_MIMETYPES.get(extension, mime_type)

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -12,6 +12,15 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
 from haystack.dataclasses import ByteStream
 
+CUSTOM_MIMETYPES = {
+    # we add markdown because it is not added by the mimetypes module
+    # see https://github.com/python/cpython/pull/17995
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
+    # we add msg because it is not added by the mimetypes module
+    ".msg": "application/vnd.ms-outlook",
+}
+
 
 @component
 class FileTypeRouter:

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -12,11 +12,10 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
 from haystack.dataclasses import ByteStream
 
+from haystack.utils.misc import _guess_mime_type  # ruff: isort: skip
+
 # We import CUSTOM_MIMETYPES here to prevent breaking change from moving to haystack.utils.misc
-from haystack.utils.misc import (
-    CUSTOM_MIMETYPES,  # pylint: disable=unused-import
-    _guess_mime_type,
-)
+from haystack.utils.misc import CUSTOM_MIMETYPES  # pylint: disable=unused-import
 
 
 @component

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -12,14 +12,11 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
 from haystack.dataclasses import ByteStream
 
-CUSTOM_MIMETYPES = {
-    # we add markdown because it is not added by the mimetypes module
-    # see https://github.com/python/cpython/pull/17995
-    ".md": "text/markdown",
-    ".markdown": "text/markdown",
-    # we add msg because it is not added by the mimetypes module
-    ".msg": "application/vnd.ms-outlook",
-}
+# We import CUSTOM_MIMETYPES here to prevent breaking change from moving to haystack.utils.misc
+from haystack.utils.misc import (
+    CUSTOM_MIMETYPES,  # pylint: disable=unused-import
+    _guess_mime_type,
+)
 
 
 @component
@@ -149,7 +146,7 @@ class FileTypeRouter:
                 source = Path(source)
 
             if isinstance(source, Path):
-                mime_type = ByteStream._guess_mime_type(source)
+                mime_type = _guess_mime_type(source)
             elif isinstance(source, ByteStream):
                 mime_type = source.mime_type
             else:

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -118,16 +118,10 @@ class ByteStream:
 
         :returns: The MIME type of the provided file path, or `None` if the MIME type cannot be determined.
         """
-        custom_mimetypes = {
-            # we add markdown because it is not added by the mimetypes module
-            # see https://github.com/python/cpython/pull/17995
-            ".md": "text/markdown",
-            ".markdown": "text/markdown",
-            # we add msg because it is not added by the mimetypes module
-            ".msg": "application/vnd.ms-outlook",
-        }
+        # Importing here to avoid circular imports
+        from haystack.components.routers.file_type_router import CUSTOM_MIMETYPES
 
         extension = path.suffix.lower()
         mime_type = mimetypes.guess_type(path.as_posix())[0]
         # lookup custom mappings if the mime type is not found
-        return custom_mimetypes.get(extension, mime_type)
+        return CUSTOM_MIMETYPES.get(extension, mime_type)

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import mimetypes
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+from haystack.utils.misc import _guess_mime_type
 
 
 @dataclass(repr=False)
@@ -48,7 +49,7 @@ class ByteStream:
         :param guess_mime_type: Whether to guess the mime type from the file.
         """
         if not mime_type and guess_mime_type:
-            mime_type = cls._guess_mime_type(filepath)
+            mime_type = _guess_mime_type(filepath)
         with open(filepath, "rb") as fd:
             return cls(data=fd.read(), mime_type=mime_type, meta=meta or {})
 
@@ -108,20 +109,3 @@ class ByteStream:
         :returns: A ByteStream instance.
         """
         return ByteStream(data=bytes(data["data"]), meta=data.get("meta", {}), mime_type=data.get("mime_type"))
-
-    @staticmethod
-    def _guess_mime_type(path: Path) -> Optional[str]:
-        """
-        Guess the MIME type of the provided file path.
-
-        :param path: The file path to get the MIME type for.
-
-        :returns: The MIME type of the provided file path, or `None` if the MIME type cannot be determined.
-        """
-        # Importing here to avoid circular imports
-        from haystack.components.routers.file_type_router import CUSTOM_MIMETYPES
-
-        extension = path.suffix.lower()
-        mime_type = mimetypes.guess_type(path.as_posix())[0]
-        # lookup custom mappings if the mime type is not found
-        return CUSTOM_MIMETYPES.get(extension, mime_type)

--- a/haystack/utils/misc.py
+++ b/haystack/utils/misc.py
@@ -2,9 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, List, Union, overload
+import mimetypes
+from pathlib import Path
+from typing import Any, List, Optional, Union, overload
 
 from numpy import exp, ndarray
+
+CUSTOM_MIMETYPES = {
+    # we add markdown because it is not added by the mimetypes module
+    # see https://github.com/python/cpython/pull/17995
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
+    # we add msg because it is not added by the mimetypes module
+    ".msg": "application/vnd.ms-outlook",
+}
 
 
 def expand_page_range(page_range: List[Union[str, int]]) -> List[int]:
@@ -56,3 +67,17 @@ def expit(x: Union[float, ndarray[Any, Any]]) -> Union[float, ndarray[Any, Any]]
     :param x: input value. Can be a scalar or a numpy array.
     """
     return 1 / (1 + exp(-x))
+
+
+def _guess_mime_type(path: Path) -> Optional[str]:
+    """
+    Guess the MIME type of the provided file path.
+
+    :param path: The file path to get the MIME type for.
+
+    :returns: The MIME type of the provided file path, or `None` if the MIME type cannot be determined.
+    """
+    extension = path.suffix.lower()
+    mime_type = mimetypes.guess_type(path.as_posix())[0]
+    # lookup custom mappings if the mime type is not found
+    return CUSTOM_MIMETYPES.get(extension, mime_type)

--- a/releasenotes/notes/doc-type-router-8ff863f493c2ce3c.yaml
+++ b/releasenotes/notes/doc-type-router-8ff863f493c2ce3c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add new component called DocumentTypeRouter which routes documents by their MIME types. MIME types can be extracted directly from document metadata or inferred from file paths using standard or user-supplied MIME type mappings.

--- a/test/components/routers/test_document_type_router.py
+++ b/test/components/routers/test_document_type_router.py
@@ -224,34 +224,6 @@ class TestDocumentTypeRouter:
         assert len(result["text/markdown"]) == 1
         assert len(result["application/vnd.ms-outlook"]) == 1
 
-    @patch("mimetypes.guess_type")
-    def test_get_mime_type_with_mocked_mimetypes(self, mock_guess_type):
-        mock_guess_type.return_value = ("text/plain", None)
-
-        router = DocumentTypeRouter(file_path_meta_field="file_path", mime_types=["text/plain"])
-
-        mime_type = router._get_mime_type(Path("test.txt"))
-        assert mime_type == "text/plain"
-        mock_guess_type.assert_called_once()
-
-    def test_get_mime_type_with_custom_extensions(self):
-        router = DocumentTypeRouter(file_path_meta_field="file_path", mime_types=["text/markdown"])
-
-        # Test markdown extension (should be in CUSTOM_MIMETYPES)
-        mime_type = router._get_mime_type(Path("readme.md"))
-        assert mime_type == "text/markdown"
-
-        # Test .msg extension
-        mime_type = router._get_mime_type(Path("email.msg"))
-        assert mime_type == "application/vnd.ms-outlook"
-
-    def test_get_mime_type_case_insensitive(self):
-        router = DocumentTypeRouter(file_path_meta_field="file_path", mime_types=["text/markdown"])
-
-        # Test uppercase extension
-        mime_type = router._get_mime_type(Path("README.MD"))
-        assert mime_type == "text/markdown"
-
     def test_serde_in_pipeline(self):
         document_type_router = DocumentTypeRouter(
             mime_type_meta_field="mime_type", mime_types=["text/plain", "application/pdf"]

--- a/test/components/routers/test_document_type_router.py
+++ b/test/components/routers/test_document_type_router.py
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from haystack import Pipeline
+from haystack.components.routers import DocumentTypeRouter
+from haystack.core.pipeline.base import component_from_dict, component_to_dict
+from haystack.dataclasses import Document
+
+
+class TestDocumentTypeRouter:
+    def test_init(self):
+        router = DocumentTypeRouter(
+            mime_type_meta_field="mime_type",
+            file_path_meta_field="file_path",
+            mime_types=["text/plain", "audio/x-wav", "image/jpeg"],
+            additional_mimetypes={"application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx"},
+        )
+        assert router.mime_types == ["text/plain", "audio/x-wav", "image/jpeg"]
+        assert router.mime_type_meta_field == "mime_type"
+        assert router.file_path_meta_field == "file_path"
+        assert router.additional_mimetypes == {
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx"
+        }
+
+    def test_init_fail_wo_mime_types(self):
+        with pytest.raises(ValueError, match="The list of mime types cannot be empty"):
+            DocumentTypeRouter(mime_type_meta_field="mime_type", mime_types=[])
+
+    def test_init_fail_wo_meta_fields(self):
+        with pytest.raises(
+            ValueError, match="At least one of 'mime_type_meta_field' or 'file_path_meta_field' must be provided"
+        ):
+            DocumentTypeRouter(mime_types=["text/plain"])
+
+    def test_init_with_invalid_regex(self):
+        with pytest.raises(ValueError, match="Invalid regex pattern"):
+            DocumentTypeRouter(mime_type_meta_field="mime_type", mime_types=["[Invalid-Regex"])
+
+    def test_to_dict(self):
+        router = DocumentTypeRouter(
+            mime_type_meta_field="mime_type",
+            file_path_meta_field="file_path",
+            mime_types=["text/plain", "audio/x-wav", "image/jpeg"],
+            additional_mimetypes={"application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx"},
+        )
+        expected_dict = {
+            "type": "haystack.components.routers.document_type_router.DocumentTypeRouter",
+            "init_parameters": {
+                "mime_type_meta_field": "mime_type",
+                "file_path_meta_field": "file_path",
+                "mime_types": ["text/plain", "audio/x-wav", "image/jpeg"],
+                "additional_mimetypes": {
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx"
+                },
+            },
+        }
+        assert component_to_dict(router, "router") == expected_dict
+
+    def test_from_dict(self):
+        router_dict = {
+            "type": "haystack.components.routers.document_type_router.DocumentTypeRouter",
+            "init_parameters": {
+                "mime_type_meta_field": "mime_type",
+                "file_path_meta_field": "file_path",
+                "mime_types": ["text/plain", "audio/x-wav", "image/jpeg"],
+                "additional_mimetypes": {
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx"
+                },
+            },
+        }
+        loaded_router = component_from_dict(DocumentTypeRouter, router_dict, name="router")
+
+        expected_router = DocumentTypeRouter(
+            mime_type_meta_field="mime_type",
+            file_path_meta_field="file_path",
+            mime_types=["text/plain", "audio/x-wav", "image/jpeg"],
+            additional_mimetypes={"application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx"},
+        )
+
+        assert loaded_router.mime_types == expected_router.mime_types
+        assert loaded_router.mime_type_meta_field == expected_router.mime_type_meta_field
+        assert loaded_router.file_path_meta_field == expected_router.file_path_meta_field
+        assert loaded_router.additional_mimetypes == expected_router.additional_mimetypes
+
+    def test_run_with_mime_type_meta_field(self):
+        docs = [
+            Document(content="Example text", meta={"mime_type": "text/plain"}),
+            Document(content="Another document", meta={"mime_type": "application/pdf"}),
+            Document(content="Audio content", meta={"mime_type": "audio/x-wav"}),
+            Document(content="Unknown type", meta={"mime_type": "application/unknown"}),
+        ]
+
+        router = DocumentTypeRouter(
+            mime_type_meta_field="mime_type", mime_types=["text/plain", "application/pdf", "audio/x-wav"]
+        )
+        result = router.run(documents=docs)
+
+        assert len(result["text/plain"]) == 1
+        assert len(result["application/pdf"]) == 1
+        assert len(result["audio/x-wav"]) == 1
+        assert len(result["unclassified"]) == 1
+        assert result["text/plain"][0].content == "Example text"
+        assert result["application/pdf"][0].content == "Another document"
+        assert result["audio/x-wav"][0].content == "Audio content"
+        assert result["unclassified"][0].content == "Unknown type"
+
+    def test_run_with_file_path_meta_field(self):
+        docs = [
+            Document(content="Example text", meta={"file_path": "example.txt"}),
+            Document(content="PDF document", meta={"file_path": "document.pdf"}),
+            Document(content="Markdown content", meta={"file_path": "readme.md"}),
+            Document(content="Unknown extension", meta={"file_path": "file.xyz"}),
+        ]
+
+        router = DocumentTypeRouter(
+            file_path_meta_field="file_path", mime_types=["text/plain", "application/pdf", "text/markdown"]
+        )
+        result = router.run(documents=docs)
+
+        assert len(result["text/plain"]) == 1
+        assert len(result["application/pdf"]) == 1
+        assert len(result["text/markdown"]) == 1
+        assert len(result["unclassified"]) == 1
+
+    def test_run_with_both_meta_fields(self):
+        docs = [
+            Document(
+                content="Text with explicit mime type", meta={"mime_type": "application/pdf", "file_path": "file.txt"}
+            ),
+            Document(content="Text inferred from path", meta={"file_path": "file.txt"}),
+        ]
+
+        router = DocumentTypeRouter(
+            mime_type_meta_field="mime_type",
+            file_path_meta_field="file_path",
+            mime_types=["text/plain", "application/pdf"],
+        )
+        result = router.run(documents=docs)
+
+        # First doc should be classified as PDF (explicit mime type)
+        assert len(result["application/pdf"]) == 1
+        assert result["application/pdf"][0].content == "Text with explicit mime type"
+
+        # Second doc should be classified as text/plain (inferred from .txt)
+        assert len(result["text/plain"]) == 1
+        assert result["text/plain"][0].content == "Text inferred from path"
+
+    def test_run_with_missing_metadata(self):
+        docs = [
+            Document(content="No metadata"),
+            Document(content="Empty meta", meta={}),
+            Document(content="Wrong meta field", meta={"other_field": "value"}),
+        ]
+
+        router = DocumentTypeRouter(mime_type_meta_field="mime_type", mime_types=["text/plain"])
+        result = router.run(documents=docs)
+
+        assert len(result["unclassified"]) == 3
+        assert "text/plain" not in result
+
+    def test_run_with_regex_patterns(self):
+        docs = [
+            Document(content="Plain text", meta={"mime_type": "text/plain"}),
+            Document(content="HTML text", meta={"mime_type": "text/html"}),
+            Document(content="Markdown text", meta={"mime_type": "text/markdown"}),
+            Document(content="JPEG image", meta={"mime_type": "image/jpeg"}),
+            Document(content="PNG image", meta={"mime_type": "image/png"}),
+            Document(content="PDF document", meta={"mime_type": "application/pdf"}),
+        ]
+
+        router = DocumentTypeRouter(mime_type_meta_field="mime_type", mime_types=[r"text/.*", r"image/.*"])
+        result = router.run(documents=docs)
+
+        assert len(result[r"text/.*"]) == 3
+        assert len(result[r"image/.*"]) == 2
+        assert len(result["unclassified"]) == 1
+
+    def test_run_with_exact_matching(self):
+        docs = [
+            Document(content="Plain text", meta={"mime_type": "text/plain"}),
+            Document(content="Markdown text", meta={"mime_type": "text/markdown"}),
+            Document(content="PDF document", meta={"mime_type": "application/pdf"}),
+        ]
+
+        router = DocumentTypeRouter(mime_type_meta_field="mime_type", mime_types=["text/plain", "application/pdf"])
+        result = router.run(documents=docs)
+
+        assert len(result["text/plain"]) == 1
+        assert len(result["application/pdf"]) == 1
+        assert len(result["unclassified"]) == 1
+        assert result["unclassified"][0].content == "Markdown text"
+
+    def test_run_with_empty_documents_list(self):
+        router = DocumentTypeRouter(mime_type_meta_field="mime_type", mime_types=["text/plain", "application/pdf"])
+        result = router.run(documents=[])
+
+        assert len(result) == 0
+
+    def test_run_with_custom_mime_types(self):
+        docs = [
+            Document(content="Word document", meta={"file_path": "document.docx"}),
+            Document(content="Markdown file", meta={"file_path": "readme.md"}),
+            Document(content="Outlook message", meta={"file_path": "email.msg"}),
+        ]
+
+        router = DocumentTypeRouter(
+            file_path_meta_field="file_path",
+            mime_types=[
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "text/markdown",
+                "application/vnd.ms-outlook",
+            ],
+            additional_mimetypes={"application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx"},
+        )
+        result = router.run(documents=docs)
+
+        assert len(result["application/vnd.openxmlformats-officedocument.wordprocessingml.document"]) == 1
+        assert len(result["text/markdown"]) == 1
+        assert len(result["application/vnd.ms-outlook"]) == 1
+
+    @patch("mimetypes.guess_type")
+    def test_get_mime_type_with_mocked_mimetypes(self, mock_guess_type):
+        mock_guess_type.return_value = ("text/plain", None)
+
+        router = DocumentTypeRouter(file_path_meta_field="file_path", mime_types=["text/plain"])
+
+        mime_type = router._get_mime_type(Path("test.txt"))
+        assert mime_type == "text/plain"
+        mock_guess_type.assert_called_once()
+
+    def test_get_mime_type_with_custom_extensions(self):
+        router = DocumentTypeRouter(file_path_meta_field="file_path", mime_types=["text/markdown"])
+
+        # Test markdown extension (should be in CUSTOM_MIMETYPES)
+        mime_type = router._get_mime_type(Path("readme.md"))
+        assert mime_type == "text/markdown"
+
+        # Test .msg extension
+        mime_type = router._get_mime_type(Path("email.msg"))
+        assert mime_type == "application/vnd.ms-outlook"
+
+    def test_get_mime_type_case_insensitive(self):
+        router = DocumentTypeRouter(file_path_meta_field="file_path", mime_types=["text/markdown"])
+
+        # Test uppercase extension
+        mime_type = router._get_mime_type(Path("README.MD"))
+        assert mime_type == "text/markdown"
+
+    def test_serde_in_pipeline(self):
+        document_type_router = DocumentTypeRouter(
+            mime_type_meta_field="mime_type", mime_types=["text/plain", "application/pdf"]
+        )
+
+        pipeline = Pipeline()
+        pipeline.add_component(instance=document_type_router, name="document_type_router")
+
+        pipeline_dict = pipeline.to_dict()
+
+        expected_components = {
+            "document_type_router": {
+                "type": "haystack.components.routers.document_type_router.DocumentTypeRouter",
+                "init_parameters": {
+                    "mime_type_meta_field": "mime_type",
+                    "file_path_meta_field": None,
+                    "mime_types": ["text/plain", "application/pdf"],
+                    "additional_mimetypes": None,
+                },
+            }
+        }
+
+        assert pipeline_dict["components"] == expected_components
+
+        pipeline_yaml = pipeline.dumps()
+        new_pipeline = Pipeline.loads(pipeline_yaml)
+        assert new_pipeline == pipeline
+
+    def test_run_preserves_document_metadata(self):
+        docs = [
+            Document(
+                content="Test content",
+                meta={
+                    "mime_type": "text/plain",
+                    "author": "John Doe",
+                    "created_at": "2023-01-01",
+                    "custom_field": "custom_value",
+                },
+            )
+        ]
+
+        router = DocumentTypeRouter(mime_type_meta_field="mime_type", mime_types=["text/plain"])
+        result = router.run(documents=docs)
+
+        classified_doc = result["text/plain"][0]
+        assert classified_doc.meta["author"] == "John Doe"
+        assert classified_doc.meta["created_at"] == "2023-01-01"
+        assert classified_doc.meta["custom_field"] == "custom_value"
+        assert classified_doc.meta["mime_type"] == "text/plain"
+
+    def test_run_with_multiple_matching_patterns(self):
+        docs = [Document(content="Plain text file", meta={"mime_type": "text/plain"})]
+
+        # Both patterns should match text/plain, but only the first should be used
+        router = DocumentTypeRouter(mime_type_meta_field="mime_type", mime_types=[r"text/.*", r"text/plain"])
+        result = router.run(documents=docs)
+
+        assert len(result[r"text/.*"]) == 1
+        assert r"text/plain" not in result or len(result[r"text/plain"]) == 0
+
+    def test_run_integration_example(self):
+        docs = [
+            Document(content="Example text", meta={"file_path": "example.txt"}),
+            Document(content="Another document", meta={"mime_type": "application/pdf"}),
+            Document(content="Unknown type"),
+        ]
+
+        router = DocumentTypeRouter(
+            mime_type_meta_field="mime_type",
+            file_path_meta_field="file_path",
+            mime_types=["text/plain", "application/pdf"],
+        )
+
+        result = router.run(documents=docs)
+
+        assert len(result["text/plain"]) == 1
+        assert len(result["application/pdf"]) == 1
+        assert len(result["unclassified"]) == 1


### PR DESCRIPTION
### Related Issues

- part of #9624

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Brings over `DocumentTypeRouter` from haystack-experimental to haystack main

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
