### PR TITLE
test: test pipeline with string variadic component irrespective of execution order

### DIFF
--- a/test/core/pipeline/features/test_run.py
+++ b/test/core/pipeline/features/test_run.py
@@ -2838,6 +2838,16 @@ def that_has_variadic_component_that_receives_a_conditional_input(pipeline_class
     ]
 
 
+class AnyOrder:  # noqa: PLW1641 # Object does not implement `__hash__` method but it's ok
+    """List wrapper with order-insensitive equality"""
+
+    def __init__(self, items):
+        self.items = items
+
+    def __eq__(self, other):
+        return isinstance(other, list) and sorted(self.items) == sorted(other)
+
+
 @given("a pipeline that has a string variadic component", target_fixture="pipeline_data")
 def that_has_a_string_variadic_component(pipeline_class):
     string_1 = "What's Natural Language Processing?"
@@ -2858,7 +2868,9 @@ def that_has_a_string_variadic_component(pipeline_class):
                 inputs={"prompt_builder_1": {"query": string_1}, "prompt_builder_2": {"query": string_2}},
                 expected_outputs={
                     "string_joiner": {
-                        "strings": ["Builder 1: What's Natural Language Processing?", "Builder 2: What's is life?"]
+                        "strings": AnyOrder(
+                            ["Builder 1: What's Natural Language Processing?", "Builder 2: What's is life?"]
+                        )
                     }
                 },
                 expected_component_calls={
@@ -2869,7 +2881,9 @@ def that_has_a_string_variadic_component(pipeline_class):
                     },
                     ("prompt_builder_2", 1): {"query": "What's is life?", "template": None, "template_variables": None},
                     ("string_joiner", 1): {
-                        "strings": ["Builder 1: What's Natural Language Processing?", "Builder 2: What's is life?"]
+                        "strings": AnyOrder(
+                            ["Builder 1: What's Natural Language Processing?", "Builder 2: What's is life?"]
+                        )
                     },
                 },
             )


### PR DESCRIPTION
### Related Issues
Flaky test from https://github.com/deepset-ai/haystack/issues/10341#issuecomment-3925898442

```
FAILED test/core/pipeline/features/test_run.py::test_running_a_correct_pipeline[AsyncPipeline-that has a string variadic component] - assert ['Builder 1: ...t's is life?"] == ["Builder 2: ... Processing?']
  
  At index 0 diff: "Builder 1: What's Natural Language Processing?" != "Builder 2: What's is life?"
  
  Full diff:
    [
  +     "Builder 1: What's Natural Language Processing?",
        "Builder 2: What's is life?",
  -     "Builder 1: What's Natural Language Processing?",
    ]
```

My impression is that execution order of Builders is non deterministic, so we should not check order.
@sjrl correct me if I am wrong

### Proposed Changes:
- fix behavioral test by adding a small class for accepting whatever order

### How did you test it?
CI

### Notes for the reviewer
I have tried to evaluate alternatives but this seems cleaner and more explicit

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
