### PR TITLE
docs: Fix broken TOC link for Haystack Enterprise Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ and LLMs into pipelines to build end-to-end NLP applications and solve your use 
 
 - [Installation](#installation)
 - [Documentation](#documentation)
-- [Features](#features)
-- [Use Cases](#features)
-- [Hayhooks (REST API Deployment)](#-tip-1)
+- [Features and Use Cases](#features)
 - [Haystack Enterprise Starter](#haystack-enterprise-starter-best-practices-and-expert-support)
 - [Telemetry](#telemetry)
 - [🖖 Community](#-community)


### PR DESCRIPTION
### Related Issues

- Link in table of contents is broken since we renamed "haystack-enterprise-best-practices-and-expert-support" to "haystack-enterprise-starter-best-practices-and-expert-support"

### Proposed Changes:

- Update link in TOC to haystack-enterprise-starter-best-practices-and-expert-support
- Remove Hayhooks (REST API Deployment)(#-tip-1) entry because the link to the tip doesn't work. I'd also say that if we believe Hayhooks is important enough to be mentioned in the TOC then it could have it's on section. I assume updating the TOC was simply forgotten in an earlier PR
- Merge Features and Use Cases in TOC

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
