### PR TITLE
fix(evaluators): strip Markdown code-block fences in `_parse_dict_from_json`

### DIFF
--- a/haystack/utils/misc.py
+++ b/haystack/utils/misc.py
@@ -173,6 +173,23 @@ def _parse_dict_from_json(
         and `raise_on_failure` is True.
     """
     cleaned_text = text.strip()
+    # Strip Markdown code-block fences produced by some LLMs (e.g. ollama/gemma3).
+    # Some models wrap their JSON output in a fenced code block like:
+    #   ```json
+    #   {"key": "value"}
+    #   ```
+    # We strip those fences only when the whole string is wrapped so we do not
+    # accidentally mangle JSON that legitimately contains backtick characters.
+    if cleaned_text.startswith("```"):
+        # Drop the opening fence line (e.g. "```json" or bare "```")
+        first_newline = cleaned_text.find("
+")
+        if first_newline != -1:
+            cleaned_text = cleaned_text[first_newline + 1:]
+        # Drop the closing fence
+        if cleaned_text.endswith("```"):
+            cleaned_text = cleaned_text[:-3]
+        cleaned_text = cleaned_text.strip()
 
     try:
         parsed_json = json.loads(cleaned_text)


### PR DESCRIPTION
## Summary

Fixes #10940

### Problem

Some LLMs (e.g. **ollama/gemma3:4b**, Mistral) wrap their JSON output in a Markdown fenced code block even when instructed to return plain JSON:

```
```json
{"relevant_statements": ["Python, created by Guido van Rossum..."]}
```
```

`_parse_dict_from_json` was calling `json.loads` directly on the raw text, which fails with:

```
Failed to parse JSON from text: ```json\n{...}\n```. Error: Expecting value: line 1 column 1 (char 0)
```

### Fix

Added a pre-processing step in `_parse_dict_from_json` that strips Markdown fenced code-block wrappers **before** attempting to parse JSON.

- The fence is only stripped when the entire string is wrapped (starts with ` ``` `) so legitimate JSON containing backtick characters is not affected.
- The language hint line (e.g. ` ```json `) is removed along with the opening fence.
- After stripping, the resulting text is trimmed and parsed normally.

### Testing

```python
from haystack.utils.misc import _parse_dict_from_json

# Previously raised JSONDecodeError:
result = _parse_dict_from_json(
    '```json\n{"relevant_statements": ["Python was created by Guido."]}\n```'
)
assert result == {"relevant_statements": ["Python was created by Guido."]}

# Bare fence also works:
result = _parse_dict_from_json('```\n{"key": "value"}\n```')
assert result == {"key": "value"}

# Plain JSON still works:
result = _parse_dict_from_json('{"key": "value"}')
assert result == {"key": "value"}
```

**Reproduction script from the issue:**
```python
from haystack.components.evaluators import ContextRelevanceEvaluator
from haystack_integrations.components.generators.ollama import OllamaChatGenerator

evaluator = ContextRelevanceEvaluator(
    chat_generator=OllamaChatGenerator(model="gemma3:4b"),
    raise_on_failure=False,
)
result = evaluator.run(
    questions=["Who created Python?"],
    contexts=[["Python, created by Guido van Rossum in the late 1980s..."]],
)
print(result["score"])  # Was: nan (parse failure). Now: 1.0
```

Signed-off-by: NIK-TIGER-BILL <nik.tiger.bill@github.com>