### PR TITLE
docs: Add documentation for LLMRanker component

### DIFF
--- a/docs-website/docs/pipeline-components/rankers.mdx
+++ b/docs-website/docs/pipeline-components/rankers.mdx
@@ -16,6 +16,7 @@ Rankers are a group of components that order documents by given criteria. Their 
 | [FastembedRanker](rankers/fastembedranker.mdx) | Ranks documents based on their similarity to the query using cross-encoder models supported by FastEmbed. |
 | [HuggingFaceTEIRanker](rankers/huggingfaceteiranker.mdx) | Ranks documents based on their similarity to the query using a Text Embeddings Inference (TEI) API endpoint. |
 | [JinaRanker](rankers/jinaranker.mdx) | Ranks documents based on their similarity to the query using Jina AI models. |
+| [LLMRanker](rankers/llmranker.mdx) | Ranks documents based on their relevance to a query using a Large Language Model and JSON-formatted output. |
 | [LostInTheMiddleRanker](rankers/lostinthemiddleranker.mdx) | Positions the most relevant documents at the beginning and at the end of the resulting list while placing the least relevant documents in the middle, based on a [research paper](https://arxiv.org/abs/2307.03172). |
 | [MetaFieldRanker](rankers/metafieldranker.mdx) | A lightweight Ranker that orders documents based on a specific metadata field value. |
 | [MetaFieldGroupingRanker](rankers/metafieldgroupingranker.mdx) | Reorders the documents by grouping them based on metadata keys. |

--- a/docs-website/docs/pipeline-components/rankers/llmranker.mdx
+++ b/docs-website/docs/pipeline-components/rankers/llmranker.mdx
@@ -1,0 +1,204 @@
+---
+title: "LLMRanker"
+id: llmranker
+slug: "/llmranker"
+description: "Use this component to rank documents based on their relevance to a query using a Large Language Model. LLMRanker leverages a ChatGenerator to evaluate and rerank documents based on JSON-formatted output."
+---
+
+# LLMRanker
+
+Use this component to rank documents based on their relevance to a query using a Large Language Model. `LLMRanker` leverages a `ChatGenerator` to evaluate and rerank documents based on JSON-formatted output.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | In a query pipeline, after a component that returns a list of documents such as a [Retriever](../retrievers.mdx) |
+| **Mandatory init variables** | None (uses default `OpenAIChatGenerator` if `chat_generator` not provided) |
+| **Mandatory run variables** | `documents`: A list of documents  <br /> <br />`query`: A query string |
+| **Output variables** | `documents`: A list of documents |
+| **API reference** | [Rankers](/reference/rankers-api) |
+| **GitHub link** | https://github.com/deepset-ai/haystack/blob/main/haystack/components/rankers/llm_ranker.py |
+
+</div>
+
+## Overview
+
+`LLMRanker` ranks documents based on their relevance to a query using a Large Language Model. The component sends the documents and query to an LLM with a structured prompt, and the LLM returns a JSON object containing the ranked document indices. The documents are then reordered based on the LLM's ranking, with the most relevant documents appearing first.
+
+By default, `LLMRanker` uses `OpenAIChatGenerator` with the `gpt-4.1-mini` model configured for JSON output. However, you can provide any `ChatGenerator` compatible component, allowing you to use different models or providers.
+
+The component handles various edge cases gracefully:
+- Duplicate documents are automatically deduplicated before ranking
+- If the LLM returns an empty ranking, an empty list is returned
+- If the LLM response cannot be parsed or is invalid, the component can either raise an error or fall back to returning documents in their original order (controlled by the `raise_on_failure` parameter)
+
+`LLMRanker` is most useful in query pipelines, such as retrieval-augmented generation (RAG) pipelines or document search pipelines, to improve document ordering based on semantic relevance. You can use it after a Retriever to refine the search results.
+
+### Authorization
+
+The default `OpenAIChatGenerator` requires an `OPENAI_API_KEY` environment variable. If using a custom `ChatGenerator`, ensure it is properly configured with the necessary API credentials.
+
+## Usage
+
+### On its own
+
+You can use `LLMRanker` outside of a pipeline to order documents based on your query.
+
+This example uses the `LLMRanker` with the default OpenAI configuration to rank documents:
+
+```python
+import os
+from haystack import Document
+from haystack.components.rankers import LLMRanker
+
+# Set your OpenAI API key
+os.environ["OPENAI_API_KEY"] = "your-api-key"
+
+ranker = LLMRanker()
+
+docs = [
+    Document(content="Paris is the capital of France."),
+    Document(content="Berlin is the capital of Germany."),
+    Document(content="Madrid is the capital of Spain."),
+]
+
+query = "What is the capital of Germany?"
+result = ranker.run(query=query, documents=docs, top_k=2)
+
+docs = result["documents"]
+print(docs[0].content)  # Most relevant document
+```
+
+### With a custom ChatGenerator
+
+You can provide a custom `ChatGenerator` to use a different model or provider:
+
+```python
+from haystack import Document
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.rankers import LLMRanker
+
+# Configure a custom chat generator
+chat_generator = OpenAIChatGenerator(
+    model="gpt-4",
+    generation_kwargs={
+        "temperature": 0.0,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "document_ranking",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "documents": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {"index": {"type": "integer"}},
+                                "required": ["index"],
+                            },
+                        }
+                    },
+                    "required": ["documents"],
+                },
+            },
+        },
+    },
+)
+
+ranker = LLMRanker(chat_generator=chat_generator)
+
+docs = [
+    Document(content="Python is a programming language."),
+    Document(content="JavaScript runs in browsers."),
+    Document(content="Rust is a systems language."),
+]
+
+result = ranker.run(query="Which language runs in web browsers?", documents=docs)
+```
+
+### In a pipeline
+
+`LLMRanker` is most efficient in query pipelines when used after a Retriever.
+
+Below is an example of a pipeline that retrieves documents from an `InMemoryDocumentStore` using `InMemoryBM25Retriever`, then uses `LLMRanker` to rerank the retrieved documents based on their relevance to the query:
+
+```python
+import os
+from haystack import Document, Pipeline
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+from haystack.components.rankers import LLMRanker
+
+# Set your OpenAI API key
+os.environ["OPENAI_API_KEY"] = "your-api-key"
+
+docs = [
+    Document(content="Paris is the capital of France."),
+    Document(content="Berlin is the capital of Germany."),
+    Document(content="Madrid is the capital of Spain."),
+]
+document_store = InMemoryDocumentStore()
+document_store.write_documents(docs)
+
+retriever = InMemoryBM25Retriever(document_store=document_store)
+ranker = LLMRanker()
+
+document_ranker_pipeline = Pipeline()
+document_ranker_pipeline.add_component(instance=retriever, name="retriever")
+document_ranker_pipeline.add_component(instance=ranker, name="ranker")
+
+document_ranker_pipeline.connect("retriever.documents", "ranker.documents")
+
+query = "What is the capital of Germany?"
+result = document_ranker_pipeline.run(
+    data={
+        "retriever": {"query": query, "top_k": 5},
+        "ranker": {"query": query, "top_k": 2},
+    },
+)
+```
+
+### With a custom prompt
+
+You can customize the prompt used for ranking by providing a custom prompt template. The prompt must include exactly the variables `query` and `documents`:
+
+```python
+from haystack import Document
+from haystack.components.rankers import LLMRanker
+
+custom_prompt = """
+Rank these documents by relevance to the query. Return JSON with document indices.
+Only include relevant documents.
+
+Query: {{ query }}
+
+Documents:
+{% for document in documents %}
+{{ loop.index }}. {{ document.content or "" }}
+{% endfor %}
+
+Return format: {"documents": [{"index": 1}, ...]}
+""".strip()
+
+ranker = LLMRanker(prompt=custom_prompt)
+```
+
+## Configuration Options
+
+The following parameters can be set when initializing `LLMRanker`:
+
+- **`chat_generator`** (optional): The `ChatGenerator` to use for ranking. If not provided, defaults to `OpenAIChatGenerator` with `gpt-4.1-mini` model configured for JSON output.
+
+- **`prompt`** (optional): A custom prompt template for reranking. Must include exactly the variables `query` and `documents`. Defaults to a standard ranking prompt.
+
+- **`top_k`** (optional, default: 10): The maximum number of documents to return.
+
+- **`raise_on_failure`** (optional, default: False): If `True`, raises an exception when generation or response parsing fails. If `False`, logs a warning and returns documents in their original order.
+
+You can also override `top_k` at runtime by passing it to the `run()` method:
+
+```python
+result = ranker.run(query=query, documents=docs, top_k=5)
+```

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -484,6 +484,7 @@ export default {
             'pipeline-components/rankers/fastembedranker',
             'pipeline-components/rankers/huggingfaceteiranker',
             'pipeline-components/rankers/jinaranker',
+            'pipeline-components/rankers/llmranker',
             'pipeline-components/rankers/lostinthemiddleranker',
             'pipeline-components/rankers/metafieldgroupingranker',
             'pipeline-components/rankers/metafieldranker',


### PR DESCRIPTION
## Description

This PR adds comprehensive documentation for the new LLMRanker component that was introduced in PR #10794.

## Changes

- Added  with:
  - Component overview and description
  - Key-value table with mandatory and optional parameters
  - Standalone usage example with default OpenAI configuration
  - Custom ChatGenerator usage example
  - Pipeline integration example with InMemoryBM25Retriever
  - Custom prompt template example
  - Configuration options documentation
  
- Updated  to include LLMRanker in the navigation menu
  
- Updated  to add LLMRanker to the overview table

## Related Issue

Fixes #10800

## CLA Confirmation

I have read and agree to the Contributor License Agreement.