### PR TITLE
fix: raise `RuntimeError` when `AsyncPipeline.run()` is called from within an async context

### DIFF
--- a/releasenotes/notes/fix-asyncpipeline-run-error-e82ede5c4f37f485.yaml
+++ b/releasenotes/notes/fix-asyncpipeline-run-error-e82ede5c4f37f485.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Raise a `RuntimeError` when `AsyncPipeline.run` is called from within an async context, indicating that `run_async` should be used instead.

--- a/test/core/pipeline/test_async_pipeline.py
+++ b/test/core/pipeline/test_async_pipeline.py
@@ -4,6 +4,8 @@
 
 import asyncio
 
+import pytest
+
 from haystack import AsyncPipeline
 
 
@@ -22,3 +24,22 @@ def test_async_pipeline_reentrance(waiting_component, spying_tracer):
     component_spans = [sp for sp in spying_tracer.spans if sp.operation_name == "haystack.component.run_async"]
     for span in component_spans:
         assert span.tags["haystack.component.visits"] == 1
+
+
+def test_run_in_sync_context(waiting_component):
+    pp = AsyncPipeline()
+    pp.add_component("wait", waiting_component())
+
+    result = pp.run({"wait_for": 0.001})
+
+    assert result == {"wait": {"waited_for": 0.001}}
+
+
+def test_run_in_async_context_raises_runtime_error():
+    pp = AsyncPipeline()
+
+    async def call_run():
+        pp.run({})
+
+    with pytest.raises(RuntimeError, match="Cannot call run\\(\\) from within an async context"):
+        asyncio.run(call_run())


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9677

### Proposed Changes:

If `run()` is called from an async context, we raise a RuntimeError saying that `await pipeline.run_async(...)` is the correct method to call.

### How did you test it?

unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
