### PR TITLE
fix: ContextRelevanceEvaluator fails with certain models (e.g. ollama gemma3:4b)

### DIFF
--- a/haystack/utils/misc.py
+++ b/haystack/utils/misc.py
@@ -174,6 +174,12 @@ def _parse_dict_from_json(
     """
     cleaned_text = text.strip()
 
+    # Some chat models wrap an otherwise valid JSON object in a markdown code fence.
+    if cleaned_text.startswith("```"):
+        lines = cleaned_text.splitlines()
+        if len(lines) >= 3 and lines[-1].strip() == "```":
+            cleaned_text = "\n".join(lines[1:-1]).strip()
+
     try:
         parsed_json = json.loads(cleaned_text)
     except json.JSONDecodeError as e:

--- a/releasenotes/notes/context-relevance-fenced-json-10940b8f9c4a.yaml
+++ b/releasenotes/notes/context-relevance-fenced-json-10940b8f9c4a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed LLM-based evaluators such as `ContextRelevanceEvaluator` so they can parse valid JSON replies that are
+    wrapped in markdown code fences by some chat models.

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -200,6 +200,27 @@ class TestContextRelevanceEvaluator:
             "individual_scores": [1, 0],
         }
 
+    def test_run_parses_markdown_fenced_json(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = ContextRelevanceEvaluator()
+
+        def chat_generator_run(self, *args, **kwargs):
+            return {"replies": [ChatMessage.from_assistant('```json\n{"relevant_statements": ["a"]}\n```')]}
+
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
+
+        results = component.run(
+            questions=["Which is the most popular global sport?"],
+            contexts=[["Football is the world's most popular sport."]],
+        )
+
+        assert results == {
+            "results": [{"score": 1, "relevant_statements": ["a"]}],
+            "score": 1,
+            "meta": None,
+            "individual_scores": [1],
+        }
+
     def test_run_missing_parameters(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = ContextRelevanceEvaluator()

--- a/test/utils/test_misc.py
+++ b/test/utils/test_misc.py
@@ -60,6 +60,10 @@ class TestJsonParsing:
         text = '{"key": "value"}'
         assert _parse_dict_from_json(text) == {"key": "value"}
 
+    def test_parse_dict_from_json_markdown_fenced(self):
+        text = '```json\n{"key": "value"}\n```'
+        assert _parse_dict_from_json(text) == {"key": "value"}
+
     def test_parse_dict_from_json_invalid(self):
         text = "invalid json"
         with pytest.raises(json.JSONDecodeError):


### PR DESCRIPTION
## Summary
- Fixes deepset-ai/haystack#10940

## Validation
- Local validation attempted in execute worker
