### PR TITLE
chore: fix type declaration error in docs build

### DIFF
--- a/docs-website/api/tsconfig.json
+++ b/docs-website/api/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2021",
     "module": "commonjs",
     "moduleResolution": "node",
-    "lib": ["ES2021"],
+    "lib": ["ES2021", "DOM"],
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
### Related Issues

Recent docs builds contain a non-blocking type error: `api/search.ts(46,31): error TS2304: Cannot find name 'fetch'.`
See for example: https://vercel.com/deepset-ai/haystack-docs/BWESa4DZ9gzXUpLo8dNUupaqXsAF

### Proposed Changes:
- fix the error by adding DOM lib to include fetch type definitions

### How did you test it?
Vercel deployment in this PR: https://vercel.com/deepset-ai/haystack-docs/64DwuvVUAK2HDDcqTzgsVPApiqYk
Type error is fixed

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
