### PR TITLE
docs: add State to pydocs config

### DIFF
--- a/docs/pydoc/config/agents_api.yml
+++ b/docs/pydoc/config/agents_api.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../../../haystack/components/agents]
-    modules: ["agent", "state"]
+    modules: ["agent", "state/state"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter

--- a/docs/pydoc/config_docusaurus/agents_api.yml
+++ b/docs/pydoc/config_docusaurus/agents_api.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../../../haystack/components/agents]
-    modules: ["agent", "state"]
+    modules: ["agent", "state/state"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter


### PR DESCRIPTION
### Related Issues

`State` API reference does not appear in the [`Agent` API reference](https://docs.haystack.deepset.ai/reference/agents-api)

### Proposed Changes:
- point pydocs config to the specific `State` module

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
