### PR TITLE
chore: Change ruff dependency version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
 installer = "uv"
 dependencies = [
   "pre-commit",
-  "ruff",
+  "ruff>=0.15.0",  # RUF104 (unmatched-suppression-comment) added in 0.15.0
   "toml",
   "reno",
   # dulwich is a reno dependency, they pin it at >=0.15.0 so pip takes ton of time to resolve the dependency tree.


### PR DESCRIPTION
### Related Issues

We refer to RUF104 in pyproject.toml, which was added in ruff 0.15.0 in February. As a consequence, running `hatch run fmt` will fail with older ruff versions installed.

```bash
hatch run fmt
ruff failed
  Cause: Failed to parse haystack/pyproject.toml
  Cause: TOML parse error at line 286, column 3
    |
286 |   "RUF104", # unmatched-suppression-comment
    |   ^^^^^^^^
Unknown rule selector: `RUF104`

ruff failed
  Cause: Failed to parse haystack/pyproject.toml
  Cause: TOML parse error at line 286, column 3
    |
286 |   "RUF104", # unmatched-suppression-comment
    |   ^^^^^^^^
Unknown rule selector: `RUF104`
```

### Proposed Changes:

Update ruff dependency to require version >=0.15.0.

### How did you test it?

Tested locally

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
