### PR TITLE
chore: OpenAI - explictly filter function tool calls

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -477,7 +477,10 @@ def _convert_chat_completion_to_chat_message(completion: ChatCompletion, choice:
     message: ChatCompletionMessage = choice.message
     text = message.content
     tool_calls = []
-    if openai_tool_calls := message.tool_calls:
+    if message.tool_calls:
+        # we currently only support function tools (not custom tools)
+        # https://platform.openai.com/docs/guides/function-calling#custom-tools
+        openai_tool_calls = [tc for tc in message.tool_calls if tc.type == "function"]
         for openai_tc in openai_tool_calls:
             arguments_str = openai_tc.function.arguments
             try:


### PR DESCRIPTION
### Related Issues

- New OpenAI release introduced custom tools, in addition to function tools (https://platform.openai.com/docs/guides/function-calling#custom-tools)
- Mypy fails in some open PRs https://github.com/deepset-ai/haystack/actions/runs/16825996128/job/47662714051?pr=9696

### Proposed Changes:
- explictly filter function tool calls to make mypy happy
  - we are not supporting custom tools currently, so it won't happen that a Haystack user generates a custom tool call

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
