### PR TITLE
fix: correct logging kwarg name in ToolInvoker serialization warning

### DIFF
--- a/haystack/components/tools/tool_invoker.py
+++ b/haystack/components/tools/tool_invoker.py
@@ -298,7 +298,7 @@ class ToolInvoker:
                     "Tool result is not JSON serializable. Falling back to str conversion. "
                     "Result: {result}\nError: {error}",
                     result=result,
-                    err=error,
+                    error=error,
                 )
                 str_result = str(result)
             return str_result


### PR DESCRIPTION
## Summary

- **Bug:** In `ToolInvoker._convert_result_to_string`, a `logger.warning` call uses the template placeholder `{error}` but passes the exception as the keyword argument `err=error`.
- **Root cause:** Keyword argument name mismatch — `err` does not match the placeholder `{error}`, so structured logging libraries (e.g. `structlog` or `logging`) leave the placeholder un-substituted, rendering the log message as the literal string `"…Error: {error}"` instead of showing the actual exception.
- **Fix:** Rename the kwarg from `err=error` to `error=error` so it matches the `{error}` placeholder.

### Before (buggy)
```python
logger.warning(
    "Tool result is not JSON serializable. Falling back to str conversion. "
    "Result: {result}\nError: {error}",
    result=result,
    err=error,       # ← kwarg name doesn't match placeholder {error}
)
```

### After (fixed)
```python
logger.warning(
    "Tool result is not JSON serializable. Falling back to str conversion. "
    "Result: {result}\nError: {error}",
    result=result,
    error=error,     # ← matches placeholder {error}
)
```

### Impact
When a tool returns a non-JSON-serializable result, the warning log message silently swallows the actual exception details, making it very hard to diagnose why serialisation failed.

> This PR was fully AI-generated using Claude Code.

## Test plan
- [ ] Trigger the warning path (pass a non-serializable tool result) and confirm the log output includes the actual exception text
- [ ] Run existing ToolInvoker unit tests: `hatch run test:unit`