### PR TITLE
ci: set actor of automated PRs as a reviewer

### DIFF
--- a/.github/workflows/docusaurus_sync.yml
+++ b/.github/workflows/docusaurus_sync.yml
@@ -9,7 +9,6 @@ on:
       - "pydoc/**"
       - "haystack/**"
       - ".github/workflows/docusaurus_sync.yml"
-  pull_request:
 
 env:
   HATCH_VERSION: "1.14.2"
@@ -59,4 +58,3 @@ jobs:
           body: |
             This PR syncs the Haystack API reference on Docusaurus. Just approve and merge it.
           reviewers: "${{ github.actor }}"
-          draft: true

--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -89,3 +89,4 @@ jobs:
             This PR creates the unstable docs for Haystack ${{ steps.versions.outputs.current_release_minor }}.
             It is expected to run during the branch-off process.
             You can inspect the docs preview (two unstable versions will be available) and merge it.
+          reviewers: "${{ github.actor }}"

--- a/.github/workflows/promote_unstable_docs.yml
+++ b/.github/workflows/promote_unstable_docs.yml
@@ -54,3 +54,4 @@ jobs:
             This PR promotes the unstable docs for Haystack ${{ steps.version.outputs.version }} to stable.
             It is expected to run at the time of the release.
             You can inspect the docs preview and merge it. There should now be only one unstable version representing the next (main) branch.
+          reviewers: "${{ github.actor }}"

--- a/.github/workflows/push_release_notes_to_website.yml
+++ b/.github/workflows/push_release_notes_to_website.yml
@@ -59,3 +59,4 @@ jobs:
             content/release-notes
           body: |
             This PR adds the release notes for Haystack ${{ env.VERSION }} to the website.
+          reviewers: "${{ github.actor }}"

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -288,7 +288,7 @@ class OpenAIChatGenerator:
         tools_strict: Optional[bool] = None,
     ):
         """
-        Invokes chat completion based on the provided messages and generation parameters. TRIGGER!
+        Invokes chat completion based on the provided messages and generation parameters.
 
         :param messages:
             A list of ChatMessage instances representing the input messages.


### PR DESCRIPTION
### Related Issues

We make extensive use of automated PR creation.

In these cases, it would be helpful if the actor (the user who triggered the automated PR creation) is also assigned as a reviewer.

### Proposed Changes:
- modify all usages of `create-pull-request` action to include the actor as a reviewer
- this works because the actual committer is the GitHub bot so the committer is different from the reviewer

### How did you test it?
Temporarily modified a workflow to create a PR: see https://github.com/deepset-ai/haystack/pull/10213. I was the actor and was automatically assigned as the reviewer.

### Notes for the reviewer
Will do the same in other related repos (core-integrations and experimental)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
