### PR TITLE
docs: promote Docusaurus docs in promote_unstable_docs workflow

### DIFF
--- a/.github/workflows/promote_unstable_docs.yml
+++ b/.github/workflows/promote_unstable_docs.yml
@@ -55,4 +55,4 @@ jobs:
           body: |
             This PR promotes the unstable docs for Haystack ${{ steps.version.outputs.version }} to stable.
             It is expected to run at the time of the release.
-            You can inspect the docs preview and merge it.
+            You can inspect the docs preview and merge it. There should now be only one unstable version representing the next (main) branch.


### PR DESCRIPTION
### Related Issues

Part of https://github.com/deepset-ai/haystack-private/issues/188

### Proposed Changes:

Use the script promote_unstable_docs_docusaurus.py (introduced in #9980) in promote_unstable_docs workflow.

The workflow runs when a tag like vX.Y.0 is pushed, to trigger the actual release.

With the additions in this PR, the workflow promotes unstable docs to stable and creates a PR with them.

### How did you test it?
Hard to test it in a realistic scenario without releasing Haystack.
However, I tested it in a simplified way in https://github.com/deepset-ai/haystack/pull/9994/commits/58246448cf795f8d4f0f0cc990f9e0105f33aca4 -> generated PR: #9995 (based on a previous branch with unstable docs)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
