### PR TITLE
docs: document type errors in docstrings

### DIFF
--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -348,7 +348,8 @@ class OpenAPIServiceConnector:
         should contain the method name (key: "name") and the arguments (key: "arguments"). The name is a string, and
         the arguments are a dictionary of key-value pairs.
         :return: A service JSON response.
-        :raises RuntimeError: If the method is not found or invocation fails.
+        :raises ValueError: If the descriptor is malformed or a required parameter is missing.
+        :raises TypeError: If the operation is not found in the OpenAPI specification.
         """
         name = method_invocation_descriptor.get("name")
         invocation_arguments = copy(method_invocation_descriptor.get("arguments", {}))

--- a/haystack/components/extractors/regex_text_extractor.py
+++ b/haystack/components/extractors/regex_text_extractor.py
@@ -96,7 +96,7 @@ class RegexTextExtractor:
           - `{"captured_text": "matched text"}` if a match is found
           - `{"captured_text": ""}` if no match is found
 
-        :raises ValueError: if receiving a list the last element is not a ChatMessage instance.
+        :raises TypeError: if receiving a list the last element is not a ChatMessage instance.
         """
         if isinstance(text_or_messages, str):
             return self._build_result(self._extract_from_text(text_or_messages))
@@ -112,7 +112,11 @@ class RegexTextExtractor:
         return {"captured_text": result}
 
     def _process_last_message(self, messages: list[ChatMessage]) -> dict:
-        """Process only the last message and build the result."""
+        """
+        Process only the last message and build the result.
+
+        :raises TypeError: If the last element of the list is not a ChatMessage instance.
+        """
         last_message = messages[-1]
         if not isinstance(last_message, ChatMessage):
             raise TypeError(f"Expected ChatMessage object, got {type(last_message)}")

--- a/haystack/components/preprocessors/markdown_header_splitter.py
+++ b/haystack/components/preprocessors/markdown_header_splitter.py
@@ -290,6 +290,8 @@ class MarkdownHeaderSplitter:
                 - A metadata field `page_number` to track the original page number.
                 - A metadata field `split_id` to identify the split chunk index within its parent document.
                 - All other metadata copied from the original document.
+        :raises ValueError: If a document has `None` content.
+        :raises TypeError: If a document's content is not a string.
         """
         if self.secondary_split and not self._is_warmed_up:
             self.warm_up()

--- a/haystack/components/rankers/hugging_face_tei.py
+++ b/haystack/components/rankers/hugging_face_tei.py
@@ -137,6 +137,9 @@ class HuggingFaceTEIRanker:
 
         :raises RuntimeError:
             - If the API returns an error response.
+
+        :raises TypeError:
+            - If the API response is not in the expected list format.
         """
         if isinstance(result, dict) and "error" in result:
             error_type = result.get("error_type", "UnknownError")
@@ -189,6 +192,9 @@ class HuggingFaceTEIRanker:
 
         :raises RuntimeError:
             - If the API returns an error response.
+
+        :raises TypeError:
+            - If the API response is not in the expected list format.
         """
         # Return empty if no documents provided
         if not documents:
@@ -246,6 +252,8 @@ class HuggingFaceTEIRanker:
             - If the API request fails.
         :raises RuntimeError:
             - If the API returns an error response.
+        :raises TypeError:
+            - If the API response is not in the expected list format.
         """
         # Return empty if no documents provided
         if not documents:

--- a/haystack/components/retrievers/in_memory/bm25_retriever.py
+++ b/haystack/components/retrievers/in_memory/bm25_retriever.py
@@ -63,6 +63,7 @@ class InMemoryBM25Retriever:
         - `REPLACE` (default): Overrides the initialization filters with the filters specified at runtime.
         Use this policy to dynamically change filtering for specific queries.
         - `MERGE`: Combines runtime filters with initialization filters to narrow down the search.
+        :raises TypeError: If the document_store is not an instance of InMemoryDocumentStore.
         :raises ValueError:
             If the specified `top_k` is not > 0.
         """

--- a/haystack/components/retrievers/in_memory/embedding_retriever.py
+++ b/haystack/components/retrievers/in_memory/embedding_retriever.py
@@ -77,6 +77,7 @@ class InMemoryEmbeddingRetriever:
         - `REPLACE` (default): Overrides the initialization filters with the filters specified at runtime.
         Use this policy to dynamically change filtering for specific queries.
         - `MERGE`: Combines runtime filters with initialization filters to narrow down the search.
+        :raises TypeError: If the document_store is not an instance of InMemoryDocumentStore.
         :raises ValueError:
             If the specified top_k is not > 0.
         """

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -149,6 +149,7 @@ class FileTypeRouter:
         :returns: A dictionary where the keys are MIME types and the values are lists of data sources.
                   Two extra keys may be returned: `"unclassified"` when a source's MIME type doesn't match any pattern
                    and `"failed"` when a source cannot be processed (for example, a file path that doesn't exist).
+        :raises TypeError: If a source is not a Path, str, or ByteStream.
         """
 
         mime_types: defaultdict[str, list[Path | ByteStream]] = defaultdict(list)

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -279,6 +279,8 @@ class ChatMessage:
     def __new__(cls, *args, **kwargs):  # noqa: ARG004
         """
         This method is reimplemented to make the changes to the `ChatMessage` dataclass more visible.
+
+        :raises TypeError: If any legacy init parameters (`role`, `content`, `meta`, `name`) are passed.
         """
 
         general_msg = (
@@ -458,6 +460,8 @@ class ChatMessage:
         :param name: An optional name for the participant. This field is only supported by OpenAI.
         :param content_parts: A list of content parts to include in the message. Specify this or text.
         :returns: A new ChatMessage instance.
+        :raises ValueError: If neither or both of text and content_parts are provided, or if content_parts is empty.
+        :raises TypeError: If a content part is not a str, TextContent, ImageContent, or FileContent.
         """
         if text is None and content_parts is None:
             raise ValueError("Either text or content_parts must be provided.")
@@ -512,6 +516,7 @@ class ChatMessage:
         :param tool_calls: The Tool calls to include in the message.
         :param reasoning: The reasoning content to include in the message.
         :returns: A new ChatMessage instance.
+        :raises TypeError: If `reasoning` is not a string or ReasoningContent object.
         """
         content: list[ChatMessageContentT] = []
         if reasoning:
@@ -603,6 +608,8 @@ class ChatMessage:
             The dictionary to build the ChatMessage object.
         :returns:
             The created object.
+        :raises ValueError: If the `role` field is missing from the dictionary.
+        :raises TypeError: If the `content` field is not a list or string.
         """
 
         # NOTE: this verbose error message provides guidance to LLMs when creating invalid messages during agent runs

--- a/haystack/evaluation/eval_run_result.py
+++ b/haystack/evaluation/eval_run_result.py
@@ -180,6 +180,9 @@ class EvaluationRunResult:
         :returns:
             JSON or DataFrame with a comparison of the detailed scores, in case the output is set to a CSV file,
              a message confirming the successful write or an error message.
+        :raises TypeError: If `other` is not an EvaluationRunResult instance, or if the detailed reports are not
+            dictionaries.
+        :raises ValueError: If the `other` parameter is missing required attributes.
         """
 
         if not isinstance(other, EvaluationRunResult):

--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -164,7 +164,8 @@ class ComponentTool(Tool):
                 "documents": {"handler": custom_handler}
             }
             ```
-        :raises ValueError: If the component is invalid or schema generation fails.
+        :raises TypeError: If the object passed is not a Haystack Component instance.
+        :raises ValueError: If the component has already been added to a pipeline, or if schema generation fails.
         """
         if not isinstance(component, Component):
             message = (

--- a/haystack/tools/tool.py
+++ b/haystack/tools/tool.py
@@ -86,6 +86,10 @@ class Tool:
             "documents": {"handler": custom_handler}
         }
         ```
+    :raises ValueError: If `function` is async, if `parameters` is not a valid JSON schema, or if the
+        `outputs_to_state`, `outputs_to_string`, or `inputs_from_state` configurations are invalid.
+    :raises TypeError: If any configuration value in `outputs_to_state`, `outputs_to_string`, or
+        `inputs_from_state` has the wrong type.
     """
 
     name: str

--- a/haystack/utils/device.py
+++ b/haystack/utils/device.py
@@ -223,6 +223,7 @@ class DeviceMap:
             The HuggingFace device map.
         :returns:
             The deserialized device map.
+        :raises TypeError: If a device value in the map is not an int, str, or torch.device.
         """
         mapping = {}
         for key, device in hf_device_map.items():


### PR DESCRIPTION
### Related Issues
Follow-up of #10640
- based on [type-check-without-type-error](https://docs.astral.sh/ruff/rules/type-check-without-type-error/#type-check-without-type-error-try004) rule, we now raise `TypeError` if type checks fails
- I forgot to update docstrings

### Proposed Changes:
- update docstrings to reflect the actual error types


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
