### PR TITLE
ci: temporarily skip Readme syncing to unblock release

### DIFF
--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -70,12 +70,13 @@ jobs:
       - name: Install create_unstable_docs.py dependencies
         run: pip install requests
 
-      - name: Release Readme version
-        env:
-          RDME_API_KEY: ${{ secrets.README_API_KEY }}
-        run: |
-          git checkout main
-          python ./.github/utils/create_unstable_docs.py --new-version ${{ steps.versions.outputs.current_release_minor }}
+      # TODO: remove this once migration to Docusaurus is complete
+      # - name: Release Readme version
+      #   env:
+      #     RDME_API_KEY: ${{ secrets.README_API_KEY }}
+      #   run: |
+      #     git checkout main
+      #     python ./.github/utils/create_unstable_docs.py --new-version ${{ steps.versions.outputs.current_release_minor }}
 
       - name: Generate unstable docs for Docusaurus
         run: |

--- a/.github/workflows/promote_unstable_docs.yml
+++ b/.github/workflows/promote_unstable_docs.yml
@@ -31,11 +31,12 @@ jobs:
       - name: Install promote_unstable_docs.py dependencies
         run: pip install requests
 
-      - name: Release Readme version
-        env:
-          RDME_API_KEY: ${{ secrets.README_API_KEY }}
-        run: |
-          python ./.github/utils/promote_unstable_docs.py --version ${{ steps.version.outputs.version }}
+      # TODO: remove this once migration to Docusaurus is complete
+      # - name: Release Readme version
+      #   env:
+      #     RDME_API_KEY: ${{ secrets.README_API_KEY }}
+      #   run: |
+      #     python ./.github/utils/promote_unstable_docs.py --version ${{ steps.version.outputs.version }}
 
       - name: Promote unstable docs for Docusaurus
         run: |


### PR DESCRIPTION
### Related Issues

There have been recent changes in Readme API. We haven't adapted our workflows because we will soon switch to Docusaurus.

Now some steps in the release process are failing, blocking the release

### Proposed Changes:
- skip Readme syncing steps

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
