### PR TITLE
docs: mention nightly prereleases in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ The simplest way to get Haystack is via pip:
 pip install haystack-ai
 ```
 
-Install from the `main` branch to try the newest features:
+Install nightly pre-releases to try the newest features:
 ```sh
-pip install git+https://github.com/deepset-ai/haystack.git@main
+pip install --pre haystack-ai
 ```
 
 Haystack supports multiple installation methods, including Docker images. For a comprehensive guide, please refer


### PR DESCRIPTION
I suggest we update installation instructions and mention nightly pre-releases instead of how to install from main branch.

### Related Issues

### Proposed Changes:

- Replace instructions for how to install from main branch with how to install nightly releases.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

Alternative is to keep things as is. I don't have a strong opinion.
@kacperlukawski I noticed that https://docs.haystack.deepset.ai/docs/installation doesn't mention installing from main branch and I assume that is intended? Would you agree that mentioning nightly pre-releases in the docs makes sense? Or better to keep it simple and not mention nightly pre-releases in the docs at all?

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
