### PR TITLE
ci: update Hatch; do not pin virtualenv

### DIFF
--- a/.github/workflows/docusaurus_sync.yml
+++ b/.github/workflows/docusaurus_sync.yml
@@ -11,7 +11,7 @@ on:
       - ".github/workflows/docusaurus_sync.yml"
 
 env:
-  HATCH_VERSION: "1.16.4"
+  HATCH_VERSION: "1.16.5"
   PYTHON_VERSION: "3.11"
 
 jobs:
@@ -30,8 +30,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install Hatch
-        # https://github.com/pypa/hatch/issues/2193
-        run: pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+        run: pip install hatch==${{ env.HATCH_VERSION }}
 
       - name: Generate API reference for Docusaurus
         run: hatch run docs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ on:
 env:
   PYTHON_VERSION: "3.10"
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-  HATCH_VERSION: "1.16.4"
+  HATCH_VERSION: "1.16.5"
   # we use HF_TOKEN instead of HF_API_TOKEN to work around a Hugging Face bug
   # see https://github.com/deepset-ai/haystack/issues/9552
   HF_TOKEN: ${{ secrets.HUGGINGFACE_API_KEY }}
@@ -34,8 +34,7 @@ jobs:
         python-version: "${{ env.PYTHON_VERSION }}"
 
     - name: Install Hatch
-      # https://github.com/pypa/hatch/issues/2193
-      run: pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+      run: pip install hatch==${{ env.HATCH_VERSION }}
 
     - name: Run tests
       run: hatch run e2e:test

--- a/.github/workflows/nightly_testpypi_release.yml
+++ b/.github/workflows/nightly_testpypi_release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  HATCH_VERSION: "1.16.4"
+  HATCH_VERSION: "1.16.5"
 
 jobs:
   nightly-release:
@@ -33,8 +33,7 @@ jobs:
           echo "Building haystack-ai version: ${NIGHTLY_VERSION}"
 
       - name: Install Hatch
-        # https://github.com/pypa/hatch/issues/2193
-        run: pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+        run: pip install hatch==${{ env.HATCH_VERSION }}
 
       - name: Build Haystack
         run: hatch build

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -8,7 +8,7 @@ on:
       - "!v[0-9]+.[0-9]+.[0-9]-rc0"
 
 env:
-  HATCH_VERSION: "1.16.4"
+  HATCH_VERSION: "1.16.5"
 
 jobs:
   release-on-pypi:
@@ -19,8 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Hatch
-        # https://github.com/pypa/hatch/issues/2193
-        run: pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+        run: pip install hatch==${{ env.HATCH_VERSION }}
 
       - name: Build Haystack
         run: hatch build

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -14,7 +14,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HF_API_TOKEN: ${{ secrets.HUGGINGFACE_API_KEY }}
   PYTHON_VERSION: "3.10"
-  HATCH_VERSION: "1.16.4"
+  HATCH_VERSION: "1.16.5"
   HAYSTACK_MPS_ENABLED: false
   HAYSTACK_XPU_ENABLED: false
 
@@ -139,8 +139,7 @@ jobs:
         id: hatch
         shell: bash
         run: |
-          # https://github.com/pypa/hatch/issues/2193
-          pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+          pip install hatch==${{ env.HATCH_VERSION }}
 
       - name: Run Tika
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HF_API_TOKEN: ${{ secrets.HUGGINGFACE_API_KEY }}
   PYTHON_VERSION: "3.10"
-  HATCH_VERSION: "1.16.4"
+  HATCH_VERSION: "1.16.5"
 
 jobs:
   format:
@@ -47,8 +47,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install Hatch
-        # https://github.com/pypa/hatch/issues/2193
-        run: pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+        run: pip install hatch==${{ env.HATCH_VERSION }}
 
       - name: Ruff - check format and linting
         run: hatch run fmt-check
@@ -98,8 +97,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install Hatch
-        # https://github.com/pypa/hatch/issues/2193
-        run: pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+        run: pip install hatch==${{ env.HATCH_VERSION }}
 
       - name: Check imports
         run: hatch run python .github/utils/check_imports.py
@@ -158,8 +156,7 @@ jobs:
         id: hatch
         shell: bash
         run: |
-          # https://github.com/pypa/hatch/issues/2193
-          pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+          pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
       - name: Run
@@ -243,8 +240,7 @@ jobs:
         id: hatch
         if: steps.files.outputs.any_changed == 'true'
         run: |
-          # https://github.com/pypa/hatch/issues/2193
-          pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+          pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
       - name: Mypy
@@ -300,8 +296,7 @@ jobs:
         id: hatch
         shell: bash
         run: |
-          # https://github.com/pypa/hatch/issues/2193
-          pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+          pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
 
@@ -358,8 +353,7 @@ jobs:
         id: hatch
         shell: bash
         run: |
-          # https://github.com/pypa/hatch/issues/2193
-          pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+          pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache/restore@v5
@@ -422,8 +416,7 @@ jobs:
         id: hatch
         shell: bash
         run: |
-          # https://github.com/pypa/hatch/issues/2193
-          pip install hatch==${{ env.HATCH_VERSION }} "virtualenv<21.0.0"
+          pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
       - name: Run


### PR DESCRIPTION
### Related Issues

virtualenv has been pinned in #10695 due to incompatibilities with Hatch 1.16.4

With Hatch 1.16.5, the incompatibilty has been fixed

### Proposed Changes:
- update Hatch to 1.16.5
- do not pin virtualenv

### How did you test it?
CI; also tested locally


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
