### PR TITLE
fix: fix promote unstable docs workflow

### DIFF
--- a/.github/workflows/promote_unstable_docs.yml
+++ b/.github/workflows/promote_unstable_docs.yml
@@ -8,7 +8,6 @@ on:
       # Exclude 1.x tags
       - "!v1.[0-9]+.[0-9]+"
 
-  pull_request:
 env:
   PYTHON_VERSION: "3.9"
 
@@ -23,6 +22,7 @@ jobs:
         id: version
         shell: bash
         # We only need `major.minor`. At this point, VERSION.txt contains the next version.
+        # For example, if we are releasing 2.20.0, VERSION.txt contains 2.21.0-rc0.
         run: |
           MAJOR=$(cut -d "." -f 1 < VERSION.txt)
           MINOR=$(cut -d "." -f 2 < VERSION.txt)


### PR DESCRIPTION
### Related Issues

Promoting unstable docs for the 2.20.0 release failed: https://github.com/deepset-ai/haystack/actions/runs/19335955350/job/55310878756

There are 2 problems:
- we unnecessarily checkout `main` but the checkout action creates `master` -> error
- the version considered in this workflow (coming from VERSION.txt) is incorrect: instead of 2.20 (docs version to promote), it is 2.21

### Proposed Changes:
- fix the above issues

### How did you test it?
Using this PR, I generated https://github.com/deepset-ai/haystack/pull/10080, which is correct

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
