### PR TITLE
fix: fix inconsistent `top_k` validation in `SentenceTransformersDiversityRanker`

### DIFF
--- a/haystack/components/rankers/sentence_transformers_diversity.py
+++ b/haystack/components/rankers/sentence_transformers_diversity.py
@@ -421,7 +421,7 @@ class SentenceTransformersDiversityRanker:
 
         if top_k is None:
             top_k = self.top_k
-        elif not 0 < top_k <= len(documents):
+        if not 0 < top_k <= len(documents):
             raise ValueError(f"top_k must be between 1 and {len(documents)}, but got {top_k}")
 
         if self.strategy == DiversityRankingStrategy.MAXIMUM_MARGIN_RELEVANCE:

--- a/releasenotes/notes/st-diversity-ranker-top-k-consistency-29535a76a07a8ff3.yaml
+++ b/releasenotes/notes/st-diversity-ranker-top-k-consistency-29535a76a07a8ff3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Ensure consistent behavior in `SentenceTransformersDiversityRanker`. Like other rankers, it now returns
+    all documents instead of raising an error when `top_k` exceeds the number of available documents.

--- a/test/components/rankers/test_sentence_transformers_diversity.py
+++ b/test/components/rankers/test_sentence_transformers_diversity.py
@@ -381,7 +381,7 @@ class TestSentenceTransformersDiversityRanker:
         query = "test"
         documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
 
-        with pytest.raises(ValueError, match="top_k must be between"):
+        with pytest.raises(ValueError, match="top_k must be > 0"):
             ranker.run(query=query, documents=documents, top_k=-5)
 
     @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])


### PR DESCRIPTION
- fixes https://github.com/deepset-ai/haystack/issues/9695

- changed elif to if in run() method to ensure top_k validation always runs regardless of whatever top_k comes from init or runtime
- Both scenarios now consistently raise ValueError with descriptive message format: 'top_k must be between 1 and X, but got Y'
- Fixes inconsistency where init top_k gave confusing MMR error while runtime top_k gave clear validation error
