### PR TITLE
style(docs): resolve header/searchbar overlap in mobile view

### DIFF
--- a/docs-website/src/css/custom.css
+++ b/docs-website/src/css/custom.css
@@ -428,6 +428,19 @@ a:hover {
   color: var(--ifm-navbar-link-hover-color, var(--ifm-color-primary)) !important;
 }
 
+/* Hide navbar title on mobile/tablet to prevent overlap with search bar */
+@media (max-width: 996px) {
+  .navbar__title {
+    display: none !important;
+  }
+
+  /* Ensure navbar brand doesn't grow too large */
+  .navbar__brand {
+    flex-shrink: 0;
+    max-width: fit-content;
+  }
+}
+
 /* Remove underline from navbar logo link */
 .navbar__logo,
 .navbar__brand {


### PR DESCRIPTION
### Proposed Changes:

Added CSS media query that hides the site title "Haystack Documentation" on mobile, leaving only the logo visible.

**Before:**
<img width="491" height="116" alt="Screenshot 2025-11-28 at 13 01 10" src="https://github.com/user-attachments/assets/49454096-88ca-44b8-9442-277c22e36ffc" />

**After:**
<img width="495" height="121" alt="Screenshot 2025-11-28 at 12 59 06" src="https://github.com/user-attachments/assets/bbb592d6-33ff-467b-a3f6-16b15b810b54" />

### How did you test it?

Live site vs Vercel preview

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
