### PR TITLE
docs : fixing docstrings dicts in `RegexTextExtractor`

### DIFF
--- a/haystack/components/extractors/regex_text_extractor.py
+++ b/haystack/components/extractors/regex_text_extractor.py
@@ -71,9 +71,9 @@ class RegexTextExtractor:
             Either a string or a list of ChatMessage objects to search through.
 
         :returns:
-          - {"captured_text": "matched text"} if a match is found
-          - {} if no match is found and self.return_empty_on_no_match=True (default behavior)
-          - {"captured_text": ""} if no match is found and self.return_empty_on_no_match=False
+          - `{"captured_text": "matched text"}` if a match is found
+          - `{}` if no match is found and self.return_empty_on_no_match=True (default behavior)
+          - `{"captured_text": ""}` if no match is found and self.return_empty_on_no_match=False
 
         :raises:
             - ValueError: if receiving a list the last element is not a ChatMessage instance.


### PR DESCRIPTION
### Proposed Changes:

- fixing docstrings dicts in `RegexTextExtractor`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
