### PR TITLE
chore: Add Google Analytics scripts to docs

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -38,6 +38,18 @@ const config = {
     locales: ['en'],
   },
 
+  headTags: [
+    {
+      tagName: "script",
+      attributes: {},
+      innerHTML: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WCKQG9T');`,
+    }
+  ],
+
   presets: [
     [
       'classic',
@@ -68,6 +80,18 @@ const config = {
   ],
 
   plugins: [
+    function gtmNoscriptPlugin() {
+      return {
+        name: "gtm-noscript",
+        injectHtmlTags() {
+          return {
+            preBodyHtmlTags: [
+              `<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WCKQG9T" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>`,
+            ],
+          };
+        },
+      };
+    },
     [
       '@docusaurus/plugin-ideal-image',
       {


### PR DESCRIPTION
### Proposed Changes:

We stopped getting data into Google Analytics after #10747 was merged. This PR aims to fix that. 
I followed the same pattern we had on the platform docs 

### How did you test it?

I built the docs website locally but it's hard to test this functionality locally.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
