### PR TITLE
chore: add 2 return type hints in test_evaluation_pipeline.py

### DIFF
--- a/e2e/pipelines/test_evaluation_pipeline.py
+++ b/e2e/pipelines/test_evaluation_pipeline.py
@@ -95,7 +95,7 @@ def evaluation_pipeline():
     return eval_pipeline
 
 
-def built_eval_input(questions, truth_docs, truth_answers, retrieved_docs, contexts, pred_answers):
+def built_eval_input(questions, truth_docs, truth_answers, retrieved_docs, contexts, pred_answers) -> dict:
     """Helper function to build the input for the evaluation pipeline"""
     return {
         "doc_mrr": {"ground_truth_documents": truth_docs, "retrieved_documents": retrieved_docs},
@@ -134,7 +134,7 @@ def run_rag_pipeline(documents, evaluation_questions, rag_pipeline_a):
     return contexts, predicted_answers, retrieved_docs, truth_docs
 
 
-def built_input_for_results_eval(rag_results):
+def built_input_for_results_eval(rag_results) -> dict:
     """Helper function to build the input for the results evaluation"""
     return {
         "Mean Reciprocal Rank": {


### PR DESCRIPTION
## Summary
Added concrete return type annotations to functions in `e2e/pipelines/test_evaluation_pipeline.py` based on static analysis of return statements.

## Changes
- Add return type hint `-> dict` to function
- Add return type hint `-> dict` to function

## Type of Change
- [x] Code quality improvement (type hints)
- [ ] Bug fix
- [ ] New feature

## Motivation
These type annotations are inferred from actual return values in the function bodies (e.g. `return True` → `-> bool`, `return []` → `-> list`). They improve:
- **IDE autocompletion** and type checking (mypy/pyright)
- **Code readability** for contributors navigating the codebase
- **Bug prevention** via static analysis

No functional changes — only type annotations added.
