### PR TITLE
chore: fix types for compatibility with transformers 5.4.0

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -249,7 +249,7 @@ class HuggingFaceLocalGenerator:
 
             # streamer parameter hooks into HF streaming, HFTokenStreamingHandler is an adapter to our streaming
             updated_generation_kwargs["streamer"] = HFTokenStreamingHandler(
-                tokenizer=self.pipeline.tokenizer,  # type: ignore[arg-type]
+                tokenizer=self.pipeline.tokenizer,
                 stream_handler=streaming_callback,
                 stop_words=self.stop_words,
                 component_info=ComponentInfo.from_component(self),

--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -322,7 +322,13 @@ def convert_message_to_hf_format(message: ChatMessage) -> dict[str, Any]:
 
 
 with LazyImport(message="Run 'pip install \"transformers[torch]\"'") as transformers_import:
-    from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast, StoppingCriteria, TextStreamer
+    from transformers import (
+        PreTrainedTokenizer,
+        PreTrainedTokenizerBase,
+        PreTrainedTokenizerFast,
+        StoppingCriteria,
+        TextStreamer,
+    )
 
     torch_import.check()
     transformers_import.check()
@@ -393,7 +399,7 @@ with LazyImport(message="Run 'pip install \"transformers[torch]\"'") as transfor
 
         def __init__(
             self,
-            tokenizer: AutoTokenizer,
+            tokenizer: PreTrainedTokenizerBase,
             stream_handler: SyncStreamingCallbackT,
             stop_words: list[str] | None = None,
             component_info: ComponentInfo | None = None,
@@ -428,7 +434,7 @@ with LazyImport(message="Run 'pip install \"transformers[torch]\"'") as transfor
 
         def __init__(
             self,
-            tokenizer: AutoTokenizer,
+            tokenizer: PreTrainedTokenizerBase,
             stream_handler: AsyncStreamingCallbackT,
             stop_words: list[str] | None = None,
             component_info: ComponentInfo | None = None,


### PR DESCRIPTION
### Related Issues

- tests failing on PRs: https://github.com/deepset-ai/haystack/actions/runs/23638257619/job/68852824637?pr=10944
- https://github.com/huggingface/transformers/releases/tag/v5.4.0 released yesterday

### Proposed Changes:
- use types compatible with transformers 5.4.0

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
