### PR TITLE
fix: reintroduce helpful error message in `ChatMessage` deserialization

### DIFF
--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -209,7 +209,19 @@ def _deserialize_content_part(part: dict[str, Any]) -> ChatMessageContentT:
         if serialization_key in part:
             return cls.from_dict(part[serialization_key])
 
-    raise ValueError(f"Unsupported content part in the serialized ChatMessage: `{part}`")
+    # NOTE: this verbose error message provides guidance to LLMs when creating invalid messages during agent runs
+    msg = (
+        f"Unsupported content part in the serialized ChatMessage: {part}. "
+        "The `content` field of the serialized ChatMessage must be a list of dictionaries, where each "
+        "dictionary contains one of these keys: 'text', 'image', 'reasoning', 'tool_call', or 'tool_call_result'. "
+        "Valid formats: [{{'text': 'Hello'}}, "
+        "{{'image': {{'base64_image': '...', ...}}}}, "
+        "{{'reasoning': {{'reasoning_text': 'I think...', 'extra': {{...}}}}}}, "
+        "{{'tool_call': {{'tool_name': 'search', 'arguments': {{}}, 'id': 'call_123'}}}}, "
+        "{{'tool_call_result': {{'result': 'data', 'origin': {{...}}, 'error': false}}}}]"
+    )
+
+    raise ValueError(msg)
 
 
 def _serialize_content_part(part: ChatMessageContentT) -> dict[str, Any]:
@@ -530,6 +542,8 @@ class ChatMessage:  # pylint: disable=too-many-public-methods # it's OK since we
         :returns:
             The created object.
         """
+
+        # NOTE: this verbose error message provides guidance to LLMs when creating invalid messages during agent runs
         if not "role" in data and not "_role" in data:
             raise ValueError(
                 "The `role` field is required in the message dictionary. "

--- a/releasenotes/notes/chatmessage-deserialization-error-message-c0a02f3c9be08092.yaml
+++ b/releasenotes/notes/chatmessage-deserialization-error-message-c0a02f3c9be08092.yaml
@@ -1,0 +1,8 @@
+---
+
+fixes:
+  - |
+    Reintroduce verbose error message when deserializing a `ChatMessage` with invalid content parts.
+    While LLMs may still generate messages in the wrong format, this error provides guidance on the expected structure,
+    making retries easier and more reliable during agent runs.
+    The error message was unintentionally removed during a previous refactoring.

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -398,11 +398,11 @@ class TestChatMessage:
 
     def test_from_dict_with_invalid_content_type(self):
         data = {"role": "assistant", "content": [{"text": "Hello"}, "invalid"]}
-        with pytest.raises(ValueError, match="Unsupported content part in the serialized ChatMessage"):
+        with pytest.raises(ValueError, match=r"Unsupported content part.*Valid formats.*"):
             ChatMessage.from_dict(data)
 
         data = {"role": "assistant", "content": [{"text": "Hello"}, {"invalid": "invalid"}]}
-        with pytest.raises(ValueError, match="Unsupported content part in the serialized ChatMessage"):
+        with pytest.raises(ValueError, match=r"Unsupported content part.*Valid formats.*"):
             ChatMessage.from_dict(data)
 
     def test_from_dict_with_missing_role(self):


### PR DESCRIPTION
### Related Issues

- fixes #9730

### Proposed Changes:
- reintroduce the helpful error message in `ChatMessage` deserialization (incorrectly removed during a refactoring)
- added comments to avoid removing the error message again

### How did you test it?
CI, adapted tests

### Notes for the reviewer
Luckily, the helpful message about role was still present: https://github.com/deepset-ai/haystack/blob/41b7ed4f472b7c26cc6cb879e8fda1197b422f49/haystack/dataclasses/chat_message.py#L533

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
