### PR TITLE
fix: correct BM25 average document length calculation

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -476,7 +476,8 @@ class InMemoryDocumentStore:
 
             self._bm25_attr[document.id] = BM25DocumentStats(Counter(tokens), len(tokens))
             self._freq_vocab_for_idf.update(set(tokens))
-            self._avg_doc_len = (len(tokens) + self._avg_doc_len * len(self._bm25_attr)) / (len(self._bm25_attr) + 1)
+            n = len(self._bm25_attr)  # N already includes the new document
+            self._avg_doc_len = (len(tokens) + self._avg_doc_len * (n - 1)) / n
         return written_documents
 
     def delete_documents(self, document_ids: list[str]) -> None:


### PR DESCRIPTION
## Summary

- **Bug:** In `InMemoryDocumentStore._write_documents`, the incremental average document length (`_avg_doc_len`) was computed with an off-by-one error in the denominator.
- **Root cause:** The new document is inserted into `_bm25_attr` *before* the average is updated, so `len(self._bm25_attr)` is already N (the new total). The old formula divided by `len(self._bm25_attr) + 1` (i.e., N+1), making the denominator one too large every time a document is added.
- **Fix:** Capture `n = len(self._bm25_attr)` (which already equals N after the insertion) and apply the standard incremental-mean formula: `avg_new = (new_len + avg_old * (n - 1)) / n`.

### Before (buggy)
```python
self._avg_doc_len = (len(tokens) + self._avg_doc_len * len(self._bm25_attr)) / (len(self._bm25_attr) + 1)
```

### After (fixed)
```python
n = len(self._bm25_attr)  # N already includes the new document
self._avg_doc_len = (len(tokens) + self._avg_doc_len * (n - 1)) / n
```

### Impact
`_avg_doc_len` is used in all three BM25 scoring variants (BM25Okapi, BM25L, BM25Plus) to normalise document length. An underestimated average causes over-normalisation of longer documents, reducing their relevance scores and degrading retrieval quality.

> This PR was fully AI-generated using Claude Code.

## Test plan
- [ ] Verify `_avg_doc_len` equals the true arithmetic mean of token counts after writing N documents
- [ ] Run existing BM25 unit tests: `hatch run test:unit`
- [ ] Confirm BM25 scores are consistent with expected values for a known corpus