### PR TITLE
fix: prevent in-place mutation of documents after embeddings by using deepcopy

### DIFF
--- a/haystack/components/embedders/hugging_face_api_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_document_embedder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from copy import deepcopy
 from typing import Any, Optional, Union
 
 from tqdm import tqdm
@@ -328,10 +329,11 @@ class HuggingFaceAPIDocumentEmbedder:
 
         embeddings = self._embed_batch(texts_to_embed=texts_to_embed, batch_size=self.batch_size)
 
-        for doc, emb in zip(documents, embeddings):
+        documents_copy = deepcopy(documents)
+        for doc, emb in zip(documents_copy, embeddings):
             doc.embedding = emb
 
-        return {"documents": documents}
+        return {"documents": documents_copy}
 
     @component.output_types(documents=list[Document])
     async def run_async(self, documents: list[Document]):
@@ -355,7 +357,8 @@ class HuggingFaceAPIDocumentEmbedder:
 
         embeddings = await self._embed_batch_async(texts_to_embed=texts_to_embed, batch_size=self.batch_size)
 
-        for doc, emb in zip(documents, embeddings):
+        documents_copy = deepcopy(documents)
+        for doc, emb in zip(documents_copy, embeddings):
             doc.embedding = emb
 
-        return {"documents": documents}
+        return {"documents": documents_copy}

--- a/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
+++ b/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from copy import copy
+from copy import deepcopy
 from typing import Any, Literal, Optional
 
 from haystack import Document, component, default_from_dict, default_to_dict
@@ -281,7 +281,7 @@ class SentenceTransformersDocumentImageEmbedder:
 
         docs_with_embeddings = []
         for doc, emb in zip(documents, embeddings):
-            copied_doc = copy(doc)
+            copied_doc = deepcopy(doc)
             copied_doc.embedding = emb
             # we store this information for later inspection
             copied_doc.meta["embedding_source"] = {"type": "image", "file_path_meta_field": self.file_path_meta_field}

--- a/haystack/components/embedders/openai_document_embedder.py
+++ b/haystack/components/embedders/openai_document_embedder.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from copy import deepcopy
 from typing import Any, Optional
 
 from more_itertools import batched
@@ -307,7 +308,8 @@ class OpenAIDocumentEmbedder:
 
         doc_ids_to_embeddings, meta = self._embed_batch(texts_to_embed=texts_to_embed, batch_size=self.batch_size)
 
-        doc_id_to_document = {doc.id: doc for doc in documents}
+        documents_copy = deepcopy(documents)
+        doc_id_to_document = {doc.id: doc for doc in documents_copy}
         for doc_id, emb in doc_ids_to_embeddings.items():
             doc_id_to_document[doc_id].embedding = emb
 
@@ -338,7 +340,8 @@ class OpenAIDocumentEmbedder:
             texts_to_embed=texts_to_embed, batch_size=self.batch_size
         )
 
-        doc_id_to_document = {doc.id: doc for doc in documents}
+        documents_copy = deepcopy(documents)
+        doc_id_to_document = {doc.id: doc for doc in documents_copy}
         for doc_id, emb in doc_ids_to_embeddings.items():
             doc_id_to_document[doc_id].embedding = emb
 

--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from copy import deepcopy
 from typing import Any, Literal, Optional
 
 from haystack import Document, component, default_from_dict, default_to_dict
@@ -257,7 +258,8 @@ class SentenceTransformersDocumentEmbedder:
             **(self.encode_kwargs if self.encode_kwargs else {}),
         )
 
-        for doc, emb in zip(documents, embeddings):
+        documents_copy = deepcopy(documents)
+        for doc, emb in zip(documents_copy, embeddings):
             doc.embedding = emb
 
-        return {"documents": documents}
+        return {"documents": documents_copy}

--- a/releasenotes/notes/fix-embedder-deepcopy-c21216149f700993.yaml
+++ b/releasenotes/notes/fix-embedder-deepcopy-c21216149f700993.yaml
@@ -1,0 +1,8 @@
+---
+issues:
+  - |
+    Document Embedders modify Documents in place #9505
+fixes:
+  - |
+    Prevented in-place mutation of input `Document` objects in all `DocumentEmbedder` components
+    by using `deepcopy` of the input documents before processing.

--- a/test/components/embedders/image/test_sentence_transformers_doc_image_embedder.py
+++ b/test/components/embedders/image/test_sentence_transformers_doc_image_embedder.py
@@ -5,6 +5,7 @@
 import glob
 import random
 import sys
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -204,9 +205,11 @@ class TestSentenceTransformersDocumentImageEmbedder:
             if path.endswith(".pdf"):
                 document.meta["page_number"] = 1
             documents.append(document)
+        documents_copy = deepcopy(documents)
 
         result = embedder.run(documents=documents)
 
+        assert documents == documents_copy
         assert isinstance(result["documents"], list)
         assert len(result["documents"]) == len(documents)
         for doc in result["documents"]:

--- a/test/components/embedders/test_azure_document_embedder.py
+++ b/test/components/embedders/test_azure_document_embedder.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from copy import deepcopy
 from unittest.mock import Mock, patch
 
 import pytest
@@ -251,6 +252,7 @@ class TestAzureOpenAIDocumentEmbedder:
             Document(content="I love cheese", meta={"topic": "Cuisine"}),
             Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
         ]
+        docs_copy = deepcopy(docs)
         # the default model is text-embedding-ada-002 even if we don't specify it, but let's be explicit
         embedder = AzureOpenAIDocumentEmbedder(
             azure_deployment="text-embedding-ada-002",
@@ -263,6 +265,7 @@ class TestAzureOpenAIDocumentEmbedder:
         documents_with_embeddings = result["documents"]
         metadata = result["meta"]
 
+        assert docs == docs_copy
         assert isinstance(documents_with_embeddings, list)
         assert len(documents_with_embeddings) == len(docs)
         for doc in documents_with_embeddings:

--- a/test/components/embedders/test_hugging_face_api_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_document_embedder.py
@@ -4,6 +4,7 @@
 
 import os
 import random
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -287,7 +288,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
             Document(content="I love cheese", meta={"topic": "Cuisine"}),
             Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
         ]
-
+        docs_copy = deepcopy(docs)
         with patch("huggingface_hub.InferenceClient.feature_extraction") as mock_embedding_patch:
             mock_embedding_patch.side_effect = mock_embedding_generation
 
@@ -314,6 +315,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
 
         documents_with_embeddings = result["documents"]
 
+        assert docs == docs_copy
         assert isinstance(documents_with_embeddings, list)
         assert len(documents_with_embeddings) == len(docs)
         for doc in documents_with_embeddings:

--- a/test/components/embedders/test_openai_document_embedder.py
+++ b/test/components/embedders/test_openai_document_embedder.py
@@ -4,6 +4,7 @@
 
 import os
 import random
+from copy import deepcopy
 from unittest.mock import Mock, patch
 
 import pytest
@@ -271,6 +272,7 @@ class TestOpenAIDocumentEmbedder:
             Document(content="I love cheese", meta={"topic": "Cuisine"}),
             Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
         ]
+        docs_copy = deepcopy(docs)
 
         model = "text-embedding-ada-002"
 
@@ -279,6 +281,7 @@ class TestOpenAIDocumentEmbedder:
         result = embedder.run(documents=docs)
         documents_with_embeddings = result["documents"]
 
+        assert docs == docs_copy
         assert isinstance(documents_with_embeddings, list)
         assert len(documents_with_embeddings) == len(docs)
         for doc in documents_with_embeddings:

--- a/test/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_document_embedder.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import random
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -288,9 +289,11 @@ class TestSentenceTransformersDocumentEmbedder:
         ]
 
         documents = [Document(content=f"document number {i}") for i in range(5)]
+        documents_copy = deepcopy(documents)
 
         result = embedder.run(documents=documents)
 
+        assert documents == documents_copy
         assert isinstance(result["documents"], list)
         assert len(result["documents"]) == len(documents)
         for doc in result["documents"]:


### PR DESCRIPTION
### Related Issues

- fixes #9505

### Proposed Changes:

Modified all `DocumentEmbedder` componentsto apply `deepcopy()` to input `Document` objects. This prevents unexpected in-place modifications when using embedders outside of a Pipeline.

Previously, input documents were modified in place the `embedding` and `meta` fields, which could led to potential side effects. This change aligns the behavior of embedders used independently with how they behave in Pipelines (where deepcopying is already standard).

### How did you test it?

- Added new deepcopy in the unit tests and verified that original documents are same before and after the call
- Ran existing tests using `hatch run test:unit`

### Notes for the reviewer

NA

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
