### PR TITLE
ci: automatically tag contributors in GitHub release notes

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           args: "--from rst --to gfm --syntax-highlighting=none --wrap=none relnotes.rst -o relnotes.md"
 
+      # We copy the relnotes file since the original one cannot be modified due to permissions
       - name: Copy relnotes file
         run: |
           cat relnotes.md > enhanced_relnotes.md


### PR DESCRIPTION
### Related Issues

- fixes #10069

### Proposed Changes:
- Modify the GitHub release workflow to automatically tag contributors for minor releases (and their release candidates)
- Other minor improvements

### How did you test it?
Tested on #10073 (PR on the v2.20.x branch). Check out the debug step of this workflow run: https://github.com/deepset-ai/haystack/actions/runs/19302188326/job/55199499137

```
## 💙 Big thank you to everyone who contributed to this release!

@Amnah199, @anakin87, @cmnemoi, @davidsbatista, @dfokina, @HamidOna, @Hansehart, @jdb78, @sjrl, @swapniel99, @TaMaN2031A, @tstadel, @vblagoje
```

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
