### PR TITLE
docs: add code block syntax to docstrings

### DIFF
--- a/haystack/components/agents/state/state.py
+++ b/haystack/components/agents/state/state.py
@@ -83,10 +83,12 @@ class State:
     A class that wraps a StateSchema and maintains an internal _data dictionary.
 
     Each schema entry has:
+    ```json
       "parameter_name": {
         "type": SomeType,
         "handler": Optional[Callable[[Any, Any], Any]]
       }
+      ```
     """
 
     def __init__(self, schema: dict[str, Any], data: Optional[dict[str, Any]] = None):


### PR DESCRIPTION
### Proposed Changes:

Adding code block syntax to docstrings, as this is causing documentation workflow to fail.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
