### PR TITLE
chore: fix CODEOWNERS to not assign reviewers to API ref updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,9 @@
 # when someone opens a pull request.
 *                       @deepset-ai/open-source-engineering
 
+# Documentation
+*.md                    @deepset-ai/documentation @deepset-ai/open-source-engineering
+
 # Auto-synced API reference (no human reviewers needed, auto-approved by GitHub bot)
 docs-website/reference/
 docs-website/reference_versioned_docs/
-
-# Documentation
-*.md                    @deepset-ai/documentation @deepset-ai/open-source-engineering


### PR DESCRIPTION
### Related Issues

- follow up of https://github.com/deepset-ai/haystack/pull/10867

The change did not work in https://github.com/deepset-ai/haystack/pull/10869 (I was requested a review) since the last line in CODEOWNERS
https://github.com/deepset-ai/haystack/blob/5e98dde883721c464334158e916ea63490f0f7c0/.github/CODEOWNERS#L14
asked for a review to `@deepset-ai/documentation` and `@deepset-ai/open-source-engineering`

(last line wins)

### Proposed Changes:
- change the order of rules to make them work (matches the syntax in [GitHub docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file)) 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
