### PR TITLE
test: fix test_image_content_from_url_wrong_mime_type

### DIFF
--- a/test/dataclasses/test_image_content.py
+++ b/test/dataclasses/test_image_content.py
@@ -221,4 +221,4 @@ def test_image_content_from_url_wrong_mime_type_pdf(test_files_path):
 @pytest.mark.integration
 def test_image_content_from_url_wrong_mime_type():
     with pytest.raises(ValueError):
-        ImageContent.from_url(url="https://example.com", size=(100, 100), detail="high", meta={"test": "test"})
+        ImageContent.from_url(url="https://www.google.com/", size=(100, 100), detail="high", meta={"test": "test"})


### PR DESCRIPTION
### Related Issues

Failing test blocking PRs: https://github.com/deepset-ai/haystack/actions/runs/22058012868/job/63731939100#step:5:751

```
FAILED test/dataclasses/test_image_content.py::test_image_content_from_url_wrong_mime_type - httpx.ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1017)
```

It seems that example.com has some certificate issues.

### Proposed Changes:
- use a different website (Google) for the test

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
