### PR TITLE
docs: add out of scope section to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,15 +16,9 @@ We encourage reports that are meaningful, high-impact, and reviewed by a human b
 
 ## Out of Scope
 
-Haystack is a Python framework intended to run inside a trusted execution environment. It assumes that the application build on top of it has already validated and sanitized all user-supplied input before passing it to the framework. Validation and sanitization of user inputs are the responsibility of the hosting application, not Haystack.
+Haystack is a framework intended to run inside a trusted execution environment. It assumes that the application built with it has already validated and sanitized user-supplied input before passing it to the framework. Validation and sanitization of input, for example URLs, file paths, filter expressions, and queries, are the responsibility of the application, not Haystack.
 
-The following classes of issues will **not** be accepted as security vulnerabilities because they can only be exploited when the surrounding application passes attacker-controlled input directly to Haystack without any prior validation:
-
-- **Filter injection** – manipulating document store filter expressions by supplying attacker-controlled filter values. Applications must validate and sanitize filter inputs before passing them to Haystack.
-- **SSRF or open redirect** – passing attacker-controlled URLs to components that fetch remote resources (e.g., URL-based document fetchers or audio transcription components). URL validation is the responsibility of the application.
-- **Path traversal or arbitrary file read/write** – passing untrusted file paths or file-like objects into components that perform file I/O. The application must restrict which paths are accessible.
-- **Prompt injection or prompt leakage** – manipulating natural-language content (e.g., documents, query strings, chat messages) to influence LLM behavior. These are inherent to the LLM threat landscape and must be mitigated at the application layer, via specialized Haystack pipeline components or via security-focused architectural approaches like the dual LLM pattern.
-- **Denial of Service via unbounded input** – crashes or memory exhaustion caused by sending arbitrarily large or malformed payloads through an exposed API endpoint.
+Any vulnerability that can only be triggered by passing unsanitized, attacker-controlled input to Haystack is considered out of scope. This reflects a conscious design decision after evaluating the trade-offs and risks: as a framework, Haystack cannot and should not enforce input validation on behalf of every application that uses it.
 
 If you are uncertain whether a finding falls within scope, feel free to reach out before submitting a full report.
 


### PR DESCRIPTION
### Related Issues

In order to help security researchers understand the scope of valid vulnerability reports, we need to better explain that Haystack as a framework relies on the hosting application to be responsible for validating and sanitizing user input before it reaches Haystack.

### Proposed Changes:

- Extend SECURITY.md with an Out of Scope section
- Add a step to reporting where security researchers are asked to briefly explain why a discovered vulnerability is not out of scope

### How did you test it?

does not apply

### Notes for the reviewer

I asked Rudy for feedback and it's already addressed. Ready to be merged from his side.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
