### PR TITLE
feat: support subclasses of ChatMessage in state schema validation

### DIFF
--- a/haystack/components/agents/state/state.py
+++ b/haystack/components/agents/state/state.py
@@ -74,7 +74,7 @@ def _validate_schema(schema: dict[str, Any]) -> None:
                 raise ValueError(f"StateSchema: 'messages' must be of type list[ChatMessage], got {definition['type']}")
             # Check if the list contains ChatMessage elements
             args = get_args(definition["type"])
-            if not args or args[0] != ChatMessage:
+            if not args or not issubclass(args[0], ChatMessage):
                 raise ValueError(f"StateSchema: 'messages' must be of type list[ChatMessage], got {definition['type']}")
 
 

--- a/releasenotes/notes/schema-validation-support-chatmessage-subclass-995fcdd860786cb3.yaml
+++ b/releasenotes/notes/schema-validation-support-chatmessage-subclass-995fcdd860786cb3.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Support subclasses of `ChatMessage` in Agent state schema validation.
+    The validation now checks for `issubclass(args[0], ChatMessage)` instead
+    of requiring exact type equality, allowing custom ChatMessage subclasses
+    to be used in the messages field.

--- a/test/components/agents/test_state_class.py
+++ b/test/components/agents/test_state_class.py
@@ -219,6 +219,16 @@ class TestState:
         with pytest.raises(ValueError, match="must be callable or None"):
             _validate_schema(invalid_schema)
 
+    def test_validate_schema_with_messages(self):
+        class ChatMessageSubclass(ChatMessage):
+            pass
+
+        schema_with_messages = {"messages": {"type": List[ChatMessage]}}
+        _validate_schema(schema_with_messages)
+
+        schema_with_messages_subclass = {"messages": {"type": List[ChatMessageSubclass]}}
+        _validate_schema(schema_with_messages_subclass)
+
     def test_state_initialization(self, basic_schema):
         # Test empty initialization
         state = State(basic_schema)
@@ -302,11 +312,11 @@ class TestState:
         schema = {
             "complex": {
                 "type": dict[str, list[int]],
-                "handler": lambda current, new: {
-                    k: current.get(k, []) + new.get(k, []) for k in set(current.keys()) | set(new.keys())
-                }
-                if current
-                else new,
+                "handler": lambda current, new: (
+                    {k: current.get(k, []) + new.get(k, []) for k in set(current.keys()) | set(new.keys())}
+                    if current
+                    else new
+                ),
             }
         }
 


### PR DESCRIPTION
### Related Issues

- addresses #9716 

### Proposed Changes:

In agent state schema validation, check for `issubclass(args[0], ChatMessage)` for `messages` instead of direct matching `ChatMessage`.

### How did you test it?

Added a new unit test for validating schemas with `messages` field.

### Notes for the reviewer

Also auto-fixed a minor formatting by black.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
