### PR TITLE
ci: refine "Release new minor version docs" workflow

### DIFF
--- a/.github/workflows/promote_unstable_docs.yml
+++ b/.github/workflows/promote_unstable_docs.yml
@@ -55,6 +55,7 @@ jobs:
             It is expected to run at the time of the release.
             You can inspect the docs preview and merge it. There should now be only one unstable version representing the next (main) branch.
           # This workflow is triggered by a tag pushed by the HaystackBot in release.yml > create-release-tag.
-          # Setting the github.actor as reviewer fails: it would attempt to request a review from the HaystackBot itself.
+          # GitHub requires reviewers to be different from the PR author, so setting `github.actor`
+          # would fail (it would request a review from the HaystackBot itself).
           # So we don't set any reviewers and instead notify the Release Manager
           # (see .github/utils/prepare_release_notification.sh).


### PR DESCRIPTION
### Related Issues
Part of #9095

When I released Haystack 2.22.0, the "Release new minor version docs" workflow failed: https://github.com/deepset-ai/haystack/actions/runs/20820104740/job/59805988487

While the docs promotion PR was successfully created (https://github.com/deepset-ai/haystack/pull/10325), assigning the GitHub actor as a reviewer failed. 
GitHub requires the reviewer to be different from the PR author and in this case the workflow is triggered by a tag created only by the HaystackBot (not by human + bot, as is common). Asking the HaystackBot itself as a reviewer is not permitted.

### Proposed Changes:
- do not assign a specific reviewer for the docs promotion PR
- (the Release Manager will still be notified via Slack with a link to the PR)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
