### PR TITLE
fix: fix wrong error message in Sentence Transformers Embedders

### DIFF
--- a/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
+++ b/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
@@ -234,7 +234,7 @@ class SentenceTransformersDocumentImageEmbedder:
         if not isinstance(documents, list) or documents and not isinstance(documents[0], Document):
             raise TypeError(
                 "SentenceTransformersDocumentImageEmbedder expects a list of Documents as input. "
-                "In case you want to embed a list of strings, please use the SentenceTransformersTextEmbedder."
+                "In case you want to embed a string, please use the SentenceTransformersTextEmbedder."
             )
         if self._embedding_backend is None:
             raise RuntimeError("The embedding model has not been loaded. Please call warm_up() before running.")

--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -234,7 +234,7 @@ class SentenceTransformersDocumentEmbedder:
         if not isinstance(documents, list) or documents and not isinstance(documents[0], Document):
             raise TypeError(
                 "SentenceTransformersDocumentEmbedder expects a list of Documents as input."
-                "In case you want to embed a list of strings, please use the SentenceTransformersTextEmbedder."
+                "In case you want to embed a string, please use the SentenceTransformersTextEmbedder."
             )
         if self.embedding_backend is None:
             raise RuntimeError("The embedding model has not been loaded. Please call warm_up() before running.")

--- a/test/core/pipeline/test_pipeline_breakpoints_rag_hybrid.py
+++ b/test/core/pipeline/test_pipeline_breakpoints_rag_hybrid.py
@@ -54,7 +54,7 @@ class TestPipelineBreakpoints:
                 if not isinstance(documents, list) or documents and not isinstance(documents[0], Document):
                     raise TypeError(
                         "SentenceTransformersDocumentEmbedder expects a list of Documents as input."
-                        "In case you want to embed a list of strings, please use the SentenceTransformersTextEmbedder."
+                        "In case you want to embed a string, please use the SentenceTransformersTextEmbedder."
                     )
 
                 import numpy as np


### PR DESCRIPTION
### Proposed Changes:
- fix the wrong error message: the `SentenceTransformersTextEmbedder` does not accept a list of string, but a single string

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
