### PR TITLE
docs: update Pipeline Serialization docs to include what objects can be auto-serialized

### DIFF
--- a/docs-website/docs/concepts/pipelines/serialization.mdx
+++ b/docs-website/docs/concepts/pipelines/serialization.mdx
@@ -95,7 +95,7 @@ The serialization system uses `default_to_dict` and `default_from_dict` to handl
 - **ComponentDevice**: device configuration is detected and restored automatically.
 - **Objects with their own `to_dict`/`from_dict`**: any init parameter whose type defines `to_dict()` is serialized by calling it; any dict in `init_parameters` with a `type` key pointing to a class with `from_dict()` is deserialized automatically.
 
-To serialize or deserialize a single component, you can use `component_to_dict` and `component_from_dict` from `haystack.core.serialization`. They use the default behavior above as a fallback when the component does not define custom `to_dict`/`from_dict`:
+To serialize or deserialize a single component, you can use `component_to_dict` and `component_from_dict` from `haystack.core.serialization`. They use the default behavior above as a fallback when the component doesn't define custom `to_dict`/`from_dict`:
 
 ```python
 from haystack import component


### PR DESCRIPTION
### Related Issues

- fixes #10486

### Proposed Changes:

- Describe in what cases default deserialization works
- Add code example for `component_to_dict` / `component_from_dict`
- Remove info about other serialization formats 
- Fix indentation of `max_runs_per_component`
- Added warning that init parameters must be stored as instance attributes

### How did you test it?

I ran the new code example locally

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
