### PR TITLE
fix: Fix parameter schema generation in `ComponentTool` when using `inputs_from_state`

### DIFF
--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -278,7 +278,7 @@ class ComponentTool(Tool):
         fields: dict[str, Any] = {}
 
         for input_name, socket in component.__haystack_input__._sockets_dict.items():  # type: ignore[attr-defined]
-            if inputs_from_state is not None and input_name in inputs_from_state:
+            if inputs_from_state is not None and input_name in list(inputs_from_state.values()):
                 continue
             input_type = socket.type
             description = param_descriptions.get(input_name, f"Input '{input_name}' for the component.")

--- a/releasenotes/notes/fix-parameter-schema-generation-component-tool-c3353ff7437115a1.yaml
+++ b/releasenotes/notes/fix-parameter-schema-generation-component-tool-c3353ff7437115a1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed parameter schema generation in `ComponentTool` when using `inputs_from_state`. Previously, parameters were only removed from the schema if the state key and parameter name matched exactly. For example, `inputs_from_state={"text": "text"}` removed `text` as expected, but `inputs_from_state={"state_text": "text"}` did not. This is now resolved, and such cases work as intended.

--- a/test/tools/test_component_tool.py
+++ b/test/tools/test_component_tool.py
@@ -184,6 +184,16 @@ class TestComponentTool:
             "description": "A simple component that generates text.",
         }
 
+    def test_from_component_with_inputs_from_state_different_names(self):
+        tool = ComponentTool(component=SimpleComponent(), inputs_from_state={"state_text": "text"})
+        assert tool.inputs_from_state == {"state_text": "text"}
+        # Inputs should be excluded from schema generation
+        assert tool.parameters == {
+            "type": "object",
+            "properties": {},
+            "description": "A simple component that generates text.",
+        }
+
     def test_from_component_with_outputs_to_state(self):
         tool = ComponentTool(component=SimpleComponent(), outputs_to_state={"replies": {"source": "reply"}})
         assert tool.outputs_to_state == {"replies": {"source": "reply"}}


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9780

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Fixed parameter schema generation in `ComponentTool` when using `inputs_from_state`. Previously, parameters were only removed from the schema if the state key and parameter name matched exactly. For example, `inputs_from_state={"text": "text"}` removed `text` as expected, but `inputs_from_state={"state_text": "text"}` did not. This is now resolved, and such cases work as intended.


### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
added a new unit test that failed before making the change

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
