### PR TITLE
docs: add smart-pipeline-connections to 2.24 sidebar

### DIFF
--- a/docs-website/versioned_sidebars/version-2.24-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.24-sidebars.json
@@ -61,7 +61,8 @@
             "concepts/pipelines/pipeline-breakpoints",
             "concepts/pipelines/pipeline-loops",
             "concepts/pipelines/pipeline-templates",
-            "concepts/pipelines/asyncpipeline"
+            "concepts/pipelines/asyncpipeline",
+            "concepts/pipelines/smart-pipeline-connections"
           ]
         },
         {


### PR DESCRIPTION
### Related Issues

In  https://docs.haystack.deepset.ai/docs/pipelines, the new Smart Pipeline Connections link is missing from the sidebar
<img width="333" height="401" alt="image" src="https://github.com/user-attachments/assets/858a8a00-f366-4c74-b329-6cc401af007e" />


### Proposed Changes:
- add the section to the 2.24 sidebar

### How did you test it?
Vercel
https://haystack-docs-git-add-smart-pipes-224-sidebar-deepset-ai.vercel.app/docs/smart-pipeline-connections
<img width="325" height="522" alt="image" src="https://github.com/user-attachments/assets/34b69189-ea25-4822-b6c3-8620babe9fdc" />

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
