### PR TITLE
chore: re-export missing symbols in __init__.py files

### DIFF
--- a/haystack/components/converters/image/__init__.py
+++ b/haystack/components/converters/image/__init__.py
@@ -15,9 +15,9 @@ _import_structure = {
 }
 
 if TYPE_CHECKING:
-    from .document_to_image import DocumentToImageContent
-    from .file_to_document import ImageFileToDocument
-    from .file_to_image import ImageFileToImageContent
-    from .pdf_to_image import PDFToImageContent
+    from .document_to_image import DocumentToImageContent as DocumentToImageContent
+    from .file_to_document import ImageFileToDocument as ImageFileToDocument
+    from .file_to_image import ImageFileToImageContent as ImageFileToImageContent
+    from .pdf_to_image import PDFToImageContent as PDFToImageContent
 else:
     sys.modules[__name__] = LazyImporter(name=__name__, module_file=__file__, import_structure=_import_structure)

--- a/haystack/components/embedders/image/__init__.py
+++ b/haystack/components/embedders/image/__init__.py
@@ -10,7 +10,9 @@ from lazy_imports import LazyImporter
 _import_structure = {"sentence_transformers_doc_image_embedder": ["SentenceTransformersDocumentImageEmbedder"]}
 
 if TYPE_CHECKING:
-    from .sentence_transformers_doc_image_embedder import SentenceTransformersDocumentImageEmbedder
+    from .sentence_transformers_doc_image_embedder import (
+        SentenceTransformersDocumentImageEmbedder as SentenceTransformersDocumentImageEmbedder,
+    )
 
 else:
     sys.modules[__name__] = LazyImporter(name=__name__, module_file=__file__, import_structure=_import_structure)


### PR DESCRIPTION
### Related Issues

- In #9521, we re-exported all symbols to the appropriate `__init__.py` files but during the multimodality migration, we forgot to do that for some new components. This is needed to avoid Pylance/VSCode errors (https://github.com/deepset-ai/haystack/issues/9506).

### Proposed Changes:
- re-export missing symbols in `__init__.py` files

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
