### PR TITLE
docs: remove Marqo references from document store docs (#10487)

### DIFF
--- a/docs-website/docs/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/docs/concepts/document-store/choosing-a-document-store.mdx
@@ -73,7 +73,6 @@ Pure vector databases, also known as just “vector databases”, offer efficien
 - [Pinecone](../../document-stores/pinecone-document-store.mdx)
 - [Qdrant](../../document-stores/qdrant-document-store.mdx)
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
-- [Marqo](https://haystack.deepset.ai/integrations/marqo-document-store) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
 
 #### Vector-capable SQL databases

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -120,11 +120,6 @@ export default {
         },
         {
           type: 'link',
-          label: 'MarqoDocumentStore',
-          href: 'https://haystack.deepset.ai/integrations/marqo-document-store/',
-        },
-        {
-          type: 'link',
           label: 'MilvusDocumentStore',
           href: 'https://haystack.deepset.ai/integrations/milvus-document-store',
         },

--- a/docs-website/versioned_docs/version-2.23/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.23/concepts/document-store/choosing-a-document-store.mdx
@@ -73,7 +73,6 @@ Pure vector databases, also known as just “vector databases”, offer efficien
 - [Pinecone](../../document-stores/pinecone-document-store.mdx)
 - [Qdrant](../../document-stores/qdrant-document-store.mdx)
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
-- [Marqo](https://haystack.deepset.ai/integrations/marqo-document-store) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
 
 #### Vector-capable SQL databases

--- a/docs-website/versioned_sidebars/version-2.23-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.23-sidebars.json
@@ -116,11 +116,6 @@
         },
         {
           "type": "link",
-          "label": "MarqoDocumentStore",
-          "href": "https://haystack.deepset.ai/integrations/marqo-document-store/"
-        },
-        {
-          "type": "link",
           "label": "MilvusDocumentStore",
           "href": "https://haystack.deepset.ai/integrations/milvus-document-store"
         },


### PR DESCRIPTION

### Related Issues

- fixes #10487

### Proposed Changes:

- Drop Marqo external integration link from `pure vector DB list`
- Remove `MarqoDocumentStore` entry from docs website sidebars
- Apply the same cleanup to versioned docs (2.23)

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Ran the docs website locally to verify that Marqo links were removed from the sidebar and document store list.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
- The diagram image ([2.0_Document_Stores_6.png](https://docs.haystack.deepset.ai/docs/choosing-a-document-store#types-of-vector-databases)) and its alt text still reference Marqo. Please advise if these should be updated too.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [ ]  (not required) I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [ ] I have documented my code.
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
