### PR TITLE
fix: fix `OpenAIChatGenerator` `response_format` serialization errors

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -220,7 +220,7 @@ class OpenAIChatGenerator:
 
         # If the response format is a Pydantic model, it's converted to openai's json schema format
         # If it's already a json schema, it's left as is
-        if response_format and issubclass(response_format, BaseModel):
+        if response_format and isinstance(response_format, type) and issubclass(response_format, BaseModel):
             json_schema = {
                 "type": "json_schema",
                 "json_schema": {

--- a/releasenotes/notes/fix-openaichat-serialization-json-object-925de0a6387ff115.yaml
+++ b/releasenotes/notes/fix-openaichat-serialization-json-object-925de0a6387ff115.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     Ensure that the `OpenAIChatGenerator` is properly serialized when `response_format` in `generation_kwargs` is
-    provided as a dictionary (for example, {`"type": "json_object"}`). Previously, this caused serialization errors.
+    provided as a dictionary (for example, `{"type": "json_object"}`). Previously, this caused serialization errors.

--- a/releasenotes/notes/fix-openaichat-serialization-json-object-925de0a6387ff115.yaml
+++ b/releasenotes/notes/fix-openaichat-serialization-json-object-925de0a6387ff115.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Ensure that the `OpenAIChatGenerator` is properly serialized when `response_format` in `generation_kwargs` is
+    provided as a dictionary (for example, {`"type": "json_object"}`). Previously, this caused serialization errors.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -341,6 +341,31 @@ class TestOpenAIChatGenerator:
             },
         }
 
+    def test_to_dict_with_response_format_json_object(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = OpenAIChatGenerator(
+            api_key=Secret.from_env_var("OPENAI_API_KEY"),
+            model="gpt-4o-mini",
+            generation_kwargs={"response_format": {"type": "json_object"}},
+        )
+        data = component.to_dict()
+        assert data == {
+            "type": "haystack.components.generators.chat.openai.OpenAIChatGenerator",
+            "init_parameters": {
+                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
+                "model": "gpt-4o-mini",
+                "api_base_url": None,
+                "organization": None,
+                "streaming_callback": None,
+                "generation_kwargs": {"response_format": {"type": "json_object"}},
+                "tools": None,
+                "tools_strict": False,
+                "max_retries": None,
+                "timeout": None,
+                "http_client_kwargs": None,
+            },
+        }
+
     def test_from_dict(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
         data = {


### PR DESCRIPTION
### Related Issues
CI failures: https://github.com/deepset-ai/haystack/actions/runs/18338584146/job/52228270117?pr=9857

`TypeError: issubclass() arg 1 must be a class`

This happens because in `OpenAIChatGenerator`:
https://github.com/deepset-ai/haystack/blob/5c69b08a76448503a918a1f89a44faa041c88bf1/haystack/components/generators/chat/openai.py#L219-L223

But `{"type": "json_object"}` is a valid `response_format`, which is a dictionary object, not a class.

(IDK why this error only emerged now)

### Proposed Changes:
- allow proper serialization of `response_format` dictionary objects

### How did you test it?
New serialization test, CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
