### PR TITLE
docs: converters - remove erroneous external integrations

### DIFF
--- a/docs-website/docs/pipeline-components/converters/external-integrations-converters.mdx
+++ b/docs-website/docs/pipeline-components/converters/external-integrations-converters.mdx
@@ -11,6 +11,4 @@ External integrations that enable extracting data from files in different format
 
 | Name | Description |
 | --- | --- |
-| [Azure Document Intelligence](https://haystack.deepset.ai/integrations/azure-doc-intelligence) | Convert PDF, PPTX, DOCX, HTML, and other document formats into Haystack documents through advanced document analysis including layout detection, table extraction, and structured content recognition.|
 | [Docling](https://haystack.deepset.ai/integrations/docling/) | Parse PDF, DOCX, HTML, and other document formats into a rich standardized representation (such as layout, tables..), which it can then export to Markdown, JSON, and other formats. |
-| [PaddleOCR](https://haystack.deepset.ai/integrations/paddleocr) | Use PaddleOCR’s text-recognition and document-parsing capabilities. |

--- a/docs-website/versioned_docs/version-2.24/pipeline-components/converters/external-integrations-converters.mdx
+++ b/docs-website/versioned_docs/version-2.24/pipeline-components/converters/external-integrations-converters.mdx
@@ -11,6 +11,4 @@ External integrations that enable extracting data from files in different format
 
 | Name | Description |
 | --- | --- |
-| [Azure Document Intelligence](https://haystack.deepset.ai/integrations/azure-doc-intelligence) | Convert PDF, PPTX, DOCX, HTML, and other document formats into Haystack documents through advanced document analysis including layout detection, table extraction, and structured content recognition.|
 | [Docling](https://haystack.deepset.ai/integrations/docling/) | Parse PDF, DOCX, HTML, and other document formats into a rich standardized representation (such as layout, tables..), which it can then export to Markdown, JSON, and other formats. |
-| [PaddleOCR](https://haystack.deepset.ai/integrations/paddleocr) | Use PaddleOCR’s text-recognition and document-parsing capabilities. |

--- a/docs-website/versioned_docs/version-2.25/pipeline-components/converters/external-integrations-converters.mdx
+++ b/docs-website/versioned_docs/version-2.25/pipeline-components/converters/external-integrations-converters.mdx
@@ -11,6 +11,4 @@ External integrations that enable extracting data from files in different format
 
 | Name | Description |
 | --- | --- |
-| [Azure Document Intelligence](https://haystack.deepset.ai/integrations/azure-doc-intelligence) | Convert PDF, PPTX, DOCX, HTML, and other document formats into Haystack documents through advanced document analysis including layout detection, table extraction, and structured content recognition.|
 | [Docling](https://haystack.deepset.ai/integrations/docling/) | Parse PDF, DOCX, HTML, and other document formats into a rich standardized representation (such as layout, tables..), which it can then export to Markdown, JSON, and other formats. |
-| [PaddleOCR](https://haystack.deepset.ai/integrations/paddleocr) | Use PaddleOCR’s text-recognition and document-parsing capabilities. |

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/converters/external-integrations-converters.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/converters/external-integrations-converters.mdx
@@ -11,6 +11,4 @@ External integrations that enable extracting data from files in different format
 
 | Name | Description |
 | --- | --- |
-| [Azure Document Intelligence](https://haystack.deepset.ai/integrations/azure-doc-intelligence) | Convert PDF, PPTX, DOCX, HTML, and other document formats into Haystack documents through advanced document analysis including layout detection, table extraction, and structured content recognition.|
 | [Docling](https://haystack.deepset.ai/integrations/docling/) | Parse PDF, DOCX, HTML, and other document formats into a rich standardized representation (such as layout, tables..), which it can then export to Markdown, JSON, and other formats. |
-| [PaddleOCR](https://haystack.deepset.ai/integrations/paddleocr) | Use PaddleOCR’s text-recognition and document-parsing capabilities. |


### PR DESCRIPTION
### Proposed Changes:
- remove from converters - external integrations some integrations that live in core-integrations and are maintained by us

### Notes for the reviewer
AzureDocumentIntelligenceConverter is lacking a proper doc page. Opened https://github.com/deepset-ai/haystack/issues/10932 to track this.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
