### PR TITLE
ci: fix stable version matching for Docker

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -2,9 +2,6 @@ name: Docker image release
 
 on:
   workflow_dispatch:
-
-  # JUST FOR TESTING, REMOVE BEFORE MERGING
-  pull_request:
   push:
     branches:
       - main
@@ -50,22 +47,22 @@ jobs:
 
       - name: Detect stable version
         run: |
-          version="v2.23.0"
-          if [[ "$version" =~ ^v2\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "${{ steps.meta.outputs.version }}" =~ ^v2\.[0-9]+\.[0-9]+$ ]]; then
             echo "IS_STABLE=true" >> "$GITHUB_ENV"
+            echo "Stable version detected"
+          else
+            echo "Not a stable version"
           fi
       - name: Build base images
         uses: docker/bake-action@v6
         env:
           IMAGE_TAG_SUFFIX: ${{ steps.meta.outputs.version }}
-          HAYSTACK_VERSION: "main"
+          HAYSTACK_VERSION: ${{ steps.meta.outputs.version }}
         with:
           source: .
           workdir: docker
           targets: base
-          # REVERT BEFORE MERGING
-          push: false
-          load: true
+          push: true
 
       - name: Test base image
         run: |
@@ -79,9 +76,9 @@ jobs:
           VERSION=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" python -c"from haystack.version import __version__; print(__version__)")
           [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in deepset/haystack:$TAG image for $PLATFORM is different from expected'"
 
-          # PLATFORM="linux/arm64"
-          # VERSION=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" python -c"from haystack.version import __version__; print(__version__)")
-          # [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in deepset/haystack:$TAG image for $PLATFORM is different from expected'"
+          PLATFORM="linux/arm64"
+          VERSION=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" python -c"from haystack.version import __version__; print(__version__)")
+          [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in deepset/haystack:$TAG image for $PLATFORM is different from expected'"
 
           # Remove image after test to avoid filling the GitHub runner and prevent its failure
           docker rmi "deepset/haystack:$TAG"

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -36,5 +36,5 @@ target "base" {
     base_image = "python:3.12-slim"
     haystack_version = "${HAYSTACK_VERSION}"
   }
-  platforms = ["linux/amd64"]
+  platforms = ["linux/amd64", "linux/arm64"]
 }


### PR DESCRIPTION
### Related Issues

In #10387, we attempted to tag Docker images for Haystack releases as `stable`.

Unfortunately, when releasing 2.23, this did not work:
- https://hub.docker.com/r/deepset/haystack/tags
- related workflow run: https://github.com/deepset-ai/haystack/actions/runs/21391303215/job/61578641842

The issue is caused by an incorrect version match: `[[ "v2.23.0" =~ ^2\.[0-9]+\.[0-9]+$ ]]`.

### Proposed Changes:
- fix the pattern for matching a stable version (add "v" prefix)
- add debug output to workflow

### How did you test it?
Docker release worklow was triggered in this PR with temporary workarounds: https://github.com/deepset-ai/haystack/actions/runs/21434580424/job/61722024574

The resolved bake definition includes the expected `stable` tag:
```
{
    "group": {
      "default": {
        "targets": [
          "base"
        ]
      }
    },
    "target": {
      "base": {
        "context": ".",
        "dockerfile": "Dockerfile.base",
        "args": {
          "base_image": "python:3.12-slim",
          "build_image": "python:3.12-slim",
          "haystack_version": "main"
        },
        "tags": [
          "deepset/haystack:base-pr-10459",
          "deepset/haystack:stable"  ### NOTE THE TAG. 
          # THIS TAG WAS MISSING IN https://github.com/deepset-ai/haystack/actions/runs/21391303215/job/61578641842
        ],
        "platforms": [
          "linux/amd64"
        ],
        "output": [
          {
            "type": "docker"
          }
        ]
      }
    }
  }
```

### Notes for the reviewer
We will only be able to publish the `stable` tag with the next release (2.24.0).
This seems like the cleanest solution.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
