### PR TITLE
feat: add runtime validation for component output keys to prevent misleading Pipeline Blocked errors

### DIFF
--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -14,6 +14,7 @@ from haystack.core.pipeline.base import (
     _COMPONENT_INPUT,
     _COMPONENT_OUTPUT,
     _COMPONENT_VISITS,
+    _validate_component_output_keys,
     ComponentPriority,
     PipelineBase,
 )
@@ -94,6 +95,8 @@ class AsyncPipeline(PipelineBase):
 
             if not isinstance(outputs, Mapping):
                 raise PipelineRuntimeError.from_invalid_output(component_name, instance.__class__, outputs)
+
+            _validate_component_output_keys(component_name, component, outputs)
 
             span.set_tag(_COMPONENT_VISITS, component_visits[component_name])
             span.set_content_tag(_COMPONENT_OUTPUT, outputs)

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -12,6 +12,7 @@ from haystack.core.pipeline.base import (
     _COMPONENT_INPUT,
     _COMPONENT_OUTPUT,
     _COMPONENT_VISITS,
+    _validate_component_output_keys,
     ComponentPriority,
     PipelineBase,
 )
@@ -101,6 +102,8 @@ class Pipeline(PipelineBase):
 
             if not isinstance(component_output, Mapping):
                 raise PipelineRuntimeError.from_invalid_output(component_name, instance.__class__, component_output)
+
+            _validate_component_output_keys(component_name, component, component_output)
 
             span.set_tag(_COMPONENT_VISITS, component_visits[component_name])
             span.set_content_tag(_COMPONENT_OUTPUT, component_output)

--- a/releasenotes/notes/validate-component-output-keys-ab0648ef9a5a4449.yaml
+++ b/releasenotes/notes/validate-component-output-keys-ab0648ef9a5a4449.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    Added runtime validation of component output keys in ``Pipeline.run()``. When a component
+    returns keys that don't match its declared ``@component.output_types``, the pipeline now
+    logs a warning identifying the misconfigured component. This helps diagnose issues where
+    a component returns wrong keys, which previously caused a confusing "Pipeline Blocked"
+    error pointing to the wrong (downstream) component.


### PR DESCRIPTION
## Related Issues

Closes #10655

## Summary

When a custom component returns wrong output keys (e.g., `{"wrong_key": value}` instead of `{"expected_key": value}`), downstream components wait forever for the expected key, resulting in a confusing "Pipeline Blocked" error that points to the **wrong** (downstream) component rather than the actual misconfigured one.

This PR adds runtime validation of component output keys after each component execution:

- After a component runs successfully and returns a valid `Mapping`, the returned keys are compared against the declared `@component.output_types`
- **Extra keys** (returned but not declared): Logs a warning that these keys will be ignored
- **Missing keys** (declared but not returned): Logs a warning that downstream components may block waiting for this data
- Validation is applied in both the sync `Pipeline._run_component` and async `AsyncPipeline._run_component_async` paths

The warnings clearly identify the **actual misconfigured component** by name and type, making it much easier to diagnose the root cause.

### Example

Before this change, a pipeline with a misconfigured component would produce:
```
WARNING - Cannot run pipeline - the next component that is meant to run is blocked.
Component name: 'second'  <-- points to the WRONG component
```

After this change, the pipeline produces an **additional** earlier warning:
```
WARNING - Component 'first' (type: MisconfiguredComponent) did not produce output keys {'other_output'}
declared in its output types. This may cause downstream components to block waiting for this data,
leading to a 'Pipeline Blocked' error.
```

## How Did You Test It?

- Added 4 new unit tests in `test/core/pipeline/test_pipeline.py`:
  - `test__run_component_warns_on_extra_output_keys` - verifies warning for undeclared output keys
  - `test__run_component_warns_on_missing_output_keys` - verifies warning for missing declared keys
  - `test__run_component_warns_on_wrong_output_keys` - verifies both warnings for completely wrong keys
  - `test__run_component_no_warning_on_correct_output_keys` - verifies no false positives
- Updated the existing `test_pipeline_is_possibly_blocked_warning_message` test to verify that the new validation warning is produced alongside the existing "Pipeline Blocked" warning, pointing to the actual misconfigured component

All existing pipeline tests continue to pass.

## Notes for the Reviewer

- The validation uses **warnings** (not errors) intentionally. Some components legitimately return partial outputs (e.g., conditional routers may not produce all declared outputs on every run). Warnings provide visibility without breaking existing valid pipelines.
- The `_validate_component_output_keys` function is defined in `base.py` and imported by both `pipeline.py` and `async_pipeline.py` to avoid duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)