### PR TITLE
fix: warm up individual tools inside Toolsets in warm_up_tools()

### DIFF
--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -189,10 +189,30 @@ class Toolset:
         """
         Prepare the Toolset for use.
 
-        Override this method to set up shared resources like database connections or HTTP sessions.
+        By default, this method iterates through and warms up all tools in the Toolset.
+        Subclasses can override this method to customize initialization behavior, such as:
+
+        - Setting up shared resources (database connections, HTTP sessions) instead of
+          warming individual tools
+        - Implementing custom initialization logic for dynamically loaded tools
+        - Controlling when and how tools are initialized
+
+        For example, a Toolset that manages tools from an external service (like MCPToolset)
+        might override this to initialize a shared connection rather than warming up
+        individual tools:
+
+        ```python
+        class MCPToolset(Toolset):
+            def warm_up(self) -> None:
+                # Only warm up the shared MCP connection, not individual tools
+                self.mcp_connection = establish_connection(self.server_url)
+        ```
+
         This method should be idempotent, as it may be called multiple times.
         """
-        pass
+        for tool in self.tools:
+            if hasattr(tool, "warm_up"):
+                tool.warm_up()
 
     def add(self, tool: Union[Tool, "Toolset"]) -> None:
         """

--- a/haystack/tools/utils.py
+++ b/haystack/tools/utils.py
@@ -15,33 +15,25 @@ def warm_up_tools(tools: "Optional[ToolsType]" = None) -> None:
     """
     Warm up tools from various formats (Tools, Toolsets, or mixed lists).
 
+    For Toolset objects, this delegates to Toolset.warm_up(), which by default
+    warms up all tools in the Toolset. Toolset subclasses can override warm_up()
+    to customize initialization behavior (e.g., setting up shared resources).
+
     :param tools: A list of Tool and/or Toolset objects, a single Toolset, or None.
     """
     if tools is None:
         return
 
-    # If tools is a single Toolset, warm up the toolset itself
-    if isinstance(tools, Toolset):
+    # If tools is a single Toolset or Tool, warm it up
+    if isinstance(tools, (Toolset, Tool)):
         if hasattr(tools, "warm_up"):
             tools.warm_up()
-        # Also warm up individual tools inside the toolset
-        for tool in tools:
-            if hasattr(tool, "warm_up"):
-                tool.warm_up()
         return
 
     # If tools is a list, warm up each item (Tool or Toolset)
     if isinstance(tools, list):
         for item in tools:
-            if isinstance(item, Toolset):
-                # Warm up the toolset itself
-                if hasattr(item, "warm_up"):
-                    item.warm_up()
-                # Also warm up individual tools inside the toolset
-                for tool in item:
-                    if hasattr(tool, "warm_up"):
-                        tool.warm_up()
-            elif isinstance(item, Tool) and hasattr(item, "warm_up"):
+            if hasattr(item, "warm_up"):
                 item.warm_up()
 
 

--- a/releasenotes/notes/fix-toolset-warm-up-3e985e6a5e95a55d.yaml
+++ b/releasenotes/notes/fix-toolset-warm-up-3e985e6a5e95a55d.yaml
@@ -1,7 +1,7 @@
-fixes:
+enhancements:
   - |
-    Fixed warm_up_tools() utility function to properly warm up individual
-    tools inside Toolset objects. Previously, only the Toolset's warm_up()
-    method was called (which is a no-op), leaving individual tools
-    uninitialized. Now both the Toolset and its contained tools are
-    properly warmed up before pipeline execution."
+    Improved Toolset warm-up architecture for better encapsulation. The base
+    Toolset.warm_up() method now warms up all tools by default, while subclasses
+    can override it to customize initialization (e.g., setting up shared resources
+    instead of warming individual tools). The warm_up_tools() utility function has
+    been simplified to delegate to Toolset.warm_up().

--- a/test/components/tools/test_tool_invoker.py
+++ b/test/components/tools/test_tool_invoker.py
@@ -136,6 +136,8 @@ class WarmupTrackingToolset(Toolset):
 
     def warm_up(self):
         self.was_warmed_up = True
+        # Call parent to warm up individual tools
+        super().warm_up()
 
 
 class TestToolInvokerCore:

--- a/test/tools/test_tools_utils.py
+++ b/test/tools/test_tools_utils.py
@@ -193,6 +193,8 @@ class WarmupTrackingToolset(Toolset):
 
     def warm_up(self):
         self.was_warmed_up = True
+        # Call parent to warm up individual tools
+        super().warm_up()
 
 
 class TestWarmUpTools:
@@ -372,6 +374,7 @@ class TestWarmUpTools:
 
             def warm_up(self):
                 self.warm_up_count += 1
+                super().warm_up()  # Also warm up individual tools
 
         tool = WarmupCountingTool(
             name="counting_tool",


### PR DESCRIPTION
### Related Issues:
* Follows up on PR #9942 (feat: Add warm_up() method to ChatGenerators)
* Addresses bug discovered during implementation of PR #9942 for issue #9907

### Proposed Changes:
The warm_up_tools() utility function was only calling warm_up() on Toolset objects themselves, but not on the individual Tool instances contained within them. This meant tools inside a Toolset were not properly initialized before use. This PR modifies warm_up_tools() to iterate through Toolsets and call warm_up() on each individual tool, in addition to calling warm_up() on the Toolset itself.

### Changes:

- Modified warm_up_tools() in haystack/tools/utils.py to iterate through
Toolsets when encountered (both as single argument and within lists)
- Added iteration to call warm_up() on each individual Tool inside Toolsets
- Added comprehensive test class TestWarmUpTools with 7 test cases

### How did you test it:

- Added 7 comprehensive unit tests in test/tools/test_tools_utils.py:
  * test_warm_up_tools_with_none - handles None input
  * test_warm_up_tools_with_single_tool - single tool in list
  * test_warm_up_tools_with_single_toolset - KEY TEST: verifies both
    Toolset and individual tools are warmed
  * test_warm_up_tools_with_list_containing_toolset - toolset within list
  * test_warm_up_tools_with_multiple_toolsets - multiple toolsets
  * test_warm_up_tools_with_mixed_tools_and_toolsets - mixed scenarios
  * test_warm_up_tools_idempotency - safe to call multiple times

### Notes for the reviewer:
I discovered this bug while implementing PR #9942 (for issue #9907). When a Toolset object is passed to a component's tools parameter, the warm_up_tools() function only calls Toolset.warm_up(), which is a no-op. It doesn't iterate through the individual tools inside the Toolset to warm them up.

Acknowledged by @vblagoje and @sjrl

This implementation:

- Modified warm_up_tools() to iterate through Toolsets and call warm_up() on each individual tool
- Added comprehensive tests for Toolset warming behavior
- Verified both the Toolset and its contained tools are warmed up

### Checklist:

- [x] I have read the contributors guidelines and the code of conduct
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the conventional commit types for my PR title: `fix:`
- [x] I documented my code
- [x] I ran pre-commit hooks and fixed any issue

