### PR TITLE
test: make Query Expander integration tests more robust

### DIFF
--- a/test/components/query/test_query_expander.py
+++ b/test/components/query/test_query_expander.py
@@ -379,7 +379,9 @@ class TestQueryExpanderIntegration:
                         "name": "query_expansion",
                         "schema": {
                             "type": "object",
-                            "properties": {"queries": {"type": "array", "items": {"type": "string"}}},
+                            "properties": {
+                                "queries": {"type": "array", "items": {"type": "string"}, "minItems": 2, "maxItems": 2}
+                            },
                             "required": ["queries"],
                             "additionalProperties": False,
                         },
@@ -393,11 +395,11 @@ class TestQueryExpanderIntegration:
         reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
     )
     def test_query_expansion(self, chat_generator):
-        expander = QueryExpander(n_expansions=3, chat_generator=chat_generator)
+        expander = QueryExpander(n_expansions=2, chat_generator=chat_generator)
         expander.warm_up()
         result = expander.run("renewable energy sources")
 
-        assert len(result["queries"]) == 4
+        assert len(result["queries"]) == 3
         assert all(len(q.strip()) > 0 for q in result["queries"])
         assert "renewable energy sources" in result["queries"]
 


### PR DESCRIPTION
### Related Issues

Flaky test reported in https://github.com/deepset-ai/haystack/issues/10341#issuecomment-3895438217

```
{"event": "Failed to parse JSON response: Expecting ',' delimiter: line 1 column 114 (char 113). Response: {\"queries\": [\"uses of quantum computing\", \"applications of quantum technologies\", \"quantum computing", "level": "warning", "timestamp": "2026-02-13T07:43:26.573143Z", "lineno": 285, "module": "haystack.components.query.query_expander", "error": "Expecting ',' delimiter: line 1 column 114 (char 113)", "response": "{\"queries\": [\"uses of quantum computing\", \"applications of quantum technologies\", \"quantum computing"}

...

=========================== short test summary info ============================
FAILED test/components/query/test_query_expander.py::TestQueryExpanderIntegration::test_different_domains - assert 0 == 2
 +  where 0 = len([])
```


The cause is: when I switched some tests to using `gpt-4.1-nano`, I forgot that to work properly with this component, the Chat Generator needs to be configured with a JSON schema.

Without the schema, the output might be an invalid JSON.

### Proposed Changes:
- keep using `gpt-4.1-nano` (fast) but provide a JSON schema

### How did you test it?
CI, local runs

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
