### PR TITLE
docs: document expected connection string for Pgvector

### DIFF
--- a/docs-website/docs/document-stores/pgvectordocumentstore.mdx
+++ b/docs-website/docs/document-stores/pgvectordocumentstore.mdx
@@ -55,7 +55,7 @@ export PG_CONN_STR="postgresql://USER:PASSWORD@HOST:PORT/DB_NAME"
 export PG_CONN_STR="host=HOST port=PORT dbname=DB_NAME user=USER password=PASSWORD"
 ```
 
-:::caution Special Characters in Passwords
+:::caution Special Characters in Connection URIs
 
 When using the URI format, special characters in the password must be [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding). Otherwise, connection errors may occur. A password like `p=ssword` would cause the error `psycopg.OperationalError: [Errno -2] Name or service not known`.
 

--- a/docs-website/versioned_docs/version-2.20/document-stores/pgvectordocumentstore.mdx
+++ b/docs-website/versioned_docs/version-2.20/document-stores/pgvectordocumentstore.mdx
@@ -55,7 +55,7 @@ export PG_CONN_STR="postgresql://USER:PASSWORD@HOST:PORT/DB_NAME"
 export PG_CONN_STR="host=HOST port=PORT dbname=DB_NAME user=USER password=PASSWORD"
 ```
 
-:::caution Special Characters in Passwords
+:::caution Special Characters in Connection URIs
 
 When using the URI format, special characters in the password must be [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding). Otherwise, connection errors may occur. A password like `p=ssword` would cause the error `psycopg.OperationalError: [Errno -2] Name or service not known`.
 

--- a/docs-website/versioned_docs/version-2.21-unstable/document-stores/pgvectordocumentstore.mdx
+++ b/docs-website/versioned_docs/version-2.21-unstable/document-stores/pgvectordocumentstore.mdx
@@ -39,11 +39,41 @@ pip install pgvector-haystack
 
 ## Usage
 
-Define the connection string to your PostgreSQL database in the `PG_CONN_STR` environment variable. For example:
+### Connection String
 
-```shell Shell
-export PG_CONN_STR="postgresql://postgres:postgres@localhost:5432/postgres"
+Define the connection string to your PostgreSQL database in the `PG_CONN_STR` environment variable. Two formats are supported:
+
+**URI format:**
+
+```shell
+export PG_CONN_STR="postgresql://USER:PASSWORD@HOST:PORT/DB_NAME"
 ```
+
+**Keyword/value format:**
+
+```shell
+export PG_CONN_STR="host=HOST port=PORT dbname=DB_NAME user=USER password=PASSWORD"
+```
+
+:::caution Special Characters in Connection URIs
+
+When using the URI format, special characters in the password must be [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding). Otherwise, connection errors may occur. A password like `p=ssword` would cause the error `psycopg.OperationalError: [Errno -2] Name or service not known`.
+
+For example, if your password is `p=ssword`, the connection string should be:
+
+```shell
+export PG_CONN_STR="postgresql://postgres:p%3Dssword@localhost:5432/postgres"
+```
+
+Alternatively, use the keyword/value format, which does not require percent-encoding:
+
+```shell
+export PG_CONN_STR="host=localhost port=5432 dbname=postgres user=postgres password=p=ssword"
+```
+
+:::
+
+For more details, see the [PostgreSQL connection string documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING).
 
 ## Initialization
 


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1738

### Proposed Changes:

- Explain proper formatting of the connection string for Pgvector

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
