### PR TITLE
fix: embedding backend id key for sent trans backend

### DIFF
--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -60,6 +60,8 @@ jobs:
               - "haystack/components/converters/tika.py"
               - "haystack/components/embedders/hugging_face_api_document_embedder.py"
               - "haystack/components/embedders/hugging_face_api_text_embedder.py"
+              - "haystack/components/embedders/backends/sentence_transformers_backend.py"
+              - "haystack/components/embedders/backends/sentence_transformers_sparse_backend.py"
               - "haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py"
               - "haystack/components/embedders/sentence_transformers_text_embedder.py"
               - "haystack/components/embedders/sentence_transformers_sparse_document_embedder.py"

--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -24,6 +24,7 @@ class _SentenceTransformersEmbeddingBackendFactory:
 
     @staticmethod
     def get_embedding_backend(  # pylint: disable=too-many-positional-arguments
+        *,
         model: str,
         device: Optional[str] = None,
         auth_token: Optional[Secret] = None,
@@ -77,6 +78,7 @@ class _SentenceTransformersEmbeddingBackend:
 
     def __init__(  # pylint: disable=too-many-positional-arguments
         self,
+        *,
         model: str,
         device: Optional[str] = None,
         auth_token: Optional[Secret] = None,

--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-
+import json
 from typing import Any, Literal, Optional, Union
 
 from haystack.lazy_imports import LazyImport
@@ -34,7 +34,20 @@ class _SentenceTransformersEmbeddingBackendFactory:
         config_kwargs: Optional[dict[str, Any]] = None,
         backend: Literal["torch", "onnx", "openvino"] = "torch",
     ):
-        embedding_backend_id = f"{model}{device}{auth_token}{truncate_dim}{backend}"
+        cache_params = {
+            "model": model,
+            "device": device,
+            "auth_token": auth_token,
+            "trust_remote_code": trust_remote_code,
+            "local_files_only": local_files_only,
+            "truncate_dim": truncate_dim,
+            "model_kwargs": model_kwargs,
+            "tokenizer_kwargs": tokenizer_kwargs,
+            "config_kwargs": config_kwargs,
+            "backend": backend,
+        }
+
+        embedding_backend_id = json.dumps(cache_params, sort_keys=True, default=str)
 
         if embedding_backend_id in _SentenceTransformersEmbeddingBackendFactory._instances:
             return _SentenceTransformersEmbeddingBackendFactory._instances[embedding_backend_id]

--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import json
 from typing import Any, Literal, Optional, Union
 

--- a/haystack/components/embedders/backends/sentence_transformers_sparse_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_sparse_backend.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from typing import Any, Literal, Optional
 
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
 from haystack.lazy_imports import LazyImport
+from haystack.utils.auth import Secret
 
 with LazyImport(message="Run 'pip install \"sentence-transformers>=5.0.0\"'") as sentence_transformers_import:
     from sentence_transformers import SparseEncoder
@@ -19,13 +21,46 @@ class _SentenceTransformersSparseEmbeddingBackendFactory:
     _instances: dict[str, "_SentenceTransformersSparseEncoderEmbeddingBackend"] = {}
 
     @staticmethod
-    def get_embedding_backend(**kwargs):
-        embedding_backend_id = json.dumps(kwargs, sort_keys=True, default=str)
+    def get_embedding_backend(
+        *,
+        model: str,
+        device: Optional[str] = None,
+        auth_token: Optional[Secret] = None,
+        trust_remote_code: bool = False,
+        local_files_only: bool = False,
+        model_kwargs: Optional[dict[str, Any]] = None,
+        tokenizer_kwargs: Optional[dict[str, Any]] = None,
+        config_kwargs: Optional[dict[str, Any]] = None,
+        backend: Literal["torch", "onnx", "openvino"] = "torch",
+    ):
+        cache_params = {
+            "model": model,
+            "device": device,
+            "auth_token": auth_token,
+            "trust_remote_code": trust_remote_code,
+            "local_files_only": local_files_only,
+            "model_kwargs": model_kwargs,
+            "tokenizer_kwargs": tokenizer_kwargs,
+            "config_kwargs": config_kwargs,
+            "backend": backend,
+        }
+
+        embedding_backend_id = json.dumps(cache_params, sort_keys=True, default=str)
 
         if embedding_backend_id in _SentenceTransformersSparseEmbeddingBackendFactory._instances:
             return _SentenceTransformersSparseEmbeddingBackendFactory._instances[embedding_backend_id]
 
-        embedding_backend = _SentenceTransformersSparseEncoderEmbeddingBackend(**kwargs)
+        embedding_backend = _SentenceTransformersSparseEncoderEmbeddingBackend(
+            model=model,
+            device=device,
+            auth_token=auth_token,
+            trust_remote_code=trust_remote_code,
+            local_files_only=local_files_only,
+            model_kwargs=model_kwargs,
+            tokenizer_kwargs=tokenizer_kwargs,
+            config_kwargs=config_kwargs,
+            backend=backend,
+        )
 
         _SentenceTransformersSparseEmbeddingBackendFactory._instances[embedding_backend_id] = embedding_backend
         return embedding_backend
@@ -36,22 +71,31 @@ class _SentenceTransformersSparseEncoderEmbeddingBackend:
     Class to manage Sparse embeddings from Sentence Transformers.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        *,
+        model: str,
+        device: Optional[str] = None,
+        auth_token: Optional[Secret] = None,
+        trust_remote_code: bool = False,
+        local_files_only: bool = False,
+        model_kwargs: Optional[dict[str, Any]] = None,
+        tokenizer_kwargs: Optional[dict[str, Any]] = None,
+        config_kwargs: Optional[dict[str, Any]] = None,
+        backend: Literal["torch", "onnx", "openvino"] = "torch",
+    ):
         sentence_transformers_import.check()
 
-        auth_token = kwargs.get("auth_token")
-        resolved_token = auth_token.resolve_value() if auth_token else None
-
         self.model = SparseEncoder(
-            model_name_or_path=kwargs["model"],
-            device=kwargs.get("device"),
-            token=resolved_token,
-            trust_remote_code=kwargs.get("trust_remote_code", False),
-            local_files_only=kwargs.get("local_files_only", False),
-            model_kwargs=kwargs.get("model_kwargs"),
-            tokenizer_kwargs=kwargs.get("tokenizer_kwargs"),
-            config_kwargs=kwargs.get("config_kwargs"),
-            backend=kwargs.get("backend", "torch"),
+            model_name_or_path=model,
+            device=device,
+            token=auth_token.resolve_value() if auth_token else None,
+            trust_remote_code=trust_remote_code,
+            local_files_only=local_files_only,
+            model_kwargs=model_kwargs,
+            tokenizer_kwargs=tokenizer_kwargs,
+            config_kwargs=config_kwargs,
+            backend=backend,
         )
 
     def embed(self, *, data: list[str], **kwargs) -> list[SparseEmbedding]:

--- a/releasenotes/notes/fix-sentence-transformers-backend-embedding-id-uniqueness.yaml-63f83bd8ad30d4c6.yaml
+++ b/releasenotes/notes/fix-sentence-transformers-backend-embedding-id-uniqueness.yaml-63f83bd8ad30d4c6.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Refactored SentenceTransformers backend to ensure unique embedding IDs by incorporating all relevant arguments and streamlined initialization using kwargs.

--- a/releasenotes/notes/fix-sentence-transformers-backend-embedding-id-uniqueness.yaml-63f83bd8ad30d4c6.yaml
+++ b/releasenotes/notes/fix-sentence-transformers-backend-embedding-id-uniqueness.yaml-63f83bd8ad30d4c6.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Refactored SentenceTransformers backend to ensure unique embedding IDs by incorporating all relevant arguments and streamlined initialization using kwargs.
+    Refactored `SentenceTransformersEmbeddingBackend` to ensure unique embedding IDs by incorporating all relevant arguments.

--- a/test/components/embedders/test_sentence_transformers_embedding_backend.py
+++ b/test/components/embedders/test_sentence_transformers_embedding_backend.py
@@ -15,13 +15,19 @@ def test_factory_behavior(mock_sentence_transformer):
     embedding_backend = _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(
         model="my_model", device="cpu"
     )
-    same_embedding_backend = _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend("my_model", "cpu")
+    same_embedding_backend = _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(
+        model="my_model", device="cpu"
+    )
     another_embedding_backend = _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(
         model="another_model", device="cpu"
+    )
+    yet_another_embedding_backend = _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(
+        model="my_model", device="cpu", trust_remote_code=True
     )
 
     assert same_embedding_backend is embedding_backend
     assert another_embedding_backend is not embedding_backend
+    assert yet_another_embedding_backend is not embedding_backend
 
 
 @patch("haystack.components.embedders.backends.sentence_transformers_backend.SentenceTransformer")


### PR DESCRIPTION
### Related Issues

- fixes #9804 

### Proposed Changes:

- Fixed embedding backend id key for sentenece transformers backend uniqueness, by passing all the arguments. Previously we didn't account for arguments like `trust_remote_code, local_files_only, model_kwargs, tokenizer_kwargs, config_kwargs`.
- Also as a small enhancement we are making use of kwargs instead of passing parameters to the `_SentenceTransformersSparseEncoderEmbeddingBackend`

### How did you test it?

Ran the exisiting test suite under `test/components/embedderstest_sentence_transformers_*`

### Notes for the reviewer

Ensured no regression caused.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
