### PR TITLE
fix: Set return_empty_on_no_match default to False in RegexTextExtractor

### DIFF
--- a/haystack/components/extractors/regex_text_extractor.py
+++ b/haystack/components/extractors/regex_text_extractor.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-import warnings
 from typing import Union
 
 from haystack import component, logging
@@ -38,7 +37,7 @@ class RegexTextExtractor:
     ```
     """
 
-    def __init__(self, regex_pattern: str, return_empty_on_no_match: bool = True):
+    def __init__(self, regex_pattern: str, return_empty_on_no_match: bool = False):
         """
         Creates an instance of the RegexTextExtractor component.
 
@@ -62,7 +61,7 @@ class RegexTextExtractor:
                 regex_pattern=regex_pattern,
             )
 
-    @component.output_types(captured_text=str, captured_texts=list[str])
+    @component.output_types(captured_text=str)
     def run(self, text_or_messages: Union[str, list[ChatMessage]]) -> dict:
         """
         Extracts text from input using the configured regex pattern.
@@ -89,12 +88,6 @@ class RegexTextExtractor:
         """Helper method to build the return dictionary based on configuration."""
         if (isinstance(result, str) and result == "") or (isinstance(result, list) and not result):
             if self.return_empty_on_no_match:
-                msg = (
-                    "Warning: In an upcoming release, the output when no matches are found will change from "
-                    "'{}' to {'captured_text': "
-                    "}"
-                )
-                warnings.warn(msg, DeprecationWarning, stacklevel=2)
                 return {}
             return {"captured_text": ""}
         return {"captured_text": result}

--- a/test/components/extractors/test_regex_text_extractor.py
+++ b/test/components/extractors/test_regex_text_extractor.py
@@ -39,28 +39,28 @@ class TestRegexTextExtractor:
         extractor = RegexTextExtractor(regex_pattern=pattern)
         text = "This text has no matching pattern"
         result = extractor.run(text_or_messages=text)
-        assert result == {}
+        assert result == {"captured_text": ""}
 
-    def test_extract_from_string_no_match_return_empty_false(self):
+    def test_extract_from_string_no_match_return_empty_true(self):
         pattern = r'<issue url="(.+?)">'
         text = "This text has no matching pattern"
-        extractor = RegexTextExtractor(regex_pattern=pattern, return_empty_on_no_match=False)
+        extractor = RegexTextExtractor(regex_pattern=pattern, return_empty_on_no_match=True)
         result = extractor.run(text_or_messages=text)
-        assert result == {"captured_text": ""}
+        assert result == {}
 
     def test_extract_from_string_empty_input(self):
         pattern = r'<issue url="(.+?)">'
         extractor = RegexTextExtractor(regex_pattern=pattern)
         text = ""
         result = extractor.run(text_or_messages=text)
-        assert result == {}
+        assert result == {"captured_text": ""}
 
-    def test_extract_from_string_empty_input_no_match_return_empty_false(self):
+    def test_extract_from_string_empty_input_return_empty_true(self):
         pattern = r'<issue url="(.+?)">'
-        extractor = RegexTextExtractor(regex_pattern=pattern, return_empty_on_no_match=False)
+        extractor = RegexTextExtractor(regex_pattern=pattern, return_empty_on_no_match=True)
         text = ""
         result = extractor.run(text_or_messages=text)
-        assert result == {"captured_text": ""}
+        assert result == {}
 
     def test_extract_from_chat_messages_single_message(self):
         pattern = r'<issue url="(.+?)">'
@@ -88,7 +88,7 @@ class TestRegexTextExtractor:
             ChatMessage.from_user("Last message with no matching pattern"),
         ]
         result = extractor.run(text_or_messages=messages)
-        assert result == {}
+        assert result == {"captured_text": ""}
 
     def test_extract_from_chat_messages_empty_list(self):
         pattern = r'<issue url="(.+?)">'


### PR DESCRIPTION
## Summary
- Changed default value of `return_empty_on_no_match` from `True` to `False`
- Removed `DeprecationWarning` that was added in preparation for this change
- Removed unused `captured_texts` output type

## Test plan
- [x] Updated existing tests to reflect new default behavior
- [x] All 23 tests pass

Closes #10252