### PR TITLE
ci: stop asking reviews for API reference updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,9 @@
 # when someone opens a pull request.
 *                       @deepset-ai/open-source-engineering
 
+# Auto-synced API reference (no human reviewers needed, auto-approved by GitHub bot)
+docs-website/reference/
+docs-website/reference_versioned_docs/
+
 # Documentation
 *.md                    @deepset-ai/documentation @deepset-ai/open-source-engineering

--- a/.github/workflows/docusaurus_sync.yml
+++ b/.github/workflows/docusaurus_sync.yml
@@ -57,4 +57,3 @@ jobs:
             docs-website/reference/haystack-api
           body: |
             This PR syncs the Haystack API reference on Docusaurus. Just approve and merge it.
-          reviewers: "${{ github.actor }}"


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack-private/issues/217

Now that the API reference updates are automatically approved and merged by GitHub Bot (see https://github.com/deepset-ai/haystack/pull/10853), we can reduce noise by stopping asking human reviewers.

### Proposed Changes:
- remove the assigned reviewer from the API reference update workflow (we should also do this in core integrations and experimental)
- do not assign PRs touching API reference (which is totally automated) to human reviewers

### How did you test it?
Hard to test it before merging, but it seems safe.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
