### PR TITLE
fix: Fix off-by-one error in BM25 average document length calculation in InMemoryDocumentStore

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -476,7 +476,9 @@ class InMemoryDocumentStore:
 
             self._bm25_attr[document.id] = BM25DocumentStats(Counter(tokens), len(tokens))
             self._freq_vocab_for_idf.update(set(tokens))
-            self._avg_doc_len = (len(tokens) + self._avg_doc_len * len(self._bm25_attr)) / (len(self._bm25_attr) + 1)
+            # Update avg doc len based on the new document and the previous average
+            n_docs = len(self._bm25_attr)
+            self._avg_doc_len = (len(tokens) + self._avg_doc_len * (n_docs - 1)) / n_docs
         return written_documents
 
     def delete_documents(self, document_ids: list[str]) -> None:

--- a/releasenotes/notes/fix-off-by-one-bm25-memory-9db7faa7cb0ac564.yaml
+++ b/releasenotes/notes/fix-off-by-one-bm25-memory-9db7faa7cb0ac564.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an off-by-one error in ``InMemoryDocumentStore.write_documents`` that caused the BM25
+    average document length to be systematically underestimated.

--- a/test/core/pipeline/features/test_run.py
+++ b/test/core/pipeline/features/test_run.py
@@ -779,7 +779,7 @@ def pipeline_that_has_a_greedy_and_variadic_component_after_a_component_with_def
                                 Document(
                                     id="328f0cbb6722c5cfa290aa2b78bcda8dc5afa09f0e2c23092afc502ba89c85e7",
                                     content="This is a simple document",
-                                    score=0.5993376509412102,
+                                    score=0.7192051811294521,
                                 )
                             ]
                         ]
@@ -789,7 +789,7 @@ def pipeline_that_has_a_greedy_and_variadic_component_after_a_component_with_def
                             Document(
                                 id="328f0cbb6722c5cfa290aa2b78bcda8dc5afa09f0e2c23092afc502ba89c85e7",
                                 content="This is a simple document",
-                                score=0.5993376509412102,
+                                score=0.7192051811294521,
                             )
                         ],
                         "query": "This is my question",
@@ -865,13 +865,13 @@ def pipeline_that_has_a_component_with_only_default_inputs(pipeline_class):
                                     Document(
                                         id="413dccdf51a54cca75b7ed2eddac04e6e58560bd2f0caf4106a3efc023fe3651",
                                         content="Paris is the capital of France",
-                                        score=1.600237583702734,
+                                        score=1.7780417596697045,
                                         meta={"source_index": 1},
                                     ),
                                     Document(
                                         id="a4a874fc2ef75015da7924d709fbdd2430e46a8e94add6e0f26cd32c1c03435d",
                                         content="Rome is the capital of Italy",
-                                        score=1.2536639934227616,
+                                        score=1.3448247718197388,
                                         meta={"source_index": 2},
                                     ),
                                 ],
@@ -886,12 +886,12 @@ def pipeline_that_has_a_component_with_only_default_inputs(pipeline_class):
                             Document(
                                 id="413dccdf51a54cca75b7ed2eddac04e6e58560bd2f0caf4106a3efc023fe3651",
                                 content="Paris is the capital of France",
-                                score=1.600237583702734,
+                                score=1.7780417596697045,
                             ),
                             Document(
                                 id="a4a874fc2ef75015da7924d709fbdd2430e46a8e94add6e0f26cd32c1c03435d",
                                 content="Rome is the capital of Italy",
-                                score=1.2536639934227616,
+                                score=1.3448247718197388,
                             ),
                         ],
                         "meta": None,
@@ -912,12 +912,12 @@ def pipeline_that_has_a_component_with_only_default_inputs(pipeline_class):
                             Document(
                                 id="413dccdf51a54cca75b7ed2eddac04e6e58560bd2f0caf4106a3efc023fe3651",
                                 content="Paris is the capital of France",
-                                score=1.600237583702734,
+                                score=1.7780417596697045,
                             ),
                             Document(
                                 id="a4a874fc2ef75015da7924d709fbdd2430e46a8e94add6e0f26cd32c1c03435d",
                                 content="Rome is the capital of Italy",
-                                score=1.2536639934227616,
+                                score=1.3448247718197388,
                             ),
                         ],
                         "query": "What is the capital of France?",
@@ -2473,7 +2473,7 @@ def that_is_linear_and_a_component_in_the_middle_receives_optional_input_from_ot
                                 content="some text about investigation and treatment of Alzheimer disease",
                                 meta={"year": 2023, "disease": "Alzheimer", "author": "John Bread"},
                                 id="doc2",
-                                score=4.046232292105687,
+                                score=4.148111588215998,
                             )
                         ]
                     }
@@ -2487,7 +2487,7 @@ def that_is_linear_and_a_component_in_the_middle_receives_optional_input_from_ot
                                     id="doc2",
                                     content="some text about investigation and treatment of Alzheimer disease",
                                     meta={"year": 2023, "disease": "Alzheimer", "author": "John Bread"},
-                                    score=4.046232292105687,
+                                    score=4.148111588215998,
                                 )
                             ]
                         ],

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -737,3 +737,32 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         results = doc_store.bm25_retrieval(query="R programming", top_k=1)
         assert len(results) == 1
         assert results[0].content == "I like R"
+
+    def test_bm25_avg_doc_len_correctness(self):
+        """Average document length should be computed correctly after writes."""
+        doc_store = InMemoryDocumentStore()
+        # Write documents with known token counts.
+        # "hello world" -> 2 tokens, "foo bar baz" -> 3 tokens, "go" -> 1 token
+        doc_store.write_documents(
+            [
+                Document(content="hello world", id="d1"),
+                Document(content="foo bar baz", id="d2"),
+                Document(content="go", id="d3"),
+            ]
+        )
+        # Average should be (2 + 3 + 1) / 3 = 2.0
+        assert doc_store._avg_doc_len == pytest.approx(2.0)
+
+    def test_bm25_avg_doc_len_after_delete(self):
+        """Average document length should remain correct after deletion."""
+        doc_store = InMemoryDocumentStore()
+        doc_store.write_documents(
+            [
+                Document(content="hello world", id="d1"),  # 2 tokens
+                Document(content="foo bar baz", id="d2"),  # 3 tokens
+            ]
+        )
+        assert doc_store._avg_doc_len == pytest.approx(2.5)
+        doc_store.delete_documents(["d1"])
+        # After removing "hello world" (2 tokens), only "foo bar baz" (3 tokens) remains
+        assert doc_store._avg_doc_len == pytest.approx(3.0)


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This PR fixes an off-by-one error in `InMemoryDocumentStore`'s `write_documents` method which caused the avg document length used in BM25 scoring to be systematically underestimated.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Addition of two unit tests and changing the expected scores in existing tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
