### PR TITLE
docs: replace emojis and fill in an empty codeblock

### DIFF
--- a/docs-website/docs/concepts/components/custom-components.mdx
+++ b/docs-website/docs/concepts/components/custom-components.mdx
@@ -81,7 +81,7 @@ An example of an extended component is Haystack's [FaithfulnessEvaluator](https:
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Build quizzes and adventures with Character Codex and llamafile](https://haystack.deepset.ai/cookbook/charactercodex_llamafile/)
 - [Run tasks concurrently within a custom component](https://haystack.deepset.ai/cookbook/concurrent_tasks/)

--- a/docs-website/docs/concepts/experimental-package.mdx
+++ b/docs-website/docs/concepts/experimental-package.mdx
@@ -58,7 +58,7 @@ pipe.run(...)
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Improving Retrieval with Auto-Merging and Hierarchical Document Retrieval](https://haystack.deepset.ai/cookbook/auto_merging_retriever)
 - [Invoking APIs with OpenAPITool](https://haystack.deepset.ai/cookbook/openapitool)

--- a/docs-website/docs/concepts/pipelines/visualizing-pipelines.mdx
+++ b/docs-website/docs/concepts/pipelines/visualizing-pipelines.mdx
@@ -29,7 +29,7 @@ To use Mermaid graphs, you must have an internet connection to reach the Mermaid
 Use the pipeline's `show()` method to display the diagram in Jupyter notebooks.
 
 ```python
-
+my_pipeline.show()
 ```
 
 ## Saving a Graph

--- a/docs-website/docs/document-stores/astradocumentstore.mdx
+++ b/docs-website/docs/document-stores/astradocumentstore.mdx
@@ -76,4 +76,4 @@ This is only a warning. Your application keeps running unless you try to store v
 
 ## Additional References
 
-:cook: Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)
+🧑‍🍳 Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)

--- a/docs-website/docs/document-stores/chromadocumentstore.mdx
+++ b/docs-website/docs/document-stores/chromadocumentstore.mdx
@@ -88,4 +88,4 @@ The Haystack Chroma integration comes with three Retriever components. They all 
 
 ## Additional References
 
-:cook: Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)
+🧑‍🍳 Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)

--- a/docs-website/docs/document-stores/opensearch-document-store.mdx
+++ b/docs-website/docs/document-stores/opensearch-document-store.mdx
@@ -66,4 +66,4 @@ print(document_store.count_documents())
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/docs/document-stores/qdrant-document-store.mdx
+++ b/docs-website/docs/document-stores/qdrant-document-store.mdx
@@ -92,4 +92,4 @@ If you want to use Document Store or collection previously created with this fea
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/docs/optimization/advanced-rag-techniques.mdx
+++ b/docs-website/docs/optimization/advanced-rag-techniques.mdx
@@ -10,7 +10,7 @@ This section of documentation talks about advanced RAQ techniques you can implem
 
 Read more about [Hypothetical Document Embeddings (HyDE)](advanced-rag-techniques/hypothetical-document-embeddings-hyde.mdx),
 
-or check out one of our cookbooks :cook::
+or check out one of our cookbooks 🧑‍🍳:
 
 - [Using Hypothetical Document Embedding (HyDE) to Improve Retrieval](https://haystack.deepset.ai/cookbook/using_hyde_for_improved_retrieval)
 - [Query Decomposition and Reasoning](https://haystack.deepset.ai/cookbook/query_decomposition)

--- a/docs-website/docs/optimization/evaluation.mdx
+++ b/docs-website/docs/optimization/evaluation.mdx
@@ -19,13 +19,13 @@ Use evaluation and its results to:
 
 ## Evaluation Options
 
-**Evaluating individual components or end-to-end pipelines.** 
+**Evaluating individual components or end-to-end pipelines.**
 
 Evaluating individual components can help understand performance bottlenecks and optimize one component at a time, for example, a Retriever or a prompt used with a Generator.
 
 End-to-end evaluation checks how the full pipeline is used and evaluates only the final outputs. The pipeline is approached as a black box.
 
-**Using ground-truth labels or no labels at all.** 
+**Using ground-truth labels or no labels at all.**
 
 Most statistical evaluators require ground truth labels, such as the documents relevant to the query or the expected answer. In contrast, most model-based evaluators work without any labels just by following the prompt instructions. However, few-shot labels included in the prompt can improve the evaluator.
 
@@ -57,7 +57,7 @@ To get started using practical examples, check out our evaluation tutorial or t
 
 :notebook: Tutorial: [Evaluating RAG Pipelines](https://haystack.deepset.ai/tutorials/35_evaluating_rag_pipelines)
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [RAG Evaluation with Prometheus 2](https://haystack.deepset.ai/cookbook/prometheus2_evaluation)
 - [RAG Pipeline Evaluation Using Ragas](https://haystack.deepset.ai/cookbook/rag_eval_ragas)

--- a/docs-website/docs/pipeline-components/audio/localwhispertranscriber.mdx
+++ b/docs-website/docs/pipeline-components/audio/localwhispertranscriber.mdx
@@ -74,4 +74,4 @@ print(result["transcriber"]["documents"][0].content)
 
 ## Additional References
 
-:cook: Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)
+🧑‍🍳 Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)

--- a/docs-website/docs/pipeline-components/audio/remotewhispertranscriber.mdx
+++ b/docs-website/docs/pipeline-components/audio/remotewhispertranscriber.mdx
@@ -34,7 +34,7 @@ transcriber = RemoteWhisperTranscriber()
 Additionally, the component requires the following parameters to work:
 
 - `model` specifies the Whisper model.
-- `api_base_url` specifies the OpenAI base URL and defaults to `"https://api.openai.com/v1"`. If you are using Whisper provider other than OpenAI set this parameter according to provider's documentation. 
+- `api_base_url` specifies the OpenAI base URL and defaults to `"https://api.openai.com/v1"`. If you are using Whisper provider other than OpenAI set this parameter according to provider's documentation.
 
 See other optional parameters in our [API documentation](/reference/audio-api).
 
@@ -53,7 +53,7 @@ from haystack.components.audio import RemoteWhisperTranscriber
 response = requests.get("https://ia903102.us.archive.org/19/items/100-Best--Speeches/EK_19690725_64kb.mp3")
 with open("kennedy_speech.mp3", "wb") as file:
     file.write(response.content)
-    
+
 transcriber = RemoteWhisperTranscriber()
 transcription = transcriber.run(sources=["./kennedy_speech.mp3"])
 
@@ -82,4 +82,4 @@ print(result["transcriber"]["documents"][0].content)
 
 ## Additional References
 
-:cook: Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)
+🧑‍🍳 Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)

--- a/docs-website/docs/pipeline-components/builders/chatpromptbuilder.mdx
+++ b/docs-website/docs/pipeline-components/builders/chatpromptbuilder.mdx
@@ -24,7 +24,7 @@ The `ChatPromptBuilder` component creates prompts using static or dynamic templa
 
 To use it, start by providing a list of `ChatMessage` objects or a special string as the template.
 
-[`ChatMessage`](../../concepts/data-classes/chatmessage.mdx) is a data class that includes message content, a role (who generated the message, such as `user`, `assistant`, `system`, `tool`), and optional metadata. 
+[`ChatMessage`](../../concepts/data-classes/chatmessage.mdx) is a data class that includes message content, a role (who generated the message, such as `user`, `assistant`, `system`, `tool`), and optional metadata.
 
 The builder looks for placeholders in the template and identifies the required variables. You can also list these variables manually. During runtime, the `run` method takes the template and the variables, fills in the placeholders, and returns the completed prompt. If required variables are missing. If the template is invalid, the builder raises an error.
 
@@ -200,7 +200,7 @@ Hello, my name is {{name}}!
 
 builder = ChatPromptBuilder(template=template)
 result = builder.run(name="John")
-  
+
 assert result["prompt"] == [ChatMessage.from_user("Hello, my name is John!")]
 ```
 
@@ -292,7 +292,7 @@ assert result["prompt"] == [
         content_parts=["Hello! I am John. What's the difference between the following images?",
         *images]
     )
-] 
+]
 ```
 
 ### In a pipeline
@@ -352,4 +352,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)
+🧑‍🍳 Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)

--- a/docs-website/docs/pipeline-components/builders/promptbuilder.mdx
+++ b/docs-website/docs/pipeline-components/builders/promptbuilder.mdx
@@ -187,7 +187,7 @@ print(result)
 
 ```python
 documents = [
-    Document(content="Joe lives in Berlin", meta={"name": "doc1"}), 
+    Document(content="Joe lives in Berlin", meta={"name": "doc1"}),
     Document(content="Joe is a software engineer", meta={"name": "doc1"}),
 ]
 new_template = """
@@ -205,8 +205,8 @@ new_template = """
     """
 p.run({
       "prompt_builder": {
-          "documents": documents, 
-          "query": question, 
+          "documents": documents,
+          "query": question,
           "template": new_template,
       },
   })
@@ -235,20 +235,20 @@ language_template = """
     """
 p.run({
       "prompt_builder": {
-          "documents": documents, 
-          "query": question, 
-          "template": language_template, 
+          "documents": documents,
+          "query": question,
+          "template": language_template,
           "template_variables": {"answer_language": "German"},
       },
   })
 ```
 
-Note that `language_template` introduces `answer_language` variable which is not bound to any pipeline variable. If not set otherwise, it would use its default value, "English". In this example, we overwrite its value to "German".  
+Note that `language_template` introduces `answer_language` variable which is not bound to any pipeline variable. If not set otherwise, it would use its default value, "English". In this example, we overwrite its value to "German".
 The `template_variables` allows you to overwrite pipeline variables (such as documents) as well.
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)
 - [Prompt Optimization with DSPy](https://haystack.deepset.ai/cookbook/prompt_optimization_with_dspy)

--- a/docs-website/docs/pipeline-components/embedders/amazonbedrockdocumentembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/amazonbedrockdocumentembedder.mdx
@@ -146,4 +146,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/docs/pipeline-components/embedders/amazonbedrocktextembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/amazonbedrocktextembedder.mdx
@@ -116,4 +116,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/docs/pipeline-components/embedders/fastembedsparsedocumentembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/fastembedsparsedocumentembedder.mdx
@@ -92,7 +92,7 @@ docs_w_sparse_embeddings = embedder.run(documents=[doc])["documents"]
 from haystack.dataclasses import Document
 from haystack_integrations.components.embedders.fastembed import FastembedSparseDocumentEmbedder
 document_list = [
-	Document(content="I love pizza!"), 
+	Document(content="I love pizza!"),
 	Document(content="I like spaghetti")
 ]
 
@@ -109,7 +109,7 @@ print(result['documents'][0])
 
 ### In a pipeline
 
-Currently, sparse embedding retrieval is only supported by `QdrantDocumentStore`.  
+Currently, sparse embedding retrieval is only supported by `QdrantDocumentStore`.
 First, install the package with:
 
 ```shell
@@ -167,4 +167,4 @@ print(result["sparse_retriever"]["documents"][0])  # noqa: T201
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/docs/pipeline-components/embedders/fastembedsparsetextembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/fastembedsparsetextembedder.mdx
@@ -21,7 +21,7 @@ For embedding lists of documents, use the [`FastembedSparseDocumentEmbedder`](fa
 
 ## Overview
 
-`FastembedSparseTextEmbedder` transforms a string into a sparse vector using sparse embedding [models](https://qdrant.github.io/fastembed/examples/Supported_Models/#supported-sparse-text-embedding-models) supported by FastEmbed. 
+`FastembedSparseTextEmbedder` transforms a string into a sparse vector using sparse embedding [models](https://qdrant.github.io/fastembed/examples/Supported_Models/#supported-sparse-text-embedding-models) supported by FastEmbed.
 
 When you perform sparse embedding retrieval, use this component first to transform your query into a sparse vector. Then, the sparse embedding Retriever will use the vector to search for similar or relevant documents.
 
@@ -69,8 +69,8 @@ If you create both a Sparse Text Embedder and a Sparse Document Embedder based o
 ```python
 from haystack_integrations.components.embedders.fastembed import FastembedSparseTextEmbedder
 
-text = """It clearly says online this will work on a Mac OS system. 
-The disk comes and it does not, only Windows. 
+text = """It clearly says online this will work on a Mac OS system.
+The disk comes and it does not, only Windows.
 Do Not order this if you have a Mac!!"""
 
 text_embedder = FastembedSparseTextEmbedder(model="prithivida/Splade_PP_en_v1")
@@ -81,7 +81,7 @@ sparse_embedding = text_embedder.run(text)["sparse_embedding"]
 
 ### In a pipeline
 
-Currently, sparse embedding retrieval is only supported by `QdrantDocumentStore`.  
+Currently, sparse embedding retrieval is only supported by `QdrantDocumentStore`.
 First, install the package with:
 
 ```shell
@@ -120,7 +120,7 @@ document_store.write_documents(documents_with_sparse_embeddings)
 query_pipeline = Pipeline()
 query_pipeline.add_component("sparse_text_embedder", FastembedSparseTextEmbedder())
 query_pipeline.add_component("sparse_retriever", QdrantSparseEmbeddingRetriever(document_store=document_store))
-query_pipeline.connect("sparse_text_embedder.sparse_embedding", 
+query_pipeline.connect("sparse_text_embedder.sparse_embedding",
 											"sparse_retriever.query_sparse_embedding")
 
 query = "Who supports fastembed?"
@@ -136,4 +136,4 @@ print(result["sparse_retriever"]["documents"][0])  # noqa: T201
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/docs/pipeline-components/embedders/jinadocumentembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/jinadocumentembedder.mdx
@@ -121,4 +121,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)
+🧑‍🍳 Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)

--- a/docs-website/docs/pipeline-components/embedders/jinatextembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/jinatextembedder.mdx
@@ -99,4 +99,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)
+🧑‍🍳 Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)

--- a/docs-website/docs/pipeline-components/embedders/nvidiadocumentembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/nvidiadocumentembedder.mdx
@@ -120,4 +120,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)
+🧑‍🍳 Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)

--- a/docs-website/docs/pipeline-components/embedders/nvidiatextembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/nvidiatextembedder.mdx
@@ -120,4 +120,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)
+🧑‍🍳 Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)

--- a/docs-website/docs/pipeline-components/evaluators/deepevalevaluator.mdx
+++ b/docs-website/docs/pipeline-components/evaluators/deepevalevaluator.mdx
@@ -35,7 +35,7 @@ DeepEval supports a number of metrics, which we expose through the [DeepEval met
 
 ## Parameters Overview
 
-To initialize a `DeepEvalEvaluator`, you need to provide the following parameters : 
+To initialize a `DeepEvalEvaluator`, you need to provide the following parameters :
 
 - `metric`: A `DeepEvalMetric`.
 - `metric_params`: Optionally, if the metric calls for any additional parameters, you should provide them here.
@@ -74,11 +74,11 @@ pipeline.add_component("evaluator", evaluator)
 To run the evaluation pipeline, you should have the _expected inputs_ for the metric ready at hand. This metric expects a list of `questions` and `contexts`. These should come from the results of the pipeline you want to evaluate.
 
 ```python
-results = pipeline.run({"evaluator": {"questions": ["When was the Rhodes Statue built?", "Where is the Pyramid of Giza?"], 
+results = pipeline.run({"evaluator": {"questions": ["When was the Rhodes Statue built?", "Where is the Pyramid of Giza?"],
                                       "contexts": [["Context for question 1"], ["Context for question 2"]],
-                                      "responses": ["Response for queston 1", "Reponse for question 2"]}})
+                                      "responses": ["Response for question 1", "response for question 2"]}})
 ```
 
 ## Additional References
 
-:cook: Cookbook: [RAG Pipeline Evaluation Using DeepEval](https://haystack.deepset.ai/cookbook/rag_eval_deep_eval)
+🧑‍🍳 Cookbook: [RAG Pipeline Evaluation Using DeepEval](https://haystack.deepset.ai/cookbook/rag_eval_deep_eval)

--- a/docs-website/docs/pipeline-components/evaluators/ragasevaluator.mdx
+++ b/docs-website/docs/pipeline-components/evaluators/ragasevaluator.mdx
@@ -35,7 +35,7 @@ Ragas supports a number of metrics, which we expose through the Ragas metric enu
 
 ## Parameters Overview
 
-To initialize a `RagasEvaluator`, you need to provide the following parameters : 
+To initialize a `RagasEvaluator`, you need to provide the following parameters :
 
 - `metric`: A `RagasMetric`.
 - `metric_params`: Optionally, if the metric calls for any additional parameters, you should provide them here.
@@ -73,7 +73,7 @@ pipeline.add_component("evaluator", evaluator)
 To run the evaluation pipeline, you should have the _expected inputs_ for the metric ready at hand. This metric expects a list of `questions` and `contexts`, which should come from the results of the pipeline you want to evaluate.
 
 ```python
-results = pipeline.run({"evaluator": {"questions": ["When was the Rhodes Statue built?", "Where is the Pyramid of Giza?"], 
+results = pipeline.run({"evaluator": {"questions": ["When was the Rhodes Statue built?", "Where is the Pyramid of Giza?"],
                                                 "contexts": [["Context for question 1"], ["Context for question 2"]]}})
 ```
 
@@ -101,7 +101,7 @@ To run the evaluation pipeline, you should have the _expected inputs_ for the me
 
 ```python
 QUESTIONS = ["Which is the most popular global sport?", "Who created the Python language?"]
-CONTEXTS = [["The popularity of sports can be measured in various ways, including TV viewership, social media presence, number of participants, and economic impact. Football is undoubtedly the world's most popular sport with major events like the FIFA World Cup and sports personalities like Ronaldo and Messi, drawing a followership of more than 4 billion people."], 
+CONTEXTS = [["The popularity of sports can be measured in various ways, including TV viewership, social media presence, number of participants, and economic impact. Football is undoubtedly the world's most popular sport with major events like the FIFA World Cup and sports personalities like Ronaldo and Messi, drawing a followership of more than 4 billion people."],
                  ["Python, created by Guido van Rossum in the late 1980s, is a high-level general-purpose programming language. Its design philosophy emphasizes code readability, and its language constructs aim to help programmers write clear, logical code for both small and large-scale software projects."]]
 RESPONSES = ["Football is the most popular sport with around 4 billion followers worldwide", "Python language was created by Guido van Rossum."]
 GROUND_TRUTHS = ["Football is the most popular sport", "Python language was created by Guido van Rossum."]
@@ -113,4 +113,4 @@ results = pipeline.run({
 
 ## Additional References
 
-:cook: Cookbook: [Evaluate a RAG pipeline using Ragas integration](https://haystack.deepset.ai/cookbook/rag_eval_ragas)
+🧑‍🍳 Cookbook: [Evaluate a RAG pipeline using Ragas integration](https://haystack.deepset.ai/cookbook/rag_eval_ragas)

--- a/docs-website/docs/pipeline-components/evaluators/sasevaluator.mdx
+++ b/docs-website/docs/pipeline-components/evaluators/sasevaluator.mdx
@@ -38,7 +38,7 @@ from haystack.components.evaluators import SASEvaluator
 sas_evaluator = SASEvaluator()
 sas_evaluator.warm_up()
 result = sas_evaluator.run(
-  ground_truth_answers=["Berlin", "Paris"], 
+  ground_truth_answers=["Berlin", "Paris"],
   predicted_answers=["Berlin", "Lyon"]
 )
 print(result["individual_scores"])
@@ -86,4 +86,4 @@ for evaluator in result:
 
 ## Additional References
 
-:cook: Cookbook: [Prompt Optimization with DSPy](https://haystack.deepset.ai/cookbook/prompt_optimization_with_dspy)
+🧑‍🍳 Cookbook: [Prompt Optimization with DSPy](https://haystack.deepset.ai/cookbook/prompt_optimization_with_dspy)

--- a/docs-website/docs/pipeline-components/generators/amazonbedrockgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/amazonbedrockgenerator.mdx
@@ -114,4 +114,4 @@ pipe.run({
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/docs/pipeline-components/generators/anthropicchatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/anthropicchatgenerator.mdx
@@ -171,4 +171,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)
+🧑‍🍳 Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)

--- a/docs-website/docs/pipeline-components/generators/guides-to-generators/function-calling.mdx
+++ b/docs-website/docs/pipeline-components/generators/guides-to-generators/function-calling.mdx
@@ -127,7 +127,7 @@ For more information and examples, see the documentation on [`OpenAPIServiceToFu
 
 :notebook: **Tutorial: **[Building a Chat Application with Function Calling](https://haystack.deepset.ai/tutorials/40_building_chat_application_with_function_calling)
 
-:cook: **Cookbooks:**
+🧑‍🍳 **Cookbooks:**
 
 - [Function Calling with OpenAIChatGenerator](https://haystack.deepset.ai/cookbook/function_calling_with_openaichatgenerator)
 - [Information Extraction with Gorilla](https://haystack.deepset.ai/cookbook/information-extraction-gorilla)

--- a/docs-website/docs/pipeline-components/generators/huggingfaceapichatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/huggingfaceapichatgenerator.mdx
@@ -193,4 +193,4 @@ print(result)
 
 ## Additional References
 
-:cook: Cookbook: [Build with Google Gemma: chat and RAG](https://haystack.deepset.ai/cookbook/gemma_chat_rag)
+🧑‍🍳 Cookbook: [Build with Google Gemma: chat and RAG](https://haystack.deepset.ai/cookbook/gemma_chat_rag)

--- a/docs-website/docs/pipeline-components/generators/huggingfaceapigenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/huggingfaceapigenerator.mdx
@@ -173,7 +173,7 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)
 - [Information Extraction with Raven](https://haystack.deepset.ai/cookbook/information_extraction_raven)

--- a/docs-website/docs/pipeline-components/generators/huggingfacelocalgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/huggingfacelocalgenerator.mdx
@@ -110,7 +110,7 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Use Zephyr 7B Beta with Hugging Face for RAG](https://haystack.deepset.ai/cookbook/zephyr-7b-beta-for-rag)
 - [Information Extraction with Gorilla](https://haystack.deepset.ai/cookbook/information-extraction-gorilla)

--- a/docs-website/docs/pipeline-components/generators/mistralchatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/mistralchatgenerator.mdx
@@ -142,4 +142,4 @@ result = rag_pipeline.run(
 
 ## Additional References
 
-:cook: Cookbook: [Web QA with Mixtral-8x7B-Instruct-v0.1](https://haystack.deepset.ai/cookbook/mixtral-8x7b-for-web-qa)
+🧑‍🍳 Cookbook: [Web QA with Mixtral-8x7B-Instruct-v0.1](https://haystack.deepset.ai/cookbook/mixtral-8x7b-for-web-qa)

--- a/docs-website/docs/pipeline-components/generators/nvidiagenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/nvidiagenerator.mdx
@@ -137,4 +137,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)
+🧑‍🍳 Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)

--- a/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
@@ -229,4 +229,4 @@ pipe.run(data={"prompt_builder": {"template_variables":{"location": location}, "
 
 :notebook: Tutorial: [Building a Chat Application with Function Calling](https://haystack.deepset.ai/tutorials/40_building_chat_application_with_function_calling)
 
-:cook: Cookbook: [Function Calling with OpenAIChatGenerator](https://haystack.deepset.ai/cookbook/function_calling_with_openaichatgenerator)
+🧑‍🍳 Cookbook: [Function Calling with OpenAIChatGenerator](https://haystack.deepset.ai/cookbook/function_calling_with_openaichatgenerator)

--- a/docs-website/docs/pipeline-components/generators/vertexaigeminichatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/vertexaigeminichatgenerator.mdx
@@ -163,4 +163,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)
+🧑‍🍳 Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)

--- a/docs-website/docs/pipeline-components/generators/vertexaigeminigenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/vertexaigeminigenerator.mdx
@@ -152,4 +152,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)
+🧑‍🍳 Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)

--- a/docs-website/docs/pipeline-components/retrievers/astraretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/astraretriever.mdx
@@ -20,7 +20,7 @@ This is an embedding-based Retriever compatible with the Astra Document Store.
 
 ## Overview
 
-`AstraEmbeddingRetriever` compares the query and document embeddings and fetches the documents most relevant to the query from the [`AstraDocumentStore`](../../document-stores/astradocumentstore.mdx) based on the outcome. 
+`AstraEmbeddingRetriever` compares the query and document embeddings and fetches the documents most relevant to the query from the [`AstraDocumentStore`](../../document-stores/astradocumentstore.mdx) based on the outcome.
 
 When using the `AstraEmbeddingRetriever` in your NLP system, make sure it has the query and document embeddings available. You can do so by adding a Document Embedder to your indexing pipeline and a Text Embedder to your query pipeline.
 
@@ -66,7 +66,7 @@ documents = [Document(content="There are over 7,000 languages spoken around the 
 						Document(content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors."),
 						Document(content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves.")]
 
-document_embedder = SentenceTransformersDocumentEmbedder(model=model)  
+document_embedder = SentenceTransformersDocumentEmbedder(model=model)
 document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)
 
@@ -92,4 +92,4 @@ Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, co
 
 ## Additional References
 
-:cook: Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)
+🧑‍🍳 Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)

--- a/docs-website/docs/pipeline-components/retrievers/chromaembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/chromaembeddingretriever.mdx
@@ -46,7 +46,7 @@ retriever.run(query_embedding=[0.1]*384)
 
 #### In a pipeline
 
-Here is how you could use the `ChromaEmbeddingRetriever` in a pipeline. In this example, you would create two pipelines: an indexing one and a querying one. 
+Here is how you could use the `ChromaEmbeddingRetriever` in a pipeline. In this example, you would create two pipelines: an indexing one and a querying one.
 
 In the indexing pipeline, the documents are passed to the Document Embedder and then written into the document Store.
 
@@ -94,4 +94,4 @@ for d in results["retriever"]["documents"]:
 
 ## Additional References
 
-:cook: Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)
+🧑‍🍳 Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)

--- a/docs-website/docs/pipeline-components/retrievers/chromaqueryretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/chromaqueryretriever.mdx
@@ -20,8 +20,8 @@ This is a a Retriever compatible with the Chroma Document Store.
 
 ## Overview
 
-The `ChromaQueryTextRetriever` is an embedding-based Retriever compatible with the `ChromaDocumentStore` that uses the Chroma [query API](https://docs.trychroma.com/reference/Collection#query).  
-This component takes a plain-text query string in input and returns the matching documents.  
+The `ChromaQueryTextRetriever` is an embedding-based Retriever compatible with the `ChromaDocumentStore` that uses the Chroma [query API](https://docs.trychroma.com/reference/Collection#query).
+This component takes a plain-text query string in input and returns the matching documents.
 Chroma will create the embedding for the query using its [embedding function](https://docs.trychroma.com/embeddings#default-all-minilm-l6-v2); in case you do not want to use the default embedding function, this must be specified at `ChromaDocumentStore` initialization.
 
 ### Usage
@@ -44,7 +44,7 @@ retriever.run(query = "How does Chroma Retriever work?")
 
 #### In a pipeline
 
-Here is how you could use the `ChromaQueryTextRetriever` in a Pipeline. In this example, you would create two pipelines: an indexing one and a querying one. 
+Here is how you could use the `ChromaQueryTextRetriever` in a Pipeline. In this example, you would create two pipelines: an indexing one and a querying one.
 
 In the indexing pipeline, the documents are written in the Document Store.
 
@@ -85,4 +85,4 @@ for d in results["retriever"]["documents"]:
 
 ## Additional References
 
-:cook: Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)
+🧑‍🍳 Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)

--- a/docs-website/docs/pipeline-components/retrievers/opensearchbm25retriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/opensearchbm25retriever.mdx
@@ -20,12 +20,12 @@ This is a keyword-based Retriever that fetches Documents matching a query from a
 
 ## Overview
 
-`OpenSearchBM25Retriever` is a keyword-based Retriever that fetches Documents matching a query from an `OpenSearchDocumentStore`. It determines the similarity between Documents and the query based on the BM25 algorithm, which computes a weighted word overlap between the two strings. 
+`OpenSearchBM25Retriever` is a keyword-based Retriever that fetches Documents matching a query from an `OpenSearchDocumentStore`. It determines the similarity between Documents and the query based on the BM25 algorithm, which computes a weighted word overlap between the two strings.
 
-Since the `OpenSearchBM25Retriever` matches strings based on word overlap, it’s often used to find exact matches to names of persons or products, IDs, or well-defined error messages. The BM25 algorithm is very lightweight and simple. Nevertheless, it can be hard to beat with more complex embedding-based approaches on out-of-domain data. 
+Since the `OpenSearchBM25Retriever` matches strings based on word overlap, it’s often used to find exact matches to names of persons or products, IDs, or well-defined error messages. The BM25 algorithm is very lightweight and simple. Nevertheless, it can be hard to beat with more complex embedding-based approaches on out-of-domain data.
 
-In addition to the `query`, the `OpenSearchBM25Retriever` accepts other optional parameters, including `top_k` (the maximum number of Documents to retrieve) and `filters` to narrow down the search space.  
-You can adjust how [inexact fuzzy matching](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness) is performed, using the `fuzziness` parameter.  
+In addition to the `query`, the `OpenSearchBM25Retriever` accepts other optional parameters, including `top_k` (the maximum number of Documents to retrieve) and `filters` to narrow down the search space.
+You can adjust how [inexact fuzzy matching](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness) is performed, using the `fuzziness` parameter.
 It is also possible to specify if all terms in the query must match using the `all_terms_must_match` parameter, which defaults to `False`.
 
 If you want more flexible matching of a query to Documents, you can use the `OpenSearchEmbeddingRetriever`, which uses vectors created by LLMs to retrieve relevant information.
@@ -136,4 +136,4 @@ GeneratedAnswer(
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/docs/pipeline-components/retrievers/opensearchembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/opensearchembeddingretriever.mdx
@@ -20,7 +20,7 @@ An embedding-based Retriever compatible with the OpenSearch Document Store.
 
 ## Overview
 
-The `OpenSearchEmbeddingRetriever` is an embedding-based Retriever compatible with the `OpenSearchDocumentStore`. It compares the query and Document embeddings and fetches the Documents most relevant to the query from the `OpenSearchDocumentStore` based on the outcome. 
+The `OpenSearchEmbeddingRetriever` is an embedding-based Retriever compatible with the `OpenSearchDocumentStore`. It compares the query and Document embeddings and fetches the Documents most relevant to the query from the `OpenSearchDocumentStore` based on the outcome.
 
 When using the `OpenSearchEmbeddingRetriever` in your NLP system, make sure it has the query and Document embeddings available. You can do so by adding a Document Embedder to your indexing pipeline and a Text Embedder to your query pipeline.
 
@@ -75,7 +75,7 @@ documents = [Document(content="There are over 7,000 languages spoken around the 
 						Document(content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors."),
 						Document(content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves.")]
 
-document_embedder = SentenceTransformersDocumentEmbedder(model=model)  
+document_embedder = SentenceTransformersDocumentEmbedder(model=model)
 document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)
 
@@ -101,4 +101,4 @@ Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, co
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/docs/pipeline-components/retrievers/qdranthybridretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/qdranthybridretriever.mdx
@@ -157,4 +157,4 @@ print(result["retriever"]["documents"][0])
 
 :notebook: Tutorial: [Creating a Hybrid Retrieval Pipeline](https://haystack.deepset.ai/tutorials/33_hybrid_retrieval)
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/docs/pipeline-components/retrievers/qdrantsparseembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/qdrantsparseembeddingretriever.mdx
@@ -130,4 +130,4 @@ print(result["sparse_retriever"]["documents"][0])  # noqa: T201
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/versioned_docs/version-2.18/concepts/components/custom-components.mdx
+++ b/docs-website/versioned_docs/version-2.18/concepts/components/custom-components.mdx
@@ -81,7 +81,7 @@ An example of an extended component is Haystack's [FaithfulnessEvaluator](https:
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Build quizzes and adventures with Character Codex and llamafile](https://haystack.deepset.ai/cookbook/charactercodex_llamafile/)
 - [Run tasks concurrently within a custom component](https://haystack.deepset.ai/cookbook/concurrent_tasks/)

--- a/docs-website/versioned_docs/version-2.18/concepts/experimental-package.mdx
+++ b/docs-website/versioned_docs/version-2.18/concepts/experimental-package.mdx
@@ -59,7 +59,7 @@ pipe.run(...)
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Improving Retrieval with Auto-Merging and Hierarchical Document Retrieval](https://haystack.deepset.ai/cookbook/auto_merging_retriever)
 - [Invoking APIs with OpenAPITool](https://haystack.deepset.ai/cookbook/openapitool)

--- a/docs-website/versioned_docs/version-2.18/concepts/pipelines/visualizing-pipelines.mdx
+++ b/docs-website/versioned_docs/version-2.18/concepts/pipelines/visualizing-pipelines.mdx
@@ -30,7 +30,7 @@ To use Mermaid graphs, you must have an internet connection to reach the Mermaid
 Use the pipeline's `show()` method to display the diagram in Jupyter notebooks.
 
 ```python
-
+my_pipeline.show()
 ```
 
 ## Saving a Graph

--- a/docs-website/versioned_docs/version-2.18/document-stores/astradocumentstore.mdx
+++ b/docs-website/versioned_docs/version-2.18/document-stores/astradocumentstore.mdx
@@ -83,4 +83,4 @@ This is only a warning. Your application keeps running unless you try to store v
 
 ## Additional References
 
-:cook: Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)
+🧑‍🍳 Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)

--- a/docs-website/versioned_docs/version-2.18/document-stores/chromadocumentstore.mdx
+++ b/docs-website/versioned_docs/version-2.18/document-stores/chromadocumentstore.mdx
@@ -89,4 +89,4 @@ The Haystack Chroma integration comes with three Retriever components. They all 
 
 ## Additional References
 
-:cook: Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)
+🧑‍🍳 Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)

--- a/docs-website/versioned_docs/version-2.18/document-stores/opensearch-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.18/document-stores/opensearch-document-store.mdx
@@ -66,4 +66,4 @@ print(document_store.count_documents())
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.18/document-stores/qdrant-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.18/document-stores/qdrant-document-store.mdx
@@ -95,4 +95,4 @@ If you want to use Document Store or collection previously created with this fea
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/versioned_docs/version-2.18/optimization/advanced-rag-techniques.mdx
+++ b/docs-website/versioned_docs/version-2.18/optimization/advanced-rag-techniques.mdx
@@ -11,7 +11,7 @@ This section of documentation talks about advanced RAQ techniques you can implem
 
 Read more about [Hypothetical Document Embeddings (HyDE)](advanced-rag-techniques/hypothetical-document-embeddings-hyde.mdx),
 
-or check out one of our cookbooks :cook::
+or check out one of our cookbooks 🧑‍🍳:
 
 - [Using Hypothetical Document Embedding (HyDE) to Improve Retrieval](https://haystack.deepset.ai/cookbook/using_hyde_for_improved_retrieval)
 - [Query Decomposition and Reasoning](https://haystack.deepset.ai/cookbook/query_decomposition)

--- a/docs-website/versioned_docs/version-2.18/optimization/evaluation.mdx
+++ b/docs-website/versioned_docs/version-2.18/optimization/evaluation.mdx
@@ -56,7 +56,7 @@ To get started using practical examples, check out our evaluation tutorial or t
 
 :notebook: Tutorial: [Evaluating RAG Pipelines](https://haystack.deepset.ai/tutorials/35_evaluating_rag_pipelines)
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [RAG Evaluation with Prometheus 2](https://haystack.deepset.ai/cookbook/prometheus2_evaluation)
 - [RAG Pipeline Evaluation Using Ragas](https://haystack.deepset.ai/cookbook/rag_eval_ragas)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/audio/localwhispertranscriber.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/audio/localwhispertranscriber.mdx
@@ -74,4 +74,4 @@ print(result["transcriber"]["documents"][0].content)
 
 ## Additional References
 
-:cook: Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)
+🧑‍🍳 Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/audio/remotewhispertranscriber.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/audio/remotewhispertranscriber.mdx
@@ -82,4 +82,4 @@ print(result["transcriber"]["documents"][0].content)
 
 ## Additional References
 
-:cook: Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)
+🧑‍🍳 Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/builders/chatpromptbuilder.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/builders/chatpromptbuilder.mdx
@@ -352,4 +352,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)
+🧑‍🍳 Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/builders/promptbuilder.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/builders/promptbuilder.mdx
@@ -248,7 +248,7 @@ The `template_variables` allows you to overwrite pipeline variables (such as doc
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)
 - [Prompt Optimization with DSPy](https://haystack.deepset.ai/cookbook/prompt_optimization_with_dspy)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/amazonbedrockdocumentembedder.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/amazonbedrockdocumentembedder.mdx
@@ -147,4 +147,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/amazonbedrocktextembedder.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/amazonbedrocktextembedder.mdx
@@ -116,4 +116,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/fastembedsparsedocumentembedder.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/fastembedsparsedocumentembedder.mdx
@@ -168,4 +168,4 @@ print(result["sparse_retriever"]["documents"][0])  # noqa: T201
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/fastembedsparsetextembedder.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/fastembedsparsetextembedder.mdx
@@ -137,4 +137,4 @@ print(result["sparse_retriever"]["documents"][0])  # noqa: T201
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/jinadocumentembedder.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/jinadocumentembedder.mdx
@@ -122,4 +122,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)
+🧑‍🍳 Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/jinatextembedder.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/jinatextembedder.mdx
@@ -100,4 +100,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)
+🧑‍🍳 Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/nvidiadocumentembedder.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/nvidiadocumentembedder.mdx
@@ -120,4 +120,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)
+🧑‍🍳 Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/nvidiatextembedder.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/embedders/nvidiatextembedder.mdx
@@ -120,4 +120,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)
+🧑‍🍳 Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/evaluators/deepevalevaluator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/evaluators/deepevalevaluator.mdx
@@ -80,4 +80,4 @@ results = pipeline.run({"evaluator": {"questions": ["When was the Rhodes Statue 
 
 ## Additional References
 
-:cook: Cookbook: [RAG Pipeline Evaluation Using DeepEval](https://haystack.deepset.ai/cookbook/rag_eval_deep_eval)
+🧑‍🍳 Cookbook: [RAG Pipeline Evaluation Using DeepEval](https://haystack.deepset.ai/cookbook/rag_eval_deep_eval)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/evaluators/ragasevaluator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/evaluators/ragasevaluator.mdx
@@ -115,4 +115,4 @@ results = pipeline.run({
 
 ## Additional References
 
-:cook: Cookbook: [Evaluate a RAG pipeline using Ragas integration](https://haystack.deepset.ai/cookbook/rag_eval_ragas)
+🧑‍🍳 Cookbook: [Evaluate a RAG pipeline using Ragas integration](https://haystack.deepset.ai/cookbook/rag_eval_ragas)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/evaluators/sasevaluator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/evaluators/sasevaluator.mdx
@@ -86,4 +86,4 @@ for evaluator in result:
 
 ## Additional References
 
-:cook: Cookbook: [Prompt Optimization with DSPy](https://haystack.deepset.ai/cookbook/prompt_optimization_with_dspy)
+🧑‍🍳 Cookbook: [Prompt Optimization with DSPy](https://haystack.deepset.ai/cookbook/prompt_optimization_with_dspy)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/amazonbedrockgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/amazonbedrockgenerator.mdx
@@ -115,4 +115,4 @@ pipe.run({
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/anthropicchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/anthropicchatgenerator.mdx
@@ -143,4 +143,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)
+🧑‍🍳 Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/guides-to-generators/function-calling.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/guides-to-generators/function-calling.mdx
@@ -120,7 +120,7 @@ For more information and examples, see the documentation on [`OpenAPIServiceToFu
 
 :notebook: **Tutorial: **[Building a Chat Application with Function Calling](https://haystack.deepset.ai/tutorials/40_building_chat_application_with_function_calling)
 
-:cook: **Cookbooks:**
+🧑‍🍳 **Cookbooks:**
 
 - [Function Calling with OpenAIChatGenerator](https://haystack.deepset.ai/cookbook/function_calling_with_openaichatgenerator)
 - [Information Extraction with Gorilla](https://haystack.deepset.ai/cookbook/information-extraction-gorilla)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/huggingfaceapichatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/huggingfaceapichatgenerator.mdx
@@ -194,4 +194,4 @@ print(result)
 
 ## Additional References
 
-:cook: Cookbook: [Build with Google Gemma: chat and RAG](https://haystack.deepset.ai/cookbook/gemma_chat_rag)
+🧑‍🍳 Cookbook: [Build with Google Gemma: chat and RAG](https://haystack.deepset.ai/cookbook/gemma_chat_rag)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/huggingfaceapigenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/huggingfaceapigenerator.mdx
@@ -175,7 +175,7 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)
 - [Information Extraction with Raven](https://haystack.deepset.ai/cookbook/information_extraction_raven)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/huggingfacelocalgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/huggingfacelocalgenerator.mdx
@@ -111,7 +111,7 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Use Zephyr 7B Beta with Hugging Face for RAG](https://haystack.deepset.ai/cookbook/zephyr-7b-beta-for-rag)
 - [Information Extraction with Gorilla](https://haystack.deepset.ai/cookbook/information-extraction-gorilla)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/mistralchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/mistralchatgenerator.mdx
@@ -113,4 +113,4 @@ result = rag_pipeline.run(
 
 ## Additional References
 
-:cook: Cookbook: [Web QA with Mixtral-8x7B-Instruct-v0.1](https://haystack.deepset.ai/cookbook/mixtral-8x7b-for-web-qa)
+🧑‍🍳 Cookbook: [Web QA with Mixtral-8x7B-Instruct-v0.1](https://haystack.deepset.ai/cookbook/mixtral-8x7b-for-web-qa)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/nvidiagenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/nvidiagenerator.mdx
@@ -137,4 +137,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)
+🧑‍🍳 Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/openaichatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/openaichatgenerator.mdx
@@ -183,4 +183,4 @@ pipe.run(data={"prompt_builder": {"template_variables":{"location": location}, "
 
 :notebook: Tutorial: [Building a Chat Application with Function Calling](https://haystack.deepset.ai/tutorials/40_building_chat_application_with_function_calling)
 
-:cook: Cookbook: [Function Calling with OpenAIChatGenerator](https://haystack.deepset.ai/cookbook/function_calling_with_openaichatgenerator)
+🧑‍🍳 Cookbook: [Function Calling with OpenAIChatGenerator](https://haystack.deepset.ai/cookbook/function_calling_with_openaichatgenerator)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/vertexaigeminichatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/vertexaigeminichatgenerator.mdx
@@ -148,4 +148,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)
+🧑‍🍳 Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/vertexaigeminigenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/vertexaigeminigenerator.mdx
@@ -140,4 +140,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)
+🧑‍🍳 Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/astraretriever.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/astraretriever.mdx
@@ -92,4 +92,4 @@ Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, co
 
 ## Additional References
 
-:cook: Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)
+🧑‍🍳 Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/chromaembeddingretriever.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/chromaembeddingretriever.mdx
@@ -94,4 +94,4 @@ for d in results["retriever"]["documents"]:
 
 ## Additional References
 
-:cook: Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)
+🧑‍🍳 Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/chromaqueryretriever.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/chromaqueryretriever.mdx
@@ -85,4 +85,4 @@ for d in results["retriever"]["documents"]:
 
 ## Additional References
 
-:cook: Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)
+🧑‍🍳 Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/opensearchbm25retriever.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/opensearchbm25retriever.mdx
@@ -136,4 +136,4 @@ GeneratedAnswer(
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/opensearchembeddingretriever.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/opensearchembeddingretriever.mdx
@@ -101,4 +101,4 @@ Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, co
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/qdranthybridretriever.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/qdranthybridretriever.mdx
@@ -159,4 +159,4 @@ print(result["retriever"]["documents"][0])
 
 :notebook: Tutorial: [Creating a Hybrid Retrieval Pipeline](https://haystack.deepset.ai/tutorials/33_hybrid_retrieval)
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/qdrantsparseembeddingretriever.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/retrievers/qdrantsparseembeddingretriever.mdx
@@ -131,4 +131,4 @@ print(result["sparse_retriever"]["documents"][0])  # noqa: T201
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/versioned_docs/version-2.19/concepts/components/custom-components.mdx
+++ b/docs-website/versioned_docs/version-2.19/concepts/components/custom-components.mdx
@@ -81,7 +81,7 @@ An example of an extended component is Haystack's [FaithfulnessEvaluator](https:
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Build quizzes and adventures with Character Codex and llamafile](https://haystack.deepset.ai/cookbook/charactercodex_llamafile/)
 - [Run tasks concurrently within a custom component](https://haystack.deepset.ai/cookbook/concurrent_tasks/)

--- a/docs-website/versioned_docs/version-2.19/concepts/experimental-package.mdx
+++ b/docs-website/versioned_docs/version-2.19/concepts/experimental-package.mdx
@@ -59,7 +59,7 @@ pipe.run(...)
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Improving Retrieval with Auto-Merging and Hierarchical Document Retrieval](https://haystack.deepset.ai/cookbook/auto_merging_retriever)
 - [Invoking APIs with OpenAPITool](https://haystack.deepset.ai/cookbook/openapitool)

--- a/docs-website/versioned_docs/version-2.19/concepts/pipelines/visualizing-pipelines.mdx
+++ b/docs-website/versioned_docs/version-2.19/concepts/pipelines/visualizing-pipelines.mdx
@@ -29,7 +29,7 @@ To use Mermaid graphs, you must have an internet connection to reach the Mermaid
 Use the pipeline's `show()` method to display the diagram in Jupyter notebooks.
 
 ```python
-
+my_pipeline.show()
 ```
 
 ## Saving a Graph

--- a/docs-website/versioned_docs/version-2.19/document-stores/astradocumentstore.mdx
+++ b/docs-website/versioned_docs/version-2.19/document-stores/astradocumentstore.mdx
@@ -83,4 +83,4 @@ This is only a warning. Your application keeps running unless you try to store v
 
 ## Additional References
 
-:cook: Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)
+🧑‍🍳 Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)

--- a/docs-website/versioned_docs/version-2.19/document-stores/chromadocumentstore.mdx
+++ b/docs-website/versioned_docs/version-2.19/document-stores/chromadocumentstore.mdx
@@ -89,4 +89,4 @@ The Haystack Chroma integration comes with three Retriever components. They all 
 
 ## Additional References
 
-:cook: Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)
+🧑‍🍳 Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)

--- a/docs-website/versioned_docs/version-2.19/document-stores/opensearch-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.19/document-stores/opensearch-document-store.mdx
@@ -66,4 +66,4 @@ print(document_store.count_documents())
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.19/document-stores/qdrant-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.19/document-stores/qdrant-document-store.mdx
@@ -92,4 +92,4 @@ If you want to use Document Store or collection previously created with this fea
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/versioned_docs/version-2.19/optimization/advanced-rag-techniques.mdx
+++ b/docs-website/versioned_docs/version-2.19/optimization/advanced-rag-techniques.mdx
@@ -11,7 +11,7 @@ This section of documentation talks about advanced RAQ techniques you can implem
 
 Read more about [Hypothetical Document Embeddings (HyDE)](advanced-rag-techniques/hypothetical-document-embeddings-hyde.mdx),
 
-or check out one of our cookbooks :cook::
+or check out one of our cookbooks 🧑‍🍳:
 
 - [Using Hypothetical Document Embedding (HyDE) to Improve Retrieval](https://haystack.deepset.ai/cookbook/using_hyde_for_improved_retrieval)
 - [Query Decomposition and Reasoning](https://haystack.deepset.ai/cookbook/query_decomposition)

--- a/docs-website/versioned_docs/version-2.19/optimization/evaluation.mdx
+++ b/docs-website/versioned_docs/version-2.19/optimization/evaluation.mdx
@@ -56,7 +56,7 @@ To get started using practical examples, check out our evaluation tutorial or t
 
 :notebook: Tutorial: [Evaluating RAG Pipelines](https://haystack.deepset.ai/tutorials/35_evaluating_rag_pipelines)
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [RAG Evaluation with Prometheus 2](https://haystack.deepset.ai/cookbook/prometheus2_evaluation)
 - [RAG Pipeline Evaluation Using Ragas](https://haystack.deepset.ai/cookbook/rag_eval_ragas)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/audio/localwhispertranscriber.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/audio/localwhispertranscriber.mdx
@@ -74,4 +74,4 @@ print(result["transcriber"]["documents"][0].content)
 
 ## Additional References
 
-:cook: Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)
+🧑‍🍳 Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/audio/remotewhispertranscriber.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/audio/remotewhispertranscriber.mdx
@@ -82,4 +82,4 @@ print(result["transcriber"]["documents"][0].content)
 
 ## Additional References
 
-:cook: Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)
+🧑‍🍳 Cookbook: [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/builders/chatpromptbuilder.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/builders/chatpromptbuilder.mdx
@@ -352,4 +352,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)
+🧑‍🍳 Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/builders/promptbuilder.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/builders/promptbuilder.mdx
@@ -248,7 +248,7 @@ The `template_variables` allows you to overwrite pipeline variables (such as doc
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)
 - [Prompt Optimization with DSPy](https://haystack.deepset.ai/cookbook/prompt_optimization_with_dspy)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/amazonbedrockdocumentembedder.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/amazonbedrockdocumentembedder.mdx
@@ -146,4 +146,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/amazonbedrocktextembedder.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/amazonbedrocktextembedder.mdx
@@ -116,4 +116,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/fastembedsparsedocumentembedder.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/fastembedsparsedocumentembedder.mdx
@@ -168,4 +168,4 @@ print(result["sparse_retriever"]["documents"][0])  # noqa: T201
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/fastembedsparsetextembedder.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/fastembedsparsetextembedder.mdx
@@ -137,4 +137,4 @@ print(result["sparse_retriever"]["documents"][0])  # noqa: T201
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/jinadocumentembedder.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/jinadocumentembedder.mdx
@@ -122,4 +122,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)
+🧑‍🍳 Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/jinatextembedder.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/jinatextembedder.mdx
@@ -100,4 +100,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)
+🧑‍🍳 Cookbook: [Using the Jina-embeddings-v2-base-en model in a Haystack RAG pipeline for legal document analysis](https://haystack.deepset.ai/cookbook/jina-embeddings-v2-legal-analysis-rag)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/nvidiadocumentembedder.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/nvidiadocumentembedder.mdx
@@ -120,4 +120,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)
+🧑‍🍳 Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/nvidiatextembedder.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/embedders/nvidiatextembedder.mdx
@@ -120,4 +120,4 @@ print(result['retriever']['documents'][0])
 
 ## Additional References
 
-:cook: Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)
+🧑‍🍳 Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/evaluators/deepevalevaluator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/evaluators/deepevalevaluator.mdx
@@ -80,4 +80,4 @@ results = pipeline.run({"evaluator": {"questions": ["When was the Rhodes Statue 
 
 ## Additional References
 
-:cook: Cookbook: [RAG Pipeline Evaluation Using DeepEval](https://haystack.deepset.ai/cookbook/rag_eval_deep_eval)
+🧑‍🍳 Cookbook: [RAG Pipeline Evaluation Using DeepEval](https://haystack.deepset.ai/cookbook/rag_eval_deep_eval)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/evaluators/ragasevaluator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/evaluators/ragasevaluator.mdx
@@ -115,4 +115,4 @@ results = pipeline.run({
 
 ## Additional References
 
-:cook: Cookbook: [Evaluate a RAG pipeline using Ragas integration](https://haystack.deepset.ai/cookbook/rag_eval_ragas)
+🧑‍🍳 Cookbook: [Evaluate a RAG pipeline using Ragas integration](https://haystack.deepset.ai/cookbook/rag_eval_ragas)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/evaluators/sasevaluator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/evaluators/sasevaluator.mdx
@@ -86,4 +86,4 @@ for evaluator in result:
 
 ## Additional References
 
-:cook: Cookbook: [Prompt Optimization with DSPy](https://haystack.deepset.ai/cookbook/prompt_optimization_with_dspy)
+🧑‍🍳 Cookbook: [Prompt Optimization with DSPy](https://haystack.deepset.ai/cookbook/prompt_optimization_with_dspy)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/amazonbedrockgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/amazonbedrockgenerator.mdx
@@ -114,4 +114,4 @@ pipe.run({
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/anthropicchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/anthropicchatgenerator.mdx
@@ -172,4 +172,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)
+🧑‍🍳 Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/guides-to-generators/function-calling.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/guides-to-generators/function-calling.mdx
@@ -119,7 +119,7 @@ For more information and examples, see the documentation on [`OpenAPIServiceToFu
 
 :notebook: **Tutorial: **[Building a Chat Application with Function Calling](https://haystack.deepset.ai/tutorials/40_building_chat_application_with_function_calling)
 
-:cook: **Cookbooks:**
+🧑‍🍳 **Cookbooks:**
 
 - [Function Calling with OpenAIChatGenerator](https://haystack.deepset.ai/cookbook/function_calling_with_openaichatgenerator)
 - [Information Extraction with Gorilla](https://haystack.deepset.ai/cookbook/information-extraction-gorilla)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/huggingfaceapichatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/huggingfaceapichatgenerator.mdx
@@ -194,4 +194,4 @@ print(result)
 
 ## Additional References
 
-:cook: Cookbook: [Build with Google Gemma: chat and RAG](https://haystack.deepset.ai/cookbook/gemma_chat_rag)
+🧑‍🍳 Cookbook: [Build with Google Gemma: chat and RAG](https://haystack.deepset.ai/cookbook/gemma_chat_rag)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/huggingfaceapigenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/huggingfaceapigenerator.mdx
@@ -174,7 +174,7 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Multilingual RAG from a podcast with Whisper, Qdrant and Mistral](https://haystack.deepset.ai/cookbook/multilingual_rag_podcast)
 - [Information Extraction with Raven](https://haystack.deepset.ai/cookbook/information_extraction_raven)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/huggingfacelocalgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/huggingfacelocalgenerator.mdx
@@ -110,7 +110,7 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbooks:
+🧑‍🍳 Cookbooks:
 
 - [Use Zephyr 7B Beta with Hugging Face for RAG](https://haystack.deepset.ai/cookbook/zephyr-7b-beta-for-rag)
 - [Information Extraction with Gorilla](https://haystack.deepset.ai/cookbook/information-extraction-gorilla)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/mistralchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/mistralchatgenerator.mdx
@@ -142,4 +142,4 @@ result = rag_pipeline.run(
 
 ## Additional References
 
-:cook: Cookbook: [Web QA with Mixtral-8x7B-Instruct-v0.1](https://haystack.deepset.ai/cookbook/mixtral-8x7b-for-web-qa)
+🧑‍🍳 Cookbook: [Web QA with Mixtral-8x7B-Instruct-v0.1](https://haystack.deepset.ai/cookbook/mixtral-8x7b-for-web-qa)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/nvidiagenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/nvidiagenerator.mdx
@@ -137,4 +137,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)
+🧑‍🍳 Cookbook: [Haystack RAG Pipeline with Self-Deployed AI models using NVIDIA NIMs](https://haystack.deepset.ai/cookbook/rag-with-nims)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/openaichatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/openaichatgenerator.mdx
@@ -182,4 +182,4 @@ pipe.run(data={"prompt_builder": {"template_variables":{"location": location}, "
 
 :notebook: Tutorial: [Building a Chat Application with Function Calling](https://haystack.deepset.ai/tutorials/40_building_chat_application_with_function_calling)
 
-:cook: Cookbook: [Function Calling with OpenAIChatGenerator](https://haystack.deepset.ai/cookbook/function_calling_with_openaichatgenerator)
+🧑‍🍳 Cookbook: [Function Calling with OpenAIChatGenerator](https://haystack.deepset.ai/cookbook/function_calling_with_openaichatgenerator)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/vertexaigeminichatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/vertexaigeminichatgenerator.mdx
@@ -147,4 +147,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)
+🧑‍🍳 Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/vertexaigeminigenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/vertexaigeminigenerator.mdx
@@ -139,4 +139,4 @@ print(res)
 
 ## Additional References
 
-:cook: Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)
+🧑‍🍳 Cookbook: [Function Calling and Multimodal QA with Gemini](https://haystack.deepset.ai/cookbook/vertexai-gemini-examples)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/astraretriever.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/astraretriever.mdx
@@ -92,4 +92,4 @@ Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, co
 
 ## Additional References
 
-:cook: Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)
+🧑‍🍳 Cookbook: [Using AstraDB as a data store in your Haystack pipelines](https://haystack.deepset.ai/cookbook/astradb_haystack_integration)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/chromaembeddingretriever.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/chromaembeddingretriever.mdx
@@ -94,4 +94,4 @@ for d in results["retriever"]["documents"]:
 
 ## Additional References
 
-:cook: Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)
+🧑‍🍳 Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/chromaqueryretriever.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/chromaqueryretriever.mdx
@@ -85,4 +85,4 @@ for d in results["retriever"]["documents"]:
 
 ## Additional References
 
-:cook: Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)
+🧑‍🍳 Cookbook: [Use Chroma for RAG and Indexing](https://haystack.deepset.ai/cookbook/chroma-indexing-and-rag-examples)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/opensearchbm25retriever.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/opensearchbm25retriever.mdx
@@ -136,4 +136,4 @@ GeneratedAnswer(
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/opensearchembeddingretriever.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/opensearchembeddingretriever.mdx
@@ -101,4 +101,4 @@ Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, co
 
 ## Additional References
 
-:cook: Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)
+🧑‍🍳 Cookbook: [PDF-Based Question Answering with Amazon Bedrock and Haystack](https://haystack.deepset.ai/cookbook/amazon_bedrock_for_documentation_qa)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/qdranthybridretriever.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/qdranthybridretriever.mdx
@@ -157,4 +157,4 @@ print(result["retriever"]["documents"][0])
 
 :notebook: Tutorial: [Creating a Hybrid Retrieval Pipeline](https://haystack.deepset.ai/tutorials/33_hybrid_retrieval)
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/qdrantsparseembeddingretriever.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/retrievers/qdrantsparseembeddingretriever.mdx
@@ -130,4 +130,4 @@ print(result["sparse_retriever"]["documents"][0])  # noqa: T201
 
 ## Additional References
 
-:cook: Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)
+🧑‍🍳 Cookbook: [Sparse Embedding Retrieval with Qdrant and FastEmbed](https://haystack.deepset.ai/cookbook/sparse_embedding_retrieval)


### PR DESCRIPTION
### Proposed Changes:

Couple of small doc fixes:
- `:cook:` replaced with actual 🧑‍🍳 emoji
- `show()` method had an empty codeblock in Visualizing Pipelines page
- Word typos

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
