### PR TITLE
fix: fix promote_unstable_docs again

### DIFF
--- a/.github/workflows/promote_unstable_docs.yml
+++ b/.github/workflows/promote_unstable_docs.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v5
+        # use VERSION.txt file from main branch
+        with:
+          ref: main
 
       - name: Get version to release
         id: version


### PR DESCRIPTION
### Related Issues

Follow up of #10079

When experimenting with a fork of Haystack to investigate release process automation,
I realized that in the `promote_unstable_docs` it's important to checkout `main` branch to get the expected version from VERSION.txt.

Since this workflow is triggered by a tag, if we don't explicitly checkout `main`, we'll get a different version number than what we expect.

### Proposed Changes:
- checkout `main` in the workflow

### How did you test it?
Release attempts in my fork

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
