### PR TITLE
build: add workflow for nighly testpypi release

### DIFF
--- a/.github/workflows/nightly_testpypi_release.yml
+++ b/.github/workflows/nightly_testpypi_release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set nightly version
         id: set-version
         run: |
-          BASE_VERSION=$(cat VERSION.txt | sed 's/-rc[0-9]*$//')
+          BASE_VERSION=$(sed 's/-rc[0-9]*$//' VERSION.txt)
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
           NIGHTLY_VERSION="${BASE_VERSION}.dev${TIMESTAMP}"
           echo "version=${NIGHTLY_VERSION}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/253

### Proposed Changes:

- Add a new workflow that gets triggered at midnight or can be manually triggered. The workflow publishes the main branch to TestPyPI as a pre-release. Naming scheme follows PEP 440 (suffix devYYYYMMDDHHMMSS) for example 2.25.0.dev20250217000000.

### How did you test it?

- I did not test the full workflow. I thought about setting up a test repo but haven't done so yet. Given that this workflow will use a different token than our regular PyPI release process, there is no risk that the workflow for some reason publishes to PyPI instead of TestPyPI. And the workflow creates only pre-releases that are only picked up when users run `pip install --index-url https://test.pypi.org/simple/ --pre haystack-ai`.
- I ran the commands that the step "set-version" uses for generating the NIGHTLY_VERSION successfully on my local machine.

### Notes for the reviewer

- ~~HAYSTACK_AI_TESTPYPI_TOKEN is not set up yet but I am working on it.~~ token added
- I thought about adding a release note to explain to users that they can run `pip install --index-url https://test.pypi.org/simple/ --pre haystack-ai` but I decided against it. Regular users do not need to be informed about this. The installation of dependencies of Haystack that are not available on TestPyPI will fail. Using `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ --pre haystack-ai` installs from PyPI as a fallback but that still might not work as expected if there is a version of a dependency available on TestPyPI. For example, there is https://test.pypi.org/project/openai/. Best to install Haystack dependencies in separate commands and with pinned version.

### Alternatives
- An alternative to nightly releases on TestPyPI could be to use this new workflow for pre-releases on PyPI on nightly basis or only with the manual trigger whenever needed.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
