### PR TITLE
fix: Make `output_type` optional in `MetadataRouter.from_dict` for YAML loading

### DIFF
--- a/haystack/components/routers/metadata_router.py
+++ b/haystack/components/routers/metadata_router.py
@@ -157,5 +157,7 @@ class MetadataRouter:
             The deserialized component instance.
         """
         init_params = data.get("init_parameters", {})
-        init_params["output_type"] = deserialize_type(init_params["output_type"])
+        if "output_type" in init_params:
+            # Deserialize the output_type to its original type
+            init_params["output_type"] = deserialize_type(init_params["output_type"])
         return default_from_dict(cls, data)

--- a/releasenotes/notes/metadata-router-output-type-optional-16a4d4d583202fde.yaml
+++ b/releasenotes/notes/metadata-router-output-type-optional-16a4d4d583202fde.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed the `from_dict` method of `MetadataRouter` so the `output_type` parameter introduced in Haystack 2.17 is now optional when loading from YAML. This ensures compatibility with older Haystack pipelines.

--- a/test/components/routers/test_metadata_router.py
+++ b/test/components/routers/test_metadata_router.py
@@ -174,6 +174,27 @@ class TestMetadataRouter:
         }
         assert router.output_type == list[Union[ByteStream, Document]]
 
+    def test_from_dict_no_output_type(self):
+        router_dict = {
+            "type": "haystack.components.routers.metadata_router.MetadataRouter",
+            "init_parameters": {
+                "rules": {
+                    "edge_1": {
+                        "operator": "AND",
+                        "conditions": [{"field": "meta.created_at", "operator": ">=", "value": "2025-02-01"}],
+                    }
+                }
+            },
+        }
+        router = MetadataRouter.from_dict(router_dict)
+        assert router.rules == {
+            "edge_1": {
+                "operator": "AND",
+                "conditions": [{"field": "meta.created_at", "operator": ">=", "value": "2025-02-01"}],
+            }
+        }
+        assert router.output_type == list[Document]
+
     def test_metadata_router_in_pipeline(self):
         document_store = InMemoryDocumentStore()
         p = Pipeline()


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
