### PR TITLE
chore: ignore mypy error for compatibility with ddtrace 4.0.0

### DIFF
--- a/haystack/tracing/datadog.py
+++ b/haystack/tracing/datadog.py
@@ -31,7 +31,9 @@ class DatadogSpan(Span):
         :param value: the value of the tag.
         """
         coerced_value = tracing_utils.coerce_tag_value(value)
-        self._span.set_tag(key, coerced_value)
+        # Although set_tag declares value: Optional[str], its implementation accepts other types.
+        # https://github.com/DataDog/dd-trace-py/blob/200b33c5221db1af975f6f7017738cd99a2da4a4/ddtrace/_trace/span.py
+        self._span.set_tag(key, coerced_value)  # type: ignore[arg-type]
 
     def raw_span(self) -> Any:
         """


### PR DESCRIPTION
### Related Issues
mypy error due to ddtrace 4.0.0 release: https://github.com/deepset-ai/haystack/actions/runs/19574501197/job/56056534417?pr=10121

After investigating, I discovered that they changed the `Span.set_tag` signature: from `value: Any` to `value: Optional[str]`.
Despite that, the method still handles other types: https://github.com/DataDog/dd-trace-py/blob/200b33c5221db1af975f6f7017738cd99a2da4a4/ddtrace/_trace/span.py#L320



### Proposed Changes:
- simply ignore the mypy error (converting `value` to string seems riskier)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
