### PR TITLE
ci: avoid coveralls blocking CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,6 +170,7 @@ jobs:
         # complicates the workflow too much for little to no gain
         if: matrix.os == 'ubuntu-latest'
         uses: coverallsapp/github-action@v2
+        continue-on-error: true
         with:
           path-to-lcov: coverage.xml
 

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -9,7 +9,6 @@ from haystack.document_stores.types import DocumentStore
 from haystack.utils import deserialize_document_store_in_init_params_inplace
 
 
-# TRIGGER
 @component
 class CacheChecker:
     """

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -9,6 +9,7 @@ from haystack.document_stores.types import DocumentStore
 from haystack.utils import deserialize_document_store_in_init_params_inplace
 
 
+# TRIGGER
 @component
 class CacheChecker:
     """


### PR DESCRIPTION
### Related Issues

Coveralls hosts our test coverage data. At the moment, the service is not working.

We call Coveralls in Ubuntu unit tests.
This step fails -> Ubuntu unit tests fail -> No integrations tests -> CI blocked -> No PRs can be merged

### Proposed Changes:
- make the Coverall step in Ubuntu unit tests continue on errors

### How did you test it?
CI. Triggered unit tests in https://github.com/deepset-ai/haystack/pull/9713/commits/04e2681da3733c226f413928b28d72d077f818e9 -> 
<img width="522" height="337" alt="image" src="https://github.com/user-attachments/assets/91964b27-e397-499a-b2be-32e62254f6c8" />

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
