### PR TITLE
docs: remove warm_up from code examples in docs pages

### DIFF
--- a/docs-website/docs/pipeline-components/audio/localwhispertranscriber.mdx
+++ b/docs-website/docs/pipeline-components/audio/localwhispertranscriber.mdx
@@ -53,7 +53,6 @@ with open("kennedy_speech.mp3", "wb") as file:
     file.write(response.content)
 
 transcriber = LocalWhisperTranscriber(model="tiny")
-transcriber.warm_up()
 
 transcription = transcriber.run(sources=["./kennedy_speech.mp3"])
 print(transcription["documents"][0].content)

--- a/docs-website/docs/pipeline-components/classifiers/transformerszeroshotdocumentclassifier.mdx
+++ b/docs-website/docs/pipeline-components/classifiers/transformerszeroshotdocumentclassifier.mdx
@@ -57,7 +57,6 @@ document_classifier = TransformersZeroShotDocumentClassifier(
     labels=["animals", "food"],
 )
 
-document_classifier.warm_up()
 document_classifier.run(documents=documents)
 ```
 

--- a/docs-website/docs/pipeline-components/downloaders/s3downloader.mdx
+++ b/docs-website/docs/pipeline-components/downloaders/s3downloader.mdx
@@ -46,7 +46,7 @@ The component downloads multiple files in parallel using the `max_workers` param
 
 The component requires two critical configurations:
 
-1. `file_root_path` parameter or `FILE_ROOT_PATH` environment variable: Specifies where files will be downloaded. This directory will be created if it doesn't exist when `warm_up()` is called.
+1. `file_root_path` parameter or `FILE_ROOT_PATH` environment variable: Specifies where files will be downloaded. This directory will be created if it doesn't exist.
 2. `S3_DOWNLOADER_BUCKET` environment variable: Specifies which S3 bucket to download files from.
 :::
 
@@ -94,9 +94,6 @@ documents = [
 ## Initialize the downloader
 downloader = S3Downloader(file_root_path="/tmp/s3_downloads")
 
-## Warm up the component
-downloader.warm_up()
-
 ## Download the files
 result = downloader.run(documents=documents)
 
@@ -119,8 +116,6 @@ documents = [
 
 ## Only download PDF files
 downloader = S3Downloader(file_root_path="/tmp/s3_downloads", file_extensions=[".pdf"])
-
-downloader.warm_up()
 
 result = downloader.run(documents=documents)
 
@@ -154,7 +149,6 @@ downloader = S3Downloader(
     s3_key_generation_function=custom_s3_key_function,
 )
 
-downloader.warm_up()
 result = downloader.run(documents=documents)
 ```
 

--- a/docs-website/docs/pipeline-components/embedders/coheredocumentimageembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/coheredocumentimageembedder.mdx
@@ -63,7 +63,6 @@ from haystack_integrations.components.embedders.cohere import (
 )
 
 embedder = CohereDocumentImageEmbedder(model="embed-v4.0")
-embedder.warm_up()
 
 documents = [
     Document(content="A photo of a cat", meta={"file_path": "cat.jpg"}),

--- a/docs-website/docs/pipeline-components/embedders/jinadocumentimageembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/jinadocumentimageembedder.mdx
@@ -65,7 +65,6 @@ from haystack import Document
 from haystack_integrations.components.embedders.jina import JinaDocumentImageEmbedder
 
 embedder = JinaDocumentImageEmbedder(model="jina-clip-v2")
-embedder.warm_up()
 
 documents = [
     Document(content="A photo of a cat", meta={"file_path": "cat.jpg"}),

--- a/docs-website/docs/pipeline-components/embedders/nvidiadocumentembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/nvidiadocumentembedder.mdx
@@ -61,7 +61,6 @@ embedder = NvidiaDocumentEmbedder(
     api_url="https://integrate.api.nvidia.com/v1",
     api_key=Secret.from_token("<your-api-key>"),
 )
-embedder.warm_up()
 
 result = embedder.run(documents=documents)
 print(result["documents"])
@@ -84,7 +83,6 @@ embedder = NvidiaDocumentEmbedder(
     api_url="http://localhost:9999/v1",
     api_key=None,
 )
-embedder.warm_up()
 
 result = embedder.run(documents=documents)
 print(result["documents"])

--- a/docs-website/docs/pipeline-components/embedders/nvidiatextembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/nvidiatextembedder.mdx
@@ -55,7 +55,6 @@ embedder = NvidiaTextEmbedder(
     api_url="https://integrate.api.nvidia.com/v1",
     api_key=Secret.from_token("<your-api-key>"),
 )
-embedder.warm_up()
 
 result = embedder.run("A transformer is a deep learning architecture")
 print(result["embedding"])
@@ -72,7 +71,6 @@ embedder = NvidiaTextEmbedder(
     api_url="http://localhost:9999/v1",
     api_key=None,
 )
-embedder.warm_up()
 
 result = embedder.run("A transformer is a deep learning architecture")
 print(result["embedding"])

--- a/docs-website/docs/pipeline-components/embedders/optimumdocumentembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/optimumdocumentembedder.mdx
@@ -62,7 +62,6 @@ doc = Document(content="I love pizza!")
 document_embedder = OptimumDocumentEmbedder(
     model="sentence-transformers/all-mpnet-base-v2",
 )
-document_embedder.warm_up()
 
 result = document_embedder.run([doc])
 print(result["documents"][0].embedding)

--- a/docs-website/docs/pipeline-components/embedders/optimumtextembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/optimumtextembedder.mdx
@@ -59,7 +59,6 @@ from haystack_integrations.components.embedders.optimum import OptimumTextEmbedd
 text_to_embed = "I love pizza!"
 
 text_embedder = OptimumTextEmbedder(model="sentence-transformers/all-mpnet-base-v2")
-text_embedder.warm_up()
 
 print(text_embedder.run(text_to_embed))
 

--- a/docs-website/docs/pipeline-components/embedders/sentencetransformersdocumentembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/sentencetransformersdocumentembedder.mdx
@@ -89,7 +89,6 @@ from haystack.components.embedders import SentenceTransformersDocumentEmbedder
 
 doc = Document(content="I love pizza!")
 doc_embedder = SentenceTransformersDocumentEmbedder()
-doc_embedder.warm_up()
 
 result = doc_embedder.run([doc])
 print(result["documents"][0].embedding)

--- a/docs-website/docs/pipeline-components/embedders/sentencetransformersdocumentimageembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/sentencetransformersdocumentimageembedder.mdx
@@ -67,7 +67,6 @@ from haystack.components.embedders.image import (
 embedder = SentenceTransformersDocumentImageEmbedder(
     model="sentence-transformers/clip-ViT-B-32",
 )
-embedder.warm_up()
 
 documents = [
     Document(content="A photo of a cat", meta={"file_path": "cat.jpg"}),

--- a/docs-website/docs/pipeline-components/embedders/sentencetransformerssparsedocumentembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/sentencetransformerssparsedocumentembedder.mdx
@@ -84,7 +84,6 @@ from haystack.components.embedders import SentenceTransformersSparseDocumentEmbe
 doc = Document(content="some text", meta={"title": "relevant title", "page number": 18})
 
 embedder = SentenceTransformersSparseDocumentEmbedder(meta_fields_to_embed=["title"])
-embedder.warm_up()
 
 docs_w_sparse_embeddings = embedder.run(documents=[doc])["documents"]
 ```
@@ -99,7 +98,6 @@ from haystack.components.embedders import SentenceTransformersSparseDocumentEmbe
 
 doc = Document(content="I love pizza!")
 doc_embedder = SentenceTransformersSparseDocumentEmbedder()
-doc_embedder.warm_up()
 
 result = doc_embedder.run([doc])
 print(result["documents"][0].sparse_embedding)

--- a/docs-website/docs/pipeline-components/embedders/sentencetransformerssparsetextembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/sentencetransformerssparsetextembedder.mdx
@@ -97,7 +97,6 @@ from haystack.components.embedders import SentenceTransformersSparseTextEmbedder
 text_to_embed = "I love pizza!"
 
 text_embedder = SentenceTransformersSparseTextEmbedder()
-text_embedder.warm_up()
 
 print(text_embedder.run(text_to_embed))
 
@@ -144,7 +143,6 @@ documents = [
 sparse_document_embedder = SentenceTransformersSparseDocumentEmbedder(
     model="prithivida/Splade_PP_en_v2",
 )
-sparse_document_embedder.warm_up()
 documents_with_sparse_embeddings = sparse_document_embedder.run(documents)["documents"]
 document_store.write_documents(documents_with_sparse_embeddings)
 

--- a/docs-website/docs/pipeline-components/embedders/sentencetransformerstextembedder.mdx
+++ b/docs-website/docs/pipeline-components/embedders/sentencetransformerstextembedder.mdx
@@ -76,7 +76,6 @@ from haystack.components.embedders import SentenceTransformersTextEmbedder
 text_to_embed = "I love pizza!"
 
 text_embedder = SentenceTransformersTextEmbedder()
-text_embedder.warm_up()
 
 print(text_embedder.run(text_to_embed))
 
@@ -104,7 +103,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder()
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)["documents"]
 document_store.write_documents(documents_with_embeddings)
 

--- a/docs-website/docs/pipeline-components/extractors/namedentityextractor.mdx
+++ b/docs-website/docs/pipeline-components/extractors/namedentityextractor.mdx
@@ -58,7 +58,6 @@ documents = [
     Document(content="New York State is home to the Empire State Building."),
 ]
 
-extractor.warm_up()
 extractor.run(documents)
 print(documents)
 ```
@@ -87,7 +86,6 @@ documents = [
     Document(content="New York State is home to the Empire State Building."),
 ]
 
-extractor.warm_up()
 extractor.run(documents)
 
 annotations = [NamedEntityExtractor.get_stored_annotations(doc) for doc in documents]

--- a/docs-website/docs/pipeline-components/generators/huggingfacelocalchatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/huggingfacelocalchatgenerator.mdx
@@ -51,7 +51,6 @@ from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
 from haystack.dataclasses import ChatMessage
 
 generator = HuggingFaceLocalChatGenerator(model="HuggingFaceH4/zephyr-7b-beta")
-generator.warm_up()
 messages = [ChatMessage.from_user("What's Natural Language Processing? Be brief.")]
 print(generator.run(messages))
 ```

--- a/docs-website/docs/pipeline-components/generators/huggingfacelocalgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/huggingfacelocalgenerator.mdx
@@ -57,7 +57,6 @@ generator = HuggingFaceLocalGenerator(
     },
 )
 
-generator.warm_up()
 print(generator.run("Who is the best American actor?"))
 ## {'replies': ['john wayne']}
 ```

--- a/docs-website/docs/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -123,7 +123,6 @@ generator = LlamaCppChatGenerator(
     n_batch=128,
     model_kwargs={"n_gpu_layers": -1},
 )
-generator.warm_up()
 messages = [ChatMessage.from_user("Who is the best American actor?")]
 result = generator.run(messages, generation_kwargs={"max_tokens": 128})
 generated_reply = result["replies"][0].content
@@ -150,7 +149,6 @@ generator = LlamaCppChatGenerator(
     n_batch=128,
     generation_kwargs={"max_tokens": 128, "temperature": 0.1},
 )
-generator.warm_up()
 messages = [ChatMessage.from_user("Who is the best American actor?")]
 result = generator.run(messages)
 ```
@@ -168,7 +166,6 @@ llm = LlamaCppChatGenerator(
     model_clip_path="mmproj-model-f16.gguf",  # CLIP model
     n_ctx=4096,  # Larger context for image processing
 )
-llm.warm_up()
 
 image = ImageContent.from_file_path("apple.jpg")
 user_message = ChatMessage.from_user(
@@ -192,7 +189,6 @@ generator = LlamaCppChatGenerator(
     n_ctx=512,
     n_batch=128,
 )
-generator.warm_up()
 messages = [ChatMessage.from_user("Who is the best American actor?")]
 result = generator.run(
     messages,

--- a/docs-website/docs/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/llamacppgenerator.mdx
@@ -90,7 +90,6 @@ generator = LlamaCppGenerator(
     n_batch=128,
     model_kwargs={"n_gpu_layers": -1},
 )
-generator.warm_up()
 prompt = f"Who is the best American actor?"
 result = generator.run(prompt, generation_kwargs={"max_tokens": 128})
 generated_text = result["replies"][0]
@@ -114,7 +113,6 @@ generator = LlamaCppGenerator(
     n_batch=128,
     generation_kwargs={"max_tokens": 128, "temperature": 0.1},
 )
-generator.warm_up()
 prompt = f"Who is the best American actor?"
 result = generator.run(prompt)
 ```
@@ -129,7 +127,6 @@ generator = LlamaCppGenerator(
     n_ctx=512,
     n_batch=128,
 )
-generator.warm_up()
 prompt = f"Who is the best American actor?"
 result = generator.run(
     prompt,

--- a/docs-website/docs/pipeline-components/generators/nvidiagenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/nvidiagenerator.mdx
@@ -56,8 +56,6 @@ generator = NvidiaGenerator(
         "max_tokens": 1024,
     },
 )
-generator.warm_up()
-
 result = generator.run(prompt="What is the answer?")
 print(result["replies"])
 print(result["meta"])
@@ -76,8 +74,6 @@ generator = NvidiaGenerator(
         "temperature": 0.2,
     },
 )
-generator.warm_up()
-
 result = generator.run(prompt="What is the answer?")
 print(result["replies"])
 print(result["meta"])

--- a/docs-website/docs/pipeline-components/generators/sagemakergenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/sagemakergenerator.mdx
@@ -63,7 +63,6 @@ Basic usage:
 from haystack_integrations.components.generators.amazon_sagemaker import SagemakerGenerator
 
 client = SagemakerGenerator(model="jumpstart-dft-hf-llm-falcon-7b-instruct-bf16")
-client.warm_up()
 response = client.run("Briefly explain what NLP is in one sentence.")
 print(response)
 

--- a/docs-website/docs/pipeline-components/preprocessors/chinesedocumentsplitter.mdx
+++ b/docs-website/docs/pipeline-components/preprocessors/chinesedocumentsplitter.mdx
@@ -72,9 +72,6 @@ doc = Document(
     content="这是第一句话，这是第二句话，这是第三句话。这是第四句话，这是第五句话，这是第六句话！",
 )
 
-## Warm up the component (loads the necessary models)
-splitter.warm_up()
-
 ## Split the document
 result = splitter.run(documents=[doc])
 print(result["documents"])  # List of split documents
@@ -101,7 +98,6 @@ splitter = ChineseDocumentSplitter(
     respect_sentence_boundary=True,
     granularity="coarse",
 )
-splitter.warm_up()
 result = splitter.run(documents=[doc])
 
 ## Each chunk will end with a complete sentence
@@ -126,7 +122,6 @@ splitter = ChineseDocumentSplitter(
     split_overlap=0,
     granularity="fine",  # More detailed segmentation
 )
-splitter.warm_up()
 result = splitter.run(documents=[doc])
 print(result["documents"])
 ```

--- a/docs-website/docs/pipeline-components/preprocessors/embeddingbaseddocumentsplitter.mdx
+++ b/docs-website/docs/pipeline-components/preprocessors/embeddingbaseddocumentsplitter.mdx
@@ -58,7 +58,6 @@ splitter = EmbeddingBasedDocumentSplitter(
     min_length=50,  # Merge splits shorter than 50 characters
     max_length=1000,  # Further split chunks longer than 1000 characters
 )
-splitter.warm_up()
 result = splitter.run(documents=[doc])
 
 # The result contains a list of Document objects, each representing a semantic chunk

--- a/docs-website/docs/pipeline-components/preprocessors/markdownheadersplitter.mdx
+++ b/docs-website/docs/pipeline-components/preprocessors/markdownheadersplitter.mdx
@@ -91,7 +91,6 @@ splitter = MarkdownHeaderSplitter(
     split_length=20,
     split_overlap=2,
 )
-splitter.warm_up()  # required when using secondary_split
 result = splitter.run(documents=[doc])
 ```
 

--- a/docs-website/docs/pipeline-components/preprocessors/recursivesplitter.mdx
+++ b/docs-website/docs/pipeline-components/preprocessors/recursivesplitter.mdx
@@ -44,7 +44,6 @@ text = ('''Artificial intelligence (AI) - Introduction
 
 AI, in its broadest sense, is intelligence exhibited by machines, particularly computer systems.
 AI technology is widely used throughout industry, government, and science. Some high-profile applications include advanced web search engines; recommendation systems; interacting via human speech; autonomous vehicles; generative and creative tools; and superhuman play and analysis in strategy games.''')
-chunker.warm_up()
 doc = Document(content=text)
 doc_chunks = chunker.run([doc])
 print(doc_chunks["documents"])

--- a/docs-website/docs/pipeline-components/rankers/huggingfaceteiranker.mdx
+++ b/docs-website/docs/pipeline-components/rankers/huggingfaceteiranker.mdx
@@ -87,7 +87,6 @@ document_store.write_documents(docs)
 
 retriever = InMemoryBM25Retriever(document_store=document_store)
 ranker = HuggingFaceTEIRanker(url="http://localhost:8080")
-ranker.warm_up()
 
 document_ranker_pipeline = Pipeline()
 document_ranker_pipeline.add_component(instance=retriever, name="retriever")

--- a/docs-website/docs/pipeline-components/rankers/nvidiaranker.mdx
+++ b/docs-website/docs/pipeline-components/rankers/nvidiaranker.mdx
@@ -57,7 +57,6 @@ This example uses `NvidiaRanker` to rank two simple documents. To run the Ranker
         model="nvidia/nv-rerankqa-mistral-4b-v3",
         api_key=Secret.from_env_var("NVIDIA_API_KEY"),
     )
-    ranker.warm_up()
 
     query = "What is the capital of Germany?"
     documents = [

--- a/docs-website/docs/pipeline-components/rankers/sentencetransformersdiversityranker.mdx
+++ b/docs-website/docs/pipeline-components/rankers/sentencetransformersdiversityranker.mdx
@@ -44,7 +44,6 @@ ranker = SentenceTransformersDiversityRanker(
     model="sentence-transformers/all-MiniLM-L6-v2",
     similarity="cosine",
 )
-ranker.warm_up()
 
 docs = [
     Document(content="Regular Exercise"),

--- a/docs-website/docs/pipeline-components/rankers/sentencetransformerssimilarityranker.mdx
+++ b/docs-website/docs/pipeline-components/rankers/sentencetransformerssimilarityranker.mdx
@@ -57,7 +57,6 @@ from haystack.components.rankers import SentenceTransformersSimilarityRanker
 ranker = SentenceTransformersSimilarityRanker()
 docs = [Document(content="Paris"), Document(content="Berlin")]
 query = "City in Germany"
-ranker.warm_up()
 result = ranker.run(query=query, documents=docs)
 docs = result["documents"]
 print(docs[0].content)
@@ -85,7 +84,6 @@ document_store.write_documents(docs)
 
 retriever = InMemoryBM25Retriever(document_store=document_store)
 ranker = SentenceTransformersSimilarityRanker()
-ranker.warm_up()
 
 document_ranker_pipeline = Pipeline()
 document_ranker_pipeline.add_component(instance=retriever, name="retriever")

--- a/docs-website/docs/pipeline-components/rankers/transformerssimilarityranker.mdx
+++ b/docs-website/docs/pipeline-components/rankers/transformerssimilarityranker.mdx
@@ -61,7 +61,6 @@ from haystack.components.rankers import TransformersSimilarityRanker
 docs = [Document(content="Paris"), Document(content="Berlin")]
 
 ranker = TransformersSimilarityRanker()
-ranker.warm_up()
 
 ranker.run(query="City in France", documents=docs, top_k=1)
 ```
@@ -88,7 +87,6 @@ document_store.write_documents(docs)
 
 retriever = InMemoryBM25Retriever(document_store=document_store)
 ranker = TransformersSimilarityRanker()
-ranker.warm_up()
 
 document_ranker_pipeline = Pipeline()
 document_ranker_pipeline.add_component(instance=retriever, name="retriever")

--- a/docs-website/docs/pipeline-components/readers/extractivereader.mdx
+++ b/docs-website/docs/pipeline-components/readers/extractivereader.mdx
@@ -62,7 +62,6 @@ docs = [
 ]
 
 reader = ExtractiveReader()
-reader.warm_up()
 
 reader.run(query="What is the capital of France?", documents=docs, top_k=2)
 ```
@@ -90,7 +89,6 @@ document_store.write_documents(docs)
 
 retriever = InMemoryBM25Retriever(document_store=document_store)
 reader = ExtractiveReader()
-reader.warm_up()
 
 extractive_qa_pipeline = Pipeline()
 extractive_qa_pipeline.add_component(instance=retriever, name="retriever")

--- a/docs-website/docs/pipeline-components/retrievers/astraretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/astraretriever.mdx
@@ -80,7 +80,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder(model=model)
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)
 
 document_store.write_documents(

--- a/docs-website/docs/pipeline-components/retrievers/azureaisearchembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/azureaisearchembeddingretriever.mdx
@@ -111,7 +111,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder(model=model)
-document_embedder.warm_up()
 
 ## Indexing Pipeline
 indexing_pipeline = Pipeline()

--- a/docs-website/docs/pipeline-components/retrievers/azureaisearchhybridretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/azureaisearchhybridretriever.mdx
@@ -115,7 +115,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder(model=model)
-document_embedder.warm_up()
 
 ## Indexing Pipeline
 indexing_pipeline = Pipeline()

--- a/docs-website/docs/pipeline-components/retrievers/elasticsearchembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/elasticsearchembeddingretriever.mdx
@@ -93,7 +93,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder(model=model)
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)
 
 document_store.write_documents(

--- a/docs-website/docs/pipeline-components/retrievers/inmemoryembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/inmemoryembeddingretriever.mdx
@@ -60,7 +60,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder()
-document_embedder.warm_up()
 
 documents_with_embeddings = document_embedder.run(documents)["documents"]
 document_store.write_documents(documents_with_embeddings)

--- a/docs-website/docs/pipeline-components/retrievers/multiqueryembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/multiqueryembeddingretriever.mdx
@@ -95,7 +95,6 @@ doc_store = InMemoryDocumentStore()
 doc_embedder = SentenceTransformersDocumentEmbedder(
     model="sentence-transformers/all-MiniLM-L6-v2",
 )
-doc_embedder.warm_up()
 documents_with_embeddings = doc_embedder.run(documents)["documents"]
 doc_store.write_documents(documents_with_embeddings)
 

--- a/docs-website/docs/pipeline-components/retrievers/opensearchembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/opensearchembeddingretriever.mdx
@@ -95,7 +95,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder(model=model)
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)
 
 document_store.write_documents(

--- a/docs-website/docs/pipeline-components/retrievers/opensearchhybridretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/opensearchhybridretriever.mdx
@@ -107,7 +107,6 @@ docs = [
 
 ## Embed the documents and add them to the document store
 doc_embedder = SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2")
-doc_embedder.warm_up()
 docs = doc_embedder.run(docs)
 doc_store.write_documents(docs['documents'])
 

--- a/docs-website/docs/pipeline-components/retrievers/pgvectorembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/pgvectorembeddingretriever.mdx
@@ -105,7 +105,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder()
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)
 
 document_store.write_documents(

--- a/docs-website/docs/pipeline-components/retrievers/pineconedenseretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/pineconedenseretriever.mdx
@@ -99,7 +99,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder()
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)
 
 document_store.write_documents(

--- a/docs-website/docs/pipeline-components/retrievers/qdrantembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/qdrantembeddingretriever.mdx
@@ -94,7 +94,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder()
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)
 
 document_store.write_documents(

--- a/docs-website/docs/pipeline-components/retrievers/weaviateembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/weaviateembeddingretriever.mdx
@@ -97,7 +97,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder()
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)
 
 document_store.write_documents(

--- a/docs-website/docs/pipeline-components/retrievers/weaviatehybridretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/weaviatehybridretriever.mdx
@@ -103,7 +103,6 @@ documents = [
 ]
 
 document_embedder = SentenceTransformersDocumentEmbedder()
-document_embedder.warm_up()
 documents_with_embeddings = document_embedder.run(documents)
 
 document_store.write_documents(

--- a/docs-website/docs/pipeline-components/routers/transformerszeroshottextrouter.mdx
+++ b/docs-website/docs/pipeline-components/routers/transformerszeroshottextrouter.mdx
@@ -58,7 +58,6 @@ from haystack.components.retrievers import InMemoryEmbeddingRetriever
 
 document_store = InMemoryDocumentStore()
 doc_embedder = SentenceTransformersDocumentEmbedder(model="intfloat/e5-base-v2")
-doc_embedder.warm_up()
 docs = [
     Document(
         content="Germany, officially the Federal Republic of Germany, is a country in the western region of "


### PR DESCRIPTION
### Related Issues

- None. Inspired by https://github.com/deepset-ai/haystack/pull/10612 I realized we could simplify code examples in our docs pages by removing warm_up calls. The code examples also had warm_up calls for HuggingFaceTEIRanker and CohereDocumentImageEmbedder both of which have never implemented it.

### Proposed Changes:

- Remove warm_up from code examples in docs pages
- Adjust one docstring in https://docs.haystack.deepset.ai/docs/s3downloader that referred to calling warm_up

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
