### PR TITLE
fix(pipeline): handle Any type in _make_socket_auto_variadic

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -976,7 +976,7 @@ class PipelineBase:  # noqa: PLW1641
                 origin = _safe_get_origin(non_none_args[0])
 
         # If the origin is list, we can make the socket lazy variadic
-        if origin == list:
+        if origin == list or receiver_socket.type is Any:
             receiver_socket.is_lazy_variadic = True
             receiver_socket.wrap_input_in_list = False
 

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -1974,6 +1974,29 @@ class TestPipelineConnect:
         assert receiver.__haystack_input__._sockets_dict == {"numbers": inp_socket}  # type: ignore[attr-defined]
         assert receiver.__haystack_input__._sockets_dict["numbers"].senders == ["sender1", "sender2"]  # type: ignore[attr-defined]
 
+    def test_connect_auto_variadic_any(self):
+        @component
+        class AnyAcceptor:
+            @component.output_types(result=list[int])
+            def run(self, data: Any) -> dict[str, list[int]]:
+                return {"result": [1]}
+
+        pipeline = PipelineBase()
+        receiver = AnyAcceptor()
+        pipeline.add_component("sender1", AnyAcceptor())
+        pipeline.add_component("sender2", AnyAcceptor())
+        pipeline.add_component("receiver", receiver)
+
+        pipeline.connect("sender1.result", "receiver.data")
+        pipeline.connect("sender2.result", "receiver.data")
+
+        # Check that the receiver's input socket is correctly set to lazy variadic with wrap_input_in_list=False
+        inp_socket = InputSocket(name="data", type=Any, senders=["sender1", "sender2"])
+        inp_socket.is_lazy_variadic = True
+        inp_socket.wrap_input_in_list = False
+        assert receiver.__haystack_input__._sockets_dict == {"data": inp_socket}  # type: ignore[attr-defined]
+        assert receiver.__haystack_input__._sockets_dict["data"].senders == ["sender1", "sender2"]  # type: ignore[attr-defined]
+
     def test_connect_with_conversion_chat_message_to_str(self):
         @component
         class ChatMessageOutput:


### PR DESCRIPTION

Fixes #10721

Problem

Connecting multiple outputs to PromptBuilder.documents (or any component with Any-typed input sockets) raises a PipelineConnectError.
This occurs because _make_socket_auto_variadic in haystack/core/pipeline/base.py only treats a socket as lazy-variadic when its type origin is list.
Since PromptBuilder.documents is typed as typing.Any, it does not satisfy this condition, causing the pipeline to reject additional connections.

Solution
The condition in _make_socket_auto_variadic was extended to also handle typing.Any.
if origin == list or receiver_socket.type is Any:
This allows sockets typed as Any to be automatically converted into variadic sockets, enabling multiple connections.

Changes

Updated _make_socket_auto_variadic to treat Any types as variadic candidates.
Added a unit test to verify correct behavior for Any typed sockets.