### PR TITLE
docs: Add markdown header splitter to api docs in 2.24-unstable

### DIFF
--- a/docs-website/reference_versioned_docs/version-2.24-unstable/haystack-api/preprocessors_api.md
+++ b/docs-website/reference_versioned_docs/version-2.24-unstable/haystack-api/preprocessors_api.md
@@ -786,6 +786,89 @@ Deserialize this component from a dictionary.
 
 The deserialized component.
 
+<a id="markdown_header_splitter"></a>
+
+## Module markdown\_header\_splitter
+
+<a id="markdown_header_splitter.MarkdownHeaderSplitter"></a>
+
+### MarkdownHeaderSplitter
+
+Split documents at ATX-style Markdown headers (#), with optional secondary splitting.
+
+This component processes text documents by:
+- Splitting them into chunks at Markdown headers (e.g., '#', '##', etc.), preserving header hierarchy as metadata.
+- Optionally applying a secondary split (by word, passage, period, or line) to each chunk
+  (using haystack's DocumentSplitter).
+- Preserving and propagating metadata such as parent headers, page numbers, and split IDs.
+
+<a id="markdown_header_splitter.MarkdownHeaderSplitter.__init__"></a>
+
+#### MarkdownHeaderSplitter.\_\_init\_\_
+
+```python
+def __init__(*,
+             page_break_character: str = "\f",
+             keep_headers: bool = True,
+             secondary_split: Literal["word", "passage", "period", "line"]
+             | None = None,
+             split_length: int = 200,
+             split_overlap: int = 0,
+             split_threshold: int = 0,
+             skip_empty_documents: bool = True)
+```
+
+Initialize the MarkdownHeaderSplitter.
+
+**Arguments**:
+
+- `page_break_character`: Character used to identify page breaks. Defaults to form feed ("").
+- `keep_headers`: If True, headers are kept in the content. If False, headers are moved to metadata.
+Defaults to True.
+- `secondary_split`: Optional secondary split condition after header splitting.
+Options are None, "word", "passage", "period", "line". Defaults to None.
+- `split_length`: The maximum number of units in each split when using secondary splitting. Defaults to 200.
+- `split_overlap`: The number of overlapping units for each split when using secondary splitting.
+Defaults to 0.
+- `split_threshold`: The minimum number of units per split when using secondary splitting. Defaults to 0.
+- `skip_empty_documents`: Choose whether to skip documents with empty content. Default is True.
+Set to False when downstream components in the Pipeline (like LLMDocumentContentExtractor) can extract text
+from non-textual documents.
+
+<a id="markdown_header_splitter.MarkdownHeaderSplitter.warm_up"></a>
+
+#### MarkdownHeaderSplitter.warm\_up
+
+```python
+def warm_up()
+```
+
+Warm up the MarkdownHeaderSplitter.
+
+<a id="markdown_header_splitter.MarkdownHeaderSplitter.run"></a>
+
+#### MarkdownHeaderSplitter.run
+
+```python
+@component.output_types(documents=list[Document])
+def run(documents: list[Document]) -> dict[str, list[Document]]
+```
+
+Run the markdown header splitter with optional secondary splitting.
+
+**Arguments**:
+
+- `documents`: List of documents to split
+
+**Returns**:
+
+A dictionary with the following key:
+- `documents`: List of documents with the split texts. Each document includes:
+- A metadata field `source_id` to track the original document.
+- A metadata field `page_number` to track the original page number.
+- A metadata field `split_id` to identify the split chunk index within its parent document.
+- All other metadata copied from the original document.
+
 <a id="recursive_splitter"></a>
 
 ## Module recursive\_splitter


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Inspired by @anakin87 PR here https://github.com/deepset-ai/haystack/pull/10556 I realized the MarkdownHeaderSplitter api docs also need to be copied into the 2.24-unstable folder since we will be cherry-picking that new component into the 2.24 release

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
