### PR TITLE
docs: Update docs to link to custom component template repo

### DIFF
--- a/docs-website/docs/concepts/components/custom-components.mdx
+++ b/docs-website/docs/concepts/components/custom-components.mdx
@@ -166,6 +166,10 @@ dc = DerivedComponent()  # ok
 
 An example of an extended component is Haystack's [FaithfulnessEvaluator](https://github.com/deepset-ai/haystack/blob/e5a80722c22c59eb99416bf0cd712f6de7cd581a/haystack/components/evaluators/faithfulness.py) derived from LLMEvaluator.
 
+## Project Template
+
+If you're building a custom component that you want to package and share, we provide a [GitHub template repository](https://github.com/deepset-ai/custom-component) that gives you a ready-made project structure. It includes the boilerplate for packaging, testing, and distributing your custom component as a standalone Python package. Use it to quickly scaffold a new integration or reusable component without setting up the project from scratch.
+
 ## Additional References
 
 🧑‍🍳 Cookbooks:

--- a/docs-website/docs/concepts/document-store/creating-custom-document-stores.mdx
+++ b/docs-website/docs/concepts/document-store/creating-custom-document-stores.mdx
@@ -29,13 +29,13 @@ This naming convention applies to the name of the git repository (`https://githu
 
 ### Structure
 
-More often than not, a Document Store can be fairly complex, and setting up a dedicated Git repository can be handy and future-proof. To ease this step, we prepared a [GitHub template](https://github.com/deepset-ai/document-store) that provides the structure you need to host a custom Document Store in a dedicated repository.
+More often than not, a Document Store can be fairly complex, and setting up a dedicated Git repository can be handy and future-proof. To ease this step, we prepared a [GitHub template](https://github.com/deepset-ai/custom-component) that provides the structure you need to host a custom Document Store in a dedicated repository. It includes the boilerplate for packaging, testing, and distributing your custom Document Store as a standalone Python package.
 
-See the instructions about [how to use the template](https://github.com/deepset-ai/document-store?tab=readme-ov-file#how-to-use-this-repo) to get you started.
+See the instructions in the [template repository](https://github.com/deepset-ai/custom-component) to get started.
 
 ### Packaging
 
-As with any other [Haystack integration](../integrations.mdx), a Document Store can be added to your Haystack applications by installing an additional Python package, for example, with `pip`. Once you have a Git repository hosting your Document Store and a `pyproject.toml` file to create an `example-haystack` package (using our [GitHub template](https://github.com/deepset-ai/document-store)), it will be possible to `pip install` it directly from sources, for example:
+As with any other [Haystack integration](../integrations.mdx), a Document Store can be added to your Haystack applications by installing an additional Python package, for example, with `pip`. Once you have a Git repository hosting your Document Store and a `pyproject.toml` file to create an `example-haystack` package (using our [GitHub template](https://github.com/deepset-ai/custom-component)), it will be possible to `pip install` it directly from sources, for example:
 
 ```shell
 pip install git+https://github.com/your-org/example-haystack.git
@@ -50,7 +50,7 @@ pip install example-haystack
 :::tip
 👍
 
-Our [GitHub template](https://github.com/deepset-ai/document-store) ships a GitHub workflow that will automatically publish the Document Store package on PyPI.
+Our [GitHub template](https://github.com/deepset-ai/custom-component) ships a GitHub workflow that will automatically publish the Document Store package on PyPI.
 :::
 
 ### Documentation

--- a/docs-website/versioned_docs/version-2.26/concepts/components/custom-components.mdx
+++ b/docs-website/versioned_docs/version-2.26/concepts/components/custom-components.mdx
@@ -166,6 +166,10 @@ dc = DerivedComponent()  # ok
 
 An example of an extended component is Haystack's [FaithfulnessEvaluator](https://github.com/deepset-ai/haystack/blob/e5a80722c22c59eb99416bf0cd712f6de7cd581a/haystack/components/evaluators/faithfulness.py) derived from LLMEvaluator.
 
+## Project Template
+
+If you're building a custom component that you want to package and share, we provide a [GitHub template repository](https://github.com/deepset-ai/custom-component) that gives you a ready-made project structure. It includes the boilerplate for packaging, testing, and distributing your custom component as a standalone Python package. Use it to quickly scaffold a new integration or reusable component without setting up the project from scratch.
+
 ## Additional References
 
 🧑‍🍳 Cookbooks:

--- a/docs-website/versioned_docs/version-2.26/concepts/document-store/creating-custom-document-stores.mdx
+++ b/docs-website/versioned_docs/version-2.26/concepts/document-store/creating-custom-document-stores.mdx
@@ -29,13 +29,13 @@ This naming convention applies to the name of the git repository (`https://githu
 
 ### Structure
 
-More often than not, a Document Store can be fairly complex, and setting up a dedicated Git repository can be handy and future-proof. To ease this step, we prepared a [GitHub template](https://github.com/deepset-ai/document-store) that provides the structure you need to host a custom Document Store in a dedicated repository.
+More often than not, a Document Store can be fairly complex, and setting up a dedicated Git repository can be handy and future-proof. To ease this step, we prepared a [GitHub template](https://github.com/deepset-ai/custom-component) that provides the structure you need to host a custom Document Store in a dedicated repository. It includes the boilerplate for packaging, testing, and distributing your custom Document Store as a standalone Python package.
 
-See the instructions about [how to use the template](https://github.com/deepset-ai/document-store?tab=readme-ov-file#how-to-use-this-repo) to get you started.
+See the instructions in the [template repository](https://github.com/deepset-ai/custom-component) to get started.
 
 ### Packaging
 
-As with any other [Haystack integration](../integrations.mdx), a Document Store can be added to your Haystack applications by installing an additional Python package, for example, with `pip`. Once you have a Git repository hosting your Document Store and a `pyproject.toml` file to create an `example-haystack` package (using our [GitHub template](https://github.com/deepset-ai/document-store)), it will be possible to `pip install` it directly from sources, for example:
+As with any other [Haystack integration](../integrations.mdx), a Document Store can be added to your Haystack applications by installing an additional Python package, for example, with `pip`. Once you have a Git repository hosting your Document Store and a `pyproject.toml` file to create an `example-haystack` package (using our [GitHub template](https://github.com/deepset-ai/custom-component)), it will be possible to `pip install` it directly from sources, for example:
 
 ```shell
 pip install git+https://github.com/your-org/example-haystack.git
@@ -50,7 +50,7 @@ pip install example-haystack
 :::tip
 👍
 
-Our [GitHub template](https://github.com/deepset-ai/document-store) ships a GitHub workflow that will automatically publish the Document Store package on PyPI.
+Our [GitHub template](https://github.com/deepset-ai/custom-component) ships a GitHub workflow that will automatically publish the Document Store package on PyPI.
 :::
 
 ### Documentation


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This PR updates the documentation pages of Custom Components and Custom Document Stores to link to our new [Custom Component Template Repo](https://github.com/deepset-ai/custom-component).

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
