### PR TITLE
fix: pin `openai>=1.99.2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "tqdm",
   "tenacity!=8.4.0",
   "lazy-imports",
-  "openai>=1.56.1",
+  "openai>=1.99.2",
   "pydantic",
   "Jinja2",
   "posthog!=3.12.0",        # telemetry # 3.12.0 was problematic https://github.com/PostHog/posthog-python/issues/187

--- a/releasenotes/notes/pin-openai-1-99-2-3b7a452effa6784f.yaml
+++ b/releasenotes/notes/pin-openai-1-99-2-3b7a452effa6784f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The `OpenAIChatGenerator` implementation uses `ChatCompletionMessageCustomToolCall`, which is only available in
+    OpenAI client >=1.99.2. We now require `openai>=1.99.2`.


### PR DESCRIPTION
### Related Issues

- fixes #9811

### Proposed Changes:
- pin `openai>=1.99.2` since `ChatCompletionMessageCustomToolCall` is only available starting from this version

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
