### PR TITLE
test: improve some tests + retry others

### DIFF
--- a/test/components/audio/test_whisper_remote.py
+++ b/test/components/audio/test_whisper_remote.py
@@ -200,6 +200,7 @@ class TestRemoteWhisperTranscriber:
         not os.environ.get("OPENAI_API_KEY", None),
         reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
     )
+    @pytest.mark.flaky(reruns=3, reruns_delay=5)
     @pytest.mark.integration
     def test_whisper_remote_transcriber_pipeline_and_url_source(self):
         pipe = Pipeline()

--- a/test/components/connectors/test_openapi_connector.py
+++ b/test/components/connectors/test_openapi_connector.py
@@ -197,6 +197,7 @@ class TestOpenAPIConnectorIntegration:
         not os.environ.get("GITHUB_TOKEN", None), reason="Export an env var called GITHUB_TOKEN to run this test."
     )
     @pytest.mark.integration
+    @pytest.mark.flaky(reruns=3, reruns_delay=5)
     def test_github_api_integration(self):
         component = OpenAPIConnector(
             openapi_spec="https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",

--- a/test/components/fetchers/test_link_content_fetcher.py
+++ b/test/components/fetchers/test_link_content_fetcher.py
@@ -182,7 +182,10 @@ class TestLinkContentFetcher:
             assert sent_headers["Accept-Language"] == "fr-FR"
             assert sent_headers["User-Agent"] == "ua-sync-1"  # rotating UA wins
 
-    @pytest.mark.integration
+
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
+@pytest.mark.integration
+class TestLinkContentFetcherIntegration:
     def test_link_content_fetcher_html(self):
         """
         Test fetching HTML content from a real URL.
@@ -195,7 +198,6 @@ class TestLinkContentFetcher:
         assert "url" in first_stream.meta and first_stream.meta["url"] == HTML_URL
         assert first_stream.mime_type == "text/html"
 
-    @pytest.mark.integration
     def test_link_content_fetcher_text(self):
         """
         Test fetching text content from a real URL.
@@ -208,7 +210,6 @@ class TestLinkContentFetcher:
         assert "url" in first_stream.meta and first_stream.meta["url"] == TEXT_URL
         assert first_stream.mime_type == "text/plain"
 
-    @pytest.mark.integration
     def test_link_content_fetcher_multiple_different_content_types(self):
         """
         This test is to ensure that the fetcher can handle a list of URLs that contain different content types.
@@ -225,7 +226,6 @@ class TestLinkContentFetcher:
                 assert len(stream.data) > 0
                 assert stream.mime_type == "application/pdf"
 
-    @pytest.mark.integration
     def test_link_content_fetcher_multiple_html_streams(self):
         """
         This test is to ensure that the fetcher can handle a list of URLs that contain different content types,
@@ -244,7 +244,6 @@ class TestLinkContentFetcher:
                 assert len(stream.data) > 0
                 assert stream.mime_type == "application/pdf"
 
-    @pytest.mark.integration
     def test_mix_of_good_and_failed_requests(self):
         """
         This test is to ensure that the fetcher can handle a list of URLs that contain URLs that fail to be fetched.
@@ -259,8 +258,8 @@ class TestLinkContentFetcher:
         assert first_stream.mime_type == "text/html"
 
 
+@pytest.mark.asyncio
 class TestLinkContentFetcherAsync:
-    @pytest.mark.asyncio
     async def test_run_async(self):
         """Test basic async fetching with a mocked response"""
         with patch("haystack.components.fetchers.link_content.httpx.AsyncClient.get") as mock_get:
@@ -276,7 +275,6 @@ class TestLinkContentFetcherAsync:
             assert first_stream.meta["content_type"] == "text/plain"
             assert first_stream.mime_type == "text/plain"
 
-    @pytest.mark.asyncio
     async def test_run_async_multiple(self):
         """Test async fetching of multiple URLs with mocked responses"""
         with patch("haystack.components.fetchers.link_content.httpx.AsyncClient.get") as mock_get:
@@ -295,14 +293,12 @@ class TestLinkContentFetcherAsync:
                 assert stream.meta["content_type"] == "text/plain"
                 assert stream.mime_type == "text/plain"
 
-    @pytest.mark.asyncio
     async def test_run_async_empty_urls(self):
         """Test async fetching with empty URL list"""
         fetcher = LinkContentFetcher()
         streams = (await fetcher.run_async(urls=[]))["streams"]
         assert len(streams) == 0
 
-    @pytest.mark.asyncio
     async def test_run_async_error_handling(self):
         """Test error handling for async fetching"""
         with patch("haystack.components.fetchers.link_content.httpx.AsyncClient.get") as mock_get:
@@ -322,7 +318,6 @@ class TestLinkContentFetcherAsync:
             with pytest.raises(httpx.HTTPStatusError):
                 await fetcher.run_async(urls=["https://www.example.com"])
 
-    @pytest.mark.asyncio
     async def test_run_async_user_agent_rotation(self):
         """Test user agent rotation in async fetching"""
         with (
@@ -355,34 +350,6 @@ class TestLinkContentFetcherAsync:
 
             mock_sleep.assert_called_once()
 
-    @pytest.mark.asyncio
-    @pytest.mark.integration
-    async def test_run_async_multiple_integration(self):
-        """Test async fetching of multiple URLs with real HTTP requests"""
-        fetcher = LinkContentFetcher()
-        streams = (await fetcher.run_async([HTML_URL, TEXT_URL]))["streams"]
-        assert len(streams) == 2
-
-        for stream in streams:
-            assert "Haystack" in stream.data.decode("utf-8")
-
-            if stream.meta["url"] == HTML_URL:
-                assert stream.meta["content_type"] == "text/html"
-                assert stream.mime_type == "text/html"
-            elif stream.meta["url"] == TEXT_URL:
-                assert stream.meta["content_type"] == "text/plain"
-                assert stream.mime_type == "text/plain"
-
-    @pytest.mark.asyncio
-    @pytest.mark.integration
-    async def test_run_async_with_client_kwargs(self):
-        """Test async fetching with custom client kwargs"""
-        fetcher = LinkContentFetcher(client_kwargs={"follow_redirects": True, "timeout": 10.0})
-        streams = (await fetcher.run_async([HTML_URL]))["streams"]
-        assert len(streams) == 1
-        assert "Haystack" in streams[0].data.decode("utf-8")
-
-    @pytest.mark.asyncio
     async def test_request_headers_merging_and_ua_override(self):
         # Patch the AsyncClient class to control the instance created by LinkContentFetcher
         with patch("haystack.components.fetchers.link_content.httpx.AsyncClient") as AsyncClientMock:
@@ -405,7 +372,6 @@ class TestLinkContentFetcherAsync:
             assert sent_headers["Accept-Language"] == "de-DE"
             assert sent_headers["User-Agent"] == "ua-async-1"  # rotating UA wins
 
-    @pytest.mark.asyncio
     async def test_duplicated_request_headers_merging(self):
         # Patch the AsyncClient class to control the instance created by LinkContentFetcher
         with patch("haystack.components.fetchers.link_content.httpx.AsyncClient") as AsyncClientMock:
@@ -439,3 +405,31 @@ class TestLinkContentFetcherAsync:
 
             assert "x-test-header" in existing_keys
             assert existing_keys["x-test-header"] == "X-TeSt-HeAdEr"
+
+
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestLinkContentFetcherAsyncIntegration:
+    async def test_run_async_multiple_integration(self):
+        """Test async fetching of multiple URLs with real HTTP requests"""
+        fetcher = LinkContentFetcher()
+        streams = (await fetcher.run_async([HTML_URL, TEXT_URL]))["streams"]
+        assert len(streams) == 2
+
+        for stream in streams:
+            assert "Haystack" in stream.data.decode("utf-8")
+
+            if stream.meta["url"] == HTML_URL:
+                assert stream.meta["content_type"] == "text/html"
+                assert stream.mime_type == "text/html"
+            elif stream.meta["url"] == TEXT_URL:
+                assert stream.meta["content_type"] == "text/plain"
+                assert stream.mime_type == "text/plain"
+
+    async def test_run_async_with_client_kwargs(self):
+        """Test async fetching with custom client kwargs"""
+        fetcher = LinkContentFetcher(client_kwargs={"follow_redirects": True, "timeout": 10.0})
+        streams = (await fetcher.run_async([HTML_URL]))["streams"]
+        assert len(streams) == 1
+        assert "Haystack" in streams[0].data.decode("utf-8")

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -1088,8 +1088,8 @@ class TestOpenAIChatGenerator:
         tool_call = message.tool_call
         assert isinstance(tool_call, ToolCall)
         assert tool_call.tool_name == "weather"
-        assert tool_call.arguments == {"city": "Paris"}
-        assert message.meta["finish_reason"] == "tool_calls"
+        assert tool_call.arguments.keys() == {"city"}
+        assert "Paris" in tool_call.arguments["city"]
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),

--- a/test/components/generators/chat/test_openai_async.py
+++ b/test/components/generators/chat/test_openai_async.py
@@ -344,7 +344,7 @@ class TestOpenAIChatGeneratorAsync:
     @pytest.mark.integration
     @pytest.mark.asyncio
     async def test_run_async_cancellation_integration(self):
-        generator = OpenAIChatGenerator(model="gpt-4")
+        generator = OpenAIChatGenerator(model="gpt-4.1-nano")
         messages = [ChatMessage.from_user("Write me an essay about the history of jazz music, at least 500 words.")]
         received_chunks = []
 

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -273,6 +273,15 @@ def weather_function(city: str) -> dict[str, Any]:
     return weather_info.get(city, {"weather": "unknown", "temperature": 0, "unit": "celsius"})
 
 
+# Tool Function used in the test_live_run_with_agent_streaming_and_reasoning test
+def calculate(expression: str) -> dict:
+    try:
+        result = eval(expression, {"__builtins__": {}})
+        return {"result": result}
+    except Exception as e:
+        return {"error": str(e)}
+
+
 @pytest.fixture
 def tools():
     weather_tool = Tool(
@@ -1064,7 +1073,8 @@ class TestOpenAIResponsesChatGenerator:
         tool_call = message.tool_call
         assert isinstance(tool_call, ToolCall)
         assert tool_call.tool_name == "weather"
-        assert tool_call.arguments == {"city": "Paris"}
+        assert tool_call.arguments.keys() == {"city"}
+        assert "Paris" in tool_call.arguments["city"]
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),
@@ -1169,14 +1179,6 @@ class TestOpenAIResponsesChatGenerator:
     )
     @pytest.mark.integration
     def test_live_run_with_agent_streaming_and_reasoning(self):
-        # Tool Function
-        def calculate(expression: str) -> dict:
-            try:
-                result = eval(expression, {"__builtins__": {}})
-                return {"result": result}
-            except Exception as e:
-                return {"error": str(e)}
-
         # Tool Definition
         calculator_tool = Tool(
             name="calculator",


### PR DESCRIPTION
### Related Issues

I analyzed test failures on main from November 1st and I found out that some integration tests are responsible of most failures. So I am trying to improve them.

### Proposed Changes:
- OpenAI `test_run_async_cancellation_integration`: use a faster model to make sure that generation already started when we cancel the task
- OpenAI `test_live_run_with_agent_streaming_and_reasoning`: define the function used here at the module level, not inside the test function. Otherwise it frequently fails with "Serialization of nested functions is not supported"
- OpenAI `test_live_run_with_toolset`: relax the requirements for the "city" value: sometimes the model produces "Paris, France" insted of "Paris" only
- Whisper remote, OpenAPI and `LinkContentFetcher`: mark tests as flaky to retry them. In these cases, failures are often due to network problems.

### How did you test it?
CI, multiple local runs

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
