### PR TITLE
chore: add missing license header to ruff_format_docs script

### DIFF
--- a/scripts/ruff_format_docs.py
+++ b/scripts/ruff_format_docs.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Pre-commit hook that runs ruff format on Python code blocks in Markdown/MDX files.
 


### PR DESCRIPTION
### Related Issues

Failing format test on main: https://github.com/deepset-ai/haystack/actions/runs/21948933334

### Proposed Changes:
- ass missing license header

### Notes for the reviewer
We should understand why the error did not trigger in the original PR.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
