### PR TITLE
docs: clarify message storage language in `State`

### DIFF
--- a/docs-website/docs/concepts/agents/state.mdx
+++ b/docs-website/docs/concepts/agents/state.mdx
@@ -2,12 +2,12 @@
 title: "State"
 id: state
 slug: "/state"
-description: "`State` is a container for storing shared information during Agent and Tool execution. It provides a structured way to maintain conversation history, share data between tools, and store intermediate results throughout an agent's workflow."
+description: "`State` is a container for storing shared information during Agent and Tool execution. It provides a structured way to store messages during execution, share data between tools, and store intermediate results throughout an agent's workflow."
 ---
 
 # State
 
-`State` is a container for storing shared information during Agent and Tool execution. It provides a structured way to maintain conversation history, share data between tools, and store intermediate results throughout an agent's workflow.
+`State` is a container for storing shared information during Agent and Tool execution. It provides a structured way to store messages during execution, share data between tools, and store intermediate results throughout an agent's workflow.
 
 ## Overview
 
@@ -30,7 +30,7 @@ State supports standard Python types:
 
 ### Automatic Message Handling
 
-State automatically includes a `messages` field to store conversation history. You don't need to define this in your schema.
+State automatically includes a `messages` field to store messages during execution. You don't need to define this in your schema.
 
 ```python
 ## State automatically adds messages field
@@ -40,11 +40,11 @@ state = State(schema={"user_id": {"type": str}})
 print("messages" in state.schema)  # True
 print(state.schema["messages"]["type"])  # list[ChatMessage]
 
-## Access conversation history
+## Access messages
 messages = state.get("messages", [])
 ```
 
-The `messages` field uses `list[ChatMessage]` type and `merge_lists` handler by default, which means new messages are appended to the conversation history.
+The `messages` field uses `list[ChatMessage]` type and `merge_lists` handler by default, which means new messages are appended during execution.
 
 ## Usage
 
@@ -171,7 +171,7 @@ You can also override handlers for individual operations:
 ```python
 def concatenate_strings(current, new):
     return f"{current}-{new}" if current else new
-    
+
 schema = {"user_name": {"type": str}}
 state = State(schema=schema)
 
@@ -505,7 +505,7 @@ result = agent.run(
 factorial_result = result["factorial_result"]
 calc_result = result["calc_result"]
 
-## Access conversation messages
+## Access messages from execution
 for message in result["messages"]:
     print(f"{message.role}: {message.text}")
 ```

--- a/docs-website/versioned_docs/version-2.19/concepts/agents/state.mdx
+++ b/docs-website/versioned_docs/version-2.19/concepts/agents/state.mdx
@@ -2,12 +2,12 @@
 title: "State"
 id: state
 slug: "/state"
-description: "`State` is a container for storing shared information during Agent and Tool execution. It provides a structured way to maintain conversation history, share data between tools, and store intermediate results throughout an agent's workflow."
+description: "`State` is a container for storing shared information during Agent and Tool execution. It provides a structured way to store messages during execution, share data between tools, and store intermediate results throughout an agent's workflow."
 ---
 
 # State
 
-`State` is a container for storing shared information during Agent and Tool execution. It provides a structured way to maintain conversation history, share data between tools, and store intermediate results throughout an agent's workflow.
+`State` is a container for storing shared information during Agent and Tool execution. It provides a structured way to store messages during execution, share data between tools, and store intermediate results throughout an agent's workflow.
 
 ## Overview
 
@@ -30,7 +30,7 @@ State supports standard Python types:
 
 ### Automatic Message Handling
 
-State automatically includes a `messages` field to store conversation history. You don't need to define this in your schema.
+State automatically includes a `messages` field to store messages during execution. You don't need to define this in your schema.
 
 ```python
 ## State automatically adds messages field
@@ -40,11 +40,11 @@ state = State(schema={"user_id": {"type": str}})
 print("messages" in state.schema)  # True
 print(state.schema["messages"]["type"])  # list[ChatMessage]
 
-## Access conversation history
+## Access messages
 messages = state.get("messages", [])
 ```
 
-The `messages` field uses `list[ChatMessage]` type and `merge_lists` handler by default, which means new messages are appended to the conversation history.
+The `messages` field uses `list[ChatMessage]` type and `merge_lists` handler by default, which means new messages are appended during execution.
 
 ## Usage
 
@@ -505,7 +505,7 @@ result = agent.run(
 factorial_result = result["factorial_result"]
 calc_result = result["calc_result"]
 
-## Access conversation messages
+## Access messages from execution
 for message in result["messages"]:
     print(f"{message.role}: {message.text}")
 ```


### PR DESCRIPTION
### Proposed Changes:

- Clarify language in `State` documentation, reflecting that `State` stores messages throughout agent execution rather than implying it's a conversation history management system.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
