### PR TITLE
fix: fix release notes aggregation during releases

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -29,33 +29,29 @@ jobs:
           python -m pip install --upgrade pip
           pip install "reno<5"
 
-      - name: Generate release notes for release candidates - minor releases
-        if: steps.version.outputs.current_pre_release != '' && endsWith(steps.version.outputs.current_release, '.0')
-        env:
-          # When generating notes for release candidates of minor versions, pick every vX.Y.Z-rcN but
-          # stop when encounter vX.Y.Z-rc0. The -rc0 tag is added automatically when
-          # we create the release branch, so we can assume it's always there.
-          EARLIEST_VERSION: v${{ steps.version.outputs.current_release }}-rc0
+      # Remove next version rc0 tag in the CI environment to prevent reno from assigning notes to future releases.
+      # This ensures release notes are correctly aggregated for the current version.
+      # This is a workaround. Can be removed if the release process is fully aligned with reno.
+      - name: Delete next version rc0 tag in the CI environment
         run: |
-          reno report --no-show-source --ignore-cache --earliest-version "$EARLIEST_VERSION" -o relnotes.rst
+          # Parse version X.Y.Z and increment Y for next minor version
+          IFS='.' read -r MAJOR MINOR _ <<< "${{ steps.version.outputs.current_release }}"
+          NEXT_MINOR=$((MINOR + 1))
+          NEXT_TAG="v${MAJOR}.${NEXT_MINOR}.0-rc0"
 
-      - name: Generate release notes for release candidates - bugfix releases
-        if: steps.version.outputs.current_pre_release != '' && !endsWith(steps.version.outputs.current_release, '.0')
+          if git rev-parse --verify "$NEXT_TAG" >/dev/null 2>&1; then
+            git tag -d "$NEXT_TAG"
+            echo "Deleted local tag $NEXT_TAG"
+          else
+            echo "Tag $NEXT_TAG does not exist locally"
+          fi
+
+      - name: Generate release notes
         env:
-          # When generating notes for release candidates of bugfix releases, pick every vX.Y.Z-rcN but
-          # stop when encounter vX.Y.Z-rc1.
-          # In this case, we don't have the -rc0 tag, because we don't need to go through commits on main,
-          # as we cherry-pick them into the release branch.
+
           EARLIEST_VERSION: v${{ steps.version.outputs.current_release }}-rc1
         run: |
           reno report --no-show-source --ignore-cache --earliest-version "$EARLIEST_VERSION" -o relnotes.rst
-
-      - name: Generate release notes for the final release
-        if: steps.version.outputs.current_pre_release == ''
-        # When generating notes for the final release vX.Y.Z, we just pass --version and reno
-        # will automatically collapse all the vX.Y.Z-rcN.
-        run: |
-          reno report --no-show-source --ignore-cache --version v${{ steps.version.outputs.current_release }} -o relnotes.rst
 
       - name: Convert to Markdown
         uses: docker://pandoc/core:3.8


### PR DESCRIPTION
### Related Issues

- fixes #10104

### Problem
During our release process, the git history contains "future" tags that appear before the current release branch.
Reno stops at these tags and incorrectly assigns notes to the future version, causing the problem described in the issue.

### Proposed Changes:
- temporarily/locally delete the next version rc0 tag (e.g. v2.22.0-rc0 for the v2.21.0 release) to prevent reno from attributing release notes to future version
- unify the notes aggregation command

### How did you test it?
I tested it extensively in my fork. You can inspect the release notes here: https://github.com/anakin87/haystack/tags

### Notes for the reviewer
This solution works but feels hacky.
I spent a lot of time trying to figure out how we can adjust our release process to be fully compatible with reno.
Unfortunately, due to poor reno documentation and limited examples, my attempts so far failed.
For example, I tried tagging the next rc0 later and experimented with various reno configurations.

A better solution likely exists, but would require studying reno deeper and redesigning part of our release process, which is difficult because and could involve dealing with previous git history. I can create another issue to track this.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
