### PR TITLE
docs: fix some docstrings

### DIFF
--- a/haystack/components/audio/whisper_remote.py
+++ b/haystack/components/audio/whisper_remote.py
@@ -57,7 +57,7 @@ class RemoteWhisperTranscriber:
         :param organization:
             Your OpenAI organization ID. See OpenAI's documentation on
             [Setting Up Your Organization](https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization).
-        :param api_base:
+        :param api_base_url:
             An optional URL to use as the API base. For details, see the
             OpenAI [documentation](https://platform.openai.com/docs/api-reference/audio).
         :param http_client_kwargs:

--- a/haystack/components/builders/chat_prompt_builder.py
+++ b/haystack/components/builders/chat_prompt_builder.py
@@ -153,7 +153,7 @@ class ChatPromptBuilder:
         :param required_variables:
             List variables that must be provided as input to ChatPromptBuilder.
             If a variable listed as required is not provided, an exception is raised.
-            If set to "*", all variables found in the prompt are required. Optional.
+            If set to `"*"`, all variables found in the prompt are required. Optional.
         :param variables:
             List input variables to use in prompt templates instead of the ones inferred from the
             `template` parameter. For example, to use more variables during prompt engineering than the ones present

--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -156,7 +156,7 @@ class PromptBuilder:
             If an optional variable is not provided, it's replaced with an empty string in the rendered prompt.
         :param required_variables: List variables that must be provided as input to PromptBuilder.
             If a variable listed as required is not provided, an exception is raised.
-            If set to "*", all variables found in the prompt are required. Optional.
+            If set to `"*"`, all variables found in the prompt are required. Optional.
         :param variables:
             List input variables to use in prompt templates instead of the ones inferred from the
             `template` parameter. For example, to use more variables during prompt engineering than the ones present

--- a/haystack/components/converters/pdfminer.py
+++ b/haystack/components/converters/pdfminer.py
@@ -144,7 +144,7 @@ class PDFMinerToDocument:
 
         see: https://pdfminersix.readthedocs.io/en/latest/faq.html#why-are-there-cid-x-values-in-the-textual-output
 
-        :param: text: The text to check for undecoded CID characters
+        :param text: The text to check for undecoded CID characters
         :returns:
             A dictionary containing detection results
         """

--- a/haystack/components/extractors/regex_text_extractor.py
+++ b/haystack/components/extractors/regex_text_extractor.py
@@ -96,8 +96,7 @@ class RegexTextExtractor:
           - `{"captured_text": "matched text"}` if a match is found
           - `{"captured_text": ""}` if no match is found
 
-        :raises:
-            - ValueError: if receiving a list the last element is not a ChatMessage instance.
+        :raises ValueError: if receiving a list the last element is not a ChatMessage instance.
         """
         if isinstance(text_or_messages, str):
             return self._build_result(self._extract_from_text(text_or_messages))

--- a/haystack/components/preprocessors/embedding_based_document_splitter.py
+++ b/haystack/components/preprocessors/embedding_based_document_splitter.py
@@ -144,10 +144,9 @@ class EmbeddingBasedDocumentSplitter:
                 - A metadata field `page_number` to track the original page number.
                 - All other metadata copied from the original document.
 
-        :raises:
-            - `RuntimeError`: If the component wasn't warmed up.
-            - `TypeError`: If the input is not a list of Documents.
-            - `ValueError`: If the document content is None or empty.
+        :raises RuntimeError: If the component wasn't warmed up.
+        :raises TypeError: If the input is not a list of Documents.
+        :raises ValueError: If the document content is None or empty.
         """
         if not self._is_warmed_up:
             raise RuntimeError(

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -73,7 +73,7 @@ class ByteStream:
 
         :param encoding: The encoding used to convert the bytes to a string. Defaults to "utf-8".
         :returns: The string representation of the ByteStream.
-        :raises: UnicodeDecodeError: If the ByteStream data cannot be decoded with the specified encoding.
+        :raises UnicodeDecodeError: If the ByteStream data cannot be decoded with the specified encoding.
         """
         return self.data.decode(encoding)
 

--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -526,7 +526,7 @@ class InMemoryDocumentStore:  # pylint: disable=too-many-public-methods
             For filter syntax, see filter_documents.
         :param meta: The metadata fields to update. These will be merged with existing metadata.
         :returns: The number of documents updated.
-        :raises: ValueError if filters have invalid syntax.
+        :raises ValueError: if filters have invalid syntax.
         """
         InMemoryDocumentStore._validate_filters(filters)
         matching = [doc for doc in self.storage.values() if document_matches_filter(filters=filters, document=doc)]
@@ -542,7 +542,7 @@ class InMemoryDocumentStore:  # pylint: disable=too-many-public-methods
         :param filters: The filters to apply to select documents for deletion.
             For filter syntax, see filter_documents.
         :returns: The number of documents deleted.
-        :raises: ValueError if filters have invalid syntax.
+        :raises ValueError: if filters have invalid syntax.
         """
         InMemoryDocumentStore._validate_filters(filters)
         matching = [doc for doc in self.storage.values() if document_matches_filter(filters=filters, document=doc)]
@@ -627,7 +627,7 @@ class InMemoryDocumentStore:  # pylint: disable=too-many-public-methods
             If not provided, the value of the `return_embedding` parameter set at component
             initialization will be used. Default is False.
         :returns: A list of the top_k documents most relevant to the query.
-        :raises: ValueError if filters have invalid syntax.
+        :raises ValueError: if filters have invalid syntax.
         """
         if len(query_embedding) == 0 or not isinstance(query_embedding[0], float):
             raise ValueError("query_embedding should be a non-empty list of floats.")

--- a/haystack/utils/asynchronous.py
+++ b/haystack/utils/asynchronous.py
@@ -10,7 +10,7 @@ def is_callable_async_compatible(func: Callable) -> bool:
     """
     Returns if the given callable is usable inside a component's `run_async` method.
 
-    :param callable:
+    :param func:
         The callable to check.
     :returns:
         True if the callable is compatible, False otherwise.

--- a/pydoc/utils_api.yml
+++ b/pydoc/utils_api.yml
@@ -1,6 +1,9 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../haystack/utils]
+    modules: ["asynchronous", "auth", "azure", "base_serialization", "callable_serialization", "deserialization",
+      "device", "filters", "http_client", "jinja2_chat_extension", "jinja2_extensions", "jupyter", "misc",
+      "requests_utils", "type_serialization", "url_validation"]
     ignore_when_discovered: ["__init__", "hf"]
 processors:
   - type: filter


### PR DESCRIPTION
### Related Issues

While working on refactoring the API reference generation, I got some warnings about errors in docstrings

### Proposed Changes:
- fix wrong parameter names and erroneous `raises` syntax
- adjust pydoc config of utils to make it work with the upcoming API reference generation refactoring

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
