### PR TITLE
feat: document TavilyWebSearch as alternative to SearchApiWebSearch

### DIFF
--- a/docs-website/docs/pipeline-components/websearch/searchapiwebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/searchapiwebsearch.mdx
@@ -33,6 +33,8 @@ To search the content of the web pages, use the [`LinkContentFetcher`](../fetche
 :::info Alternative search
 
 To use [Serper Dev](https://serper.dev/?gclid=Cj0KCQiAgqGrBhDtARIsAM5s0_kPElllv3M59UPok1Ad-ZNudLaY21zDvbt5qw-b78OcUoqqvplVHRwaAgRgEALw_wcB) as an alternative, see its respective [documentation page](serperdevwebsearch.mdx).
+
+To use [Tavily](https://tavily.com/) as an alternative web search provider, see the [TavilyWebSearch documentation](https://docs.haystack.deepset.ai/docs/tavilywebsearch).
 :::
 
 ## Usage

--- a/haystack/components/websearch/searchapi.py
+++ b/haystack/components/websearch/searchapi.py
@@ -23,6 +23,9 @@ class SearchApiWebSearch:
     """
     Uses [SearchApi](https://www.searchapi.io/) to search the web for relevant documents.
 
+    See also: `TavilyWebSearch` for an alternative web search component powered by
+    [Tavily](https://tavily.com/).
+
     Usage example:
     ```python
     from haystack.components.websearch import SearchApiWebSearch


### PR DESCRIPTION
## Summary

- Added a "See also: TavilyWebSearch" cross-reference in the `SearchApiWebSearch` class docstring so users discover the Tavily alternative.
- Added a note in the `searchapiwebsearch.mdx` docs page pointing users to TavilyWebSearch as an alternative provider.

## Files changed

- `haystack/components/websearch/searchapi.py` — added Tavily cross-reference in class docstring
- `docs-website/docs/pipeline-components/websearch/searchapiwebsearch.mdx` — added Tavily alternative note in the info box

## Dependency changes

None — this is a documentation-only change.

## Environment variable changes

None.

## Notes for reviewers

Purely additive documentation change. No logic, dependencies, or env vars were altered.

### Automated Review

- Passed after 1 attempt(s)
- Final review: Purely additive documentation changes — a "See also" note in the SearchApiWebSearch class docstring and a cross-reference line in the MDX page. No code logic, imports, or dependencies were altered, so there are no regressions. Two minor issues: the Python docstring uses a backtick reference to TavilyWebSearch (which does not exist in this package), and the MDX URL pattern differs from how other external integrations are typically linked in this repo. Neither issue blocks approval.
