### PR TITLE
chore: HuggingFaceLocalChatGenerator - check defensively before shutting down executor

### DIFF
--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -256,7 +256,7 @@ class HuggingFaceLocalChatGenerator:
         """
         Cleanup when the instance is being destroyed.
         """
-        if self._owns_executor:
+        if hasattr(self, "_owns_executor") and self._owns_executor and hasattr(self, "executor"):
             self.executor.shutdown(wait=True)
 
     def shutdown(self) -> None:


### PR DESCRIPTION
### Related Issues
https://github.com/deepset-ai/haystack/issues/10341#issuecomment-3778261915

```
  Traceback (most recent call last):
    File "/Users/stefano.fiorucci/dev/haystack/haystack/components/generators/chat/hugging_face_local.py", line 259, in __del__
      if self._owns_executor:
  AttributeError: 'HuggingFaceLocalChatGenerator' object has no attribute '_owns_executor'
```

Not a test failure but I thought about improving a little bit this component, which sometimes also makes Windows tests hang in relation to executor deletion. So this change could help...

### Proposed Changes:
- invoke `self.executor.shutdown` only after checking its existence: at deletion time, it might happen that the class still exists but its attributes have already been deleted. Aligned with `InMemoryDocumentStore`:
https://github.com/deepset-ai/haystack/blob/d7fe524b21cf4ed257b47662642383b52eb3aa40/haystack/document_stores/in_memory/document_store.py#L129

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
