### PR TITLE
ci: reduce Vale linter runs

### DIFF
--- a/docs-website/docs/development/deployment/docker.mdx
+++ b/docs-website/docs/development/deployment/docker.mdx
@@ -13,7 +13,7 @@ Learn how to deploy your Haystack pipelines through Docker starting from the bas
 
 The most basic form of Haystack deployment happens through Docker containers. Becoming familiar with running and customizing Haystack Docker images is useful as they form the basis for more advanced deployment.
 
-Haystack releases are officially distributed through the [`deepset/haystack`](https://hub.docker.com/r/deepset/haystack) Docker image. Haystack images come in different flavors depending on the specific components they ship and the Haystack version.
+Haystack releases are officially distributed through the [`deepset/haystack`](https://hub.docker.com/r/deepset/haystack) Docker image. Haystack images come in different flavors depending on the specific components they ship and the Haystack version. 
 
 :::info
 At the moment, the only flavor available for Haystack is `base`, which ships exactly what you would get by installing Haystack locally with `pip install haystack-ai`.
@@ -35,9 +35,9 @@ docker run -it --rm deepset/haystack:base-v2.12.1 python -c"from haystack.versio
 
 Chances are your application will be more complex than a simple script, and you’ll need to install additional dependencies inside the Docker image along with Haystack.
 
-For example, you might want to run a simple indexing pipeline using [Chroma](../../document-stores/chromadocumentstore.mdx) as your Document Store using a Docker container. The `base` image only contains a basic install of Haystack, but you need to install the Chroma integration (`chroma-haystack`) package additionally. The best approach would be to create a custom Docker image shipping the extra dependency.
+For example, you might want to run a simple indexing pipeline using [Chroma](../../document-stores/chromadocumentstore.mdx) as your Document Store using a Docker container. The `base` image only contains a basic install of Haystack, but you need to install the Chroma integration (`chroma-haystack`) package additionally. The best approach would be to create a custom Docker image shipping the extra dependency. 
 
-Assuming you have a `main.py` script in your current folder, the Dockerfile would look like this:
+Assuming you have a `main.py` script in your current folder, the Dockerfile would look like this: 
 
 ```shell
 FROM deepset/haystack:base-v2.12.1


### PR DESCRIPTION
### Related Issues

Vale linter (used for language linting docs) currently runs often, also on pushes on main and on automated PRs, where its suggestions are not meant to be taken into consideration. This wastes compute.

### Proposed Changes:
- Only run Vale on pull requests
- Make sure the workflow runs only when `docs-website/docs` is touched, aligned with Vale configuration: https://github.com/deepset-ai/haystack/blob/e89cc68c925e483e710d27f8d36fb5a9e2cea0ec/.github/workflows/docs-website-vale.yml#L36
This avoids running the workflow for old docs versions and API references (autogenerated)

### How did you test it?
Temporarily triggered in this PR. See for example https://github.com/deepset-ai/haystack/pull/10331#discussion_r2675713599

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
