### PR TITLE
chore: make tests run on scripts + fix linting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ on:
       - "test/**/*.py"
       - "pyproject.toml"
       - ".github/utils/*.py"
+      - "scripts/*.py"
 
 env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/tests_skipper_trigger.yml
+++ b/.github/workflows/tests_skipper_trigger.yml
@@ -17,6 +17,7 @@ on:
       - "test/**/*.py"
       - "pyproject.toml"
       - ".github/utils/*.py"
+      - "scripts/*.py"
 
 jobs:
   check_if_changed:
@@ -40,6 +41,7 @@ jobs:
               - "test/**/*.py"
               - "pyproject.toml"
               - ".github/utils/*.py"
+              - "scripts/*.py"
 
   trigger-catch-all:
     name: Tests completed

--- a/scripts/ruff_format_docs.py
+++ b/scripts/ruff_format_docs.py
@@ -113,7 +113,9 @@ def main() -> int:
     for path in args.files:
         with open(path) as f:
             original = f.read()
-        new = PYTHON_FENCE_RE.sub(lambda m: _format_code_block(m, line_length=args.line_length, path=path), original)
+        new = PYTHON_FENCE_RE.sub(
+            lambda m, path=path: _format_code_block(m, line_length=args.line_length, path=path), original
+        )
         if new != original:
             with open(path, "w") as f:
                 f.write(new)


### PR DESCRIPTION
### Related Issues
We noticed that format and other tests did not run on #10552
but they later failed on main: https://github.com/deepset-ai/haystack/actions/runs/21948933334/job/63393975716

### Proposed Changes:
- add the script folder to the tests workflow (and related test skipper)
- fix linting error in the script (https://github.com/deepset-ai/haystack/actions/runs/21949123187/job/63402845698)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
