### PR TITLE
docs: add missing pages to 2.21 sidebar

### DIFF
--- a/docs-website/versioned_sidebars/version-2.21-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.21-sidebars.json
@@ -458,6 +458,13 @@
         },
         {
           "type": "category",
+          "label": "Query",
+          "items": [
+            "pipeline-components/query/queryexpander"
+          ]
+        },
+        {
+          "type": "category",
           "label": "Rankers",
           "link": {
             "type": "doc",
@@ -513,6 +520,8 @@
             "pipeline-components/retrievers/inmemoryembeddingretriever",
             "pipeline-components/retrievers/mongodbatlasembeddingretriever",
             "pipeline-components/retrievers/mongodbatlasfulltextretriever",
+            "pipeline-components/retrievers/multiqueryembeddingretriever",
+            "pipeline-components/retrievers/multiquerytextretriever",
             "pipeline-components/retrievers/opensearchbm25retriever",
             "pipeline-components/retrievers/opensearchembeddingretriever",
             "pipeline-components/retrievers/opensearchhybridretriever",


### PR DESCRIPTION
### Proposed Changes:

- One of the previous PRs overwrote the sidebar so that the new documentation pages could not be found, this PR is adding them back

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
