### PR TITLE
perf: use deque for sentence span merging in SentenceSplitter

### DIFF
--- a/haystack/components/preprocessors/sentence_tokenizer.py
+++ b/haystack/components/preprocessors/sentence_tokenizer.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
+from collections import deque
 from pathlib import Path
 from typing import Any, Literal
 
@@ -169,13 +170,14 @@ class SentenceSplitter:
         """
         new_sentence_spans = []
         quote_spans = [match.span() for match in QUOTE_SPANS_RE.finditer(text)]
-        while sentence_spans:
-            span = sentence_spans.pop(0)
-            next_span = sentence_spans[0] if len(sentence_spans) > 0 else None
+        spans_queue = deque(sentence_spans)
+        while spans_queue:
+            span = spans_queue.popleft()
+            next_span = spans_queue[0] if spans_queue else None
             while next_span and SentenceSplitter._needs_join(text, span, next_span, quote_spans):
-                sentence_spans.pop(0)
+                spans_queue.popleft()
                 span = (span[0], next_span[1])
-                next_span = sentence_spans[0] if len(sentence_spans) > 0 else None
+                next_span = spans_queue[0] if spans_queue else None
             start, end = span
             new_sentence_spans.append((start, end))
         return new_sentence_spans


### PR DESCRIPTION
## Problem

`SentenceSplitter._apply_split_rules()` uses `list.pop(0)` (3 call-sites) to consume sentence spans from the front of a list while merging adjacent spans that match quote/list/parenthetical rules.

`list.pop(0)` is **O(n)** because CPython must shift every remaining element left by one slot. On documents with many sentences this adds up.

## Solution

Wrap the incoming `sentence_spans` list in a `collections.deque` and replace all `.pop(0)` calls with `.popleft()`, which is **O(1)** amortised.

`deque[0]` indexing, boolean truthiness checks, and iteration all work identically to `list`, so no other API surface changes are needed. The original `sentence_spans` parameter is not mutated.

## Testing

All 8 tests in `test/components/preprocessors/test_sentence_tokenizer.py` pass (2 consecutive clean runs).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>