### PR TITLE
docs: add quota note for OpenAIChatGenerator in get-started guide

### DIFF
--- a/docs-website/docs/overview/get-started.mdx
+++ b/docs-website/docs/overview/get-started.mdx
@@ -46,7 +46,7 @@ In the example below, we show how to set an API key using a Haystack [Secret](..
 New users on the free tier may immediately encounter a `429` ("insufficient_quota") error when running
 the example below.
 
-If you do not have enough OpenAI credits, you may skip this example or use an alternative generator such as
+If you do not have enough OpenAI credits, you may skip this example or use an alternative Generator such as
 `HuggingFaceAPIChatGenerator`.
 :::
 


### PR DESCRIPTION
This PR addresses an onboarding issue where new users following the Get Started
tutorial can immediately run into an HTTP 429 ("insufficient_quota") error when
running the `OpenAIChatGenerator` example.

Changes:

- Add a `note` block above the example explaining that `OpenAIChatGenerator`
  requires an OpenAI API key with sufficient quota.
- Mention that free-tier users may see a 429 error when running the example.
- Suggest using `HuggingFaceAPIChatGenerator` as an alternative for users
  without OpenAI credits.

This is a documentation-only change and does not modify any runtime behavior.