### PR TITLE
docs: clarify component init serialization

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -34,7 +34,11 @@ Components should take only "basic" Python types as parameters of their `__init_
 dictionaries containing only such values. Anything else (objects, functions, etc) will raise an exception at init
 time. If there's the need for such values, consider serializing them to a string.
 
-_(TODO explain how to use classes and functions in init. In the meantime see `test/components/test_accumulate.py`)_
+If you need to accept classes or callables, accept either a string import path or the callable itself. Resolve strings
+to objects in `__init__`, and serialize objects back to importable strings in `to_dict()` so that `from_dict()` can load
+them (for example, store `"module_path.symbol_name"` and load it via `importlib`). This keeps init parameters JSON
+serializable for pipeline save/load. See `haystack.testing.sample_components.accumulate.Accumulate` for a reference
+implementation.
 
 The `__init__` must be extremely lightweight, because it's a frequent operation during the construction and
 validation of the pipeline. If a component has some heavy state to initialize (models, backends, etc...) refer to


### PR DESCRIPTION
### Related Issues
- n/a (replaces the TODO in `haystack/core/component/component.py`)

### Proposed Changes
Clarify how components should handle callable/class init params.

### How did you test it?
Not run (docstring-only change).

### Checklist
- [x] I have read the contributors guidelines and the code of conduct.
- [ ] I have updated the related issue with new insights and changes. (n/a)
- [ ] I have added unit tests and updated the docstrings. (docstring-only)
- [x] I've used one of the conventional commit types for my PR title (`docs: clarify component init serialization`).
- [ ] I have documented my code. (already a documentation change)
- [ ] I have added a release note file. (requesting `ignore-for-release-notes`)
- [ ] I have run pre-commit hooks and fixed any issue. (run if you prefer; otherwise leave unchecked)
