### PR TITLE
chore(docs): fix text formatting + position of external integrations in sidebars

### DIFF
--- a/docs-website/docs/overview/telemetry.mdx
+++ b/docs-website/docs/overview/telemetry.mdx
@@ -11,9 +11,9 @@ Haystack relies on anonymous usage statistics to continuously improve. That's wh
 
 ## What Information Is Shared?
 
-Telemetry in Haystack comprises anonymous usage statistics of base components, such as `DocumentStore`, `Retriever`, `Reader`, or any other pipeline component. We receive an event every time these components are initialized. This way, we know which components are most relevant to our community. For the same reason, an event is also sent when one of the tutorials is executed. 
+Telemetry in Haystack comprises anonymous usage statistics of base components, such as `DocumentStore`, `Retriever`, `Reader`, or any other pipeline component. We receive an event every time these components are initialized. This way, we know which components are most relevant to our community. For the same reason, an event is also sent when one of the tutorials is executed.
 
-Each event contains an anonymous, randomly generated user ID (`uuid`)  and a collection of properties about your execution environment. They **never ** contain properties that can be used to identify you, such as:
+Each event contains an anonymous, randomly generated user ID (`uuid`)  and a collection of properties about your execution environment. They **never** contain properties that can be used to identify you, such as:
 
 - IP addresses
 - Hostnames
@@ -43,11 +43,11 @@ Here is an exemplary event that is sent when tutorial 1 is executed by running `
 }
 ```
 
-Our telemetry code can be directly inspected on [GitHub](https://github.com/deepset-ai/haystack/blob/5d66d040cc303ab49225587cd61290f1987a5d1f/haystack/telemetry/_telemetry.py). 
+Our telemetry code can be directly inspected on [GitHub](https://github.com/deepset-ai/haystack/blob/5d66d040cc303ab49225587cd61290f1987a5d1f/haystack/telemetry/_telemetry.py).
 
 ## How Does Telemetry Help?
 
-Thanks to telemetry, we can understand the needs of the community: _"What pipeline nodes are most popular?", "Should we focus on supporting one specific Document Store?", "How many people use Haystack on Windows?"_ are some of the questions telemetry helps us answer. Metadata about the operating system and installed dependencies allows us to quickly identify and address issues caused by specific setups. 
+Thanks to telemetry, we can understand the needs of the community: _"What pipeline nodes are most popular?", "Should we focus on supporting one specific Document Store?", "How many people use Haystack on Windows?"_ are some of the questions telemetry helps us answer. Metadata about the operating system and installed dependencies allows us to quickly identify and address issues caused by specific setups.
 
 In short, by sharing this information, you enable us to continuously improve Haystack for everyone.
 
@@ -61,7 +61,7 @@ You can disable telemetry by setting the environment variable `HAYSTACK_TELEMETR
 
 ### Using a Bash Shell
 
-If you are using a bash shell, add the following line to the file `~/.bashrc` to disable telemetry: `export HAYSTACK_TELEMETRY_ENABLED=False`. 
+If you are using a bash shell, add the following line to the file `~/.bashrc` to disable telemetry: `export HAYSTACK_TELEMETRY_ENABLED=False`.
 
 ### Using zsh
 
@@ -69,7 +69,7 @@ If you are using zsh as your shell, for example, on macOS, add  the following li
 
 ### On Windows
 
-To disable telemetry on Windows, set a user-level environment variable by running this command in the standard command prompt: `setx HAYSTACK_TELEMETRY_ENABLED "False"`. 
+To disable telemetry on Windows, set a user-level environment variable by running this command in the standard command prompt: `setx HAYSTACK_TELEMETRY_ENABLED "False"`.
 
 Alternatively, run the following command in Windows PowerShell: `[Environment]::SetEnvironmentVariable("HAYSTACK_TELEMETRY_ENABLED","False","User")`.
 

--- a/docs-website/docs/pipeline-components/generators/guides-to-generators/function-calling.mdx
+++ b/docs-website/docs/pipeline-components/generators/guides-to-generators/function-calling.mdx
@@ -125,7 +125,7 @@ For example, you can easily connect an LLM with a ChatGenerator to an external s
 
 For more information and examples, see the documentation on [`OpenAPIServiceToFunctions`](../../converters/openapiservicetofunctions.mdx) and [`OpenAPIServiceConnector`](../../connectors/openapiserviceconnector.mdx).
 
-:notebook: **Tutorial: **[Building a Chat Application with Function Calling](https://haystack.deepset.ai/tutorials/40_building_chat_application_with_function_calling)
+:notebook: **Tutorial:** [Building a Chat Application with Function Calling](https://haystack.deepset.ai/tutorials/40_building_chat_application_with_function_calling)
 
 🧑‍🍳 **Cookbooks:**
 

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -158,9 +158,9 @@ export default {
             id: 'pipeline-components/audio'
           },
           items: [
-            'pipeline-components/audio/external-integrations-audio',
             'pipeline-components/audio/localwhispertranscriber',
             'pipeline-components/audio/remotewhispertranscriber',
+            'pipeline-components/audio/external-integrations-audio',
           ],
         },
         {
@@ -203,7 +203,6 @@ export default {
             id: 'pipeline-components/connectors'
           },
           items: [
-            'pipeline-components/connectors/external-integrations-connectors',
             'pipeline-components/connectors/githubfileeditor',
             'pipeline-components/connectors/githubissuecommenter',
             'pipeline-components/connectors/githubissueviewer',
@@ -215,6 +214,7 @@ export default {
             'pipeline-components/connectors/openapiconnector',
             'pipeline-components/connectors/openapiserviceconnector',
             'pipeline-components/connectors/weaveconnector',
+            'pipeline-components/connectors/external-integrations-connectors',
           ],
         },
         {
@@ -229,7 +229,6 @@ export default {
             'pipeline-components/converters/csvtodocument',
             'pipeline-components/converters/documenttoimagecontent',
             'pipeline-components/converters/docxtodocument',
-            'pipeline-components/converters/external-integrations-converters',
             'pipeline-components/converters/htmltodocument',
             'pipeline-components/converters/imagefiletodocument',
             'pipeline-components/converters/imagefiletoimagecontent',
@@ -248,6 +247,7 @@ export default {
             'pipeline-components/converters/tikadocumentconverter',
             'pipeline-components/converters/unstructuredfileconverter',
             'pipeline-components/converters/xlsxtodocument',
+            'pipeline-components/converters/external-integrations-converters',
           ],
         },
         {
@@ -274,7 +274,6 @@ export default {
             'pipeline-components/embedders/coheredocumentembedder',
             'pipeline-components/embedders/coheredocumentimageembedder',
             'pipeline-components/embedders/coheretextembedder',
-            'pipeline-components/embedders/external-integrations-embedders',
             'pipeline-components/embedders/fastembeddocumentembedder',
             'pipeline-components/embedders/fastembedsparsedocumentembedder',
             'pipeline-components/embedders/fastembedsparsetextembedder',
@@ -307,6 +306,7 @@ export default {
             'pipeline-components/embedders/vertexaitextembedder',
             'pipeline-components/embedders/watsonxdocumentembedder',
             'pipeline-components/embedders/watsonxtextembedder',
+            'pipeline-components/embedders/external-integrations-embedders',
           ],
         },
         {
@@ -324,11 +324,11 @@ export default {
             'pipeline-components/evaluators/documentmrrevaluator',
             'pipeline-components/evaluators/documentndcgevaluator',
             'pipeline-components/evaluators/documentrecallevaluator',
-            'pipeline-components/evaluators/external-integrations-evaluators',
             'pipeline-components/evaluators/faithfulnessevaluator',
             'pipeline-components/evaluators/llmevaluator',
             'pipeline-components/evaluators/ragasevaluator',
             'pipeline-components/evaluators/sasevaluator',
+            'pipeline-components/evaluators/external-integrations-evaluators',
           ],
         },
         {
@@ -352,8 +352,8 @@ export default {
             id: 'pipeline-components/fetchers'
           },
           items: [
-            'pipeline-components/fetchers/external-integrations-fetchers',
             'pipeline-components/fetchers/linkcontentfetcher',
+            'pipeline-components/fetchers/external-integrations-fetchers',
           ],
         },
         {
@@ -383,7 +383,6 @@ export default {
             'pipeline-components/generators/coherechatgenerator',
             'pipeline-components/generators/coheregenerator',
             'pipeline-components/generators/dalleimagegenerator',
-            'pipeline-components/generators/external-integrations-generators',
             'pipeline-components/generators/fallbackchatgenerator',
             'pipeline-components/generators/googleaigeminichatgenerator',
             'pipeline-components/generators/googleaigeminigenerator',
@@ -417,6 +416,7 @@ export default {
             'pipeline-components/generators/vertexaitextgenerator',
             'pipeline-components/generators/watsonxchatgenerator',
             'pipeline-components/generators/watsonxgenerator',
+            'pipeline-components/generators/external-integrations-generators',
           ],
         },
         {
@@ -464,7 +464,6 @@ export default {
             'pipeline-components/rankers/choosing-the-right-ranker',
             'pipeline-components/rankers/amazonbedrockranker',
             'pipeline-components/rankers/cohereranker',
-            'pipeline-components/rankers/external-integrations-rankers',
             'pipeline-components/rankers/fastembedranker',
             'pipeline-components/rankers/huggingfaceteiranker',
             'pipeline-components/rankers/jinaranker',
@@ -475,6 +474,7 @@ export default {
             'pipeline-components/rankers/sentencetransformersdiversityranker',
             'pipeline-components/rankers/sentencetransformerssimilarityranker',
             'pipeline-components/rankers/transformerssimilarityranker',
+            'pipeline-components/rankers/external-integrations-rankers',
           ],
         },
         {
@@ -574,9 +574,9 @@ export default {
             id: 'pipeline-components/websearch'
           },
           items: [
-            'pipeline-components/websearch/external-integrations-websearch',
             'pipeline-components/websearch/searchapiwebsearch',
             'pipeline-components/websearch/serperdevwebsearch',
+            'pipeline-components/websearch/external-integrations-websearch',
           ],
         },
         {
@@ -646,7 +646,6 @@ export default {
       items: [
         'development/logging',
         'development/tracing',
-        'development/external-integrations-development',
         'development/enabling-gpu-acceleration',
         'development/hayhooks',
         {
@@ -662,6 +661,7 @@ export default {
             'development/deployment/openshift',
           ],
         },
+        'development/external-integrations-development',
       ],
     },
   ],

--- a/docs-website/versioned_docs/version-2.19/overview/telemetry.mdx
+++ b/docs-website/versioned_docs/version-2.19/overview/telemetry.mdx
@@ -13,7 +13,7 @@ Haystack relies on anonymous usage statistics to continuously improve. That's wh
 
 Telemetry in Haystack comprises anonymous usage statistics of base components, such as `DocumentStore`, `Retriever`, `Reader`, or any other pipeline component. We receive an event every time these components are initialized. This way, we know which components are most relevant to our community. For the same reason, an event is also sent when one of the tutorials is executed.
 
-Each event contains an anonymous, randomly generated user ID (`uuid`)  and a collection of properties about your execution environment. They **never ** contain properties that can be used to identify you, such as:
+Each event contains an anonymous, randomly generated user ID (`uuid`)  and a collection of properties about your execution environment. They **never** contain properties that can be used to identify you, such as:
 
 - IP addresses
 - Hostnames

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/guides-to-generators/function-calling.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/guides-to-generators/function-calling.mdx
@@ -117,7 +117,7 @@ For example, you can easily connect an LLM with a ChatGenerator to an external s
 
 For more information and examples, see the documentation on [`OpenAPIServiceToFunctions`](../../converters/openapiservicetofunctions.mdx) and [`OpenAPIServiceConnector`](../../connectors/openapiserviceconnector.mdx).
 
-:notebook: **Tutorial: **[Building a Chat Application with Function Calling](https://haystack.deepset.ai/tutorials/40_building_chat_application_with_function_calling)
+:notebook: **Tutorial:** [Building a Chat Application with Function Calling](https://haystack.deepset.ai/tutorials/40_building_chat_application_with_function_calling)
 
 🧑‍🍳 **Cookbooks:**
 

--- a/docs-website/versioned_sidebars/version-2.19-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.19-sidebars.json
@@ -154,9 +154,9 @@
             "id": "pipeline-components/audio"
           },
           "items": [
-            "pipeline-components/audio/external-integrations-audio",
             "pipeline-components/audio/localwhispertranscriber",
-            "pipeline-components/audio/remotewhispertranscriber"
+            "pipeline-components/audio/remotewhispertranscriber",
+            "pipeline-components/audio/external-integrations-audio"
           ]
         },
         {
@@ -199,7 +199,6 @@
             "id": "pipeline-components/connectors"
           },
           "items": [
-            "pipeline-components/connectors/external-integrations-connectors",
             "pipeline-components/connectors/githubfileeditor",
             "pipeline-components/connectors/githubissuecommenter",
             "pipeline-components/connectors/githubissueviewer",
@@ -210,7 +209,8 @@
             "pipeline-components/connectors/langfuseconnector",
             "pipeline-components/connectors/openapiconnector",
             "pipeline-components/connectors/openapiserviceconnector",
-            "pipeline-components/connectors/weaveconnector"
+            "pipeline-components/connectors/weaveconnector",
+            "pipeline-components/connectors/external-integrations-connectors"
           ]
         },
         {
@@ -225,7 +225,6 @@
             "pipeline-components/converters/csvtodocument",
             "pipeline-components/converters/documenttoimagecontent",
             "pipeline-components/converters/docxtodocument",
-            "pipeline-components/converters/external-integrations-converters",
             "pipeline-components/converters/htmltodocument",
             "pipeline-components/converters/imagefiletodocument",
             "pipeline-components/converters/imagefiletoimagecontent",
@@ -243,7 +242,8 @@
             "pipeline-components/converters/textfiletodocument",
             "pipeline-components/converters/tikadocumentconverter",
             "pipeline-components/converters/unstructuredfileconverter",
-            "pipeline-components/converters/xlsxtodocument"
+            "pipeline-components/converters/xlsxtodocument",
+            "pipeline-components/converters/external-integrations-converters"
           ]
         },
         {
@@ -270,7 +270,6 @@
             "pipeline-components/embedders/coheredocumentembedder",
             "pipeline-components/embedders/coheredocumentimageembedder",
             "pipeline-components/embedders/coheretextembedder",
-            "pipeline-components/embedders/external-integrations-embedders",
             "pipeline-components/embedders/fastembeddocumentembedder",
             "pipeline-components/embedders/fastembedsparsedocumentembedder",
             "pipeline-components/embedders/fastembedsparsetextembedder",
@@ -302,7 +301,8 @@
             "pipeline-components/embedders/vertexaidocumentembedder",
             "pipeline-components/embedders/vertexaitextembedder",
             "pipeline-components/embedders/watsonxdocumentembedder",
-            "pipeline-components/embedders/watsonxtextembedder"
+            "pipeline-components/embedders/watsonxtextembedder",
+            "pipeline-components/embedders/external-integrations-embedders"
           ]
         },
         {
@@ -320,11 +320,11 @@
             "pipeline-components/evaluators/documentmrrevaluator",
             "pipeline-components/evaluators/documentndcgevaluator",
             "pipeline-components/evaluators/documentrecallevaluator",
-            "pipeline-components/evaluators/external-integrations-evaluators",
             "pipeline-components/evaluators/faithfulnessevaluator",
             "pipeline-components/evaluators/llmevaluator",
             "pipeline-components/evaluators/ragasevaluator",
-            "pipeline-components/evaluators/sasevaluator"
+            "pipeline-components/evaluators/sasevaluator",
+            "pipeline-components/evaluators/external-integrations-evaluators"
           ]
         },
         {
@@ -348,8 +348,8 @@
             "id": "pipeline-components/fetchers"
           },
           "items": [
-            "pipeline-components/fetchers/external-integrations-fetchers",
-            "pipeline-components/fetchers/linkcontentfetcher"
+            "pipeline-components/fetchers/linkcontentfetcher",
+            "pipeline-components/fetchers/external-integrations-fetchers"
           ]
         },
         {
@@ -379,7 +379,6 @@
             "pipeline-components/generators/coherechatgenerator",
             "pipeline-components/generators/coheregenerator",
             "pipeline-components/generators/dalleimagegenerator",
-            "pipeline-components/generators/external-integrations-generators",
             "pipeline-components/generators/fallbackchatgenerator",
             "pipeline-components/generators/googleaigeminichatgenerator",
             "pipeline-components/generators/googleaigeminigenerator",
@@ -412,7 +411,8 @@
             "pipeline-components/generators/vertexaiimageqa",
             "pipeline-components/generators/vertexaitextgenerator",
             "pipeline-components/generators/watsonxchatgenerator",
-            "pipeline-components/generators/watsonxgenerator"
+            "pipeline-components/generators/watsonxgenerator",
+            "pipeline-components/generators/external-integrations-generators"
           ]
         },
         {
@@ -460,7 +460,6 @@
             "pipeline-components/rankers/choosing-the-right-ranker",
             "pipeline-components/rankers/amazonbedrockranker",
             "pipeline-components/rankers/cohereranker",
-            "pipeline-components/rankers/external-integrations-rankers",
             "pipeline-components/rankers/fastembedranker",
             "pipeline-components/rankers/huggingfaceteiranker",
             "pipeline-components/rankers/jinaranker",
@@ -470,7 +469,8 @@
             "pipeline-components/rankers/nvidiaranker",
             "pipeline-components/rankers/sentencetransformersdiversityranker",
             "pipeline-components/rankers/sentencetransformerssimilarityranker",
-            "pipeline-components/rankers/transformerssimilarityranker"
+            "pipeline-components/rankers/transformerssimilarityranker",
+            "pipeline-components/rankers/external-integrations-rankers"
           ]
         },
         {
@@ -570,9 +570,9 @@
             "id": "pipeline-components/websearch"
           },
           "items": [
-            "pipeline-components/websearch/external-integrations-websearch",
             "pipeline-components/websearch/searchapiwebsearch",
-            "pipeline-components/websearch/serperdevwebsearch"
+            "pipeline-components/websearch/serperdevwebsearch",
+            "pipeline-components/websearch/external-integrations-websearch"
           ]
         },
         {
@@ -642,7 +642,6 @@
       "items": [
         "development/logging",
         "development/tracing",
-        "development/external-integrations-development",
         "development/enabling-gpu-acceleration",
         "development/hayhooks",
         {
@@ -657,7 +656,8 @@
             "development/deployment/kubernetes",
             "development/deployment/openshift"
           ]
-        }
+        },
+        "development/external-integrations-development"
       ]
     }
   ]


### PR DESCRIPTION
### Proposed Changes:

- Fix instances where the bold formatting syntax was done incorrectly
- Fix 2.20 and 2.19 sidebars to have External Integration pages be position at the end of their respective category

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
