### PR TITLE
docs: add a Multi-Agent with ComponentTool example

### DIFF
--- a/docs-website/docs/pipeline-components/agents-1/agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent.mdx
@@ -54,6 +54,40 @@ You can additionally configure:
 For a complete list of available parameters, refer to the [Agents API Documentation](/reference/agents-api).
 :::
 
+### Agents as Tools
+
+You can wrap an `Agent` using [`ComponentTool`](../../tools/componenttool.mdx) to create multi-agent systems where specialized agents act as tools for a coordinator agent.
+
+When wrapping an `Agent` as a `ComponentTool`, use the `outputs_to_string` parameter with `{"source": "last_message"}` to extract only the agent's final response text, rather than the execution trace with tool calls to keep the coordinator agent's context clean and focused.
+
+```python
+## Wrap the agent as a ComponentTool with outputs_to_string
+research_tool = ComponentTool(
+    component=research_agent, # another agent component
+    name="research_specialist",
+    description="A specialist that can research topics from the knowledge base",
+    outputs_to_string={"source": "last_message"}  ## Extract only the final response
+)
+
+## Create a coordinator agent that uses the specialist
+coordinator_agent = Agent(
+    chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+    tools=[research_tool],
+    system_prompt="You are a coordinator that delegates research tasks to a specialist.",
+    exit_conditions=["text"]
+)
+
+## Warm up and run
+research_agent.warm_up()
+coordinator_agent.warm_up()
+
+result = coordinator_agent.run(
+    messages=[ChatMessage.from_user("Tell me about Haystack")]
+)
+
+print(result["last_message"].text)
+```
+
 ### Streaming
 
 You can stream output as it’s generated. Pass a callback to `streaming_callback`. Use the built-in `print_streaming_chunk` to print text tokens and tool events (tool calls and tool results).
@@ -132,47 +166,6 @@ response = agent.run(messages=[ChatMessage.from_user("What is 7 * (4 + 2)?")])
 print(response["messages"])
 print("Calc Result:", response.get("calc_result"))
 ```
-
-### Agents as Tools
-
-You can wrap an `Agent` using [`ComponentTool`](../../tools/componenttool.mdx) to create multi-agent systems where specialized agents act as tools for a coordinator agent.
-
-When wrapping an `Agent` as a `ComponentTool`, use the `outputs_to_string` parameter with `{"source": "last_message"}` to extract only the agent's final response text, rather than the execution trace with tool calls to keep the coordinator agent's context clean and focused.
-
-```python
-from haystack.components.generators.chat import OpenAIChatGenerator
-from haystack.dataclasses import ChatMessage
-from haystack.tools import Tool, ComponentTool
-from haystack.components.agents import Agent
-
-## Wrap the agent as a ComponentTool with outputs_to_string
-research_tool = ComponentTool(
-    component=research_agent, # another agent component
-    name="research_specialist",
-    description="A specialist that can research topics from the knowledge base",
-    outputs_to_string={"source": "last_message"}  ## Extract only the final response
-)
-
-## Create a coordinator agent that uses the specialist
-coordinator_agent = Agent(
-    chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
-    tools=[research_tool],
-    system_prompt="You are a coordinator that delegates research tasks to a specialist.",
-    exit_conditions=["text"]
-)
-
-## Warm up and run
-research_agent.warm_up()
-coordinator_agent.warm_up()
-
-result = coordinator_agent.run(
-    messages=[ChatMessage.from_user("Tell me about Haystack")]
-)
-
-print(result["last_message"].text)
-```
-
-When you run this code, the coordinator agent receives the user's question and delegates it to the `research_specialist` tool (which is the wrapped research agent). The research agent then uses its `search_knowledge_base` tool to find relevant information, and returns only its final answer back to the coordinator, which presents it to the user.
 
 ### In a pipeline
 

--- a/docs-website/versioned_docs/version-2.20-unstable/pipeline-components/agents-1/agent.mdx
+++ b/docs-website/versioned_docs/version-2.20-unstable/pipeline-components/agents-1/agent.mdx
@@ -54,6 +54,40 @@ You can additionally configure:
 For a complete list of available parameters, refer to the [Agents API Documentation](/reference/agents-api).
 :::
 
+### Agents as Tools
+
+You can wrap an `Agent` using [`ComponentTool`](../../tools/componenttool.mdx) to create multi-agent systems where specialized agents act as tools for a coordinator agent.
+
+When wrapping an `Agent` as a `ComponentTool`, use the `outputs_to_string` parameter with `{"source": "last_message"}` to extract only the agent's final response text, rather than the execution trace with tool calls to keep the coordinator agent's context clean and focused.
+
+```python
+## Wrap the agent as a ComponentTool with outputs_to_string
+research_tool = ComponentTool(
+    component=research_agent, # another agent component
+    name="research_specialist",
+    description="A specialist that can research topics from the knowledge base",
+    outputs_to_string={"source": "last_message"}  ## Extract only the final response
+)
+
+## Create a coordinator agent that uses the specialist
+coordinator_agent = Agent(
+    chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+    tools=[research_tool],
+    system_prompt="You are a coordinator that delegates research tasks to a specialist.",
+    exit_conditions=["text"]
+)
+
+## Warm up and run
+research_agent.warm_up()
+coordinator_agent.warm_up()
+
+result = coordinator_agent.run(
+    messages=[ChatMessage.from_user("Tell me about Haystack")]
+)
+
+print(result["last_message"].text)
+```
+
 ### Streaming
 
 You can stream output as it’s generated. Pass a callback to `streaming_callback`. Use the built-in `print_streaming_chunk` to print text tokens and tool events (tool calls and tool results).
@@ -197,4 +231,6 @@ print(agent_output["database_agent"]["messages"][-1].text)
 
 🧑‍🍳 Cookbook: [Build a GitHub Issue Resolver Agent](https://haystack.deepset.ai/cookbook/github_issue_resolver_agent)
 
-📓 Tutorial: [Build a Tool-Calling Agent](https://haystack.deepset.ai/tutorials/43_building_a_tool_calling_agent)
+📓 Tutorials:
+- [Build a Tool-Calling Agent](https://haystack.deepset.ai/tutorials/43_building_a_tool_calling_agent)
+- [Creating a Multi-Agent System](https://haystack.deepset.ai/tutorials/45_creating_a_multi_agent_system)


### PR DESCRIPTION
### Related Issues

- fixes #10031 

### Proposed Changes:

- Add a simple example of Agent use within ComponentTool, using `outputs_to_string`
- Add a link to the multi-agent tutorial

### How did you test it?

Tested the code in Colab succesfully

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
