### PR TITLE
feat: Add ModelsLabImageGenerator component

### DIFF
--- a/haystack/components/generators/__init__.py
+++ b/haystack/components/generators/__init__.py
@@ -13,6 +13,7 @@ _import_structure = {
     "hugging_face_local": ["HuggingFaceLocalGenerator"],
     "hugging_face_api": ["HuggingFaceAPIGenerator"],
     "openai_dalle": ["DALLEImageGenerator"],
+    "modelslab": ["ModelsLabImageGenerator"],
 }
 
 if TYPE_CHECKING:
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
     from .hugging_face_local import HuggingFaceLocalGenerator as HuggingFaceLocalGenerator
     from .openai import OpenAIGenerator as OpenAIGenerator
     from .openai_dalle import DALLEImageGenerator as DALLEImageGenerator
+    from .modelslab import ModelsLabImageGenerator as ModelsLabImageGenerator
 
 else:
     sys.modules[__name__] = LazyImporter(name=__name__, module_file=__file__, import_structure=_import_structure)

--- a/haystack/components/generators/modelslab.py
+++ b/haystack/components/generators/modelslab.py
@@ -1,0 +1,277 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ModelsLab image generation component for Haystack pipelines."""
+
+import time
+from typing import Any, Optional
+
+from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.utils import Secret
+
+logger = logging.getLogger(__name__)
+
+MODELSLAB_BASE_URL = "https://modelslab.com/api/v6"
+MODELSLAB_TEXT2IMG_URL = f"{MODELSLAB_BASE_URL}/images/text2img"
+MODELSLAB_FETCH_URL = f"{MODELSLAB_BASE_URL}/images/fetch"
+MODELSLAB_POLLING_INTERVAL = 3  # seconds
+MODELSLAB_POLLING_TIMEOUT = 300  # seconds (5 minutes)
+
+
+@component
+class ModelsLabImageGenerator:
+    """
+    Generates images using ModelsLab's text-to-image API.
+
+    ModelsLab provides access to 200+ AI models including Flux, SDXL, Stable Diffusion,
+    and thousands of community fine-tunes via a single unified API.
+
+    For details on ModelsLab API parameters, see
+    [ModelsLab documentation](https://docs.modelslab.com/image-generation/community-models/text2img).
+
+    ### Usage example
+
+    ```python
+    from haystack.components.generators import ModelsLabImageGenerator
+
+    generator = ModelsLabImageGenerator(model="flux")
+    response = generator.run("A breathtaking sunset over snow-capped mountains.")
+    print(response["images"])  # list of image URLs
+    ```
+
+    ### Pipeline usage
+
+    ```python
+    from haystack import Pipeline
+    from haystack.components.generators import ModelsLabImageGenerator
+
+    pipeline = Pipeline()
+    pipeline.add_component("image_gen", ModelsLabImageGenerator(model="flux", width=1024, height=1024))
+    result = pipeline.run({"image_gen": {"prompt": "A futuristic city at night"}})
+    print(result["image_gen"]["images"])
+    ```
+    """
+
+    def __init__(
+        self,
+        model: str = "flux",
+        width: int = 512,
+        height: int = 512,
+        samples: int = 1,
+        num_inference_steps: int = 30,
+        guidance_scale: float = 7.5,
+        negative_prompt: Optional[str] = None,
+        seed: Optional[int] = None,
+        api_key: Secret = Secret.from_env_var("MODELSLAB_API_KEY"),
+        api_base_url: Optional[str] = None,
+    ):
+        """
+        Creates an instance of ModelsLabImageGenerator.
+
+        :param model: The model to use for image generation. Defaults to ``"flux"``.
+            Supports any ModelsLab community model ID, e.g. ``"sdxl"``, ``"realistic-vision-v51"``.
+        :param width: Width of the generated image in pixels (must be divisible by 8). Defaults to ``512``.
+        :param height: Height of the generated image in pixels (must be divisible by 8). Defaults to ``512``.
+        :param samples: Number of images to generate per request (1–4). Defaults to ``1``.
+        :param num_inference_steps: Number of denoising steps (1–50). Defaults to ``30``.
+        :param guidance_scale: Classifier-free guidance scale (1–20). Higher values follow the prompt
+            more closely. Defaults to ``7.5``.
+        :param negative_prompt: Optional negative prompt to steer generation away from undesired content.
+        :param seed: Optional random seed for reproducible results.
+        :param api_key: The ModelsLab API key. Reads from the ``MODELSLAB_API_KEY`` environment variable
+            by default.
+        :param api_base_url: Optional custom base URL for the ModelsLab API. Defaults to
+            ``https://modelslab.com/api/v6``.
+        """
+        self.model = model
+        self.width = width
+        self.height = height
+        self.samples = samples
+        self.num_inference_steps = num_inference_steps
+        self.guidance_scale = guidance_scale
+        self.negative_prompt = negative_prompt
+        self.seed = seed
+        self.api_key = api_key
+        self.api_base_url = api_base_url or MODELSLAB_BASE_URL
+
+    def _build_url(self, path: str) -> str:
+        return f"{self.api_base_url.rstrip('/')}/{path.lstrip('/')}"
+
+    def _poll_for_result(self, generation_id: int, api_key: str) -> list[str]:
+        """
+        Poll the ModelsLab fetch endpoint until image generation completes.
+
+        :param generation_id: The ModelsLab generation task ID.
+        :param api_key: The resolved API key.
+        :returns: List of generated image URLs.
+        :raises TimeoutError: If polling exceeds MODELSLAB_POLLING_TIMEOUT seconds.
+        :raises RuntimeError: If the API returns an error status.
+        """
+        try:
+            import requests  # noqa: PLC0415
+        except ImportError as e:
+            raise ImportError(
+                "Could not import `requests`. Install it with `pip install requests`."
+            ) from e
+
+        fetch_url = self._build_url(f"images/fetch/{generation_id}")
+        start = time.time()
+
+        while True:
+            if time.time() - start > MODELSLAB_POLLING_TIMEOUT:
+                raise TimeoutError(
+                    f"ModelsLab image generation timed out after {MODELSLAB_POLLING_TIMEOUT}s "
+                    f"(generation_id={generation_id})."
+                )
+
+            response = requests.post(
+                fetch_url,
+                json={"key": api_key},
+                headers={"Content-Type": "application/json"},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+            status = data.get("status", "")
+
+            if status == "success":
+                return data.get("output", [])
+            elif status == "error":
+                raise RuntimeError(
+                    f"ModelsLab image generation failed: {data.get('message', 'unknown error')}"
+                )
+            elif status == "processing":
+                logger.debug(
+                    f"ModelsLab: generation {generation_id} still processing, retrying in {MODELSLAB_POLLING_INTERVAL}s"
+                )
+                time.sleep(MODELSLAB_POLLING_INTERVAL)
+            else:
+                raise RuntimeError(f"ModelsLab: unexpected status '{status}' for generation {generation_id}")
+
+    @component.output_types(images=list[str], metadata=list[dict])
+    def run(
+        self,
+        prompt: str,
+        model: Optional[str] = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        samples: Optional[int] = None,
+        negative_prompt: Optional[str] = None,
+        seed: Optional[int] = None,
+    ):
+        """
+        Generate images from a text prompt using the ModelsLab API.
+
+        :param prompt: The text prompt describing the image to generate.
+        :param model: Overrides the model set at initialization.
+        :param width: Overrides the width set at initialization.
+        :param height: Overrides the height set at initialization.
+        :param samples: Overrides the number of samples set at initialization.
+        :param negative_prompt: Overrides the negative prompt set at initialization.
+        :param seed: Overrides the seed set at initialization.
+        :returns:
+            A dictionary with:
+            - ``images``: A list of image URLs (one per sample).
+            - ``metadata``: A list of dicts with generation metadata (model, width, height, generation_time).
+        """
+        try:
+            import requests  # noqa: PLC0415
+        except ImportError as e:
+            raise ImportError(
+                "Could not import `requests`. Install it with `pip install requests`."
+            ) from e
+
+        resolved_model = model or self.model
+        resolved_width = width or self.width
+        resolved_height = height or self.height
+        resolved_samples = samples or self.samples
+        resolved_negative_prompt = negative_prompt or self.negative_prompt
+        resolved_seed = seed or self.seed
+        api_key = self.api_key.resolve_value() or ""
+
+        payload: dict[str, Any] = {
+            "key": api_key,
+            "prompt": prompt,
+            "model_id": resolved_model,
+            "width": resolved_width,
+            "height": resolved_height,
+            "samples": resolved_samples,
+            "num_inference_steps": self.num_inference_steps,
+            "guidance_scale": self.guidance_scale,
+            "safety_checker": "no",
+        }
+        if resolved_negative_prompt:
+            payload["negative_prompt"] = resolved_negative_prompt
+        if resolved_seed is not None:
+            payload["seed"] = resolved_seed
+
+        text2img_url = self._build_url("images/text2img")
+        response = requests.post(
+            text2img_url,
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=60,
+        )
+        response.raise_for_status()
+        data = response.json()
+        status = data.get("status", "")
+
+        if status == "error":
+            raise RuntimeError(f"ModelsLab error: {data.get('message', 'unknown error')}")
+
+        if status == "processing":
+            generation_id = data.get("id")
+            if not generation_id:
+                raise RuntimeError("ModelsLab returned 'processing' status without a generation ID.")
+            logger.info(f"ModelsLab: generation {generation_id} is processing, polling for result...")
+            image_urls = self._poll_for_result(generation_id=generation_id, api_key=api_key)
+        elif status == "success":
+            image_urls = data.get("output", [])
+        else:
+            raise RuntimeError(f"ModelsLab: unexpected response status '{status}'.")
+
+        generation_time = data.get("generationTime")
+        metadata = [
+            {
+                "model": resolved_model,
+                "width": resolved_width,
+                "height": resolved_height,
+                "generation_time": generation_time,
+            }
+            for _ in image_urls
+        ]
+
+        return {"images": image_urls, "metadata": metadata}
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+
+        :returns: The serialized component as a dictionary.
+        """
+        return default_to_dict(
+            self,
+            model=self.model,
+            width=self.width,
+            height=self.height,
+            samples=self.samples,
+            num_inference_steps=self.num_inference_steps,
+            guidance_scale=self.guidance_scale,
+            negative_prompt=self.negative_prompt,
+            seed=self.seed,
+            api_key=self.api_key.to_dict(),
+            api_base_url=self.api_base_url,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ModelsLabImageGenerator":
+        """
+        Deserialize this component from a dictionary.
+
+        :param data: The dictionary representation of this component.
+        :returns: The deserialized component instance.
+        """
+        if api_key := data.get("init_parameters", {}).get("api_key"):
+            data["init_parameters"]["api_key"] = Secret.from_dict(api_key)
+        return default_from_dict(cls, data)

--- a/releasenotes/notes/add-modelslab-image-generator-a3f9c21b4d8e7f05.yaml
+++ b/releasenotes/notes/add-modelslab-image-generator-a3f9c21b4d8e7f05.yaml
@@ -1,0 +1,33 @@
+---
+features:
+  - |
+    Added a new **ModelsLabImageGenerator** component that generates images using
+    `ModelsLab's text-to-image API <https://docs.modelslab.com/image-generation/community-models/text2img>`_.
+
+    ModelsLab provides access to 200+ AI models including Flux, SDXL, Stable Diffusion,
+    and thousands of community fine-tunes via a single unified API.
+
+    **Basic usage:**
+
+    .. code-block:: python
+
+        from haystack.components.generators import ModelsLabImageGenerator
+
+        generator = ModelsLabImageGenerator(model="flux", width=1024, height=1024)
+        result = generator.run("A breathtaking sunset over snow-capped mountains.")
+        print(result["images"])  # list of image URLs
+
+    **Pipeline usage:**
+
+    .. code-block:: python
+
+        from haystack import Pipeline
+        from haystack.components.generators import ModelsLabImageGenerator
+
+        pipeline = Pipeline()
+        pipeline.add_component("image_gen", ModelsLabImageGenerator(model="flux"))
+        result = pipeline.run({"image_gen": {"prompt": "A futuristic city at night"}})
+        print(result["image_gen"]["images"])
+
+    Set the ``MODELSLAB_API_KEY`` environment variable or pass ``api_key`` explicitly.
+    The component handles ModelsLab's async generation flow (polling) automatically.

--- a/test/components/generators/test_modelslab.py
+++ b/test/components/generators/test_modelslab.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from haystack.components.generators.modelslab import ModelsLabImageGenerator
+from haystack.utils import Secret
+
+
+class TestModelsLabImageGenerator:
+    def test_init_default(self):
+        generator = ModelsLabImageGenerator()
+        assert generator.model == "flux"
+        assert generator.width == 512
+        assert generator.height == 512
+        assert generator.samples == 1
+        assert generator.num_inference_steps == 30
+        assert pytest.approx(generator.guidance_scale) == 7.5
+        assert generator.negative_prompt is None
+        assert generator.seed is None
+        assert generator.api_key == Secret.from_env_var("MODELSLAB_API_KEY")
+        assert generator.api_base_url == "https://modelslab.com/api/v6"
+
+    def test_init_with_params(self):
+        generator = ModelsLabImageGenerator(
+            model="sdxl",
+            width=1024,
+            height=1024,
+            samples=2,
+            num_inference_steps=20,
+            guidance_scale=9.0,
+            negative_prompt="blurry, ugly",
+            seed=42,
+            api_key=Secret.from_env_var("MY_API_KEY"),
+            api_base_url="https://custom.modelslab.com/api/v6",
+        )
+        assert generator.model == "sdxl"
+        assert generator.width == 1024
+        assert generator.height == 1024
+        assert generator.samples == 2
+        assert generator.num_inference_steps == 20
+        assert pytest.approx(generator.guidance_scale) == 9.0
+        assert generator.negative_prompt == "blurry, ugly"
+        assert generator.seed == 42
+        assert generator.api_key == Secret.from_env_var("MY_API_KEY")
+        assert generator.api_base_url == "https://custom.modelslab.com/api/v6"
+
+    def test_to_dict(self, monkeypatch):
+        monkeypatch.setenv("MODELSLAB_API_KEY", "test-key")
+        generator = ModelsLabImageGenerator()
+        data = generator.to_dict()
+        assert data == {
+            "type": "haystack.components.generators.modelslab.ModelsLabImageGenerator",
+            "init_parameters": {
+                "model": "flux",
+                "width": 512,
+                "height": 512,
+                "samples": 1,
+                "num_inference_steps": 30,
+                "guidance_scale": 7.5,
+                "negative_prompt": None,
+                "seed": None,
+                "api_key": {"type": "env_var", "env_vars": ["MODELSLAB_API_KEY"], "strict": True},
+                "api_base_url": "https://modelslab.com/api/v6",
+            },
+        }
+
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("MODELSLAB_API_KEY", "test-key")
+        data = {
+            "type": "haystack.components.generators.modelslab.ModelsLabImageGenerator",
+            "init_parameters": {
+                "model": "sdxl",
+                "width": 768,
+                "height": 768,
+                "samples": 1,
+                "num_inference_steps": 30,
+                "guidance_scale": 7.5,
+                "negative_prompt": None,
+                "seed": None,
+                "api_key": {"type": "env_var", "env_vars": ["MODELSLAB_API_KEY"], "strict": True},
+                "api_base_url": "https://modelslab.com/api/v6",
+            },
+        }
+        generator = ModelsLabImageGenerator.from_dict(data)
+        assert generator.model == "sdxl"
+        assert generator.width == 768
+        assert generator.height == 768
+
+    def test_run_success(self, monkeypatch):
+        """Test successful synchronous image generation."""
+        monkeypatch.setenv("MODELSLAB_API_KEY", "test-key")
+        generator = ModelsLabImageGenerator(model="flux", width=512, height=512)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "status": "success",
+            "output": ["https://cdn.modelslab.com/image1.png"],
+            "generationTime": 2.5,
+            "id": 12345,
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response) as mock_post:
+            result = generator.run("A beautiful sunset over mountains")
+
+        assert result["images"] == ["https://cdn.modelslab.com/image1.png"]
+        assert len(result["metadata"]) == 1
+        assert result["metadata"][0]["model"] == "flux"
+        assert result["metadata"][0]["width"] == 512
+        assert result["metadata"][0]["height"] == 512
+        assert pytest.approx(result["metadata"][0]["generation_time"]) == 2.5
+
+        # Verify request payload
+        call_args = mock_post.call_args
+        payload = call_args.kwargs["json"]
+        assert payload["prompt"] == "A beautiful sunset over mountains"
+        assert payload["model_id"] == "flux"
+        assert payload["key"] == "test-key"
+        assert payload["width"] == 512
+        assert payload["height"] == 512
+
+    def test_run_with_overrides(self, monkeypatch):
+        """Test run() method respects per-call overrides."""
+        monkeypatch.setenv("MODELSLAB_API_KEY", "test-key")
+        generator = ModelsLabImageGenerator(model="flux", width=512, height=512)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "status": "success",
+            "output": ["https://cdn.modelslab.com/image1.png"],
+            "generationTime": 3.1,
+            "id": 99999,
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response):
+            result = generator.run(
+                "A futuristic cityscape",
+                model="sdxl",
+                width=1024,
+                height=768,
+                negative_prompt="blurry",
+            )
+
+        assert result["images"] == ["https://cdn.modelslab.com/image1.png"]
+        assert result["metadata"][0]["model"] == "sdxl"
+        assert result["metadata"][0]["width"] == 1024
+
+    def test_run_processing_polls(self, monkeypatch):
+        """Test that processing status triggers polling until success."""
+        monkeypatch.setenv("MODELSLAB_API_KEY", "test-key")
+        generator = ModelsLabImageGenerator()
+
+        initial_response = MagicMock()
+        initial_response.json.return_value = {
+            "status": "processing",
+            "id": 54321,
+            "fetch_result": "https://modelslab.com/api/v6/images/fetch/54321",
+            "eta": 5,
+        }
+        initial_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=initial_response), \
+             patch.object(generator, "_poll_for_result", return_value=["https://cdn.modelslab.com/polled.png"]) as mock_poll:
+            result = generator.run("A polled image")
+
+        mock_poll.assert_called_once_with(generation_id=54321, api_key="test-key")
+        assert result["images"] == ["https://cdn.modelslab.com/polled.png"]
+
+    def test_run_error_raises(self, monkeypatch):
+        """Test that an error status raises RuntimeError."""
+        monkeypatch.setenv("MODELSLAB_API_KEY", "test-key")
+        generator = ModelsLabImageGenerator()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "status": "error",
+            "message": "Invalid API key",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response), pytest.raises(RuntimeError, match="Invalid API key"):
+            generator.run("Test prompt")
+
+    def test_run_processing_missing_id_raises(self, monkeypatch):
+        """Test processing status without an ID raises RuntimeError."""
+        monkeypatch.setenv("MODELSLAB_API_KEY", "test-key")
+        generator = ModelsLabImageGenerator()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "processing"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response), pytest.raises(RuntimeError, match="generation ID"):
+            generator.run("Test prompt")


### PR DESCRIPTION
## Summary

Adds **ModelsLabImageGenerator**, a Haystack pipeline component for image generation using ModelsLab's text-to-image API.

ModelsLab provides access to 200+ AI models (Flux, SDXL, Stable Diffusion, community fine-tunes) via a single unified API.

---

## What this PR adds

| File | Purpose |
|------|---------|
| `haystack/components/generators/modelslab.py` | Main component class |
| `haystack/components/generators/__init__.py` | Export registration |
| `test/components/generators/test_modelslab.py` | 9 unit tests (all passing) |
| `releasenotes/notes/add-modelslab-image-generator-*.yaml` | Release note |

---

## Output types

- `images`: list of image URLs
- `metadata`: generation metadata (model, width, height, generation_time)

---

## Key features

- **Automatic async polling**: Handles ModelsLab's `processing` status by polling until success (up to 300s)
- **Per-call overrides**: model, width, height, samples, negative_prompt, seed
- **Secret-based API key**: Reads `MODELSLAB_API_KEY` from env or accepts explicit Secret
- **Serializable**: to_dict/from_dict for pipeline persistence

---

## Usage

```python
from haystack.components.generators import ModelsLabImageGenerator

generator = ModelsLabImageGenerator(model='flux', width=1024, height=1024)
result = generator.run('A breathtaking sunset over snow-capped mountains.')
print(result['images'])  # ['https://cdn.modelslab.com/...']
```

Or in a pipeline:

```python
from haystack import Pipeline
pipeline = Pipeline()
pipeline.add_component('image_gen', ModelsLabImageGenerator(model='flux'))
result = pipeline.run({'image_gen': {'prompt': 'A futuristic city at night'}})
print(result['image_gen']['images'])
```

---

## API Reference

- Docs: https://docs.modelslab.com/image-generation/community-models/text2img
- Get API key: https://modelslab.com/dashboard/api-keys

---

## Tests

All 9 tests passing:

```bash
python -m pytest test/components/generators/test_modelslab.py -v
```