### PR TITLE
Docs: clarify purpose of State class

### DIFF
--- a/haystack/components/agents/state/state.py
+++ b/haystack/components/agents/state/state.py
@@ -80,13 +80,23 @@ def _validate_schema(schema: dict[str, Any]) -> None:
 
 class State:
     """
-    A class that wraps a StateSchema and maintains an internal _data dictionary.
+    State is a container for storing shared information (documents, context, intermediate
+    results) during the execution of Agents and their tools.
 
-    Each schema entry has:
-      "parameter_name": {
-        "type": SomeType,
-        "handler": Optional[Callable[[Any, Any], Any]]
-      }
+    Internally it wraps a `_data` dictionary defined by a `StateSchema`. Each schema entry has:
+        "parameter_name": {
+            "type": SomeType,                        # expected type
+            "handler": Optional[Callable[[Any, Any], Any]]  # merge/update function
+        }
+
+    This makes it possible for different components in a pipeline or agent to
+    read from and write to the same context.
+
+    Example (simplified):
+        >>> state = State()
+        >>> state["query"] = "What is AI?"
+        >>> state["answer"] = "Artificial Intelligence is..."
+
     """
 
     def __init__(self, schema: dict[str, Any], data: Optional[dict[str, Any]] = None):


### PR DESCRIPTION
### Related Issues

- part of #9738 

### Proposed Changes:

Expanded the State class docstring to explain its purpose as shared context for Agents and tools
Clarified how schema entries are defined (type, optional handler)
Added a minimal usage snippet for quick understanding

### How did you test it?

Manual verification: built and imported the State class to ensure the docstring renders correctly

### Notes for the reviewer

This change only affects documentation (no functional changes)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
