### PR TITLE
fix: allow multiple connections to Any-typed input sockets

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -955,7 +955,7 @@ class PipelineBase:  # noqa: PLW1641
         We automatically set the receiver socket as lazy variadic if:
             - it has at least one sender already connected
             - it's not already variadic
-            - its type is list or Optional[list]
+            - its type is list, Optional[list], or Any
 
         NOTE: We also disable wrapping inputs into list for these auto-variadic sockets, so the sender outputs match the
         type of the receiver socket.
@@ -975,8 +975,9 @@ class PipelineBase:  # noqa: PLW1641
             if len(non_none_args) == 1:
                 origin = _safe_get_origin(non_none_args[0])
 
-        # If the origin is list, we can make the socket lazy variadic
-        if origin == list:
+        # If the origin is list, or the type is Any (which is compatible with
+        # any type including lists), we can make the socket lazy variadic
+        if origin == list or receiver_socket.type is Any:
             receiver_socket.is_lazy_variadic = True
             receiver_socket.wrap_input_in_list = False
 

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -310,3 +310,28 @@ class TestPipeline:
             ChatMessage.from_user("Hello, world!"),
             ChatMessage.from_assistant("Hello, world!"),
         ]
+
+    def test_auto_variadic_connection_to_prompt_builder_any_typed_input(self):
+        """Regression test for #10721: connecting multiple outputs to PromptBuilder.documents
+        (typed as Any) should succeed because _make_socket_auto_variadic now handles Any."""
+        from haystack.components.builders import PromptBuilder
+        from haystack.document_stores.in_memory import InMemoryDocumentStore
+        from haystack.components.retrievers import InMemoryBM25Retriever
+
+        store1 = InMemoryDocumentStore()
+        store1.write_documents([Document(content="Document from store 1")])
+        store2 = InMemoryDocumentStore()
+        store2.write_documents([Document(content="Document from store 2")])
+
+        template = (
+            "{% for doc in documents %}{{ doc.content }} {% endfor %}"
+            "Question: {{ query }}"
+        )
+        p = Pipeline()
+        p.add_component("retriever_1", InMemoryBM25Retriever(document_store=store1))
+        p.add_component("retriever_2", InMemoryBM25Retriever(document_store=store2))
+        p.add_component("prompt_builder", PromptBuilder(template=template))
+
+        # Both connections must succeed (previously the 2nd raised PipelineConnectError)
+        p.connect("retriever_1.documents", "prompt_builder.documents")
+        p.connect("retriever_2.documents", "prompt_builder.documents")


### PR DESCRIPTION
## Summary

Fixes #10721 — connecting multiple outputs to `PromptBuilder.documents` fails with `PipelineConnectError` because `documents` is typed as `Any` and `_make_socket_auto_variadic` doesn't recognize it as variadic-eligible.

## Root Cause

`_make_socket_auto_variadic` only converts sockets to lazy variadic when their type origin is `list` (or `Optional[list]`). `PromptBuilder` sets all template variables to type `Any` via `component.set_input_type(self, var, Any)`. Since `get_origin(Any)` returns `None`, the function returns the socket unchanged, and the second `connect()` call raises `PipelineConnectError`.

## Fix

Add an `Any` type check in `_make_socket_auto_variadic`:

```python
if origin == list or receiver_socket.type is Any:
    receiver_socket.is_lazy_variadic = True
    receiver_socket.wrap_input_in_list = False
```

`Any` is compatible with any type including lists, so it's safe to allow variadic connections.

## Tests

Added `test_auto_variadic_connection_to_prompt_builder_any_typed_input` — reproduces the exact scenario from #10721 with two `InMemoryBM25Retriever` outputs connected to `PromptBuilder.documents`. All 11 pipeline tests pass.
