### PR TITLE
fix: `ChatMessage.from_user` - raise error if `text` and `content_parts` are `None`; pin `ddtrace`

### DIFF
--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -368,9 +368,9 @@ class ChatMessage:
         :param content_parts: A list of content parts to include in the message. Specify this or text.
         :returns: A new ChatMessage instance.
         """
-        if not text and not content_parts:
+        if text is None and content_parts is None:
             raise ValueError("Either text or content_parts must be provided.")
-        if text and content_parts:
+        if text is not None and content_parts is not None:
             raise ValueError("Only one of text or content_parts can be provided.")
 
         content: Sequence[Union[TextContent, ImageContent]] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ dependencies = [
 
   # Tracing
   "opentelemetry-sdk",
-  "ddtrace",
+  "ddtrace<3.11.0",
 
   # Structured logging
   "structlog",

--- a/releasenotes/notes/chatmessage-fromuser-allow-empty-text-1fd34aab49e40946.yaml
+++ b/releasenotes/notes/chatmessage-fromuser-allow-empty-text-1fd34aab49e40946.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Improved validation in the `ChatMessage.from_user` class method. The method now raises an error if neither
+    `text` nor `content_parts` are provided. It does not raise an error if `text` is an empty string.

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -108,6 +108,14 @@ def test_from_user_fails_if_text_and_content_parts():
         ChatMessage.from_user(text="text", content_parts=[TextContent(text="text")])
 
 
+def test_from_user_empty_text():
+    message = ChatMessage.from_user(text="")
+    assert message.role == ChatRole.USER
+    assert message._content == [TextContent(text="")]
+    assert message.text == ""
+    assert message.texts == [""]
+
+
 def test_from_user_with_content_parts(base64_image_string):
     content_parts = [TextContent(text="text"), ImageContent(base64_image=base64_image_string)]
     message = ChatMessage.from_user(content_parts=content_parts)


### PR DESCRIPTION
### Related Issues

- (reported by Platform) In Haystack 2.16.0, with the introduction of multimodality, we are rasing an error in `ChatMessage.from_user` if `text` and `content_parts` are both empty or `None`. The error should be raised only if they are `None`.

### Proposed Changes:
- fix the validation, raising an error only if `text` and `content_parts` are both `None`.
- due to [recent errors](https://github.com/deepset-ai/haystack/actions/runs/16592744217/job/46932163130), I am also pinning `ddtrace`. This is a test dependency and this change won't directly impact users.

### How did you test it?
CI; new test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
