### PR TITLE
Revert "chore(deps): bump actions/checkout from 5 to 6"

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docs-website-test-docs-snippets.yml
+++ b/.github/workflows/docs-website-test-docs-snippets.yml
@@ -29,7 +29,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/docs-website-vale.yml
+++ b/.github/workflows/docs-website-vale.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/docstring_labeler.yml
+++ b/.github/workflows/docstring_labeler.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout base commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.base_ref }}
 
@@ -36,7 +36,7 @@ jobs:
           echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: Checkout HEAD commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           # This must be set to correctly checkout a fork

--- a/.github/workflows/docusaurus_sync.yml
+++ b/.github/workflows/docusaurus_sync.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout Haystack repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v5
 
     - uses: actions/setup-python@v6
       with:

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
           fetch-depth: 0  # slow but needed by reno

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: main
 

--- a/.github/workflows/promote_unstable_docs.yml
+++ b/.github/workflows/promote_unstable_docs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         # use VERSION.txt file from main branch
         with:
           ref: main

--- a/.github/workflows/push_release_notes_to_website.yml
+++ b/.github/workflows/push_release_notes_to_website.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Haystack home repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           repository: deepset-ai/haystack-home
 

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Install Hatch
         run: pip install hatch==${{ env.HATCH_VERSION }}

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           # With the default value of 1, there are corner cases where tj-actions/changed-files
           # fails with a `no merge base` error

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -47,7 +47,7 @@ jobs:
     outputs:
       changes: ${{ steps.changes.outputs.changes }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Check for changed code
         id: changes
         uses: dorny/paths-filter@v3
@@ -125,7 +125,7 @@ jobs:
             install_cmd: "echo 'No additional dependencies needed'"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v6
         with:
@@ -89,7 +89,7 @@ jobs:
     needs: format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v6
         with:
@@ -145,7 +145,7 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v6
         with:
@@ -213,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           # With the default value of 1, there are corner cases where tj-actions/changed-files
           # fails with a `no merge base` error
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v6
         with:
@@ -346,7 +346,7 @@ jobs:
       HAYSTACK_MPS_ENABLED: false
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v6
         with:
@@ -409,7 +409,7 @@ jobs:
       HAYSTACK_XPU_ENABLED: false
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/tests_skipper_trigger.yml
+++ b/.github/workflows/tests_skipper_trigger.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       code_changes: ${{ steps.changes.outputs.code_changes }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Check for changed code
         id: changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36

--- a/.github/workflows/workflows_linting.yml
+++ b/.github/workflows/workflows_linting.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - uses: actions/setup-go@v6
 


### PR DESCRIPTION
Reverts deepset-ai/haystack#10118

The new version of actions/checkout is not compatible with peter-evans/create-pull-request, which we use extensively for docs sync: https://github.com/peter-evans/create-pull-request/issues/4228