### PR TITLE
docs: standardize GitHub capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Read more about telemetry in Haystack or how you can opt out in [Haystack docs](
 
 ## 🖖 Community
 
-If you have a feature request or a bug report, feel free to open an [issue in GitHub](https://github.com/deepset-ai/haystack/issues). We regularly check these, so you can expect a quick response. If you'd like to discuss a topic or get more general advice on how to make Haystack work for your project, you can start a thread in [Github Discussions](https://github.com/deepset-ai/haystack/discussions) or our [Discord channel](https://discord.com/invite/VBpFzsgRVF). We also check [𝕏 (Twitter)](https://twitter.com/haystack_ai) and [Stack Overflow](https://stackoverflow.com/questions/tagged/haystack).
+If you have a feature request or a bug report, feel free to open an [issue in GitHub](https://github.com/deepset-ai/haystack/issues). We regularly check these, so you can expect a quick response. If you'd like to discuss a topic or get more general advice on how to make Haystack work for your project, you can start a thread in [GitHub Discussions](https://github.com/deepset-ai/haystack/discussions) or our [Discord channel](https://discord.com/invite/VBpFzsgRVF). We also check [𝕏 (Twitter)](https://twitter.com/haystack_ai) and [Stack Overflow](https://stackoverflow.com/questions/tagged/haystack).
 
 ## Contributing to Haystack
 

--- a/docs-website/docs/pipeline-components/preprocessors/recursivesplitter.mdx
+++ b/docs-website/docs/pipeline-components/preprocessors/recursivesplitter.mdx
@@ -17,7 +17,7 @@ This component recursively breaks down text into smaller chunks by applying a gi
 | Mandatory run variables            | `documents`: A list of documents                                                                                                                       |
 | Output variables                   | `documents`: A list of documents                                                                                                                       |
 | API reference                      | [PreProcessors](/reference/preprocessors-api)                                                                                                                 |
-| Github link                        | https://github.com/deepset-ai/haystack/blob/main/haystack/components/preprocessors/recursive_splitter.py                                             |
+| GitHub link                        | https://github.com/deepset-ai/haystack/blob/main/haystack/components/preprocessors/recursive_splitter.py                                             |
 
 </div>
 


### PR DESCRIPTION
## Summary
- replace  with  in 
- replace  with  in the RecursiveSplitter docs table

## Why
Use consistent branding and terminology across docs for polish and clarity.