### PR TITLE
test: mock arrow.now to prevent flakiness in Jinja2 Time extension tests

### DIFF
--- a/test/components/builders/test_prompt_builder.py
+++ b/test/components/builders/test_prompt_builder.py
@@ -81,14 +81,6 @@ class TestPromptBuilder:
         assert set(outputs.keys()) == {"prompt"}
         assert outputs["prompt"].type == str
 
-    @patch("haystack.components.builders.prompt_builder.Jinja2TimeExtension")
-    def test_init_with_missing_extension_dependency(self, extension_mock):
-        extension_mock.side_effect = ImportError
-        builder = PromptBuilder(template="This is a {{ variable }}")
-        assert builder._env.extensions == {}
-        res = builder.run(variable="test")
-        assert res == {"prompt": "This is a test"}
-
     def test_to_dict(self):
         builder = PromptBuilder(
             template="This is a {{ variable }}", variables=["var1", "var2"], required_variables=["var1", "var3"]
@@ -277,6 +269,70 @@ class TestPromptBuilder:
         }
         assert result == expected_dynamic
 
+    def test_warning_no_required_variables(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _ = PromptBuilder(template="This is a {{ variable }}")
+            assert "but `required_variables` is not set." in caplog.text
+
+    def test_variables_correct_with_assignment(self) -> None:
+        template = """{% if existing_documents is not none %}
+{% set existing_doc_len = existing_documents|length %}
+{% else %}
+{% set existing_doc_len = 0 %}
+{% endif %}
+{% for doc in docs %}
+<document reference="{{loop.index + existing_doc_len}}">
+{{ doc.content }}
+</document>
+{% endfor %}
+"""
+        builder = PromptBuilder(template=template, required_variables="*")
+        assert set(builder.variables) == {"docs", "existing_documents"}
+        assert builder.required_variables == "*"
+
+    def test_variables_correct_with_tuple_assignment(self):
+        template = """{% if existing_documents is not none -%}
+{% set x, y = (existing_documents|length, 1) -%}
+{% else -%}
+{% set x, y = (0, 1) -%}
+{% endif -%}
+x={{ x }}, y={{ y }}
+"""
+        builder = PromptBuilder(template=template, required_variables="*")
+        assert builder.variables == ["existing_documents"]
+        assert builder.required_variables == "*"
+        res = builder.run(existing_documents=None)
+        assert res["prompt"] == "x=0, y=1"
+
+    def test_variables_correct_with_list_assignment(self):
+        template = """{% if existing_documents is not none -%}
+{% set x, y = [existing_documents|length, 1] -%}
+{% else -%}
+{% set x, y = [0, 1] -%}
+{% endif -%}
+x={{ x }}, y={{ y }}
+"""
+        builder = PromptBuilder(template=template, required_variables="*")
+        assert builder.variables == ["existing_documents"]
+        assert builder.required_variables == "*"
+        res = builder.run(existing_documents=None)
+        assert res["prompt"] == "x=0, y=1"
+
+
+class TestPromptBuilderWithJinja2TimeExtension:
+    @pytest.fixture(autouse=True)
+    def mock_now(self, monkeypatch):
+        """Mock the arrow.now function to return a fixed datetime"""
+        monkeypatch.setattr("arrow.now", lambda timezone="UTC": arrow.get("1970-01-01 00:00:00").to(timezone))
+
+    @patch("haystack.components.builders.prompt_builder.Jinja2TimeExtension")
+    def test_init_with_missing_extension_dependency(self, extension_mock):
+        extension_mock.side_effect = ImportError
+        builder = PromptBuilder(template="This is a {{ variable }}")
+        assert builder._env.extensions == {}
+        res = builder.run(variable="test")
+        assert res == {"prompt": "This is a test"}
+
     def test_with_custom_dateformat(self) -> None:
         template = "Formatted date: {% now 'UTC', '%Y-%m-%d' %}"
         builder = PromptBuilder(template=template)
@@ -332,52 +388,3 @@ class TestPromptBuilder:
         # Expect ValueError for invalid offset
         with pytest.raises(ValueError, match="Invalid offset or operator"):
             builder.run()
-
-    def test_warning_no_required_variables(self, caplog):
-        with caplog.at_level(logging.WARNING):
-            _ = PromptBuilder(template="This is a {{ variable }}")
-            assert "but `required_variables` is not set." in caplog.text
-
-    def test_variables_correct_with_assignment(self) -> None:
-        template = """{% if existing_documents is not none %}
-{% set existing_doc_len = existing_documents|length %}
-{% else %}
-{% set existing_doc_len = 0 %}
-{% endif %}
-{% for doc in docs %}
-<document reference="{{loop.index + existing_doc_len}}">
-{{ doc.content }}
-</document>
-{% endfor %}
-"""
-        builder = PromptBuilder(template=template, required_variables="*")
-        assert set(builder.variables) == {"docs", "existing_documents"}
-        assert builder.required_variables == "*"
-
-    def test_variables_correct_with_tuple_assignment(self):
-        template = """{% if existing_documents is not none -%}
-{% set x, y = (existing_documents|length, 1) -%}
-{% else -%}
-{% set x, y = (0, 1) -%}
-{% endif -%}
-x={{ x }}, y={{ y }}
-"""
-        builder = PromptBuilder(template=template, required_variables="*")
-        assert builder.variables == ["existing_documents"]
-        assert builder.required_variables == "*"
-        res = builder.run(existing_documents=None)
-        assert res["prompt"] == "x=0, y=1"
-
-    def test_variables_correct_with_list_assignment(self):
-        template = """{% if existing_documents is not none -%}
-{% set x, y = [existing_documents|length, 1] -%}
-{% else -%}
-{% set x, y = [0, 1] -%}
-{% endif -%}
-x={{ x }}, y={{ y }}
-"""
-        builder = PromptBuilder(template=template, required_variables="*")
-        assert builder.variables == ["existing_documents"]
-        assert builder.required_variables == "*"
-        res = builder.run(existing_documents=None)
-        assert res["prompt"] == "x=0, y=1"

--- a/test/utils/test_jinja2_extensions.py
+++ b/test/utils/test_jinja2_extensions.py
@@ -12,6 +12,11 @@ from haystack.utils import Jinja2TimeExtension
 
 
 class TestJinja2TimeExtension:
+    @pytest.fixture(autouse=True)
+    def mock_now(self, monkeypatch):
+        """Mock the arrow.now function to return a fixed datetime"""
+        monkeypatch.setattr("arrow.now", lambda timezone="UTC": arrow.get("1970-01-01 00:00:00").to(timezone))
+
     @pytest.fixture
     def jinja_env(self) -> Environment:
         return Environment(extensions=[Jinja2TimeExtension])


### PR DESCRIPTION
### Related Issues

Flaky test reported in https://github.com/deepset-ai/haystack/issues/10341#issuecomment-3778070961

For our Jinja2 Time extension tests, there are some tests similar to this
https://github.com/deepset-ai/haystack/blob/e9232fee338741d3825aa1eef67ebf225a679558/test/utils/test_jinja2_extensions.py#L43-L45

The problem is: sometimes a second passes between the first call to `arrow.now()` (inside `jinja_extension._get_datetime()`) and the second one, making the test fail.

### Proposed Changes:
- mock `arrow.now` in tests to always return a fixed time
- reorganize a bit test suites to group tests related to Jinja2 Time extension in a specific class

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
