### PR TITLE
ci: temporarily disable Test Python snippets in docs workflow

### DIFF
--- a/.github/workflows/docs-website-test-docs-snippets.yml
+++ b/.github/workflows/docs-website-test-docs-snippets.yml
@@ -9,6 +9,7 @@ on:
         description: 'Haystack version to test against (e.g., 2.16.1, main)'
         required: false
         default: 'main'
+        type: string
 
   # TEMPORARILY DISABLED
   # push:


### PR DESCRIPTION
### Related Issues

During the docs migration, this workflow keeps running but:
- it's not yet properly configured, so it's only testing one documentation page
- however, takes several minutes for installation, wasting time and compute

### Proposed Changes:
- temporarily disable "Test Python snippets in docs" workflow

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
