### PR TITLE
test: replace OpenAPIConnector flaky integration test

### DIFF
--- a/test/components/connectors/test_openapi_connector.py
+++ b/test/components/connectors/test_openapi_connector.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
-import sys
 from unittest.mock import Mock, patch
 
 import pytest
@@ -194,17 +194,36 @@ class TestOpenAPIConnectorIntegration:
         assert isinstance(response, dict)
         assert "response" in response
 
-    @pytest.mark.skipif(
-        not os.environ.get("GITHUB_TOKEN", None), reason="Export an env var called GITHUB_TOKEN to run this test."
-    )
     @pytest.mark.integration
-    @pytest.mark.skipif(sys.platform != "linux", reason="We only test on Linux to avoid hitting rate limits")
-    @pytest.mark.flaky(reruns=3, reruns_delay=10)
-    def test_github_api_integration(self):
-        component = OpenAPIConnector(
-            openapi_spec="https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
-            credentials=Secret.from_env_var("GITHUB_TOKEN"),
+    def test_open_meteo_integration(self):
+        open_meteo_spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Open-Meteo Weather API", "version": "1.0.0"},
+            "servers": [{"url": "https://api.open-meteo.com"}],
+            "paths": {
+                "/v1/forecast": {
+                    "get": {
+                        "operationId": "get_forecast",
+                        "parameters": [
+                            {"name": "latitude", "in": "query", "required": True, "schema": {"type": "number"}},
+                            {"name": "longitude", "in": "query", "required": True, "schema": {"type": "number"}},
+                            {"name": "current", "in": "query", "required": False, "schema": {"type": "string"}},
+                        ],
+                        "responses": {"200": {"description": "Weather forecast"}},
+                    }
+                }
+            },
+        }
+        component = OpenAPIConnector(openapi_spec=json.dumps(open_meteo_spec))
+        response = component.run(
+            operation_id="get_forecast", arguments={"latitude": 52.52, "longitude": 13.41, "current": "temperature_2m"}
         )
-        response = component.run(operation_id="search_repos", arguments={"q": "deepset-ai"})
         assert isinstance(response, dict)
         assert "response" in response
+
+        weather_data = response["response"]
+        assert isinstance(weather_data, dict)
+        assert weather_data["latitude"] == pytest.approx(52.52, abs=0.1)
+        assert weather_data["longitude"] == pytest.approx(13.41, abs=0.1)
+        assert "current" in weather_data
+        assert "temperature_2m" in weather_data["current"]


### PR DESCRIPTION
### Related Issues

Flaky test reported in https://github.com/deepset-ai/haystack/issues/10341#issuecomment-3944892741

> FAILED test/components/connectors/test_openapi_connector.py::TestOpenAPIConnectorIntegration::test_github_api_integration - openapi_llm.utils.HttpClientError: HTTP error occurred: 403 Client Error: rate limit exceeded for url: https://api.github.com/search/repositories?q=deepset-ai
= 1 failed, 277 passed, 13 skipped, 4756 deselected, 4 warnings, 3 rerun in 210.51s (0:03:30) =

We tried fixing it in the past but GitHub still raises rate limits errors

### Proposed Changes:
- replace the OpenAPI connector GitHub integration tests with [Open Meteo](https://open-meteo.com/en/pricing): free API, no authentication, max 600 calls per minute on the free plan (a lot)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
