### PR TITLE
build: publish pre-releases to PyPI instead of TestPyPI

### DIFF
--- a/.github/workflows/nightly_testpypi_release.yml
+++ b/.github/workflows/nightly_testpypi_release.yml
@@ -1,4 +1,4 @@
-name: Nightly release to TestPyPI
+name: Nightly pre-release on PyPI
 
 on:
   schedule:
@@ -39,8 +39,8 @@ jobs:
       - name: Build Haystack
         run: hatch build
 
-      - name: Publish to TestPyPI
+      - name: Publish to PyPI
         env:
           HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.HAYSTACK_AI_TESTPYPI_TOKEN }}
-        run: hatch publish -r test -y
+          HATCH_INDEX_AUTH: ${{ secrets.HAYSTACK_AI_PYPI_TOKEN }}
+        run: hatch publish -y


### PR DESCRIPTION
### Related Issues

- Fixes https://github.com/deepset-ai/haystack-private/issues/264

### Proposed Changes:

- Publish nightly pre-releases to PyPI instead of TestPyPI

### How did you test it?

- Same workflow ran the past two weeks using TestPyPI

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
