### PR TITLE
chore: update `SentenceTransformersEmbeddingBackend.embed` type hint to include images

### DIFF
--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from haystack.lazy_imports import LazyImport
 from haystack.utils.auth import Secret
 
 with LazyImport(message="Run 'pip install \"sentence-transformers>=4.1.0\"'") as sentence_transformers_import:
     from sentence_transformers import SentenceTransformer
+
+with LazyImport(message="Run 'pip install \"pillow\"'") as pillow_import:
+    from PIL.Image import Image
 
 
 class _SentenceTransformersEmbeddingBackendFactory:
@@ -84,6 +87,8 @@ class _SentenceTransformersEmbeddingBackend:
             backend=backend,
         )
 
-    def embed(self, data: List[str], **kwargs) -> List[List[float]]:
-        embeddings = self.model.encode(data, **kwargs).tolist()
+    def embed(self, data: Union[List[str], List["Image"]], **kwargs: Any) -> List[List[float]]:
+        # Sentence Transformers encode can work with Images, but the type hint does not reflect that
+        # https://sbert.net/examples/sentence_transformer/applications/image-search
+        embeddings = self.model.encode(data, **kwargs).tolist()  # type: ignore[arg-type]
         return embeddings

--- a/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
+++ b/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import copy
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.components.converters.image.image_utils import (
@@ -22,8 +22,6 @@ from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kw
 
 with LazyImport("Run 'pip install pillow'") as pillow_import:
     from PIL import Image as PILImage
-    from PIL.Image import Image
-    from PIL.ImageFile import ImageFile
 
 
 @component

--- a/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
+++ b/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
@@ -21,7 +21,7 @@ from haystack.utils.device import ComponentDevice
 from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 
 with LazyImport("Run 'pip install pillow'") as pillow_import:
-    from PIL import Image as PILImage
+    from PIL import Image
 
 
 @component
@@ -259,7 +259,7 @@ class SentenceTransformersDocumentImageEmbedder:
                 pdf_page_infos.append(pdf_page_info)
             else:
                 # Process images directly
-                image = PILImage.open(image_source_info["path"])
+                image = Image.open(image_source_info["path"])
                 images_to_embed[doc_idx] = image
 
         pdf_images_by_doc_idx = _batch_convert_pdf_pages_to_images(pdf_page_infos=pdf_page_infos, return_base64=False)

--- a/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
+++ b/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
@@ -261,7 +261,7 @@ class SentenceTransformersDocumentImageEmbedder:
                 pdf_page_infos.append(pdf_page_info)
             else:
                 # Process images directly
-                image: Union["Image", "ImageFile"] = PILImage.open(image_source_info["path"])
+                image = PILImage.open(image_source_info["path"])
                 images_to_embed[doc_idx] = image
 
         pdf_images_by_doc_idx = _batch_convert_pdf_pages_to_images(pdf_page_infos=pdf_page_infos, return_base64=False)
@@ -273,9 +273,7 @@ class SentenceTransformersDocumentImageEmbedder:
             raise RuntimeError(f"Conversion failed for some documents. Document IDs: {none_images_doc_ids}.")
 
         embeddings = self._embedding_backend.embed(
-            # TODO: when moving this component to Haystack, adjust the signature of the embedding backend embed method
-            # to also accept a list of PIL images
-            images_to_embed,  # type: ignore[arg-type]
+            data=images_to_embed,
             batch_size=self.batch_size,
             show_progress_bar=self.progress_bar,
             normalize_embeddings=self.normalize_embeddings,

--- a/test/components/embedders/image/test_sentence_transformers_doc_image_embedder.py
+++ b/test/components/embedders/image/test_sentence_transformers_doc_image_embedder.py
@@ -191,8 +191,8 @@ class TestSentenceTransformersDocumentImageEmbedder:
     def test_run(self, test_files_path):
         embedder = SentenceTransformersDocumentImageEmbedder(model="model")
         embedder._embedding_backend = MagicMock()
-        embedder._embedding_backend.embed = lambda x, **kwargs: [
-            [random.random() for _ in range(16)] for _ in range(len(x))
+        embedder._embedding_backend.embed = lambda data, **kwargs: [
+            [random.random() for _ in range(16)] for _ in range(len(data))
         ]
 
         image_paths = glob.glob(str(test_files_path / "images" / "*.*")) + glob.glob(


### PR DESCRIPTION
### Related Issues

resolve this comment

https://github.com/deepset-ai/haystack/blob/8e792a3d12932da73ba9831aa32e7cf12740c3fc/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py#L275-L278

### Proposed Changes:
- include images in `SentenceTransformersEmbeddingBackend.embed` type hint
- while doing this, I discovered that while `SentenceTransformers.encode` works with images, their type hint does not reflect that (I may open an issue on their repository for this)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
