### PR TITLE
ci: add sniffio dependency for docs sync

### DIFF
--- a/.github/workflows/docs_search_sync.yml
+++ b/.github/workflows/docs_search_sync.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch: # Activate this workflow manually
   schedule:
     - cron: "0 1 * * *"
-  pull_request:
 
 # Running this workflow multiple times in parallel can cause issues with files uploads and deletions.
 concurrency:


### PR DESCRIPTION
### Related Issues

- Failing workflow that syncs docs with dAP: https://github.com/deepset-ai/haystack/actions/runs/19808323499/job/56746089936
- Root cause: reported in https://github.com/deepset-ai/deepset-cloud-sdk/issues/286

### Proposed Changes:
- install the missing `sniffio` dependency in the CI
- (if the root cause is solved, in the future we can remove the dependency installation from the CI)

### How did you test it?
Temporarily modified the workflow to test it in this PR. Works -> https://github.com/deepset-ai/haystack/actions/runs/19820214512/job/56780622289

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
