### PR TITLE
fix: Update finish reason in output of `HuggingFaceAPIChatGenerator` to match between stream and non-stream modes

### DIFF
--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -40,6 +40,7 @@ with LazyImport(message="Run 'pip install \"huggingface_hub[inference]>=0.27.0\"
         ChatCompletionInputStreamOptions,
         ChatCompletionInputTool,
         ChatCompletionOutput,
+        ChatCompletionOutputComplete,
         ChatCompletionOutputToolCall,
         ChatCompletionStreamOutput,
         ChatCompletionStreamOutputChoice,
@@ -112,7 +113,9 @@ def _convert_tools_to_hfapi_tools(
     return hf_tools
 
 
-def _map_hf_finish_reason_to_haystack(choice: "ChatCompletionStreamOutputChoice") -> Optional[FinishReason]:
+def _map_hf_finish_reason_to_haystack(
+    choice: Union["ChatCompletionStreamOutputChoice", "ChatCompletionOutputComplete"],
+) -> Optional[FinishReason]:
     """
     Map HuggingFace finish reasons to Haystack FinishReason literals.
 
@@ -133,7 +136,10 @@ def _map_hf_finish_reason_to_haystack(choice: "ChatCompletionStreamOutputChoice"
         return None
 
     # Check if this choice contains tool call information
-    has_tool_calls = choice.delta.tool_calls is not None or choice.delta.tool_call_id is not None
+    if isinstance(choice, ChatCompletionStreamOutputChoice):
+        has_tool_calls = choice.delta.tool_calls is not None or choice.delta.tool_call_id is not None
+    else:
+        has_tool_calls = choice.message.tool_calls is not None or choice.message.tool_call_id is not None
 
     # If we detect tool calls, override the finish reason
     if has_tool_calls:
@@ -538,9 +544,10 @@ class HuggingFaceAPIChatGenerator:
 
         tool_calls = _convert_hfapi_tool_calls(choice.message.tool_calls)
 
+        mapped_finish_reason = _map_hf_finish_reason_to_haystack(choice) if choice.finish_reason else None
         meta: Dict[str, Any] = {
             "model": self._client.model,
-            "finish_reason": choice.finish_reason,
+            "finish_reason": mapped_finish_reason,
             "index": choice.index,
         }
 

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -587,7 +587,7 @@ class TestHuggingFaceAPIChatGenerator:
         assert response["replies"][0].tool_calls[0].arguments == {"city": "Paris"}
         assert response["replies"][0].tool_calls[0].id == "0"
         assert response["replies"][0].meta == {
-            "finish_reason": "stop",
+            "finish_reason": "tool_calls",
             "index": 0,
             "model": "meta-llama/Llama-3.1-70B-Instruct",
             "usage": {"completion_tokens": 30, "prompt_tokens": 426},


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/2141

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
In [this previous PR](https://github.com/deepset-ai/haystack/pull/9536), we introduced a finish_reason field to StreamingChunk. When used with the HuggingFaceAPIChatGenerator, this new field was included in the meta of the returned ChatMessage. However, the update only applied when streaming was enabled. If streaming was disabled, the old finish_reason was still returned. This PR fixes that by ensuring the updated finish_reason is used even when streaming is off.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Updated unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
