### PR TITLE
feat: Add runtime validation warning for mismatched component output keys

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -419,6 +419,26 @@ class Pipeline(PipelineBase):
                     error.pipeline_snapshot_file_path = full_file_path
                     raise error
 
+                # Validate that the component's output keys match its declared output sockets.
+                # A mismatch (e.g. returning {"wrong_key": ...} when output_types declares "some_key")
+                # would silently cause downstream components to never receive input, eventually
+                # triggering a misleading "Pipeline Blocked" error.
+                expected_output_keys = set(component.get("output_sockets", {}).keys())
+                actual_output_keys = set(component_outputs.keys())
+                unexpected_keys = actual_output_keys - expected_output_keys
+                missing_keys = expected_output_keys - actual_output_keys
+                if unexpected_keys:
+                    logger.warning(
+                        "Component '{component_name}' returned unexpected output keys: {unexpected_keys}. "
+                        "Declared output keys are: {expected_keys}. "
+                        "This is likely a bug in the component's run() method — the returned dictionary keys "
+                        "must match the keys declared via @component.output_types(). "
+                        "Downstream components connected to the declared keys will not receive any input.",
+                        component_name=component_name,
+                        unexpected_keys=unexpected_keys,
+                        expected_keys=expected_output_keys,
+                    )
+
                 # Updates global input state with component outputs and returns outputs that should go to
                 # pipeline outputs.
                 component_pipeline_outputs = self._write_component_outputs(

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -311,3 +311,36 @@ class TestPipeline:
             ChatMessage.from_user("Hello, world!"),
             ChatMessage.from_assistant("Hello, world!"),
         ]
+
+    def test_pipeline_warns_on_mismatched_component_output_keys(self, caplog):
+        """
+        Test that the pipeline emits a warning when a component returns output keys
+        that don't match its declared @component.output_types().
+        This helps users debug misleading 'Pipeline Blocked' errors caused by
+        misconfigured custom components (see issue #10655).
+        """
+
+        @component
+        class MismatchedOutput:
+            @component.output_types(some_key=str)
+            def run(self, inp: str) -> dict[str, str]:
+                return {"wrong_key": inp}  # Returns wrong key
+
+        @component
+        class Receiver:
+            @component.output_types(result=str)
+            def run(self, some_key: str) -> dict[str, str]:
+                return {"result": some_key}
+
+        p = Pipeline()
+        p.add_component("mismatched", MismatchedOutput())
+        p.add_component("receiver", Receiver())
+        p.connect("mismatched.some_key", "receiver.some_key")
+
+        with caplog.at_level(logging.WARNING):
+            # The pipeline will run but receiver won't get input due to key mismatch
+            result = p.run({"mismatched": {"inp": "hello"}})
+
+        # Verify the warning was emitted about unexpected output keys
+        assert any("unexpected output keys" in record.message for record in caplog.records)
+        assert any("wrong_key" in record.message for record in caplog.records)


### PR DESCRIPTION
Fixes #10655

## Summary

When a custom component returns dictionary keys that don't match its declared `@component.output_types()`, downstream components silently never receive input, eventually causing a misleading **"Pipeline Blocked"** error. This makes the real issue (a misconfigured component) very hard to debug.

This PR adds a runtime warning in `Pipeline.run()` that catches this mismatch immediately after a component executes.

## Problem

```python
@component
class MyComp:
    @component.output_types(some_key=str)
    def run(self, inp: str):
        return {"wrong_key": inp}  # Bug: wrong key
```

When connected as `pipe.connect("mycomp.some_key", "comp2.query")`, the connection succeeds at build time (validated against `output_types`), but at runtime `comp2` never receives input because the actual output dict has `wrong_key` instead of `some_key`. This eventually triggers a `Pipeline Blocked` error pointing at `comp2` — not the real culprit.

## Solution

After `_run_component()` returns, we now compare the actual output keys against the declared `output_sockets` for that component. If there are unexpected keys, a warning is logged:

```
WARNING - Component 'mismatched' returned unexpected output keys: {'wrong_key'}.
Declared output keys are: {'some_key'}.
This is likely a bug in the component's run() method — the returned dictionary keys
must match the keys declared via @component.output_types().
Downstream components connected to the declared keys will not receive any input.
```

This warning appears **before** the "Pipeline Blocked" error, giving users a clear pointer to the actual problem.

## Changes

- **`haystack/core/pipeline/pipeline.py`**: Added output key validation after component execution in `Pipeline.run()`
- **`test/core/pipeline/test_pipeline.py`**: Added unit test with a deliberately misconfigured component that verifies the warning is emitted

## Test Results

```
test_pipeline.py::TestPipeline::test_pipeline_warns_on_mismatched_component_output_keys PASSED

WARNING  Component 'mismatched' returned unexpected output keys: {'wrong_key'}.
Declared output keys are: {'some_key'}.
```