### PR TITLE
chore: export `ReasoningContent` to `haystack.dataclasses`

### DIFF
--- a/haystack/dataclasses/__init__.py
+++ b/haystack/dataclasses/__init__.py
@@ -10,7 +10,7 @@ from lazy_imports import LazyImporter
 _import_structure = {
     "answer": ["Answer", "ExtractedAnswer", "GeneratedAnswer"],
     "byte_stream": ["ByteStream"],
-    "chat_message": ["ChatMessage", "ChatRole", "TextContent", "ToolCall", "ToolCallResult"],
+    "chat_message": ["ChatMessage", "ChatRole", "ReasoningContent", "TextContent", "ToolCall", "ToolCallResult"],
     "image_content": ["ImageContent"],
     "document": ["Document"],
     "sparse_embedding": ["SparseEmbedding"],
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from .byte_stream import ByteStream as ByteStream
     from .chat_message import ChatMessage as ChatMessage
     from .chat_message import ChatRole as ChatRole
+    from .chat_message import ReasoningContent as ReasoningContent
     from .chat_message import TextContent as TextContent
     from .chat_message import ToolCall as ToolCall
     from .chat_message import ToolCallResult as ToolCallResult


### PR DESCRIPTION
### Proposed Changes:
- export `ReasoningContent` to `haystack.dataclasses`, as we do for other `ChatMessage` content parts


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
