### PR TITLE
docs: fixing comment typos

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -605,7 +605,7 @@ class _Component:
 
         return new_cls
 
-    # Call signature when the the decorator is usead without parens (@component).
+    # Call signature when the decorator is used without parens (@component).
     @overload
     def __call__(self, cls: type[T]) -> type[T]: ...
 


### PR DESCRIPTION
### Proposed Changes:

- minor typos in code comments

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
