### PR TITLE
chore: update Spacy test dependency for Python 3.14 support

### DIFF
--- a/e2e/pipelines/test_named_entity_extractor.py
+++ b/e2e/pipelines/test_named_entity_extractor.py
@@ -18,12 +18,6 @@ from haystack.components.extractors import (
     NamedEntityExtractorBackend,
 )
 
-# spacy uses pydantic.v1 which is not compatible with Python 3.14 (PEP 649 deferred annotations)
-skip_spacy = pytest.mark.skipif(
-    sys.version_info >= (3, 14),
-    reason="spacy/pydantic.v1 not compatible with Python 3.14",
-)
-
 
 @pytest.fixture
 def raw_texts() -> list:
@@ -90,7 +84,6 @@ def test_ner_extractor_hf_backend_private_models(raw_texts, hf_annotations, batc
 
 
 @pytest.mark.parametrize("batch_size", [1, 3])
-@skip_spacy
 def test_ner_extractor_spacy_backend(raw_texts, spacy_annotations, batch_size) -> None:
     extractor = NamedEntityExtractor(backend=NamedEntityExtractorBackend.SPACY, model="en_core_web_trf")
     extractor.warm_up()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:h
 template = "test"
 extra-dependencies = [
   # NamedEntityExtractor
-  "spacy>=3.8,<3.9; python_version < '3.14'",
+  "spacy>=3.8.13,<3.9",
   "en-core-web-trf @ https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.8.0/en_core_web_trf-3.8.0-py3-none-any.whl",
 ]
 


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/pull/10634

Two days ago, a [new version of Spacy was released](https://github.com/explosion/spaCy/releases/tag/release-v3.8.12), with full support for Python 3.14

### Proposed Changes:
- update Spacy test dependency in pyproject
- remove code for handling Spacy-Python 3.14 incompatibility

### How did you test it?
Tested locally with 3.14.0

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
