### PR TITLE
docs(reference): add API reference homepage content

### DIFF
--- a/docs-website/reference/index.mdx
+++ b/docs-website/reference/index.mdx
@@ -4,12 +4,18 @@ title: API Documentation
 sidebar_position: 1
 ---
 
-# API Documentation
+# API Reference
 
-THIS IS A PLACEHOLDER FOR THE API DOCUMENTATION.
+Complete technical reference for Haystack classes, functions, and modules.
 
-Haystack API endpoints are grouped into three collections:
+## Haystack API
 
-- Main API
-- Integrations API
-- Experiments API
+Core framework API for the `haystack-ai` package. This includes all base components, pipelines, document stores, data classes, and utilities that make up the Haystack framework.
+
+## Integrations API
+
+API reference for official Haystack integrations distributed as separate packages (for example, `<integration-name>-haystack`). Each integration provides components that connect Haystack to external services, models, or platforms. For more information, see the [integrations documentation](/docs/integrations).
+
+## Experiments API
+
+API reference for experimental features. These APIs are under active development and may change in future releases. For more information, see the [experimental features documentation](/docs/experimental-package).

--- a/docs-website/reference_versioned_docs/version-2.18/index.mdx
+++ b/docs-website/reference_versioned_docs/version-2.18/index.mdx
@@ -4,12 +4,18 @@ title: API Documentation
 sidebar_position: 1
 ---
 
-# API Documentation
+# API Reference
 
-THIS IS A PLACEHOLDER FOR THE API DOCUMENTATION.
+Complete technical reference for Haystack classes, functions, and modules.
 
-Haystack API endpoints are grouped into three collections:
+## Haystack API
 
-- Main API
-- Integrations API
-- Experiments API
+Core framework API for the `haystack-ai` package. This includes all base components, pipelines, document stores, data classes, and utilities that make up the Haystack framework.
+
+## Integrations API
+
+API reference for official Haystack integrations distributed as separate packages (for example, `<integration-name>-haystack`). Each integration provides components that connect Haystack to external services, models, or platforms. For more information, see the [integrations documentation](/docs/integrations).
+
+## Experiments API
+
+API reference for experimental features. These APIs are under active development and may change in future releases. For more information, see the [experimental features documentation](/docs/experimental-package).

--- a/docs-website/reference_versioned_docs/version-2.19/index.mdx
+++ b/docs-website/reference_versioned_docs/version-2.19/index.mdx
@@ -4,12 +4,18 @@ title: API Documentation
 sidebar_position: 1
 ---
 
-# API Documentation
+# API Reference
 
-THIS IS A PLACEHOLDER FOR THE API DOCUMENTATION.
+Complete technical reference for Haystack classes, functions, and modules.
 
-Haystack API endpoints are grouped into three collections:
+## Haystack API
 
-- Main API
-- Integrations API
-- Experiments API
+Core framework API for the `haystack-ai` package. This includes all base components, pipelines, document stores, data classes, and utilities that make up the Haystack framework.
+
+## Integrations API
+
+API reference for official Haystack integrations distributed as separate packages (for example, `<integration-name>-haystack`). Each integration provides components that connect Haystack to external services, models, or platforms. For more information, see the [integrations documentation](/docs/integrations).
+
+## Experiments API
+
+API reference for experimental features. These APIs are under active development and may change in future releases. For more information, see the [experimental features documentation](/docs/experimental-package).


### PR DESCRIPTION
### Proposed Changes:

- Adding content to API Reference homepages
- Extend the `versionedReferenceLinks.js` plugin to handle linking between appropriate versions of `/docs/` and `/reference/`

### How did you test it?

Works well on local build & Vercel deployment preview

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
