### PR TITLE
docs: add unsafe=True to make code properly run

### DIFF
--- a/docs-website/versioned_docs/version-2.20/optimization/advanced-rag-techniques/hypothetical-document-embeddings-hyde.mdx
+++ b/docs-website/versioned_docs/version-2.20/optimization/advanced-rag-techniques/hypothetical-document-embeddings-hyde.mdx
@@ -53,7 +53,8 @@ prompt_builder = PromptBuilder(
 adapter = OutputAdapter(
     template="{{answers | build_doc}}",
     output_type=List[Document],
-    custom_filters={"build_doc": lambda data: [Document(content=d) for d in data]}
+    custom_filters={"build_doc": lambda data: [Document(content=d) for d in data]},
+    unsafe=True
 )
 
 embedder = SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2")


### PR DESCRIPTION
### Proposed Changes:

**Add `unsafe=True` to the HyDE docs make code properly run.**

Without this change, `OutputAdapter` has an output of type string, which results in the following error:

> Error: SentenceTransformersDocumentEmbedder expects a list of Documents as input.In case you want to embed a string, please use the SentenceTransformersTextEmbedder.

_Note: the cookbook repo's Jupyter Notebook should also be updated._

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

Running the code in the docs on my machine.

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

The current code does not run

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
