### PR TITLE
fix: ensure sentence_transformers_similarity score is a float to not np.float

### DIFF
--- a/haystack/components/rankers/sentence_transformers_similarity.py
+++ b/haystack/components/rankers/sentence_transformers_similarity.py
@@ -276,7 +276,7 @@ class SentenceTransformersSimilarityRanker:
         ranked_docs = []
         for el in ranking_result:
             index = el["corpus_id"]
-            score = el["score"]
+            score = float(el["score"])
             document = copy(documents[index])
             document.score = score
             ranked_docs.append(document)

--- a/releasenotes/notes/fix-SentenceTransformersSimilarityRanker-score-float-a1988363b01dfc32.yaml
+++ b/releasenotes/notes/fix-SentenceTransformersSimilarityRanker-score-float-a1988363b01dfc32.yaml
@@ -1,0 +1,16 @@
+---
+highlights: >
+    Fixed a serialization issue in `SentenceTransformersSimilarityRanker` where
+    document scores were returned as `numpy.float32` instead of standard Python `float`.
+    This ensures better compatibility with tools relying on JSON serialization (e.g. Hayhooks).
+upgrade:
+  - |
+    No upgrade steps are required for this fix.
+issues:
+  - |
+    SentenceTransformersSimilarityRanker returns Documents with numpy score #9664
+fixes:
+  - |
+    Ensure that the `score` field in `SentenceTransformersSimilarityRanker` is
+    returned as a Python `float` instead of `numpy.float32`. This prevents potential
+    serialization issues in downstream integrations.

--- a/releasenotes/notes/fix-SentenceTransformersSimilarityRanker-score-float-a1988363b01dfc32.yaml
+++ b/releasenotes/notes/fix-SentenceTransformersSimilarityRanker-score-float-a1988363b01dfc32.yaml
@@ -1,14 +1,4 @@
 ---
-highlights: >
-    Fixed a serialization issue in `SentenceTransformersSimilarityRanker` where
-    document scores were returned as `numpy.float32` instead of standard Python `float`.
-    This ensures better compatibility with tools relying on JSON serialization (e.g. Hayhooks).
-upgrade:
-  - |
-    No upgrade steps are required for this fix.
-issues:
-  - |
-    SentenceTransformersSimilarityRanker returns Documents with numpy score #9664
 fixes:
   - |
     Ensure that the `score` field in `SentenceTransformersSimilarityRanker` is

--- a/test/components/rankers/test_sentence_transformers_similarity.py
+++ b/test/components/rankers/test_sentence_transformers_similarity.py
@@ -368,7 +368,6 @@ class TestSentenceTransformersSimilarityRanker:
         assert len(out["documents"]) == 2
         for d in out["documents"]:
             assert isinstance(d.score, float)
-            assert not isinstance(d.score, np.floating)
 
     @pytest.mark.integration
     @pytest.mark.slow
@@ -393,6 +392,9 @@ class TestSentenceTransformersSimilarityRanker:
         assert docs_after[1].score == pytest.approx(sorted_scores[1], abs=1e-6)
         assert docs_after[2].score == pytest.approx(sorted_scores[2], abs=1e-6)
 
+        for doc in docs_after:
+            assert isinstance(doc.score, float)
+
     @pytest.mark.integration
     @pytest.mark.slow
     def test_run_top_k(self):
@@ -413,6 +415,9 @@ class TestSentenceTransformersSimilarityRanker:
         sorted_scores = sorted([doc.score for doc in docs_after], reverse=True)
         assert [doc.score for doc in docs_after] == sorted_scores
 
+        for doc in docs_after:
+            assert isinstance(doc.score, float)
+
     @pytest.mark.integration
     @pytest.mark.slow
     def test_run_single_document(self):
@@ -423,3 +428,4 @@ class TestSentenceTransformersSimilarityRanker:
         docs_after = output["documents"]
 
         assert len(docs_after) == 1
+        assert isinstance(docs_after[0].score, float)


### PR DESCRIPTION
### Related Issues

- fixes #9664

### Proposed Changes:

The SentenceTransformersSimilarityRanker CrossEncoder model was returning score as a numpy.float32 without casting to float, which can cause JSON serialization issues in downstream integrations.

Explicitly cast the score to a standard Python float before assigning it to Document.score.

### How did you test it?

Added a unit test to verify that Document.score is always a Python float.
Ran all existing unit tests with hatch run test:unit to ensure no regressions.

### Notes for the reviewer

The change is minimal but important for serialization compatibility.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
