### PR TITLE
enhancement: support flattened verbosity generation_kwarg for OpenAIResponsesChatGenerator

### DIFF
--- a/releasenotes/notes/support-flattened-verbosity-generation_kwarg-with-OpenAIResponsesChatGenerator-e7681b9a4dda2560.yaml
+++ b/releasenotes/notes/support-flattened-verbosity-generation_kwarg-with-OpenAIResponsesChatGenerator-e7681b9a4dda2560.yaml
@@ -1,0 +1,25 @@
+---
+enhancements:
+  - |
+      Support for flattened ``verbosity`` in ``generation_kwargs`` of ``OpenAIResponsesChatGenerator``
+
+      The ``OpenAIResponsesChatGenerator`` component now supports flattened ``verbosity`` generation
+      keyword arguments, allowing users to specify verbositydirectly
+      without nesting them in ``text``. This enhancement simplifies the configuration process
+      and improves usability.
+
+      Example:
+       .. code:: python
+          from haystack.components.generators.chat import OpenAIResponsesChatGenerator
+
+          generator = OpenAIResponsesChatGenerator(
+              model="gpt-4",
+              generation_kwargs={
+                  "verbosity": "low",
+              }
+          )
+fixes:
+  - |
+    Use ``create`` instead of ``parse`` method of the OpenAI Responses python client when ``text`` is set but no ``text_format`` is set.
+    ``parse`` requires a type from ``text_format`` to be set, to actually parse the response into that type.
+    With ``text`` set but no ``text_format``, we just want to create a normal response without parsing.

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -496,11 +496,13 @@ class TestRun:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         chat_messages = [ChatMessage.from_user("What's the capital of France")]
         component = OpenAIResponsesChatGenerator(
-            model="gpt-4", generation_kwargs={"reasoning_effort": "low", "reasoning_summary": "auto"}
+            model="gpt-4",
+            generation_kwargs={"reasoning_effort": "low", "reasoning_summary": "auto", "verbosity": "low"},
         )
         results = component.run(chat_messages)
         assert len(results["replies"]) == 1
         assert openai_mock_responses.call_args.kwargs["reasoning"] == {"effort": "low", "summary": "auto"}
+        assert openai_mock_responses.call_args.kwargs["text"] == {"verbosity": "low"}
 
     def test_run_with_params_streaming(self, openai_mock_responses_stream_text_delta):
         streaming_callback_called = False


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:
- support flattened `verbosity` generation_kwarg for OpenAIResponsesChatGenerator
- fixed incorrect usage of `OpenAI.responses.parse` when no `text_format` type is given (to convert the response into this type)

### How did you test it?
- added verbosity to flattened generation_kwargs test
- ran integration tests locally as well

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
