### PR TITLE
fix: improve pipeline blocked error message to show root cause

### DIFF
--- a/releasenotes/notes/improve-pipeline-blocked-error-message-10440b2c3d4e5f6g.yaml
+++ b/releasenotes/notes/improve-pipeline-blocked-error-message-10440b2c3d4e5f6g.yaml
@@ -1,0 +1,9 @@
+---
+improvements:
+  - |
+    Improved pipeline "possibly blocked" error messages to point to the most upstream
+    blocked component instead of a downstream component. When a pipeline is blocked,
+    the error message now uses topological sorting to identify the root cause component
+    that is actually blocked, rather than reporting a component that is blocked as a
+    consequence of an upstream blockage. This makes debugging pipeline configuration
+    issues much easier by directing users to the actual source of the problem.


### PR DESCRIPTION
## Summary
Fixes the pipeline "possibly blocked" error message to correctly point to the most upstream (root cause) blocked component instead of potentially showing a downstream component that is blocked as a consequence.

## Problem
As described in #10440, when a pipeline is blocked with a configuration like:
```
Comp1 > BlockedComp > Comp2
```

The error message could say "component `Comp2` is blocked" even though `BlockedComp` is the actual root cause. This happens because the pipeline uses a FIFO queue that doesn't guarantee topological ordering, making debugging difficult.

## Solution
Added a new method `_find_most_upstream_blocked_component()` that:
1. Collects all blocked components from the priority queue
2. Uses NetworkX's topological sort to determine which blocked component comes first in the dependency graph
3. Returns that component for error reporting

## Changes
- **haystack/core/pipeline/base.py**: Added `_find_most_upstream_blocked_component()` method that uses topological sorting to find the most upstream blocked component
- **haystack/core/pipeline/pipeline.py**: Updated to use the new method when reporting blocked component errors
- **haystack/core/pipeline/async_pipeline.py**: Updated to use the same logic for async pipelines

## Test Plan
Existing test `test_pipeline_is_possibly_blocked_warning_message` still passes. The test creates a blocked pipeline and verifies the warning is raised - with this fix, the warning now correctly identifies the actual blocked component.

Manual testing can be done by creating a pipeline with a chain of components where one in the middle is blocked due to missing inputs, and verifying that the error message points to that component rather than a downstream one.

Fixes #10440

---

This PR was created with assistance from Claude Code (Sonnet 4.5).