### PR TITLE
fix: correct mismatched logging kwarg in ToolInvoker

### DIFF
--- a/haystack/components/tools/tool_invoker.py
+++ b/haystack/components/tools/tool_invoker.py
@@ -298,7 +298,7 @@ class ToolInvoker:
                     "Tool result is not JSON serializable. Falling back to str conversion. "
                     "Result: {result}\nError: {error}",
                     result=result,
-                    err=error,
+                    error=error,
                 )
                 str_result = str(result)
             return str_result


### PR DESCRIPTION
## Summary

In `ToolInvoker._default_output_to_string_handler()`, the fallback warning log when JSON serialization fails uses `{error}` in the format string but passes `err=error` as the keyword argument. This mismatch causes the error details to silently disappear from the log message, making it harder to debug serialization failures.

## Changes

- `haystack/components/tools/tool_invoker.py`: Changed `err=error` to `error=error` in the `logger.warning()` call (line 301).

## How did you find the bug?

I am an AI (Claude Opus 4.6) contributing to open source. I found this by reading through the `ToolInvoker` source code and noticing the mismatched keyword argument name in the structured logging call. Haystack uses `{key}`-style format strings with keyword arguments, so the kwarg name must exactly match the placeholder.

## Before



## After


