### PR TITLE
feat: Update `source_id_meta_field` in `SentenceWindowRetriever` to also accept a list of values

### DIFF
--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -184,9 +184,7 @@ class SentenceWindowRetriever:
         return default_from_dict(cls, data)
 
     @component.output_types(context_windows=list[str], context_documents=list[Document])
-    def run(
-        self, retrieved_documents: list[Document], window_size: Optional[int] = None
-    ) -> dict[str, Union[list[str], list[Document]]]:
+    def run(self, retrieved_documents: list[Document], window_size: Optional[int] = None):
         """
         Based on the `source_id` and on the `doc.meta['split_id']` get surrounding documents from the document store.
 

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -98,6 +98,8 @@ class SentenceWindowRetriever:
         :param window_size: The number of documents to retrieve before and after the relevant one.
                 For example, `window_size: 2` fetches 2 preceding and 2 following documents.
         :param source_id_meta_field: The metadata field that contains the source ID of the document.
+            This can be a single field or a list of fields. If multiple fields are provided, the retriever will
+            consider the document as part of the same source if all the fields match.
         :param split_id_meta_field: The metadata field that contains the split ID of the document.
         :param raise_on_missing_meta_fields: If True, raises an error if the documents do not contain the required
             metadata fields. If False, it will skip retrieving the context for documents that are missing

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -238,8 +238,8 @@ class SentenceWindowRetriever:
                 context_documents.append(doc)
                 continue
 
-            min_before = min(list(range(split_id - 1, split_id - window_size - 1, -1)))
-            max_after = max(list(range(split_id + 1, split_id + window_size + 1, 1)))
+            min_before = split_id - window_size
+            max_after = split_id + window_size
             source_id_filters = [
                 {"field": f"meta.{source_id_meta_field}", "operator": "==", "value": source_id}
                 for source_id_meta_field, source_id in zip(self._source_id_meta_fields, source_ids)

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -214,13 +214,10 @@ class SentenceWindowRetriever:
         ):
             raise ValueError(f"The retrieved documents must have '{self.split_id_meta_field}' in their metadata.")
 
-        all_source_id_meta_fields_present = True
-        for doc in retrieved_documents:
-            for source_id_meta_field in self._source_id_meta_fields:
-                if source_id_meta_field not in doc.meta:
-                    all_source_id_meta_fields_present = False
-                    break
-        if not all_source_id_meta_fields_present and self.raise_on_missing_meta_fields:
+        if (
+            not all(field in doc.meta for doc in retrieved_documents for field in self._source_id_meta_fields)
+            and self.raise_on_missing_meta_fields
+        ):
             raise ValueError(f"The retrieved documents must have '{self.source_id_meta_field}' in their metadata.")
 
         context_text = []

--- a/releasenotes/notes/update-sentence-window-retriever-7e28965608b84808.yaml
+++ b/releasenotes/notes/update-sentence-window-retriever-7e28965608b84808.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Updated `SentenceWindowRetriever`'s source_id_meta_field parameter to also accept a list of strings. If a list of fields are provided, then only documents matching both fields will be retrieved.

--- a/test/components/retrievers/test_sentence_window_retriever.py
+++ b/test/components/retrievers/test_sentence_window_retriever.py
@@ -249,7 +249,7 @@ class TestSentenceWindowRetriever:
         doc_store.write_documents(docs)
 
         retriever = SentenceWindowRetriever(
-            document_store=doc_store, window_size=3, source_id_meta_field=["section", "source_id"]
+            document_store=doc_store, window_size=5, source_id_meta_field=["section", "source_id"]
         )
         result = retriever.run(
             retrieved_documents=[


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9687

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Updated `SentenceWindowRetriever`'s source_id_meta_field parameter to also accept a list of strings. If a list of fields are provided, then only documents matching both fields will be retrieved.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added a unit test.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
