### PR TITLE
fix: resolve in-place dataclass mutations

### DIFF
--- a/haystack/components/builders/chat_prompt_builder.py
+++ b/haystack/components/builders/chat_prompt_builder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 import json
 from copy import deepcopy
 from typing import Any, Literal
@@ -269,7 +270,7 @@ class ChatPromptBuilder:
                     rendered_text = compiled_template.render(template_variables_combined)
                     # deep copy the message to avoid modifying the original message
                     rendered_message: ChatMessage = deepcopy(message)
-                    rendered_message._content = [TextContent(text=rendered_text)]
+                    rendered_message = dataclasses.replace(rendered_message, _content=[TextContent(text=rendered_text)])
                     processed_messages.append(rendered_message)
                 else:
                     processed_messages.append(message)

--- a/haystack/components/converters/image/file_to_image.py
+++ b/haystack/components/converters/image/file_to_image.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 import mimetypes
 from pathlib import Path
 from typing import Any, Literal
@@ -124,7 +125,7 @@ class ImageFileToImageContent:
                 continue
 
             if bytestream.mime_type is None and isinstance(source, Path):
-                bytestream.mime_type = mimetypes.guess_type(source.as_posix())[0]
+                bytestream = dataclasses.replace(bytestream, mime_type=mimetypes.guess_type(source.as_posix())[0])
 
             if bytestream.data == _EMPTY_BYTE_STRING:
                 logger.warning("File {source} is empty. Skipping it.", source=source)

--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -263,7 +263,7 @@ class LLMMetadataExtractor:
                 for idx, page in enumerate(pages["documents"]):
                     if idx + 1 in expanded_range:
                         content += page.content
-                doc_copy.content = content
+                doc_copy = replace(doc_copy, content=content)
             else:
                 doc_copy = document
 

--- a/haystack/components/fetchers/link_content.py
+++ b/haystack/components/fetchers/link_content.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import dataclasses
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -248,7 +249,7 @@ class LinkContentFetcher:
         if len(urls) == 1:
             stream_metadata, stream = self._fetch(urls[0])
             stream.meta.update(stream_metadata)
-            stream.mime_type = stream.meta.get("content_type", None)
+            stream = dataclasses.replace(stream, mime_type=stream.meta.get("content_type", None))
             streams.append(stream)
         else:
             with ThreadPoolExecutor() as executor:
@@ -257,7 +258,7 @@ class LinkContentFetcher:
             for stream_metadata, stream in results:  # type: ignore
                 if stream_metadata is not None and stream is not None:
                     stream.meta.update(stream_metadata)
-                    stream.mime_type = stream.meta.get("content_type", None)
+                    stream = dataclasses.replace(stream, mime_type=stream.meta.get("content_type", None))
                     streams.append(stream)
 
         return {"streams": streams}
@@ -302,7 +303,7 @@ class LinkContentFetcher:
                 stream_metadata, stream = result_tuple
                 if stream_metadata is not None and stream is not None:
                     stream.meta.update(stream_metadata)
-                    stream.mime_type = stream.meta.get("content_type", None)
+                    stream = dataclasses.replace(stream, mime_type=stream.meta.get("content_type", None))
                     streams.append(stream)
 
         return {"streams": streams}

--- a/haystack/components/rankers/hugging_face_tei.py
+++ b/haystack/components/rankers/hugging_face_tei.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import copy
+import dataclasses
 from enum import Enum
 from typing import Any
 from urllib.parse import urljoin
@@ -160,8 +160,7 @@ class HuggingFaceTEIRanker:
         ranked_docs = []
         for item in result[:final_k]:
             index: int = item["index"]
-            doc_copy = copy.copy(documents[index])
-            doc_copy.score = item["score"]
+            doc_copy = dataclasses.replace(documents[index], score=item["score"])
             ranked_docs.append(doc_copy)
         return {"documents": ranked_docs}
 

--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 from collections import defaultdict
 from collections.abc import Callable
 from typing import Any, Literal
@@ -401,8 +402,7 @@ class MetaFieldRanker:
                 scores_map[document.id] += score * (1 - weight)
                 scores_map[sorted_doc.id] += self._calc_linear_score(rank=i, amount=len(sorted_documents)) * weight
 
-        for document in documents:
-            document.score = scores_map[document.id]
+        documents = [dataclasses.replace(doc, score=scores_map[doc.id]) for doc in documents]
 
         return sorted(documents, key=lambda doc: doc.score if doc.score else -1, reverse=True)
 

--- a/haystack/components/rankers/sentence_transformers_similarity.py
+++ b/haystack/components/rankers/sentence_transformers_similarity.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from copy import copy
+import dataclasses
 from pathlib import Path
 from typing import Any, Literal
 
@@ -288,8 +288,7 @@ class SentenceTransformersSimilarityRanker:
         for el in ranking_result:
             index = el["corpus_id"]
             score = float(el["score"])
-            document = copy(deduplicated_documents[index])
-            document.score = score
+            document = dataclasses.replace(deduplicated_documents[index], score=score)
             ranked_docs.append(document)
 
         if score_threshold is not None:

--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 from pathlib import Path
 from typing import Any
 
@@ -318,8 +319,8 @@ class TransformersSimilarityRanker:
         ranked_docs = []
         for sorted_index in list_sorted_indices:
             i = sorted_index
-            deduplicated_documents[i].score = list_similarity_scores[i]
-            ranked_docs.append(deduplicated_documents[i])
+            doc = dataclasses.replace(deduplicated_documents[i], score=list_similarity_scores[i])
+            ranked_docs.append(doc)
 
         if score_threshold is not None:
             ranked_docs = [doc for doc in ranked_docs if doc.score >= score_threshold]

--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 import math
 from pathlib import Path
 from typing import Any
@@ -322,7 +323,7 @@ class ExtractiveReader:
 
     def _add_answer_page_number(self, answer: ExtractedAnswer) -> ExtractedAnswer:
         if answer.meta is None:
-            answer.meta = {}
+            answer = dataclasses.replace(answer, meta={})
 
         if answer.document_offset is None:
             return answer
@@ -341,7 +342,8 @@ class ExtractiveReader:
         if answer.document.content:
             ans_start = answer.document_offset.start
             answer_page_number = answer.document.meta["page_number"] + answer.document.content[:ans_start].count("\f")
-            answer.meta.update({"answer_page_number": answer_page_number})
+            new_meta = {**answer.meta, "answer_page_number": answer_page_number}
+            answer = dataclasses.replace(answer, meta=new_meta)
 
         return answer
 
@@ -389,8 +391,7 @@ class ExtractiveReader:
         for query_id in range(query_ids[-1] + 1):
             current_answers = []
             while i < len(answers_without_query) and query_ids[i // answers_per_seq] == query_id:
-                answer = answers_without_query[i]
-                answer.query = queries[query_id]
+                answer = dataclasses.replace(answers_without_query[i], query=queries[query_id])
                 current_answers.append(answer)
                 i += 1
             current_answers = sorted(current_answers, key=lambda ans: ans.score, reverse=True)

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 from collections.abc import Mapping
 from typing import Any
 
@@ -409,8 +410,11 @@ class Pipeline(PipelineBase):
                     # agent snapshot and attach it to the pipeline snapshot we create here.
                     # We also update the break_point to be an AgentBreakpoint.
                     if error.pipeline_snapshot and error.pipeline_snapshot.agent_snapshot:
-                        pipeline_snapshot.agent_snapshot = error.pipeline_snapshot.agent_snapshot
-                        pipeline_snapshot.break_point = error.pipeline_snapshot.agent_snapshot.break_point
+                        pipeline_snapshot = dataclasses.replace(
+                            pipeline_snapshot,
+                            agent_snapshot=error.pipeline_snapshot.agent_snapshot,
+                            break_point=error.pipeline_snapshot.agent_snapshot.break_point,
+                        )
 
                     # Attach the pipeline snapshot to the error before re-raising
                     error.pipeline_snapshot = pipeline_snapshot

--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import dataclasses
 import json
 import math
 import re
@@ -432,8 +433,7 @@ class InMemoryDocumentStore:
             docs = list(self.storage.values())
 
         if not self.return_embedding:
-            for doc in docs:
-                doc.embedding = None
+            docs = [dataclasses.replace(doc, embedding=None) for doc in docs]
 
         return docs
 

--- a/releasenotes/notes/resolve-dataclass-inplace-mutations-1276192f751c4cb1.yaml
+++ b/releasenotes/notes/resolve-dataclass-inplace-mutations-1276192f751c4cb1.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Replaced in-place dataclass mutations with `dataclasses.replace()` across multiple components
+    (rankers, joiners, fetchers, converters, readers, document stores, and pipeline) to avoid
+    unintended side effects and eliminate deprecation warnings introduced by the dataclass mutation
+    detection in PR #10650.


### PR DESCRIPTION
## Summary
- Replaces in-place dataclass attribute mutations (`doc.score = x`, `stream.mime_type = y`, etc.) with `dataclasses.replace()` across 12 source files
- Resolves the deprecation warnings introduced by the dataclass mutation detection added in #10650
- Adds a release note documenting the change

## Related Issue
Fixes #10659

## Changes by file

| File | Mutation fixed |
|------|---------------|
| `chat_prompt_builder.py` | `rendered_message._content = [...]` |
| `pipeline.py` | `pipeline_snapshot.agent_snapshot = ...`, `pipeline_snapshot.break_point = ...` |
| `file_to_image.py` | `bytestream.mime_type = ...` |
| `llm_metadata_extractor.py` | `doc_copy.content = content` |
| `link_content.py` | `stream.mime_type = ...` (3 places: sync run, sync multi-url, async) |
| `document_joiner.py` | `doc.score = ...` (3 methods: _merge, _reciprocal_rank_fusion, _distribution_based_rank_fusion) |
| `hugging_face_tei.py` | `doc_copy.score = ...` |
| `meta_field.py` | `document.score = ...` |
| `sentence_transformers_similarity.py` | `document.score = score` |
| `transformers_similarity.py` | `deduplicated_documents[i].score = ...` |
| `extractive.py` | `answer.query = ...`, `answer.meta = {}`, `answer.meta.update(...)` |
| `in_memory/document_store.py` | `doc.embedding = None` |

## Test plan
- [ ] Existing unit tests should pass (this is a mechanical refactoring that preserves behavior)
- [ ] Verify no new dataclass mutation warnings are emitted in the changed code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)