### PR TITLE
chore: deprecate PredefinedPipeline templates and PipelineTemplate

### DIFF
--- a/haystack/core/pipeline/template.py
+++ b/haystack/core/pipeline/template.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import warnings
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from warnings import warn
 
 from jinja2 import PackageLoader, TemplateSyntaxError, meta
 from jinja2.sandbox import SandboxedEnvironment
@@ -24,15 +24,6 @@ class PredefinedPipeline(Enum):
     RAG = "rag"
     INDEXING = "indexing"
     CHAT_WITH_WEBSITE = "chat_with_website"
-
-    def __init__(self, value: str):  # noqa: B027
-        warnings.warn(
-            "`PredefinedPipeline` is deprecated. "
-            "It will be removed in Haystack version 2.25. "
-            "Pipeline YAML files should be used instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
 
 class PipelineTemplate:
@@ -85,6 +76,12 @@ class PipelineTemplate:
 
         :param template_content: The raw template source to use in the template.
         """
+        msg = (
+            "`PipelineTemplate` and `PredefinedPipeline` are deprecated. "
+            "They will be removed in Haystack version 2.25. "
+            "Pipeline YAML files should be used instead."
+        )
+        warn(msg, DeprecationWarning, stacklevel=4)
         env = SandboxedEnvironment(
             loader=PackageLoader("haystack.core.pipeline", "predefined"), trim_blocks=True, lstrip_blocks=True
         )

--- a/releasenotes/notes/deprecate-predefined-pipeline-1a2b3c4d.yaml
+++ b/releasenotes/notes/deprecate-predefined-pipeline-1a2b3c4d.yaml
@@ -1,5 +1,5 @@
 ---
 deprecations:
   - |
-    Deprecated ``PredefinedPipeline`` and its options (like ``PredefinedPipeline.CHAT_WITH_WEBSITE``).
+    Deprecated ``PipelineTemplate``, ``PredefinedPipeline`` and its options (like ``PredefinedPipeline.CHAT_WITH_WEBSITE``).
     These templates will be removed in Haystack 2.25. Users should switch to using Pipeline YAML files.

--- a/test/core/pipeline/test_templates.py
+++ b/test/core/pipeline/test_templates.py
@@ -47,6 +47,11 @@ class TestPipelineTemplate:
         tpl = PipelineTemplate.from_predefined(PredefinedPipeline.INDEXING)
         assert len(tpl.template_content)
 
+    def test_from_predefined_emits_deprecation_warning(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "")
+        with pytest.warns(DeprecationWarning, match="PipelineTemplate.*deprecated.*2\\.25"):
+            PipelineTemplate.from_predefined(PredefinedPipeline.INDEXING)
+
     #  Building a pipeline directly using all default components specified in a predefined or custom template.
     def test_build_pipeline_with_default_components(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "fake_key")


### PR DESCRIPTION
### Related Issues

* Closes #10473

---

### Proposed Changes

* Deprecated the `PredefinedPipeline` templates as discussed in the issue.
* Added clear deprecation warnings to guide users toward YAML-based pipelines.
* Updated relevant documentation/comments where applicable.

---

### How did you test it?

* Ran the existing test suite locally.
* Manually verified that deprecation warnings are raised as expected.
* Ensured no breaking changes to existing functionality.

---

### Notes for the reviewer

* The changes are intentionally minimal and scoped only to deprecation.
* Please let me know if you’d prefer a different wording for the warnings or additional docs updates.

---

### Checklist

* [x] I have read the contributors guidelines and the code of conduct.
* [x] I have updated the related issue with new insights and changes.
* [ ] I have added unit tests and updated the docstrings. *(not applicable / no behavior change)*
* [x] I've used one of the conventional commit types for my PR title (`chore:` or `docs:`).
* [x] I have documented my code where applicable.
* [x] I have added a release note file, following the contributors guidelines. *(required for deprecations)*
* [x] I have run pre-commit hooks and fixed any issue.