### PR TITLE
ci: update release notes path to use only version number without 'v' prefix

### DIFF
--- a/.github/workflows/push_release_notes_to_website.yml
+++ b/.github/workflows/push_release_notes_to_website.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           VERSION_NUMBER="${VERSION:1}"
           RELEASE_DATE=$(gh release view "$VERSION" --repo deepset-ai/haystack --json publishedAt --jq '.publishedAt | split("T")[0]')
-          RELEASE_NOTES_PATH="content/release-notes/$VERSION.md"
+          RELEASE_NOTES_PATH="content/release-notes/$VERSION_NUMBER.md"
 
           {
             echo "---"


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

For consistency with existing release note files in https://github.com/deepset-ai/haystack-home, this PR updates the `push_release_notes_to_website.yml` workflow to use only the version number for the file name without the prefix 'v'.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
