### PR TITLE
fix: cap supported Python versions below 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "LLM framework to build customizable, production-ready LLM applications. Connect components (models, vector DBs, file converters) to pipelines or agents that can interact with your data."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 authors = [{ name = "deepset.ai", email = "malte.pietsch@deepset.ai" }]
 keywords = [
   "BERT",

--- a/releasenotes/notes/restrict-python-version-below-3-14-2f8f2e3b3f3c9b57.yaml
+++ b/releasenotes/notes/restrict-python-version-below-3-14-2f8f2e3b3f3c9b57.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Restrict package metadata ``requires-python`` to ``>=3.10,<3.14`` so unsupported Python 3.14 environments are
+    rejected early during setup.

--- a/test/test_python_version_constraints.py
+++ b/test/test_python_version_constraints.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+from pathlib import Path
+
+
+def test_requires_python_marks_py314_as_unsupported():
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    pyproject_text = pyproject_path.read_text(encoding="utf-8")
+
+    match = re.search(r'^requires-python\s*=\s*"([^"]+)"', pyproject_text, flags=re.MULTILINE)
+
+    assert match is not None
+    assert match.group(1) == ">=3.10,<3.14"


### PR DESCRIPTION
## What does this PR do?

Fixes #10509 by preventing unsupported Python 3.14 environments from being selected for Haystack development and installation workflows.

### Changes
- Restrict `project.requires-python` in `pyproject.toml` from `>=3.10` to `>=3.10,<3.14`.
- Add a regression test that asserts the Python requirement string keeps the `<3.14` upper bound.
- Add a release notes entry.

## Why is this needed?

`CONTRIBUTING.md` already documents Python `<3.14` for local test runs, but package metadata still allowed `3.14`, which can lead to unsupported environments and avoidable test failures.

## Test plan

- `uv run --with pytest pytest -q test/test_python_version_constraints.py`
- `uv run --with pytest pytest -q test/core/test_type_utils.py::test_type_name_pep_604 test/utils/test_type_serialization.py::test_output_type_serialization_pep_604`
- `uv run --with pytest --with pytest-cov pytest -q test/test_python_version_constraints.py --cov=test.test_python_version_constraints --cov-report=term-missing`
