### PR TITLE
ci: fix docker build for docker/bake-action@v7

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -59,8 +59,7 @@ jobs:
           IMAGE_TAG_SUFFIX: ${{ steps.meta.outputs.version }}
           HAYSTACK_VERSION: ${{ steps.meta.outputs.version }}
         with:
-          source: .
-          workdir: docker
+          source: ./docker
           targets: base
           push: true
 


### PR DESCRIPTION
### Related Issues

Failing Docker build on main: https://github.com/deepset-ai/haystack/actions/runs/22767613434/job/66039533682
due to https://github.com/docker/bake-action/releases/tag/v7.0.0

> The workdir input is now merged into source; use source for local and remote ([docs](https://github.com/docker/bake-action?tab=readme-ov-file#source-semantics))

### Proposed Changes:
- adapt the action inputs to new syntax

### How did you test it?
Hard to test in a PR (but possible). I'd prefer to try (and quickly revert if does not work).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
