### PR TITLE
build: Remove job that cleans up old nightly pre-releases

### DIFF
--- a/.github/workflows/nightly_testpypi_release.yml
+++ b/.github/workflows/nightly_testpypi_release.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   HATCH_VERSION: "1.16.4"
-  PYPI_CLEANUP_VERSION: "0.1.10"
 
 jobs:
   nightly-release:
@@ -45,16 +44,3 @@ jobs:
           HATCH_INDEX_USER: __token__
           HATCH_INDEX_AUTH: ${{ secrets.HAYSTACK_AI_TESTPYPI_TOKEN }}
         run: hatch publish -r test -y
-
-  # Remove .dev* pre-releases on TestPyPI that are older than 7 days (keeps index manageable).
-  cleanup-old-nightlies:
-    runs-on: ubuntu-latest
-    needs: nightly-release
-    steps:
-      - name: Delete nightly pre-releases older than 7 days from TestPyPI
-        env:
-          PYPI_CLEANUP_PASSWORD: ${{ secrets.HAYSTACK_AI_TESTPYPI_TOKEN }}
-        run: |
-          pip install pypi-cleanup==${{ env.PYPI_CLEANUP_VERSION }}
-          pypi-cleanup -u __token__ -p haystack-ai -t https://test.pypi.org/ \
-            -d 7 --do-it -y -v


### PR DESCRIPTION
### Related Issues

Unfortunately TestPyPI/ PyPI / pypi-cleanup don't support deletion of releases with token-based authentication. Token-based authentication only works for publishing new releases.
Deletion of releases with pypi-cleanup requires providing the password of the owner of the package and 2FA code. A maintainer's password is not enough. Therefore, we can't reliably automate the deletion of old pre-releases.

### Proposed Changes:

- Remove the job that tried to delete old pre-releases. Was added in https://github.com/deepset-ai/haystack/pull/10708

### How did you test it?

I created separate maintainer and owner accounts on TestPyPI to test using my machine.

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
