### PR TITLE
ci: disable Readme sync workflow on push events

### DIFF
--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     paths:
       - "docs/pydoc/**"
-  push:
-    branches:
-      - main
-      # release branches have the form v1.9.x
-      - "v[0-9]+.[0-9]+.x"
-      # Exclude 1.x release branches, there's another workflow handling those
-      - "!v1.[0-9]+.x"
+  # TODO: remove this workflow once migration to Docusaurus is complete
+  # push:
+  #   branches:
+  #     - main
+  #     # release branches have the form v1.9.x
+  #     - "v[0-9]+.[0-9]+.x"
+  #     # Exclude 1.x release branches, there's another workflow handling those
+  #     - "!v1.[0-9]+.x"
 
 env:
   HATCH_VERSION: "1.14.2"


### PR DESCRIPTION
### Related Issues

There have been recent changes in Readme API. We haven't adapted our workflows because we will soon switch to Docusaurus.

The workflow "Sync docs with Readme" is always failing, wasting compute.

### Proposed Changes:
- Disable the workflow. We'll remove it once migration to Docusaurus is complete.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
