### PR TITLE
feat(openai-responses): add SUPPORTED_MODELS and model docs link

### DIFF
--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -59,6 +59,7 @@ class OpenAIResponsesChatGenerator:
 
     For details on OpenAI API parameters, see
     [OpenAI documentation](https://platform.openai.com/docs/api-reference/responses).
+    For currently available models, see [OpenAI model docs](https://developers.openai.com/api/docs/models).
 
     ### Usage example
 
@@ -73,6 +74,23 @@ class OpenAIResponsesChatGenerator:
     print(response)
     ```
     """
+
+    SUPPORTED_MODELS = [
+        "gpt-5-mini",
+        "gpt-5-nano",
+        "gpt-5",
+        "gpt-5.1",
+        "gpt-5.2",
+        "gpt-5.2-pro",
+        "gpt-5-pro",
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-nano",
+        "gpt-4o",
+        "gpt-4o-mini",
+    ]
+    """A non-exhaustive list of Responses API models supported by this component.
+    See https://developers.openai.com/api/docs/models for the full list and snapshot IDs."""
 
     def __init__(
         self,

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -102,6 +102,13 @@ class RecordingCallback:
 
 
 class TestInitialization:
+    def test_supported_models(self):
+        """SUPPORTED_MODELS is a non-empty list of strings."""
+        models = OpenAIResponsesChatGenerator.SUPPORTED_MODELS
+        assert isinstance(models, list)
+        assert len(models) > 0
+        assert all(isinstance(m, str) for m in models)
+
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = OpenAIResponsesChatGenerator()


### PR DESCRIPTION
## Summary
- add SUPPORTED_MODELS class variable to OpenAIResponsesChatGenerator
- add class-level docstring note linking to OpenAI model documentation
- add unit test to assert SUPPORTED_MODELS is a non-empty list of strings

## Validation
- pytest -q test/components/generators/chat/test_openai_responses.py -k supported_models

Closes #10743