### PR TITLE
test: replace model for HuggingFaceAPIChatGenerator tool calling integration test

### DIFF
--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -831,13 +831,13 @@ class TestHuggingFaceAPIChatGenerator:
         """
         We test the round trip: generate tool call, pass tool message, generate response.
 
-        The model used here (Qwen/Qwen2.5-72B-Instruct) is not gated and kept in a warm state.
+        The model used here (Qwen/Qwen3-Next-80B-A3B-Instruct) is not gated and kept in a warm state.
         """
 
         chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen2.5-72B-Instruct", "provider": "together"},
+            api_params={"model": "Qwen/Qwen3-Next-80B-A3B-Instruct", "provider": "together"},
             generation_kwargs={"temperature": 0.5},
         )
 


### PR DESCRIPTION
### Related Issues

failing nightly slow tests: https://github.com/deepset-ai/haystack/actions/runs/21808104887/job/62914900522

```
Bad request:
{'message': 'Unable to access non-serverless model Qwen/Qwen2.5-72B-Instruct-Turbo. Please visit https://api.together.ai/models/Qwen/Qwen2.5-72B-Instruct-Turbo to create and start a new dedicated endpoint for the model.', 'type': 'invalid_request_error', 'param': None, 'code': 'model_not_available'}
= 1 failed, 42 passed, 2 skipped, 4896 deselected, 17 warnings in 134.85s (0:02:14) =
```

### Proposed Changes:
- replace the model for `HuggingFaceAPIChatGenerator` tool calling integration test with an available one

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
