### PR TITLE
chore: faster Docusaurus builds

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -22,6 +22,11 @@ const config = {
   onBrokenAnchors: 'throw',
   onDuplicateRoutes: 'throw',
 
+  future: {
+    experimental_faster: true,
+    v4: true,
+  },
+
   markdown: {
     hooks: {
       onBrokenMarkdownLinks: 'throw',

--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.8.1",
+    "@docusaurus/faster": "^3.9.2",
     "@docusaurus/plugin-content-docs": "^3.8.1",
     "@docusaurus/plugin-ideal-image": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",


### PR DESCRIPTION
### Proposed Changes:
- adopt configurations suggested in https://docusaurus.io/blog/releases/3.8#docusaurus-faster to make Docusaurus builds faster

### How did you test it?
Hard to measure the impact in this PR where I'm not changing docs, but I'd try.
Local builds are impressively faster.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
