### PR TITLE
refactor: avoid top-level package import when importing DeserializationError

### DIFF
--- a/haystack/utils/deserialization.py
+++ b/haystack/utils/deserialization.py
@@ -4,7 +4,7 @@
 
 from typing import Any
 
-from haystack import DeserializationError
+from haystack.core.errors import DeserializationError
 from haystack.core.serialization import component_from_dict, default_from_dict, import_class_by_name
 
 


### PR DESCRIPTION
### Related Issues

I ran into some import errors when running `from haystack.document_stores.in_memory import InMemoryDocumentStore` while working on handling the serialization of DocumentStore in default_from_dict / default_to_dict. I believe we can improve the import independent of that work.
```
>>> from haystack.document_stores.in_memory import InMemoryDocumentStore
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    from haystack.document_stores.in_memory import InMemoryDocumentStore
  File "/Users/julian/deepset/dev/haystack/haystack/__init__.py", line 12, in <module>
    from haystack.core.component import component
  File "/Users/julian/deepset/dev/haystack/haystack/core/__init__.py", line 5, in <module>
    from .super_component import SuperComponent
  File "/Users/julian/deepset/dev/haystack/haystack/core/super_component/__init__.py", line 5, in <module>
    from .super_component import SuperComponent, super_component
  File "/Users/julian/deepset/dev/haystack/haystack/core/super_component/super_component.py", line 12, in <module>
    from haystack.core.pipeline.async_pipeline import AsyncPipeline
  File "/Users/julian/deepset/dev/haystack/haystack/core/pipeline/__init__.py", line 5, in <module>
    from .async_pipeline import AsyncPipeline
  File "/Users/julian/deepset/dev/haystack/haystack/core/pipeline/async_pipeline.py", line 12, in <module>
    from haystack.core.pipeline.base import (
    ...<5 lines>...
    )
  File "/Users/julian/deepset/dev/haystack/haystack/core/pipeline/base.py", line 37, in <module>
    from haystack.core.serialization import (
    ...<4 lines>...
    )
  File "/Users/julian/deepset/dev/haystack/haystack/core/serialization.py", line 14, in <module>
    from haystack.utils.deserialization import deserialize_document_store_in_init_params_inplace
  File "/Users/julian/deepset/dev/haystack/haystack/utils/deserialization.py", line 7, in <module>
    from haystack import DeserializationError
ImportError: cannot import name 'DeserializationError' from 'haystack' (consider renaming '/Users/julian/deepset/dev/haystack/haystack/__init__.py' if it has the same name as a library you intended to import)
```

### Proposed Changes:

- Fix circular import by changing `from haystack import DeserializationError` to `from haystack.core.errors import DeserializationError`.

### How did you test it?

ran `from haystack.document_stores.in_memory import InMemoryDocumentStore` locally

### Notes for the reviewer

I can wait with the change and make it part of a future PR that causes the circular import error. However, I believe the changed import is an improvement even if we decide not to handle DocumentStore serialization in default_from_dict / default_to_dict

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
