### PR TITLE
fix: Add type hint

### DIFF
--- a/haystack/utils/jinja2_extensions.py
+++ b/haystack/utils/jinja2_extensions.py
@@ -55,7 +55,7 @@ class Jinja2TimeExtension(Extension):
         if offset and operator:
             try:
                 # Parse the offset and apply it to the datetime object
-                replace_params = {
+                replace_params: dict[str, Any] = {
                     interval.strip(): float(operator + value.strip())
                     for param in offset.split(",")
                     for interval, value in [param.split("=")]


### PR DESCRIPTION
### Related Issues

- fixes failing mypy test in haystack main CI (e.g. https://github.com/deepset-ai/haystack/actions/runs/18643827377/job/53147458172#step:6:57)

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Adds type hint to a kwargs dict so mypy no longer complains. Arrow had a new release 2 days ago https://pypi.org/project/arrow/1.4.0/ but I can't immediately tell if that change caused this issue. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
