### PR TITLE
fix: Propagate tracing context in sync ToolInvoker.run(...)

### DIFF
--- a/haystack/components/tools/tool_invoker.py
+++ b/haystack/components/tools/tool_invoker.py
@@ -554,7 +554,7 @@ class ToolInvoker:
                 for params in tool_call_params:
                     # Preserve contextvars (e.g., active tracing span) inside threadpool workers
                     ctx = contextvars.copy_context()
-                    future = executor.submit(lambda p=params, c=ctx: c.run(self._execute_single_tool_call, **p))
+                    future = executor.submit(lambda: ctx.run(partial(self._execute_single_tool_call, **params)))
                     futures.append(future)
 
                 # 3) Gather and process results: handle errors and merge outputs into state

--- a/haystack/components/tools/tool_invoker.py
+++ b/haystack/components/tools/tool_invoker.py
@@ -223,7 +223,7 @@ class ToolInvoker:
         def _runner() -> Any:
             try:
                 return ctx.run(partial(tool_to_invoke.invoke, **final_args))
-            except ToolInvocationError as e:  # noqa: PERF203
+            except ToolInvocationError as e:
                 return e
 
         return _runner
@@ -625,21 +625,6 @@ class ToolInvoker:
             )
 
         return {"tool_messages": tool_messages, "state": state}
-
-    @staticmethod
-    def _execute_single_tool_call(tool_to_invoke: Tool, final_args: dict[str, Any]) -> Union[ToolInvocationError, Any]:
-        """
-        Execute a single tool call. This method is designed to be run in a thread pool.
-
-        :param tool_to_invoke: The Tool object that should be invoked.
-        :param final_args: The final arguments to pass to the tool.
-        :returns: Either a ToolInvocationError or the actual tool result.
-        """
-        try:
-            tool_result = tool_to_invoke.invoke(**final_args)
-            return tool_result
-        except ToolInvocationError as e:
-            return e
 
     @staticmethod
     async def invoke_tool_safely(

--- a/releasenotes/notes/fix-trace-parentage-sync-toolinvoker-27eb727cb563a46f.yaml
+++ b/releasenotes/notes/fix-trace-parentage-sync-toolinvoker-27eb727cb563a46f.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed missing trace parentage for tools executed via the synchronous ToolInvoker path.
+    Updated `ToolInvoker.run()` to propagate `contextvars` into ThreadPoolExecutor workers,
+    ensuring all tool spans (ComponentTool, Agent wrapped in ComponentTool, or custom tools)
+    are correctly linked to the outer Agent's trace instead of starting new root traces.
+    This improves end-to-end observability across the entire tool execution chain.


### PR DESCRIPTION
## Why
Fixes missing trace context parentage for all tools executed via the synchronous ToolInvoker path. This ensures spans emitted by any tool (ComponentTool, Agent wrapped in ComponentTool, or other custom tools) are correctly linked to the outer component trace (e.g Agent or pipeline), improving end-to-end observability across the entire tool execution chain.

## What
- Updated `haystack/components/tools/tool_invoker.py` (sync path) to propagate `contextvars` into `ThreadPoolExecutor` workers:
  - Wrap each submission with `contextvars.copy_context().run(...)`
  - Preserves the active tracing span so all tool spans become children of the ToolInvoker/Pipeline spans
- No public API changes; no configuration changes

## How can it be used
After this change, any tool invoked through ToolInvoker (ComponentTool, Agent wrapped in ComponentTool, or custom tools) automatically produces child spans under the calling Agent's span; no user code changes required.

Example pattern (unchanged for users):
```python
macro_agent = Agent(chat_generator=llm, tools=[day_tool, lodging_tool, objective_clarifier_tool])
response = macro_agent.run(messages=[ChatMessage.from_user("Plan a 4-day trip...")])
# Tracing backends now show: haystack.agent.run (macro) → tool_invoker → [any tool span] → ...
```

## How did you test it
- Relied on the existing test suite (no new tests added)
- Manually verified in a tracing backend that:
  - All tool spans invoked via ToolInvoker are children of the outer Agent's ToolInvoker span
  - Async path remained unaffected

## Notes for the reviewer
- The async code path already preserved context; this change brings the sync path to parity.
- Please sanity-check for any other threadpool submissions that may need similar `contextvars` propagation in the future.
