### PR TITLE
docs: remove DynamicChatPromptBuilder from code snippets

### DIFF
--- a/docs-website/docs/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/docs/pipeline-components/connectors/langfuseconnector.mdx
@@ -74,7 +74,7 @@ os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from haystack.components.builders import DynamicChatPromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack import Pipeline
@@ -84,8 +84,8 @@ from haystack_integrations.components.connectors.langfuse import LangfuseConnect
 if __name__ == "__main__":
     pipe = Pipeline()
     pipe.add_component("tracer", LangfuseConnector("Chat example"))
-    pipe.add_component("prompt_builder", DynamicChatPromptBuilder())
-    pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", OpenAIChatGenerator())
 
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         data={
             "prompt_builder": {
                 "template_variables": {"location": "Berlin"},
-                "prompt_source": messages,
+                "template": messages,
             },
         },
     )

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/connectors/langfuseconnector.mdx
@@ -71,7 +71,7 @@ os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from haystack.components.builders import DynamicChatPromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack import Pipeline
@@ -81,8 +81,8 @@ from haystack_integrations.components.connectors.langfuse import LangfuseConnect
 if __name__ == "__main__":
     pipe = Pipeline()
     pipe.add_component("tracer", LangfuseConnector("Chat example"))
-    pipe.add_component("prompt_builder", DynamicChatPromptBuilder())
-    pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", OpenAIChatGenerator())
 
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
@@ -97,7 +97,7 @@ if __name__ == "__main__":
         data={
             "prompt_builder": {
                 "template_variables": {"location": "Berlin"},
-                "prompt_source": messages,
+                "template": messages,
             },
         },
     )

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/connectors/langfuseconnector.mdx
@@ -74,7 +74,7 @@ os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from haystack.components.builders import DynamicChatPromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack import Pipeline
@@ -84,8 +84,8 @@ from haystack_integrations.components.connectors.langfuse import LangfuseConnect
 if __name__ == "__main__":
     pipe = Pipeline()
     pipe.add_component("tracer", LangfuseConnector("Chat example"))
-    pipe.add_component("prompt_builder", DynamicChatPromptBuilder())
-    pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", OpenAIChatGenerator())
 
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         data={
             "prompt_builder": {
                 "template_variables": {"location": "Berlin"},
-                "prompt_source": messages,
+                "template": messages,
             },
         },
     )

--- a/docs-website/versioned_docs/version-2.20/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.20/pipeline-components/connectors/langfuseconnector.mdx
@@ -74,7 +74,7 @@ os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from haystack.components.builders import DynamicChatPromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack import Pipeline
@@ -84,8 +84,8 @@ from haystack_integrations.components.connectors.langfuse import LangfuseConnect
 if __name__ == "__main__":
     pipe = Pipeline()
     pipe.add_component("tracer", LangfuseConnector("Chat example"))
-    pipe.add_component("prompt_builder", DynamicChatPromptBuilder())
-    pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", OpenAIChatGenerator())
 
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         data={
             "prompt_builder": {
                 "template_variables": {"location": "Berlin"},
-                "prompt_source": messages,
+                "template": messages,
             },
         },
     )

--- a/docs-website/versioned_docs/version-2.21/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.21/pipeline-components/connectors/langfuseconnector.mdx
@@ -74,7 +74,7 @@ os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from haystack.components.builders import DynamicChatPromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack import Pipeline
@@ -84,8 +84,8 @@ from haystack_integrations.components.connectors.langfuse import LangfuseConnect
 if __name__ == "__main__":
     pipe = Pipeline()
     pipe.add_component("tracer", LangfuseConnector("Chat example"))
-    pipe.add_component("prompt_builder", DynamicChatPromptBuilder())
-    pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", OpenAIChatGenerator())
 
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         data={
             "prompt_builder": {
                 "template_variables": {"location": "Berlin"},
-                "prompt_source": messages,
+                "template": messages,
             },
         },
     )

--- a/docs-website/versioned_docs/version-2.22/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.22/pipeline-components/connectors/langfuseconnector.mdx
@@ -74,7 +74,7 @@ os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from haystack.components.builders import DynamicChatPromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack import Pipeline
@@ -84,8 +84,8 @@ from haystack_integrations.components.connectors.langfuse import LangfuseConnect
 if __name__ == "__main__":
     pipe = Pipeline()
     pipe.add_component("tracer", LangfuseConnector("Chat example"))
-    pipe.add_component("prompt_builder", DynamicChatPromptBuilder())
-    pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", OpenAIChatGenerator())
 
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         data={
             "prompt_builder": {
                 "template_variables": {"location": "Berlin"},
-                "prompt_source": messages,
+                "template": messages,
             },
         },
     )

--- a/docs-website/versioned_docs/version-2.23/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.23/pipeline-components/connectors/langfuseconnector.mdx
@@ -74,7 +74,7 @@ os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from haystack.components.builders import DynamicChatPromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack import Pipeline
@@ -84,8 +84,8 @@ from haystack_integrations.components.connectors.langfuse import LangfuseConnect
 if __name__ == "__main__":
     pipe = Pipeline()
     pipe.add_component("tracer", LangfuseConnector("Chat example"))
-    pipe.add_component("prompt_builder", DynamicChatPromptBuilder())
-    pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", OpenAIChatGenerator())
 
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         data={
             "prompt_builder": {
                 "template_variables": {"location": "Berlin"},
-                "prompt_source": messages,
+                "template": messages,
             },
         },
     )

--- a/docs-website/versioned_docs/version-2.24/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.24/pipeline-components/connectors/langfuseconnector.mdx
@@ -74,7 +74,7 @@ os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from haystack.components.builders import DynamicChatPromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack import Pipeline
@@ -84,8 +84,8 @@ from haystack_integrations.components.connectors.langfuse import LangfuseConnect
 if __name__ == "__main__":
     pipe = Pipeline()
     pipe.add_component("tracer", LangfuseConnector("Chat example"))
-    pipe.add_component("prompt_builder", DynamicChatPromptBuilder())
-    pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", OpenAIChatGenerator())
 
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         data={
             "prompt_builder": {
                 "template_variables": {"location": "Berlin"},
-                "prompt_source": messages,
+                "template": messages,
             },
         },
     )

--- a/docs-website/versioned_docs/version-2.25/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.25/pipeline-components/connectors/langfuseconnector.mdx
@@ -74,7 +74,7 @@ os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from haystack.components.builders import DynamicChatPromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack import Pipeline
@@ -84,8 +84,8 @@ from haystack_integrations.components.connectors.langfuse import LangfuseConnect
 if __name__ == "__main__":
     pipe = Pipeline()
     pipe.add_component("tracer", LangfuseConnector("Chat example"))
-    pipe.add_component("prompt_builder", DynamicChatPromptBuilder())
-    pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", OpenAIChatGenerator())
 
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         data={
             "prompt_builder": {
                 "template_variables": {"location": "Berlin"},
-                "prompt_source": messages,
+                "template": messages,
             },
         },
     )

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/connectors/langfuseconnector.mdx
@@ -74,7 +74,7 @@ os.environ["LANGFUSE_HOST"] = "https://cloud.langfuse.com"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
 
-from haystack.components.builders import DynamicChatPromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack import Pipeline
@@ -84,8 +84,8 @@ from haystack_integrations.components.connectors.langfuse import LangfuseConnect
 if __name__ == "__main__":
     pipe = Pipeline()
     pipe.add_component("tracer", LangfuseConnector("Chat example"))
-    pipe.add_component("prompt_builder", DynamicChatPromptBuilder())
-    pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+    pipe.add_component("prompt_builder", ChatPromptBuilder())
+    pipe.add_component("llm", OpenAIChatGenerator())
 
     pipe.connect("prompt_builder.prompt", "llm.messages")
 
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         data={
             "prompt_builder": {
                 "template_variables": {"location": "Berlin"},
-                "prompt_source": messages,
+                "template": messages,
             },
         },
     )


### PR DESCRIPTION
### Related Issues

- `DynamicChatPromptBuilder` was removed in https://github.com/deepset-ai/haystack/pull/8085 (July 2024) but still appears in some docs pages

### Proposed Changes:
- replace it with `ChatPromptBuilder`
- remove the legacy OpenAI model from the code snippet (less maintenance work in the future)

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
