### PR TITLE
docs: replace Wikimedia image with Unsplash image to avoid 403 error

### DIFF
--- a/docs-website/docs/concepts/data-classes/chatmessage.mdx
+++ b/docs-website/docs/concepts/data-classes/chatmessage.mdx
@@ -117,13 +117,12 @@ print(user_message.texts)
 ```python
 from haystack.dataclasses import ChatMessage, ImageContent
 
-capybara_image_url = (
-    "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/"
-    "Cattle_tyrant_%28Machetornis_rixosa%29_on_Capybara.jpg/"
-    "960px-Cattle_tyrant_%28Machetornis_rixosa%29_on_Capybara.jpg?download"
+lion_image_url = (
+    "https://images.unsplash.com/photo-1546182990-dffeafbe841d?"
+	"ixlib=rb-4.0&q=80&w=1080&fit=max"
 )
 
-image_content = ImageContent.from_url(capybara_image_url, detail="low")
+image_content = ImageContent.from_url(lion_image_url, detail="low")
 
 user_message = ChatMessage.from_user(
 	content_parts=[


### PR DESCRIPTION
### Related Issues

- fixes #10046

### Proposed Changes:

Replaced the Wikimedia image URL that returns a 403 response with an unsplash one that runs as expected. Unsplash [license](https://unsplash.com/license) allows using their images in this context.

### How did you test it?

Run the new code, and it worked smoothly.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
