### PR TITLE
docs: remove stale Marqo document store links

### DIFF
--- a/docs-website/docs/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/docs/concepts/document-store/choosing-a-document-store.mdx
@@ -34,7 +34,7 @@ We can group vector databases into five categories, from more specialized to gen
 We are working on supporting all these types in Haystack.
 
 In the meantime, here’s the most recent overview of available integrations:
-<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Marqo, Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
+<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
 
 #### Summary
 
@@ -73,7 +73,6 @@ Pure vector databases, also known as just “vector databases”, offer efficien
 - [Pinecone](../../document-stores/pinecone-document-store.mdx)
 - [Qdrant](../../document-stores/qdrant-document-store.mdx)
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
-- [Marqo](https://haystack.deepset.ai/integrations/marqo-document-store) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
 
 #### Vector-capable SQL databases

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -120,11 +120,6 @@ export default {
         },
         {
           type: 'link',
-          label: 'MarqoDocumentStore',
-          href: 'https://haystack.deepset.ai/integrations/marqo-document-store/',
-        },
-        {
-          type: 'link',
           label: 'MilvusDocumentStore',
           href: 'https://haystack.deepset.ai/integrations/milvus-document-store',
         },

--- a/docs-website/versioned_docs/version-2.18/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.18/concepts/document-store/choosing-a-document-store.mdx
@@ -35,7 +35,7 @@ We are working on supporting all these types in Haystack.
 
 In the meantime, here’s the most recent overview of available integrations:
 
-<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Marqo, Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg"/>
+<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg"/>
 
 #### Summary
 
@@ -70,7 +70,6 @@ Pure vector databases, also known as just “vector databases”, offer efficien
 - [Pinecone](../../document-stores/pinecone-document-store.mdx)
 - [Qdrant](../../document-stores/qdrant-document-store.mdx)
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
-- [Marqo](https://haystack.deepset.ai/integrations/marqo-document-store) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
 
 #### Vector-capable SQL databases

--- a/docs-website/versioned_docs/version-2.19/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.19/concepts/document-store/choosing-a-document-store.mdx
@@ -35,7 +35,7 @@ We are working on supporting all these types in Haystack.
 
 In the meantime, here’s the most recent overview of available integrations:
 
-<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Marqo, Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg"/>
+<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg"/>
 
 #### Summary
 
@@ -69,7 +69,6 @@ Pure vector databases, also known as just “vector databases”, offer efficien
 - [Pinecone](../../document-stores/pinecone-document-store.mdx)
 - [Qdrant](../../document-stores/qdrant-document-store.mdx)
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
-- [Marqo](https://haystack.deepset.ai/integrations/marqo-document-store) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
 
 #### Vector-capable SQL databases

--- a/docs-website/versioned_docs/version-2.20/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.20/concepts/document-store/choosing-a-document-store.mdx
@@ -34,7 +34,7 @@ We can group vector databases into five categories, from more specialized to gen
 We are working on supporting all these types in Haystack.
 
 In the meantime, here’s the most recent overview of available integrations:
-<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Marqo, Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
+<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
 
 #### Summary
 
@@ -73,7 +73,6 @@ Pure vector databases, also known as just “vector databases”, offer efficien
 - [Pinecone](../../document-stores/pinecone-document-store.mdx)
 - [Qdrant](../../document-stores/qdrant-document-store.mdx)
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
-- [Marqo](https://haystack.deepset.ai/integrations/marqo-document-store) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
 
 #### Vector-capable SQL databases

--- a/docs-website/versioned_docs/version-2.21/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.21/concepts/document-store/choosing-a-document-store.mdx
@@ -34,7 +34,7 @@ We can group vector databases into five categories, from more specialized to gen
 We are working on supporting all these types in Haystack.
 
 In the meantime, here’s the most recent overview of available integrations:
-<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Marqo, Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
+<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
 
 #### Summary
 
@@ -73,7 +73,6 @@ Pure vector databases, also known as just “vector databases”, offer efficien
 - [Pinecone](../../document-stores/pinecone-document-store.mdx)
 - [Qdrant](../../document-stores/qdrant-document-store.mdx)
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
-- [Marqo](https://haystack.deepset.ai/integrations/marqo-document-store) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
 
 #### Vector-capable SQL databases

--- a/docs-website/versioned_docs/version-2.22/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.22/concepts/document-store/choosing-a-document-store.mdx
@@ -34,7 +34,7 @@ We can group vector databases into five categories, from more specialized to gen
 We are working on supporting all these types in Haystack.
 
 In the meantime, here’s the most recent overview of available integrations:
-<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Marqo, Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
+<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
 
 #### Summary
 
@@ -73,7 +73,6 @@ Pure vector databases, also known as just “vector databases”, offer efficien
 - [Pinecone](../../document-stores/pinecone-document-store.mdx)
 - [Qdrant](../../document-stores/qdrant-document-store.mdx)
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
-- [Marqo](https://haystack.deepset.ai/integrations/marqo-document-store) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
 
 #### Vector-capable SQL databases

--- a/docs-website/versioned_docs/version-2.23/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.23/concepts/document-store/choosing-a-document-store.mdx
@@ -34,7 +34,7 @@ We can group vector databases into five categories, from more specialized to gen
 We are working on supporting all these types in Haystack.
 
 In the meantime, here’s the most recent overview of available integrations:
-<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Marqo, Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
+<ClickableImage src="/img/2c188e9-2.0_Document_Stores_6.png" alt="Document store categories diagram showing four types: pure vector databases (Chroma, Milvus, Pinecone, Weaviate, Qdrant), full-text search databases (Elasticsearch, OpenSearch), vector-capable SQL databases (Pgvector for PostgreSQL), and vector-capable NoSQL databases (DataStax Astra, MongoDB, neo4j)" className="img-light-bg" />
 
 #### Summary
 
@@ -73,7 +73,6 @@ Pure vector databases, also known as just “vector databases”, offer efficien
 - [Pinecone](../../document-stores/pinecone-document-store.mdx)
 - [Qdrant](../../document-stores/qdrant-document-store.mdx)
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
-- [Marqo](https://haystack.deepset.ai/integrations/marqo-document-store) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
 
 #### Vector-capable SQL databases

--- a/docs-website/versioned_sidebars/version-2.18-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.18-sidebars.json
@@ -114,11 +114,6 @@
         },
         {
           "type": "link",
-          "label": "MarqoDocumentStore",
-          "href": "https://haystack.deepset.ai/integrations/marqo-document-store/"
-        },
-        {
-          "type": "link",
           "label": "MilvusDocumentStore",
           "href": "https://haystack.deepset.ai/integrations/milvus-document-store"
         },

--- a/docs-website/versioned_sidebars/version-2.19-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.19-sidebars.json
@@ -114,11 +114,6 @@
         },
         {
           "type": "link",
-          "label": "MarqoDocumentStore",
-          "href": "https://haystack.deepset.ai/integrations/marqo-document-store/"
-        },
-        {
-          "type": "link",
           "label": "MilvusDocumentStore",
           "href": "https://haystack.deepset.ai/integrations/milvus-document-store"
         },

--- a/docs-website/versioned_sidebars/version-2.20-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.20-sidebars.json
@@ -116,11 +116,6 @@
         },
         {
           "type": "link",
-          "label": "MarqoDocumentStore",
-          "href": "https://haystack.deepset.ai/integrations/marqo-document-store/"
-        },
-        {
-          "type": "link",
           "label": "MilvusDocumentStore",
           "href": "https://haystack.deepset.ai/integrations/milvus-document-store"
         },

--- a/docs-website/versioned_sidebars/version-2.21-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.21-sidebars.json
@@ -116,11 +116,6 @@
         },
         {
           "type": "link",
-          "label": "MarqoDocumentStore",
-          "href": "https://haystack.deepset.ai/integrations/marqo-document-store/"
-        },
-        {
-          "type": "link",
           "label": "MilvusDocumentStore",
           "href": "https://haystack.deepset.ai/integrations/milvus-document-store"
         },

--- a/docs-website/versioned_sidebars/version-2.22-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.22-sidebars.json
@@ -116,11 +116,6 @@
         },
         {
           "type": "link",
-          "label": "MarqoDocumentStore",
-          "href": "https://haystack.deepset.ai/integrations/marqo-document-store/"
-        },
-        {
-          "type": "link",
           "label": "MilvusDocumentStore",
           "href": "https://haystack.deepset.ai/integrations/milvus-document-store"
         },

--- a/docs-website/versioned_sidebars/version-2.23-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.23-sidebars.json
@@ -116,11 +116,6 @@
         },
         {
           "type": "link",
-          "label": "MarqoDocumentStore",
-          "href": "https://haystack.deepset.ai/integrations/marqo-document-store/"
-        },
-        {
-          "type": "link",
           "label": "MilvusDocumentStore",
           "href": "https://haystack.deepset.ai/integrations/milvus-document-store"
         },

--- a/releasenotes/notes/remove-marqo-doc-links-6a9f3c7e42b1e1d2.yaml
+++ b/releasenotes/notes/remove-marqo-doc-links-6a9f3c7e42b1e1d2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Remove outdated Marqo document store links from the document store guide and docs sidebars to avoid broken
+    integration URLs.


### PR DESCRIPTION
## What does this PR do?

Fixes #10487 by removing outdated Marqo references that point to a non-existing integration page.

### Changes
- Remove the Marqo external integration bullet from the "Pure vector databases" list in:
  - current docs (`docs-website/docs/...`)
  - all published versioned docs (`2.18` to `2.23`)
- Remove `MarqoDocumentStore` from:
  - current sidebar (`docs-website/sidebars.js`)
  - all published versioned sidebars (`version-2.18` to `version-2.23`)
- Update the corresponding image alt text so it no longer lists Marqo.
- Add a release notes entry.

## Why is this needed?

The Marqo integration URL currently resolves to nowhere. Keeping these links in the docs and sidebar creates broken navigation paths for users.

## Test plan

- `jq empty docs-website/versioned_sidebars/version-2.18-sidebars.json docs-website/versioned_sidebars/version-2.19-sidebars.json docs-website/versioned_sidebars/version-2.20-sidebars.json docs-website/versioned_sidebars/version-2.21-sidebars.json docs-website/versioned_sidebars/version-2.22-sidebars.json docs-website/versioned_sidebars/version-2.23-sidebars.json`
- `npm --prefix docs-website run build`
- `grep -R --line-number "[Mm]arqo" docs-website/docs docs-website/versioned_docs docs-website/sidebars.js docs-website/versioned_sidebars` (no matches expected)
