### PR TITLE
chore: remove dead code in `ChatGenerator` protocol

### DIFF
--- a/haystack/components/generators/chat/types/protocol.py
+++ b/haystack/components/generators/chat/types/protocol.py
@@ -2,14 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Protocol, TypeVar
+from typing import Any, Protocol
 
 from haystack.dataclasses import ChatMessage
 
 # Ellipsis are needed to define the Protocol but pylint complains. See https://github.com/pylint-dev/pylint/issues/9319.
 # pylint: disable=unnecessary-ellipsis
-
-T = TypeVar("T", bound="ChatGenerator")
 
 
 class ChatGenerator(Protocol):


### PR DESCRIPTION
### Proposed Changes:
- remove unused `TypeVar` (it was used in the past when this protocol included `to_dict`/`from_dict`)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
