### PR TITLE
ci: auto-approve and merge API reference sync PRs

### DIFF
--- a/.github/workflows/auto_approve_api_ref_sync.yml
+++ b/.github/workflows/auto_approve_api_ref_sync.yml
@@ -22,7 +22,8 @@ jobs:
   auto-approve-and-merge:
     if: |
       github.event.pull_request.user.login == 'HaystackBot' &&
-      startsWith(github.event.pull_request.head.ref, 'sync-docusaurus-api-reference')
+      startsWith(github.event.pull_request.head.ref, 'sync-docusaurus-api-reference') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-slim
     steps:
       - name: Approve PR


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/217

### Proposed Changes:

- create a workflow that detects automatically generated API reference sync PRs, approves and merges them
  - uses GitHub bot: it might work since the PR author is a different user (HaystackBot); should also be compatible with our repo settings
  - targets specific paths, PR author and branch names to restrict the scope
  - It uses `--auto` to merge PRs: they will be merged only after the required checks (from Branch Protection Rules) finish running. It's worth noting that Vercel deployments are not included in Branch Protection Rules, so we won't wait for them. To prevent broken builds (that, however, would not break the website), I already added a workflow to check API reference <-> Docusaurus compliance in https://github.com/deepset-ai/haystack/pull/10843.

### How did you test it?
I haven't found a good way to test it before merging.
Worst-case scenario: it won't approve and merge PRs. So it should be safe to merge.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
