### PR TITLE
test: mark test_open_meteo_integration as flaky to retry

### DIFF
--- a/test/components/connectors/test_openapi_connector.py
+++ b/test/components/connectors/test_openapi_connector.py
@@ -195,6 +195,7 @@ class TestOpenAPIConnectorIntegration:
         assert "response" in response
 
     @pytest.mark.integration
+    @pytest.mark.flaky(reruns=3, reruns_delay=5)
     def test_open_meteo_integration(self):
         open_meteo_spec = {
             "openapi": "3.0.0",


### PR DESCRIPTION
### Related Issues

From https://github.com/deepset-ai/haystack/issues/10341#issuecomment-4132820057

> FAILED test/components/connectors/test_openapi_connector.py::TestOpenAPIConnectorIntegration::test_open_meteo_integration - openapi_llm.utils.HttpClientError: HTTP error occurred: HTTPSConnectionPool(host='api.open-meteo.com', port=443): Max retries exceeded with url: /v1/forecast?latitude=52.52&longitude=13.41&current=temperature_2m (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1017)')))

### Proposed Changes:
- mark the test as `flaky` and retry: the error is a transient network issue

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
