### PR TITLE
chore: Update docs-website/reference/haystack-api/classifiers_api.md

### DIFF
--- a/haystack/components/classifiers/document_language_classifier.py
+++ b/haystack/components/classifiers/document_language_classifier.py
@@ -40,7 +40,15 @@ class DocumentLanguageClassifier:
 
     p = Pipeline()
     p.add_component(instance=DocumentLanguageClassifier(languages=["en"]), name="language_classifier")
-    p.add_component(instance=MetadataRouter(rules={"en": {"language": {"$eq": "en"}}}), name="router")
+    p.add_component(
+    instance=MetadataRouter(rules={
+        "en": {
+            "field": "meta.language",
+            "operator": "==",
+            "value": "en"
+        }
+    }),
+    name="router")
     p.add_component(instance=DocumentWriter(document_store=document_store), name="writer")
     p.connect("language_classifier.documents", "router.documents")
     p.connect("router.en", "writer.documents")


### PR DESCRIPTION
Our classifiers_api.md contains invalid script sample which fails with:
```
ValueError                                Traceback (most recent call last)
Cell In[1], line 14
     12 p = Pipeline()
     13 p.add_component(instance=DocumentLanguageClassifier(languages=["en"]), name="language_classifier")
---> 14 p.add_component(instance=MetadataRouter(rules={"en": {"language": {"$eq": "en"}}}), name="router")
     15 p.add_component(instance=DocumentWriter(document_store=document_store), name="writer")
     16 p.connect("language_classifier.documents", "router.documents")

File ~/workspace/haystack/haystack/core/component/component.py:290, in ComponentMeta.__call__(cls, *args, **kwargs)
    288 pre_init_hook = _COMPONENT_PRE_INIT_HOOK.get()
    289 if pre_init_hook is None or pre_init_hook.in_progress:
--> 290     instance = super().__call__(*args, **kwargs)
    291 else:
    292     try:

File ~/workspace/haystack/haystack/components/routers/metadata_router.py:105, in MetadataRouter.__init__(self, rules, output_type)
    103 for rule in self.rules.values():
    104     if "operator" not in rule:
--> 105         raise ValueError(
    106             "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
    107         )
    108 component.set_output_types(self, unmatched=self.output_type, **dict.fromkeys(rules, self.output_type))

ValueError: Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details.
```

This is a fix for it. 