### PR TITLE
docs: fix `exit_conditions` in Agent docstring

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -61,8 +61,8 @@ class Agent:
     """
     A Haystack component that implements a tool-using agent with provider-agnostic chat model support.
 
-    The component processes messages and executes tools until an exit_condition condition is met.
-    The exit_condition can be triggered either by a direct text response or by invoking a specific designated tool.
+    The component processes messages and executes tools until an exit condition is met.
+    The exit condition can be triggered either by a direct text response or by invoking a specific designated tool.
 
     When you call an Agent without tools, it acts as a ChatGenerator, produces one response, then exits.
 
@@ -78,7 +78,7 @@ class Agent:
     agent = Agent(
         chat_generator=OpenAIChatGenerator(),
         tools=tools,
-        exit_condition="search",
+        exit_conditions=["search"],
     )
 
     # Run the agent

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -63,6 +63,7 @@ class Agent:
 
     The component processes messages and executes tools until an exit condition is met.
     The exit condition can be triggered either by a direct text response or by invoking a specific designated tool.
+    Multiple exit conditions can be specified.
 
     When you call an Agent without tools, it acts as a ChatGenerator, produces one response, then exits.
 


### PR DESCRIPTION
### Proposed Changes:

- Improve the incorrect `Agent` docstring in relation to `exit_conditions`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
