### PR TITLE
fix: `OpenAIChatGenerator` - improve the logic to exclude custom tool calls

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -8,7 +8,12 @@ from datetime import datetime
 from typing import Any, Optional, Union
 
 from openai import AsyncOpenAI, AsyncStream, OpenAI, Stream
-from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionMessage,
+    ChatCompletionMessageCustomToolCall,
+)
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
 
@@ -480,7 +485,7 @@ def _convert_chat_completion_to_chat_message(completion: ChatCompletion, choice:
     if message.tool_calls:
         # we currently only support function tools (not custom tools)
         # https://platform.openai.com/docs/guides/function-calling#custom-tools
-        openai_tool_calls = [tc for tc in message.tool_calls if tc.type == "function"]
+        openai_tool_calls = [tc for tc in message.tool_calls if not isinstance(tc, ChatCompletionMessageCustomToolCall)]
         for openai_tc in openai_tool_calls:
             arguments_str = openai_tc.function.arguments
             try:

--- a/releasenotes/notes/openai-better-exclude-custom-tcs-35e52e359b248fc8.yaml
+++ b/releasenotes/notes/openai-better-exclude-custom-tcs-35e52e359b248fc8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    In `OpenAIChatGenerator`, improved the logic to exclude unsupported custom tool calls.
+    The previous implementation caused compatibility issues with the Mistral Haystack core integration,
+    which extends `OpenAIChatGenerator`.


### PR DESCRIPTION
### Related Issues
Failing Mistral tests after 2.17.0 release: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/17085056523/job/48447452402

### Proposed Changes:
- improve the logic to exclude unsupported custom tool calls

### How did you test it?
CI; locally tested with Mistral integration

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
