### PR TITLE
chore: update API docs path in Docusaurus workflow

### DIFF
--- a/.github/workflows/docusaurus_sync.yml
+++ b/.github/workflows/docusaurus_sync.yml
@@ -14,7 +14,7 @@ env:
   HATCH_VERSION: "1.14.1"
   PYTHON_VERSION: "3.9"
   DOCS_REPO: "deepset-ai/haystack-docs"
-  DOCS_REPO_PATH: "docs/api/haystack-api"
+  DOCS_REPO_PATH: "reference/haystack-api"
 
 jobs:
   sync:


### PR DESCRIPTION
### Proposed Changes:

I need the API docs to sync to /reference/ folder now

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
