### PR TITLE
fix: OpenAIChatGenerator - handle `delta` set to `None`

### DIFF
--- a/releasenotes/notes/fix-openai-delta-none-f675b96881cc5b66.yaml
+++ b/releasenotes/notes/fix-openai-delta-none-f675b96881cc5b66.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    In ``OpenAIChatGenerator``, streaming now handles cases where a ``ChatCompletionChunk`` has a ``delta`` set to
+    ``None`` in ``choices``. This can occur with some OpenAI-compatible providers, and the component will now handle
+    it gracefully.


### PR DESCRIPTION
### Related Issues

CometAPI test failure: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/21051179135/job/60537589509

```
>       if choice.delta.tool_calls:
           ^^^^^^^^^^^^^^^^^^^^^^^
E       AttributeError: 'NoneType' object has no attribute 'tool_calls'
```

Sometimes `delta` is `None`.

Somewhat related docs: https://apidoc.cometapi.com/streamed-output-1623253m0


### Proposed Changes:

- in `OpenAIChatGenerator`, handle these cases gracefully

### How did you test it?
CI, new test + enriched existing test

### Notes for the reviewer
- **Open for discussion**: I am basically creating an almost empty `StreamingChunk`. We might also decide to return `None` but this would require modifying the code a bit more.
- Once we agree on the approach, I'll open a similar PR in CometAPI integration to patch the Chat Generator (waiting for this change to be released).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
