### PR TITLE
docs: Remove warm-up calls from Fastembed examples

### DIFF
--- a/docs-website/docs/pipeline-components/embedders/fastembeddocumentembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/fastembeddocumentembedder.mdx
@@ -108,7 +108,6 @@ document_list = [
 ]
 
 doc_embedder = FastembedDocumentEmbedder()
-doc_embedder.warm_up()
 
 result = doc_embedder.run(document_list)
 print(result["documents"][0].embedding)

--- a/docs-website/docs/pipeline-components/embedders/fastembedsparsedocumentembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/fastembedsparsedocumentembedder.mdx
@@ -107,7 +107,6 @@ document_list = [
 ]
 
 doc_embedder = FastembedSparseDocumentEmbedder()
-doc_embedder.warm_up()
 
 result = doc_embedder.run(document_list)
 print(result["documents"][0])

--- a/docs-website/docs/pipeline-components/embedders/fastembedsparsetextembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/fastembedsparsetextembedder.mdx
@@ -80,7 +80,6 @@ The disk comes and it does not, only Windows.
 Do Not order this if you have a Mac!!"""
 
 text_embedder = FastembedSparseTextEmbedder(model="prithivida/Splade_PP_en_v1")
-text_embedder.warm_up()
 
 sparse_embedding = text_embedder.run(text)["sparse_embedding"]
 ```
@@ -125,7 +124,6 @@ sparse_document_embedder = FastembedSparseDocumentEmbedder(
     model="prithivida/Splade_PP_en_v1",
 )
 
-sparse_document_embedder.warm_up()
 documents_with_sparse_embeddings = sparse_document_embedder.run(documents)["documents"]
 document_store.write_documents(documents_with_sparse_embeddings)
 

--- a/docs-website/docs/pipeline-components/embedders/fastembedtextembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/fastembedtextembedder.mdx
@@ -91,7 +91,6 @@ text = """It clearly says online this will work on a Mac OS system.
 The disk comes and it does not, only Windows.
 Do Not order this if you have a Mac!!"""
 text_embedder = FastembedTextEmbedder(model="BAAI/bge-small-en-v1.5")
-text_embedder.warm_up()
 embedding = text_embedder.run(text)["embedding"]
 ```
 
@@ -116,7 +115,6 @@ documents = [
 ]
 
 document_embedder = FastembedDocumentEmbedder()
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)["documents"]
 document_store.write_documents(documents_with_embeddings)
 

--- a/docs-website/docs/pipeline-components/rankers/fastembedranker.mdx
+++ b/docs-website/docs/pipeline-components/rankers/fastembedranker.mdx
@@ -74,7 +74,6 @@ from haystack_integrations.components.rankers.fastembed import FastembedRanker
 docs = [Document(content="Paris"), Document(content="Berlin")]
 
 ranker = FastembedRanker()
-ranker.warm_up()
 
 ranker.run(query="City in France", documents=docs, top_k=1)
 ```


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack-core-integrations/pull/2834 and https://github.com/deepset-ai/haystack-core-integrations/pull/2678

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR updates the documentation pages of the Fastembed components to reflect the fact that an explicit `warm_up` call is not needed anymore.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
