### PR TITLE
chore: exclude github-actions[bot] from contributors list

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -72,7 +72,7 @@ jobs:
           END: ${{ github.ref_name }}
         run: |
           JQ_EXPR='[.commits[].author.login]
-            | map(select(. != null and . != "HaystackBot" and . != "dependabot[bot]"))
+            | map(select(. != null and . != "HaystackBot" and . != "dependabot[bot]" and . != "github-actions[bot]"))
             | unique
             | sort_by(ascii_downcase)
             | map("@\(.)")


### PR DESCRIPTION
### Related Issues

Related to #10074 (part of release automation #9095)

Currently, `github-actions[bot]` is included in the contributors list. See https://github.com/deepset-ai/haystack/releases/tag/v2.22.0-rc1

### Proposed Changes:
- filter out `github-actions[bot]` from the contributors list

### How did you test it?
Tested the command locally

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
