### PR TITLE
test: use small Sentence Transformers models in tests

### DIFF
--- a/test/components/embedders/test_sentence_transformers_text_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_text_embedder.py
@@ -279,48 +279,6 @@ class TestSentenceTransformersTextEmbedder:
         with pytest.raises(TypeError, match="SentenceTransformersTextEmbedder expects a string as input"):
             embedder.run(text=list_integers_input)
 
-    @pytest.mark.integration
-    @pytest.mark.slow
-    def test_run_trunc(self, monkeypatch):
-        """
-        sentence-transformers/paraphrase-albert-small-v2 maps sentences & paragraphs to a 768 dimensional dense vector
-        space
-        """
-        monkeypatch.delenv("HF_API_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
-        checkpoint = "sentence-transformers/paraphrase-albert-small-v2"
-        text = "a nice text to embed"
-
-        embedder_def = SentenceTransformersTextEmbedder(model=checkpoint)
-        embedder_def.warm_up()
-        result_def = embedder_def.run(text=text)
-        embedding_def = result_def["embedding"]
-
-        embedder_trunc = SentenceTransformersTextEmbedder(model=checkpoint, truncate_dim=128)
-        embedder_trunc.warm_up()
-        result_trunc = embedder_trunc.run(text=text)
-        embedding_trunc = result_trunc["embedding"]
-
-        assert len(embedding_def) == 768
-        assert len(embedding_trunc) == 128
-
-    @pytest.mark.integration
-    @pytest.mark.slow
-    def test_run_quantization(self):
-        """
-        sentence-transformers/paraphrase-albert-small-v2 maps sentences & paragraphs to a 768 dimensional dense vector
-        space
-        """
-        checkpoint = "sentence-transformers/paraphrase-albert-small-v2"
-        text = "a nice text to embed"
-
-        embedder_def = SentenceTransformersTextEmbedder(model=checkpoint, precision="int8")
-        embedder_def.warm_up()
-        result_def = embedder_def.run(text=text)
-        embedding_def = result_def["embedding"]
-
-        assert len(embedding_def) == 768
-        assert all(isinstance(el, int) for el in embedding_def)
-
     def test_embed_encode_kwargs(self):
         embedder = SentenceTransformersTextEmbedder(model="model", encode_kwargs={"task": "retrieval.query"})
         embedder.embedding_backend = MagicMock()
@@ -416,3 +374,49 @@ class TestSentenceTransformersTextEmbedder:
             config_kwargs=None,
             backend="torch",
         )
+
+    @pytest.mark.integration
+    @pytest.mark.slow
+    def test_run_trunc(self, monkeypatch):
+        """
+        sentence-transformers-testing/stsb-bert-tiny-safetensors maps sentences & paragraphs to a 128 dimensional dense
+        vector space
+        """
+        monkeypatch.delenv("HF_API_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
+        monkeypatch.delenv("HF_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
+        checkpoint = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+        text = "a nice text to embed"
+
+        embedder_def = SentenceTransformersTextEmbedder(model=checkpoint)
+        embedder_def.warm_up()
+        result_def = embedder_def.run(text=text)
+        embedding_def = result_def["embedding"]
+
+        embedder_trunc = SentenceTransformersTextEmbedder(model=checkpoint, truncate_dim=64)
+        embedder_trunc.warm_up()
+        result_trunc = embedder_trunc.run(text=text)
+        embedding_trunc = result_trunc["embedding"]
+
+        assert len(embedding_def) == 128
+        assert len(embedding_trunc) == 64
+
+    @pytest.mark.integration
+    @pytest.mark.slow
+    def test_run_quantization(self, monkeypatch):
+        """
+        sentence-transformers-testing/stsb-bert-tiny-safetensors maps sentences & paragraphs to a 128 dimensional dense
+        vector space
+        """
+        monkeypatch.delenv("HF_API_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
+        monkeypatch.delenv("HF_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
+
+        checkpoint = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+        text = "a nice text to embed"
+
+        embedder_def = SentenceTransformersTextEmbedder(model=checkpoint, precision="int8")
+        embedder_def.warm_up()
+        result_def = embedder_def.run(text=text)
+        embedding_def = result_def["embedding"]
+
+        assert len(embedding_def) == 128
+        assert all(isinstance(el, int) for el in embedding_def)

--- a/test/components/evaluators/test_sas_evaluator.py
+++ b/test/components/evaluators/test_sas_evaluator.py
@@ -130,7 +130,9 @@ class TestSASEvaluator:
     @pytest.mark.slow
     def test_run_with_single_prediction(self, monkeypatch):
         monkeypatch.delenv("HF_API_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
-        evaluator = SASEvaluator("sentence-transformers-testing/stsb-bert-tiny-safetensors")
+        evaluator = SASEvaluator(
+            "sentence-transformers-testing/stsb-bert-tiny-safetensors", device=ComponentDevice.from_str("cpu")
+        )
 
         ground_truths = ["US $2.3 billion"]
         evaluator.warm_up()
@@ -138,8 +140,8 @@ class TestSASEvaluator:
             ground_truth_answers=ground_truths, predicted_answers=["A construction budget of US $2.3 billion"]
         )
         assert len(result) == 2
-        assert result["score"] == pytest.approx(0.816154, abs=1e-5)
-        assert result["individual_scores"] == pytest.approx([0.816154], abs=1e-5)
+        assert result["score"] == pytest.approx(0.855047, abs=1e-5)
+        assert result["individual_scores"] == pytest.approx([0.855047], abs=1e-5)
 
     @pytest.mark.integration
     @pytest.mark.slow

--- a/test/components/evaluators/test_sas_evaluator.py
+++ b/test/components/evaluators/test_sas_evaluator.py
@@ -108,7 +108,7 @@ class TestSASEvaluator:
     @pytest.mark.slow
     def test_run_with_matching_predictions(self, monkeypatch):
         monkeypatch.delenv("HF_API_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
-        evaluator = SASEvaluator()
+        evaluator = SASEvaluator("sentence-transformers-testing/stsb-bert-tiny-safetensors")
         ground_truths = [
             "A construction budget of US $2.3 billion",
             "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
@@ -130,7 +130,7 @@ class TestSASEvaluator:
     @pytest.mark.slow
     def test_run_with_single_prediction(self, monkeypatch):
         monkeypatch.delenv("HF_API_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
-        evaluator = SASEvaluator()
+        evaluator = SASEvaluator("sentence-transformers-testing/stsb-bert-tiny-safetensors")
 
         ground_truths = ["US $2.3 billion"]
         evaluator.warm_up()
@@ -138,14 +138,14 @@ class TestSASEvaluator:
             ground_truth_answers=ground_truths, predicted_answers=["A construction budget of US $2.3 billion"]
         )
         assert len(result) == 2
-        assert result["score"] == pytest.approx(0.689089, abs=1e-5)
-        assert result["individual_scores"] == pytest.approx([0.689089], abs=1e-5)
+        assert result["score"] == pytest.approx(0.816154, abs=1e-5)
+        assert result["individual_scores"] == pytest.approx([0.816154], abs=1e-5)
 
     @pytest.mark.integration
     @pytest.mark.slow
     def test_run_with_mismatched_predictions(self, monkeypatch):
         monkeypatch.delenv("HF_API_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
-        evaluator = SASEvaluator()
+        evaluator = SASEvaluator("sentence-transformers-testing/stsb-bert-tiny-safetensors")
         ground_truths = [
             "US $2.3 billion",
             "Paris's cultural magnificence is symbolized by the Eiffel Tower",
@@ -159,35 +159,14 @@ class TestSASEvaluator:
         evaluator.warm_up()
         result = evaluator.run(ground_truth_answers=ground_truths, predicted_answers=predictions)
         assert len(result) == 2
-        assert result["score"] == pytest.approx(0.8227189)
-        assert result["individual_scores"] == pytest.approx([0.689089, 0.870389, 0.908679], abs=1e-5)
-
-    @pytest.mark.integration
-    @pytest.mark.slow
-    def test_run_with_bi_encoder_model(self, monkeypatch):
-        monkeypatch.delenv("HF_API_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
-        evaluator = SASEvaluator(model="sentence-transformers/all-mpnet-base-v2")
-        ground_truths = [
-            "A construction budget of US $2.3 billion",
-            "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
-            "The Meiji Restoration in 1868 transformed Japan into a modernized world power.",
-        ]
-        predictions = [
-            "A construction budget of US $2.3 billion",
-            "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
-            "The Meiji Restoration in 1868 transformed Japan into a modernized world power.",
-        ]
-        evaluator.warm_up()
-        result = evaluator.run(ground_truth_answers=ground_truths, predicted_answers=predictions)
-        assert len(result) == 2
-        assert result["score"] == pytest.approx(1.0)
-        assert result["individual_scores"] == pytest.approx([1.0, 1.0, 1.0])
+        assert result["score"] == pytest.approx(0.912335)
+        assert result["individual_scores"] == pytest.approx([0.855047, 0.907907, 0.974050], abs=1e-5)
 
     @pytest.mark.integration
     @pytest.mark.slow
     def test_run_with_cross_encoder_model(self, monkeypatch):
         monkeypatch.delenv("HF_API_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
-        evaluator = SASEvaluator(model="cross-encoder/ms-marco-MiniLM-L-6-v2")
+        evaluator = SASEvaluator(model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce")
         ground_truths = [
             "A construction budget of US $2.3 billion",
             "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
@@ -201,7 +180,5 @@ class TestSASEvaluator:
         evaluator.warm_up()
         result = evaluator.run(ground_truth_answers=ground_truths, predicted_answers=predictions)
         assert len(result) == 2
-        assert result["score"] == pytest.approx(0.999967, abs=1e-5)
-        assert result["individual_scores"] == pytest.approx(
-            [0.9999765157699585, 0.999968409538269, 0.9999572038650513], abs=1e-5
-        )
+        assert result["score"] == pytest.approx(0.938108, abs=1e-5)
+        assert result["individual_scores"] == pytest.approx([0.930112, 0.9431504, 0.9410622], abs=1e-5)

--- a/test/components/rankers/test_sentence_transformers_diversity.py
+++ b/test/components/rankers/test_sentence_transformers_diversity.py
@@ -583,7 +583,7 @@ class TestSentenceTransformersDiversityRanker:
     def test_run_real_world_use_case(self, similarity, monkeypatch):
         monkeypatch.delenv("HF_API_TOKEN", raising=False)  # https://github.com/deepset-ai/haystack/issues/8811
         ranker = SentenceTransformersDiversityRanker(
-            model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity
+            model="sentence-transformers-testing/stsb-bert-tiny-safetensors", similarity=similarity
         )
         ranker.warm_up()
         query = "What are the reasons for long-standing animosities between Russia and Poland?"
@@ -670,20 +670,22 @@ class TestSentenceTransformersDiversityRanker:
         ]
 
         ranker = SentenceTransformersDiversityRanker(
-            model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity, strategy="maximum_margin_relevance"
+            model="sentence-transformers-testing/stsb-bert-tiny-safetensors",
+            similarity=similarity,
+            strategy="maximum_margin_relevance",
         )
         ranker.warm_up()
 
         # lambda_threshold=1, the most relevant document should be returned first
         results = ranker.run(query=query, documents=docs, lambda_threshold=1, top_k=len(docs))
         expected = [
-            "Solar power generation",
-            "Wind turbine technology",
             "Geothermal energy extraction",
-            "Hydroelectric dam systems",
+            "Wind turbine technology",
+            "Solar power generation",
             "Biomass fuel production",
-            "Ancient Egyptian hieroglyphics",
+            "Hydroelectric dam systems",
             "Baking sourdough bread",
+            "Ancient Egyptian hieroglyphics",
             "18th-century French literature",
         ]
         assert [doc.content for doc in results["documents"]] == expected
@@ -691,13 +693,13 @@ class TestSentenceTransformersDiversityRanker:
         # lambda_threshold=0, after the most relevant one, diverse documents should be returned
         results = ranker.run(query=query, documents=docs, lambda_threshold=0, top_k=len(docs))
         expected = [
-            "Solar power generation",
+            "Geothermal energy extraction",
+            "18th-century French literature",
             "Ancient Egyptian hieroglyphics",
             "Baking sourdough bread",
-            "18th-century French literature",
+            "Solar power generation",
             "Biomass fuel production",
             "Hydroelectric dam systems",
-            "Geothermal energy extraction",
             "Wind turbine technology",
         ]
         assert [doc.content for doc in results["documents"]] == expected

--- a/test/components/rankers/test_sentence_transformers_similarity.py
+++ b/test/components/rankers/test_sentence_transformers_similarity.py
@@ -372,13 +372,13 @@ class TestSentenceTransformersSimilarityRanker:
     @pytest.mark.integration
     @pytest.mark.slow
     def test_run(self):
-        ranker = SentenceTransformersSimilarityRanker(model="cross-encoder/ms-marco-MiniLM-L-6-v2")
+        ranker = SentenceTransformersSimilarityRanker(model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce")
         ranker.warm_up()
 
         query = "City in Bosnia and Herzegovina"
         docs_before_texts = ["Berlin", "Belgrade", "Sarajevo"]
         expected_first_text = "Sarajevo"
-        expected_scores = [2.2864143829792738e-05, 0.00012495707778725773, 0.009869757108390331]
+        expected_scores = [0.14568544924259186, 0.18189962208271027, 0.5728498697280884]
 
         docs_before = [Document(content=text) for text in docs_before_texts]
         output = ranker.run(query=query, documents=docs_before)
@@ -398,7 +398,9 @@ class TestSentenceTransformersSimilarityRanker:
     @pytest.mark.integration
     @pytest.mark.slow
     def test_run_top_k(self):
-        ranker = SentenceTransformersSimilarityRanker(model="cross-encoder/ms-marco-MiniLM-L-6-v2", top_k=2)
+        ranker = SentenceTransformersSimilarityRanker(
+            model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce", top_k=2
+        )
         ranker.warm_up()
 
         query = "City in Bosnia and Herzegovina"
@@ -421,7 +423,9 @@ class TestSentenceTransformersSimilarityRanker:
     @pytest.mark.integration
     @pytest.mark.slow
     def test_run_single_document(self):
-        ranker = SentenceTransformersSimilarityRanker(model="cross-encoder/ms-marco-MiniLM-L-6-v2", device=None)
+        ranker = SentenceTransformersSimilarityRanker(
+            model="cross-encoder-testing/reranker-bert-tiny-gooaq-bce", device=None
+        )
         ranker.warm_up()
         docs_before = [Document(content="Berlin")]
         output = ranker.run(query="City in Germany", documents=docs_before)


### PR DESCRIPTION
### Related Issues

While working on Sentence Transformers Sparse Embedders, I noticed that the project Sentence Transformers uses some small models in the CI

### Proposed Changes:
- adopt small models in testing, to hopefully save time in downloading and inference

### How did you test it?
CI, small adaptations to existing tests

### Notes for the reviewer
It's hard to measure the speed improvements because the duration of this workflow often depends on how responsive HF is for model downloading. With only this PR as a comparison point, exact gains are unclear, but some improvement is expected.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
