### PR TITLE
Suggested changes pipeline crash

### DIFF
--- a/haystack/core/errors.py
+++ b/haystack/core/errors.py
@@ -49,16 +49,6 @@ class PipelineRuntimeError(Exception):
         )
         return cls(component_name, component_type, message)
 
-    @classmethod
-    def from_pipeline_crash(
-        cls, component_name: str, component_type: type, original_error: Exception, pipeline_outputs: Any
-    ) -> "PipelineRuntimeError":
-        """
-        Create a PipelineRuntimeError from a pipeline crash with serialized outputs.
-        """
-        message = f"Pipeline execution failed at component '{component_name}': {str(original_error)}"
-        return cls(component_name, component_type, message, pipeline_outputs)
-
 
 class PipelineComponentsBlockedError(PipelineRuntimeError):
     def __init__(self) -> None:

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -387,15 +387,10 @@ class Pipeline(PipelineBase):
                         component_visits=component_visits,
                         parent_span=span,
                     )
-                except Exception as e:
-                    if isinstance(e, BreakpointException):
-                        raise
-                    raise PipelineRuntimeError.from_pipeline_crash(
-                        component_name=component_name,
-                        component_type=type(component),
-                        original_error=e,
-                        pipeline_outputs=pipeline_outputs,
-                    ) from e
+                except PipelineRuntimeError as error:
+                    # Attach partial pipeline outputs to the error before re-raising
+                    error.pipeline_outputs = pipeline_outputs
+                    raise error
 
                 # Updates global input state with component outputs and returns outputs that should go to
                 # pipeline outputs.

--- a/test/core/pipeline/test_pipeline_crash_regular_pipeline_outputs_raised.py
+++ b/test/core/pipeline/test_pipeline_crash_regular_pipeline_outputs_raised.py
@@ -98,8 +98,11 @@ class TestPipelineOutputsRaisedInException:
             embedder.warm_up()
             return embedder
 
-    @patch.dict("os.environ", {"OPENAI_API_KEY": "test-api-key"})
-    def test_hybrid_rag_pipeline_crash_on_embedding_retriever(self, mock_sentence_transformers_text_embedder):
+    def test_hybrid_rag_pipeline_crash_on_embedding_retriever(
+        self, mock_sentence_transformers_text_embedder, monkeypatch
+    ):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+
         document_store = setup_document_store()
         text_embedder = mock_sentence_transformers_text_embedder
         invalid_embedding_retriever = InvalidOutputEmbeddingRetriever()
@@ -164,10 +167,11 @@ class TestPipelineOutputsRaisedInException:
         assert "answer_builder" not in pipeline_outputs, "Answer builder should not have run due to crash"
 
     @pytest.mark.asyncio
-    @patch.dict("os.environ", {"OPENAI_API_KEY": "test-api-key"})
     async def test_async_hybrid_rag_pipeline_crash_on_embedding_retriever(
-        self, mock_sentence_transformers_text_embedder
+        self, mock_sentence_transformers_text_embedder, monkeypatch
     ):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+
         document_store = setup_document_store()
         text_embedder = mock_sentence_transformers_text_embedder
         invalid_embedding_retriever = InvalidOutputEmbeddingRetriever()

--- a/test/core/pipeline/test_pipeline_crash_regular_pipeline_outputs_raised.py
+++ b/test/core/pipeline/test_pipeline_crash_regular_pipeline_outputs_raised.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -163,10 +162,6 @@ class TestPipelineOutputsRaisedInException:
         assert "prompt_builder" not in pipeline_outputs, "Prompt builder should not have run due to crash"
         assert "llm" not in pipeline_outputs, "LLM should not have run due to crash"
         assert "answer_builder" not in pipeline_outputs, "Answer builder should not have run due to crash"
-
-    from unittest.mock import patch
-
-    import pytest
 
     @pytest.mark.asyncio
     @patch.dict("os.environ", {"OPENAI_API_KEY": "test-api-key"})


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

@davidsbatista I wanted to propose a slightly different way to attach the `pipeline_outputs` to the `PipelineRuntimeError`. Mostly, I noticed that `Pipeline._run_component` already raises a `PipelineRuntimeError` so to avoid having to `PipelineRuntimeError`'s present in the traceback I thought it best to intercept the one raised by `_run_component` and just attach the `pipeline_outputs` to it. 

What do you think?

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
