### PR TITLE
  feat: add image support to `HuggingFaceAPIChatGenerator`

### DIFF
--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -255,6 +255,33 @@ class HuggingFaceAPIChatGenerator:
     result = generator.run(messages)
     print(result)
     ```
+
+    #### With vision-language models (VLMs) for multimodal input
+
+    ```python
+    from haystack.components.generators.chat import HuggingFaceAPIChatGenerator
+    from haystack.dataclasses import ChatMessage, ImageContent
+    from haystack.utils import Secret
+    from haystack.utils.hf import HFGenerationAPIType
+
+    # Create an image from file path, URL, or base64
+    image = ImageContent.from_file_path("path/to/your/image.jpg")
+
+    # Create a multimodal message with both text and image
+    messages = [ChatMessage.from_user(content_parts=["Describe this image in detail", image])]
+
+    generator = HuggingFaceAPIChatGenerator(
+        api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+        api_params={
+            "model": "llava-hf/llava-1.5-7b-hf",  # Example VLM model
+            "provider": "huggingface"
+        },
+        token=Secret.from_token("<your-api-key>")
+    )
+
+    result = generator.run(messages)
+    print(result)
+    ```
     """
 
     def __init__(  # pylint: disable=too-many-positional-arguments

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -223,6 +223,33 @@ class HuggingFaceAPIChatGenerator:
     print(result)
     ```
 
+    #### With the serverless inference API (Inference Providers) and text+image input
+
+    ```python
+    from haystack.components.generators.chat import HuggingFaceAPIChatGenerator
+    from haystack.dataclasses import ChatMessage, ImageContent
+    from haystack.utils import Secret
+    from haystack.utils.hf import HFGenerationAPIType
+
+    # Create an image from file path, URL, or base64
+    image = ImageContent.from_file_path("path/to/your/image.jpg")
+
+    # Create a multimodal message with both text and image
+    messages = [ChatMessage.from_user(content_parts=["Describe this image in detail", image])]
+
+    generator = HuggingFaceAPIChatGenerator(
+        api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+        api_params={
+            "model": "Qwen/Qwen2.5-VL-7B-Instruct",  # Vision Language Model
+            "provider": "hyperbolic"
+        },
+        token=Secret.from_token("<your-api-key>")
+    )
+
+    result = generator.run(messages)
+    print(result)
+    ```
+
     #### With paid inference endpoints
 
     ```python
@@ -251,33 +278,6 @@ class HuggingFaceAPIChatGenerator:
 
     generator = HuggingFaceAPIChatGenerator(api_type="text_generation_inference",
                                             api_params={"url": "http://localhost:8080"})
-
-    result = generator.run(messages)
-    print(result)
-    ```
-
-    #### With vision-language models (VLMs) for multimodal input
-
-    ```python
-    from haystack.components.generators.chat import HuggingFaceAPIChatGenerator
-    from haystack.dataclasses import ChatMessage, ImageContent
-    from haystack.utils import Secret
-    from haystack.utils.hf import HFGenerationAPIType
-
-    # Create an image from file path, URL, or base64
-    image = ImageContent.from_file_path("path/to/your/image.jpg")
-
-    # Create a multimodal message with both text and image
-    messages = [ChatMessage.from_user(content_parts=["Describe this image in detail", image])]
-
-    generator = HuggingFaceAPIChatGenerator(
-        api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-        api_params={
-            "model": "llava-hf/llava-1.5-7b-hf",  # Example VLM model
-            "provider": "huggingface"
-        },
-        token=Secret.from_token("<your-api-key>")
-    )
 
     result = generator.run(messages)
     print(result)

--- a/releasenotes/notes/add-image-support-huggingface-api-chat-generator-9671.yaml
+++ b/releasenotes/notes/add-image-support-huggingface-api-chat-generator-9671.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Added multimodal support to `HuggingFaceAPIChatGenerator` to enable vision-language model (VLM) usage with images and text.
+    Users can now send both text and images to VLM models through Hugging Face APIs. The implementation follows the HF VLM API format
+    specification and maintains full backward compatibility with text-only messages.

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -871,9 +871,6 @@ class TestHuggingFaceAPIChatGenerator:
         reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
     )
     def test_live_run_multimodal(self, test_files_path):
-        """
-        Test multimodal functionality with a vision-language model.
-        """
         image_path = test_files_path / "images" / "apple.jpg"
         # Resize the image to keep this test fast
         image_content = ImageContent.from_file_path(file_path=image_path, size=(100, 100))
@@ -881,7 +878,7 @@ class TestHuggingFaceAPIChatGenerator:
 
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen2-VL-7B-Instruct", "provider": "together"},
+            api_params={"model": "Qwen/Qwen2.5-VL-7B-Instruct", "provider": "hyperbolic"},
             generation_kwargs={"max_tokens": 20},
         )
 
@@ -893,7 +890,6 @@ class TestHuggingFaceAPIChatGenerator:
         message = response["replies"][0]
         assert message.text
         assert len(message.text) > 0
-        # Basic assertion that it recognized the image content
         assert any(word in message.text.lower() for word in ["apple", "fruit", "red"])
 
     @pytest.mark.asyncio

--- a/test/utils/test_hf.py
+++ b/test/utils/test_hf.py
@@ -12,7 +12,8 @@ from haystack.utils.hf import convert_message_to_hf_format, resolve_hf_device_ma
 
 # Test images (1x1 pixel PNGs for testing)
 TEST_IMAGE_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
-TEST_IMAGE_JPEG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYGAAAAAACAABAAAABJRU5ErkJggg=="
+# Second PNG image with different content for testing multiple images
+TEST_IMAGE_PNG2 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII="
 
 
 def test_resolve_hf_device_map_only_device():
@@ -89,7 +90,7 @@ def test_convert_message_to_hf_invalid():
 
 def test_convert_message_to_hf_format_with_images():
     # Test image with text message (image-only not supported by ChatMessage.from_user)
-    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png", validation=False)
+    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png")
     message = ChatMessage.from_user(content_parts=["Analyze this image", image])
 
     result = convert_message_to_hf_format(message)
@@ -105,7 +106,7 @@ def test_convert_message_to_hf_format_with_images():
 
 def test_convert_message_to_hf_format_with_text_and_images():
     # Test text + image message
-    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png", validation=False)
+    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png")
     message = ChatMessage.from_user(content_parts=["Describe this image", image])
 
     result = convert_message_to_hf_format(message)
@@ -120,9 +121,9 @@ def test_convert_message_to_hf_format_with_text_and_images():
 
 
 def test_convert_message_to_hf_format_with_multiple_images():
-    # Test multiple images
-    image1 = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png", validation=False)
-    image2 = ImageContent(base64_image=TEST_IMAGE_JPEG, mime_type="image/jpeg", validation=False)
+    # Test multiple images (both PNG format with different content)
+    image1 = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png")
+    image2 = ImageContent(base64_image=TEST_IMAGE_PNG2, mime_type="image/png")
     message = ChatMessage.from_user(content_parts=["Compare these images", image1, image2])
 
     result = convert_message_to_hf_format(message)
@@ -131,15 +132,15 @@ def test_convert_message_to_hf_format_with_multiple_images():
         "content": [
             {"type": "text", "text": "Compare these images"},
             {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}},
-            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{TEST_IMAGE_JPEG}"}},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG2}"}},
         ],
     }
     assert result == expected
 
 
 def test_convert_message_to_hf_format_image_without_mime_type():
-    # Test image without MIME type (should default to image/jpeg)
-    image = ImageContent(base64_image=TEST_IMAGE_PNG, validation=False)
+    # Test image without explicit MIME type (should be auto-detected as PNG from the data)
+    image = ImageContent(base64_image=TEST_IMAGE_PNG)
     message = ChatMessage.from_user(content_parts=["What is this?", image])
 
     result = convert_message_to_hf_format(message)
@@ -147,7 +148,7 @@ def test_convert_message_to_hf_format_image_without_mime_type():
         "role": "user",
         "content": [
             {"type": "text", "text": "What is this?"},
-            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{TEST_IMAGE_PNG}"}},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}},
         ],
     }
     assert result == expected
@@ -155,7 +156,7 @@ def test_convert_message_to_hf_format_image_without_mime_type():
 
 def test_convert_message_to_hf_format_image_only_direct_construction():
     # Test image-only message using direct ChatMessage construction
-    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png", validation=False)
+    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png")
     message = ChatMessage(_role=ChatRole.USER, _content=[image])
 
     result = convert_message_to_hf_format(message)
@@ -163,12 +164,4 @@ def test_convert_message_to_hf_format_image_only_direct_construction():
         "role": "user",
         "content": [{"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}}],
     }
-    assert result == expected
-
-
-def test_convert_message_to_hf_format_backward_compatibility():
-    # Test that text-only messages still work as before (backward compatibility)
-    message = ChatMessage.from_user("Just text, no images")
-    result = convert_message_to_hf_format(message)
-    expected = {"role": "user", "content": "Just text, no images"}
     assert result == expected

--- a/test/utils/test_hf.py
+++ b/test/utils/test_hf.py
@@ -7,13 +7,9 @@ import logging
 import pytest
 
 from haystack.dataclasses import ChatMessage, ChatRole, ImageContent, TextContent, ToolCall
+from haystack.dataclasses.chat_message import ToolCallResult
 from haystack.utils.device import ComponentDevice
 from haystack.utils.hf import convert_message_to_hf_format, resolve_hf_device_map
-
-# Test images (1x1 pixel PNGs for testing)
-TEST_IMAGE_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
-# Second PNG image with different content for testing multiple images
-TEST_IMAGE_PNG2 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII="
 
 
 def test_resolve_hf_device_map_only_device():
@@ -81,49 +77,23 @@ def test_convert_message_to_hf_invalid():
         convert_message_to_hf_format(message)
 
     message = ChatMessage(
-        _role=ChatRole.ASSISTANT,
-        _content=[TextContent(text="I have an answer"), TextContent(text="I have another answer")],
+        _role=ChatRole.USER,
+        _content=[
+            TextContent(text="I have an answer"),
+            ToolCallResult(
+                result="result!",
+                origin=ToolCall(id="123", tool_name="weather", arguments={"city": "Paris"}),
+                error=None,
+            ),
+        ],
     )
     with pytest.raises(ValueError):
         convert_message_to_hf_format(message)
 
 
-def test_convert_message_to_hf_format_with_images():
-    # Test image with text message (image-only not supported by ChatMessage.from_user)
-    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png")
-    message = ChatMessage.from_user(content_parts=["Analyze this image", image])
-
-    result = convert_message_to_hf_format(message)
-    expected = {
-        "role": "user",
-        "content": [
-            {"type": "text", "text": "Analyze this image"},
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}},
-        ],
-    }
-    assert result == expected
-
-
-def test_convert_message_to_hf_format_with_text_and_images():
-    # Test text + image message
-    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png")
-    message = ChatMessage.from_user(content_parts=["Describe this image", image])
-
-    result = convert_message_to_hf_format(message)
-    expected = {
-        "role": "user",
-        "content": [
-            {"type": "text", "text": "Describe this image"},
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}},
-        ],
-    }
-    assert result == expected
-
-
-def test_convert_message_to_hf_format_with_multiple_images():
-    # Test multiple images (both PNG format with different content)
-    image1 = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png")
-    image2 = ImageContent(base64_image=TEST_IMAGE_PNG2, mime_type="image/png")
+def test_convert_message_to_hf_format_with_multiple_images(base64_image_string):
+    image1 = ImageContent(base64_image=base64_image_string)
+    image2 = ImageContent(base64_image=base64_image_string)
     message = ChatMessage.from_user(content_parts=["Compare these images", image1, image2])
 
     result = convert_message_to_hf_format(message)
@@ -131,37 +101,8 @@ def test_convert_message_to_hf_format_with_multiple_images():
         "role": "user",
         "content": [
             {"type": "text", "text": "Compare these images"},
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}},
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG2}"}},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{base64_image_string}"}},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{base64_image_string}"}},
         ],
-    }
-    assert result == expected
-
-
-def test_convert_message_to_hf_format_image_without_mime_type():
-    # Test image without explicit MIME type (should be auto-detected as PNG from the data)
-    image = ImageContent(base64_image=TEST_IMAGE_PNG)
-    message = ChatMessage.from_user(content_parts=["What is this?", image])
-
-    result = convert_message_to_hf_format(message)
-    expected = {
-        "role": "user",
-        "content": [
-            {"type": "text", "text": "What is this?"},
-            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}},
-        ],
-    }
-    assert result == expected
-
-
-def test_convert_message_to_hf_format_image_only_direct_construction():
-    # Test image-only message using direct ChatMessage construction
-    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png")
-    message = ChatMessage(_role=ChatRole.USER, _content=[image])
-
-    result = convert_message_to_hf_format(message)
-    expected = {
-        "role": "user",
-        "content": [{"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}}],
     }
     assert result == expected

--- a/test/utils/test_hf.py
+++ b/test/utils/test_hf.py
@@ -6,9 +6,13 @@ import logging
 
 import pytest
 
-from haystack.dataclasses import ChatMessage, ChatRole, TextContent, ToolCall
+from haystack.dataclasses import ChatMessage, ChatRole, ImageContent, TextContent, ToolCall
 from haystack.utils.device import ComponentDevice
 from haystack.utils.hf import convert_message_to_hf_format, resolve_hf_device_map
+
+# Test images (1x1 pixel PNGs for testing)
+TEST_IMAGE_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+TEST_IMAGE_JPEG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYGAAAAAACAABAAAABJRU5ErkJggg=="
 
 
 def test_resolve_hf_device_map_only_device():
@@ -81,3 +85,90 @@ def test_convert_message_to_hf_invalid():
     )
     with pytest.raises(ValueError):
         convert_message_to_hf_format(message)
+
+
+def test_convert_message_to_hf_format_with_images():
+    # Test image with text message (image-only not supported by ChatMessage.from_user)
+    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png", validation=False)
+    message = ChatMessage.from_user(content_parts=["Analyze this image", image])
+
+    result = convert_message_to_hf_format(message)
+    expected = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Analyze this image"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}},
+        ],
+    }
+    assert result == expected
+
+
+def test_convert_message_to_hf_format_with_text_and_images():
+    # Test text + image message
+    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png", validation=False)
+    message = ChatMessage.from_user(content_parts=["Describe this image", image])
+
+    result = convert_message_to_hf_format(message)
+    expected = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this image"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}},
+        ],
+    }
+    assert result == expected
+
+
+def test_convert_message_to_hf_format_with_multiple_images():
+    # Test multiple images
+    image1 = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png", validation=False)
+    image2 = ImageContent(base64_image=TEST_IMAGE_JPEG, mime_type="image/jpeg", validation=False)
+    message = ChatMessage.from_user(content_parts=["Compare these images", image1, image2])
+
+    result = convert_message_to_hf_format(message)
+    expected = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Compare these images"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}},
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{TEST_IMAGE_JPEG}"}},
+        ],
+    }
+    assert result == expected
+
+
+def test_convert_message_to_hf_format_image_without_mime_type():
+    # Test image without MIME type (should default to image/jpeg)
+    image = ImageContent(base64_image=TEST_IMAGE_PNG, validation=False)
+    message = ChatMessage.from_user(content_parts=["What is this?", image])
+
+    result = convert_message_to_hf_format(message)
+    expected = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What is this?"},
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{TEST_IMAGE_PNG}"}},
+        ],
+    }
+    assert result == expected
+
+
+def test_convert_message_to_hf_format_image_only_direct_construction():
+    # Test image-only message using direct ChatMessage construction
+    image = ImageContent(base64_image=TEST_IMAGE_PNG, mime_type="image/png", validation=False)
+    message = ChatMessage(_role=ChatRole.USER, _content=[image])
+
+    result = convert_message_to_hf_format(message)
+    expected = {
+        "role": "user",
+        "content": [{"type": "image_url", "image_url": {"url": f"data:image/png;base64,{TEST_IMAGE_PNG}"}}],
+    }
+    assert result == expected
+
+
+def test_convert_message_to_hf_format_backward_compatibility():
+    # Test that text-only messages still work as before (backward compatibility)
+    message = ChatMessage.from_user("Just text, no images")
+    result = convert_message_to_hf_format(message)
+    expected = {"role": "user", "content": "Just text, no images"}
+    assert result == expected


### PR DESCRIPTION
##  Related Issues

  Fixes #9671

  ## Proposed Changes

  This PR adds multimodal support to `HuggingFaceAPIChatGenerator` to enable vision-language model (VLM) usage with images
  and text. The implementation follows the HF VLM API format specification.

  ### Key Changes:
  - **Extended `convert_message_to_hf_format()`** in `haystack/utils/hf.py` to handle `ImageContent` objects
  - **Added proper HF VLM API format**: `{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}`
  - **Supports base64 images** with MIME type handling (defaults to `image/jpeg`)
  - **Maintains full backward compatibility** with text-only messages
  - **Updated component documentation** with VLM usage examples

  ## How did you test it?

  - ✅ **Unit tests**: Added 6 comprehensive test cases covering:
    - Text + image messages
    - Multiple images in one message
    - Image without MIME type (defaults to jpeg)
    - Image-only messages (via direct construction)
    - Backward compatibility with text-only messages
  - ✅ **Integration testing**: Verified end-to-end message conversion works correctly
  - ✅ **Code quality**: All formatting, type checking, and pre-commit hooks pass

  ## Notes for the reviewer

  - The implementation uses constants for test images to keep tests clean and avoid long lines
  - Type annotations were added to ensure proper typing for multimodal content
  - The HF VLM API format follows the exact specification from the official documentation
  - No breaking changes - existing text-only usage remains unchanged

  ## Checklist

  - [x] I have read the contributors guidelines and the code of conduct
  - [x] I have updated the related issue with new insights and changes
  - [x] I added unit tests and updated the docstrings
  - [x] I've used one of the conventional commit types for my PR title: `feat:`
  - [x] I documented my code
  - [x] I ran pre-commit hooks and fixed any issue