### PR TITLE
test: remove test comparing Extractive Reader with HF question-answering pipeline

### DIFF
--- a/test/components/readers/test_extractive.py
+++ b/test/components/readers/test_extractive.py
@@ -9,7 +9,6 @@ from unittest.mock import Mock, patch
 import pytest
 import torch
 from _pytest.monkeypatch import MonkeyPatch
-from transformers import pipeline
 
 from haystack import Document, ExtractedAnswer
 from haystack.components.readers import ExtractiveReader
@@ -827,27 +826,3 @@ def test_roberta(del_hf_env_vars):
     # assert answers[1][1].score == pytest.approx(0.6604189872741699)
     # assert answers[1][2].data is None
     # assert answers[1][2].score == pytest.approx(0.1002123719777046)
-
-
-@pytest.mark.integration
-@pytest.mark.slow
-def test_matches_hf_pipeline(del_hf_env_vars):
-    reader = ExtractiveReader(
-        "deepset/tinyroberta-squad2", device=ComponentDevice.from_str("cpu"), overlap_threshold=None
-    )
-    answers = reader.run(example_queries[0], [[example_documents[0][0]]][0], top_k=20, no_answer=False)[
-        "answers"
-    ]  # [0] Remove first two indices when batching support is reintroduced
-    pipe = pipeline("question-answering", model=reader.model, tokenizer=reader.tokenizer, align_to_words=False)
-    answers_hf = pipe(
-        question=example_queries[0],
-        context=example_documents[0][0].content,
-        max_answer_len=1_000,
-        handle_impossible_answer=False,
-        top_k=20,
-    )  # We need to disable HF postprocessing features to make the results comparable. This is related to https://github.com/huggingface/transformers/issues/26286
-    assert len(answers) == len(answers_hf) == 20
-    for answer, answer_hf in zip(answers, answers_hf, strict=True):
-        assert answer.document_offset.start == answer_hf["start"]
-        assert answer.document_offset.end == answer_hf["end"]
-        assert answer.data == answer_hf["answer"]


### PR DESCRIPTION
### Related Issues
- Failing test comparing the output of Extractive Reader with HF question-answering pipeline: https://github.com/deepset-ai/haystack/actions/runs/22695932583/job/65802198251
- Question-answering pipeline was removed in https://github.com/huggingface/transformers/pull/43325 and released in Transformers 5.3.0

### Proposed Changes:
- remove the test that uses the now deleted HF Transformers question-answering pipeline 

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
