### PR TITLE
docs: remove references to discontinued Marqo Document Store

### DIFF
--- a/docs-website/docs/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/docs/concepts/document-store/choosing-a-document-store.mdx
@@ -34,7 +34,7 @@ We can group vector databases into five categories, from more specialized to gen
 We are working on supporting all these types in Haystack.
 
 In the meantime, here’s the most recent overview of available integrations:
-<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Marqo, Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
+<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
 
 #### Summary
 
@@ -73,7 +73,6 @@ Pure vector databases, also known as just “vector databases”, offer efficien
 - [Pinecone](../../document-stores/pinecone-document-store.mdx)
 - [Qdrant](../../document-stores/qdrant-document-store.mdx)
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
-- [Marqo](https://haystack.deepset.ai/integrations/marqo-document-store) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
 
 #### Vector-capable SQL databases

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -120,11 +120,6 @@ export default {
         },
         {
           type: 'link',
-          label: 'MarqoDocumentStore',
-          href: 'https://haystack.deepset.ai/integrations/marqo-document-store/',
-        },
-        {
-          type: 'link',
           label: 'MilvusDocumentStore',
           href: 'https://haystack.deepset.ai/integrations/milvus-document-store',
         },


### PR DESCRIPTION
## Summary

Removes all references to the discontinued Marqo Document Store from the documentation.

**Changes made:**
- Removed Marqo from the list of pure vector databases in `/docs-website/docs/concepts/document-store/choosing-a-document-store.mdx`
- Updated the document store diagram alt text to remove Marqo
- Removed the `MarqoDocumentStore` integration tile from the sidebar navigation

Fixes #10487

## Test plan
- [ ] Documentation builds without errors
- [ ] Sidebar navigation no longer shows MarqoDocumentStore link
- [ ] Document store page no longer references Marqo
- [ ] Diagram alt text accurately reflects available integrations