### PR TITLE
docs: Add doc strings for `query_suffix` and `document_suffix` for `SentenceTransformersSimilarityRanker`

### DIFF
--- a/haystack/components/rankers/sentence_transformers_similarity.py
+++ b/haystack/components/rankers/sentence_transformers_similarity.py
@@ -75,9 +75,15 @@ class SentenceTransformersSimilarityRanker:
         :param query_prefix:
             A string to add at the beginning of the query text before ranking.
             Use it to prepend the text with an instruction, as required by reranking models like `bge`.
+        :param query_suffix:
+            A string to add at the end of the query text before ranking.
+            Use it to append the text with an instruction, as required by reranking models like `qwen`.
         :param document_prefix:
             A string to add at the beginning of each document before ranking. You can use it to prepend the document
             with an instruction, as required by embedding models like `bge`.
+        :param document_suffix:
+            A string to add at the end of each document before ranking. You can use it to append the document
+            with an instruction, as required by embedding models like `qwen`.
         :param meta_fields_to_embed:
             List of metadata fields to embed with the document.
         :param embedding_separator:


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
