### PR TITLE
feat: document TavilyWebSearch as fallback option for SerperDevWebSearch

### DIFF
--- a/docs-website/docs/pipeline-components/websearch/serperdevwebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/serperdevwebsearch.mdx
@@ -34,7 +34,7 @@ To search the content of the web pages, use the [`LinkContentFetcher`](../fetche
 
 To use [Search API](https://www.searchapi.io/) as an alternative, see its respective [documentation page](searchapiwebsearch.mdx).
 
-To use [Tavily](https://tavily.com/) as an alternative web search provider, see the [TavilyWebSearch](tavilywebsearch.mdx) component. Tavily offers an AI-optimised search API that can serve as a drop-in replacement in most pipelines.
+To use [Tavily](https://tavily.com/) as an alternative web search provider, see the [TavilyWebSearch](https://docs.haystack.deepset.ai/docs/tavilywebsearch) component. Tavily offers an AI-optimised search API that can serve as a drop-in replacement in most pipelines.
 :::
 
 ## Usage

--- a/haystack/components/websearch/serper_dev.py
+++ b/haystack/components/websearch/serper_dev.py
@@ -27,8 +27,8 @@ class SerperDevWebSearch:
     See the [Serper Dev website](https://serper.dev/) for more details.
 
     See also: `TavilyWebSearch` – a drop-in alternative web search component powered by
-    [Tavily](https://tavily.com/). Available as `TavilyWebSearch` in `haystack.components.websearch`
-    — importable via `from haystack.components.websearch import TavilyWebSearch`.
+    `Tavily <https://tavily.com/>`_. Available via the
+    `haystack-ai-tavily <https://pypi.org/project/haystack-ai-tavily/>`_ integration package.
 
     Usage example:
     ```python


### PR DESCRIPTION
## Summary
- Added a "See also" reference to `TavilyWebSearch` in the `SerperDevWebSearch` class docstring
- Added a note about Tavily as an alternative provider in the SerperDevWebSearch documentation page

This is a purely additive documentation change. No logic, dependencies, or environment variables were altered. The existing `SERPERDEV_API_KEY` configuration is unchanged.

## Files changed
- `haystack/components/websearch/serper_dev.py` — Added cross-reference to TavilyWebSearch in class docstring
- `docs-website/docs/pipeline-components/websearch/serperdevwebsearch.mdx` — Added Tavily alternative note in the "Alternative search" info box

## Notes for reviewers
- No dependency or env var changes required
- No tests affected (docstring-only change)

Generated with [Claude Code](https://claude.com/claude-code)

### Automated Review

- Passed after 3 attempt(s)
- Final review: Additive documentation-only changes that correctly point users to TavilyWebSearch as an alternative. The broken relative MDX link from attempt 2 is properly resolved with an absolute URL following the established docs.haystack.deepset.ai/docs/ pattern. The PyPI reference accurately reflects that TavilyWebSearch is an external integration, not part of core haystack. One minor style inconsistency exists in the Python docstring (RST-style links vs Markdown). No functional code is affected.
