### PR TITLE
docs: make Docusaurus sync open PRs

### DIFF
--- a/.github/workflows/docusaurus_sync.yml
+++ b/.github/workflows/docusaurus_sync.yml
@@ -46,20 +46,15 @@ jobs:
           # Using rsync to copy files. This will also remove files in dest that are no longer in source.
           rsync -av --delete --exclude='.git/' "$SOURCE_PATH/" "$DEST_PATH/"
 
-      - name: Commit and push changes
-        env:
-            GITHUB_TOKEN: ${{ secrets.HAYSTACK_BOT_TOKEN }}
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-          cd docs-website
-
-          if [[ -n $(git status -s) ]]; then
-            echo "Syncing docs with Docusaurus..."
-            git add .
-            git commit -m "docs: Sync Haystack API reference"
-            git push
-          else
-            echo "No changes to sync with Docusaurus."
-          fi
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.HAYSTACK_BOT_TOKEN }}
+          commit-message: "Sync Haystack API reference on Docusaurus"
+          branch: sync-docusaurus-api-reference
+          base: main
+          title: "docs: sync Haystack API reference on Docusaurus"
+          add-paths: |
+            docs-website/reference/haystack-api
+          body: |
+            This PR syncs the Haystack API reference on Docusaurus. Just approve and merge it.


### PR DESCRIPTION
### Related Issues

Part of https://github.com/deepset-ai/haystack-private/issues/132.

Due to Branch Protection Rules, the bot cannot force push API reference updates on main, so we make it create PRs.
According to [create-pull-request action docs](https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#action-behaviour), if the PR already exists, it is just updated.

### Proposed Changes:
- modify docusaurus_sync workflow to create PRs

### How did you test it?
Hard to test. I'll manually trigger this workflow once this PR is merged. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
