### PR TITLE
fix: Fix initializing an Agent from an AgentSnapshot

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -359,11 +359,7 @@ class Agent:
         state_data = current_inputs["tool_invoker"]["state"].data
         state = State(schema=self.state_schema, data=state_data)
 
-        if isinstance(snapshot.break_point.break_point, ToolBreakpoint):
-            skip_chat_generator = True
-        else:
-            skip_chat_generator = False
-
+        skip_chat_generator = isinstance(snapshot.break_point.break_point, ToolBreakpoint)
         streaming_callback = current_inputs["chat_generator"].get("streaming_callback", streaming_callback)
         streaming_callback = select_streaming_callback(  # type: ignore[call-overload]
             init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=requires_async

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -360,13 +360,9 @@ class Agent:
         state = State(schema=self.state_schema, data=state_data)
 
         if isinstance(snapshot.break_point.break_point, ToolBreakpoint):
-            messages = current_inputs["tool_invoker"]["messages"]
             skip_chat_generator = True
         else:
-            messages = current_inputs["chat_generator"]["messages"]
             skip_chat_generator = False
-
-        state.set("messages", messages)
 
         streaming_callback = current_inputs["chat_generator"].get("streaming_callback", streaming_callback)
         streaming_callback = select_streaming_callback(  # type: ignore[call-overload]

--- a/releasenotes/notes/fix-openai-agent-snapshot-init-1ca26789564a53fe.yaml
+++ b/releasenotes/notes/fix-openai-agent-snapshot-init-1ca26789564a53fe.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Prevent duplication of the last assistant message in chat history when initializing from an AgentSnapshot.
+    Prevent duplication of the last assistant message in the chat history when initializing from an `AgentSnapshot`.

--- a/releasenotes/notes/fix-openai-agent-snapshot-init-1ca26789564a53fe.yaml
+++ b/releasenotes/notes/fix-openai-agent-snapshot-init-1ca26789564a53fe.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Prevent duplication of the last assistant message in chat history when initializing from an AgentSnapshot.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -141,7 +141,7 @@ class MockChatGenerator:
         return {"type": "MockChatGeneratorWithoutRunAsync", "data": {}}
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "MockChatGeneratorWithoutRunAsync":
+    def from_dict(cls, data: dict[str, Any]) -> "MockChatGenerator":
         return cls()
 
     @component.output_types(replies=list[ChatMessage])


### PR DESCRIPTION
### Related Issues

- fixes issue that initializing from an AgentSnapshot after a ToolBreakpoint results in an error from OpenAI since we added in the ToolCall message from the assistant twice into the chat history
- In general we were erroneously copying the last message from the assistant whether restarting from a chat generator break point or a tool break point

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Don't duplicate the last message in the chat history

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Updated unit tests to better test for this behavior
- Added integration test to cover this behavior

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

@mpangrazzi the large diff is mostly coming from tests where I'm comparing against a full agent snapshot. The actual code changes are small.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
