### PR TITLE
ci: fix docker build

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -56,6 +56,7 @@ jobs:
           IMAGE_TAG_SUFFIX: ${{ steps.meta.outputs.version }}
           HAYSTACK_VERSION: ${{ steps.meta.outputs.version }}
         with:
+          source: .
           workdir: docker
           targets: base
           push: true


### PR DESCRIPTION
### Related Issues
In #10387, Docker build was refactored using the new `docker/bake-action@v6` (we were using v5).
v6 contains a [breaking change](https://github.com/docker/bake-action/releases/tag/v6.0.0): by default, uses Git context instead of Path context. This resulted in Docker build failure: https://github.com/deepset-ai/haystack/actions/runs/21062435927/job/60571674643

### Proposed Changes:
- keep the new action version but use the Path context (as explained in [v6 release notes](https://github.com/docker/bake-action/releases/tag/v6.0.0))

### How did you test it?
Not tested but when experimenting with the previous PR and Path context things worked correctly. I just was not aware that Path context was explictly required to be set also for main.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
