### PR TITLE
ci: add workflow to push release notes to Haystack website

### DIFF
--- a/.github/workflows/push_release_notes_to_website.yml
+++ b/.github/workflows/push_release_notes_to_website.yml
@@ -8,12 +8,9 @@ on:
         required: true
         type: string
 
-  pull_request:
-
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # VERSION: ${{ inputs.version }}
-  VERSION: v2.20.0-rc1
+  VERSION: ${{ inputs.version }}
 
 jobs:
   push-release-notes-to-website:
@@ -62,4 +59,3 @@ jobs:
             content/release-notes
           body: |
             This PR adds the release notes for Haystack ${{ env.VERSION }} to the website.
-          draft: true


### PR DESCRIPTION
### Related Issues

- fixes #10075

### Proposed Changes:
- introduce a manually triggered workflow to push finalized GitHub release notes to the Haystack website
  - the workflow gets the release notes, adds the required frontmatter and opens a PR to the website repo
  - in case of errors, it fails fast. Running the workflow multiple times for the same Haystack version should have no side effects (if existing, the PR is updated).

### How did you test it?
Tested on this PR trying to release notes for v2.20.0-rc1 (we typically don't do this for release candidates)
See https://github.com/deepset-ai/haystack-home/pull/480 and https://haystack-home-nrr4t4g9l-deepset-ai.vercel.app/release-notes/v2.20.0-rc1


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
