### PR TITLE
docs: use ChatMessage.txt (no content) and remove gpt-3.5-turbo mentions

### DIFF
--- a/docs-website/docs/concepts/data-classes.mdx
+++ b/docs-website/docs/concepts/data-classes.mdx
@@ -197,7 +197,7 @@ from haystack.dataclasses import StreamingChunk, ToolCallDelta, ReasoningContent
 chunk = StreamingChunk(
     content="Hello world",
     start=True,
-    meta={"model": "gpt-3.5-turbo"},
+    meta={"model": "gpt-5-mini"},
 )
 
 ## Tool call chunk

--- a/docs-website/docs/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/docs/pipeline-components/connectors/weaveconnector.mdx
@@ -59,7 +59,7 @@ from haystack_integrations.components.connectors.weave import WeaveConnector
 
 pipe = Pipeline()
 pipe.add_component("prompt_builder", ChatPromptBuilder())
-pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+pipe.add_component("llm", OpenAIChatGenerator())
 pipe.connect("prompt_builder.prompt", "llm.messages")
 
 connector = WeaveConnector(pipeline_name="test_pipeline")

--- a/docs-website/docs/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -125,7 +125,7 @@ generator = LlamaCppChatGenerator(
 )
 messages = [ChatMessage.from_user("Who is the best American actor?")]
 result = generator.run(messages, generation_kwargs={"max_tokens": 128})
-generated_reply = result["replies"][0].content
+generated_reply = result["replies"][0].text
 print(generated_reply)
 ```
 

--- a/docs-website/docs/pipeline-components/joiners/answerjoiner.mdx
+++ b/docs-website/docs/pipeline-components/joiners/answerjoiner.mdx
@@ -50,7 +50,7 @@ messages = [
 
 pipe = Pipeline()
 pipe.add_component("gpt-4o", OpenAIChatGenerator(model="gpt-4o"))
-pipe.add_component("llama", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+pipe.add_component("llama", OpenAIChatGenerator())
 pipe.add_component("aba", AnswerBuilder())
 pipe.add_component("abb", AnswerBuilder())
 pipe.add_component("joiner", AnswerJoiner())

--- a/docs-website/docs/pipeline-components/retrievers/opensearchbm25retriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/opensearchbm25retriever.mdx
@@ -151,7 +151,7 @@ GeneratedAnswer(
   documents=[
     Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, content: 'There are over 7,000 languages spoken around the world today.', score: 7.179112),
     Document(id=7f225626ad1019b273326fbaf11308edfca6d663308a4a3533ec7787367d59a2, content: 'In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the ph...', score: 1.1426818)],
-  meta={'model': 'gpt-3.5-turbo-0613', 'index': 0, 'finish_reason': 'stop', 'usage': {'prompt_tokens': 86, 'completion_tokens': 13, 'total_tokens': 99}})
+  meta={'model': 'gpt-5-mini', 'index': 0, 'finish_reason': 'stop', 'usage': {'prompt_tokens': 86, 'completion_tokens': 13, 'total_tokens': 99}})
 ```
 
 ## Additional References

--- a/docs-website/docs/pipeline-components/websearch/firecrawlwebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/firecrawlwebsearch.mdx
@@ -102,5 +102,5 @@ query = "What is Haystack by deepset?"
 
 result = pipe.run(data={"search": {"query": query}, "prompt_builder": {"query": query}})
 
-print(result["llm"]["replies"][0].content)
+print(result["llm"]["replies"][0].text)
 ```

--- a/docs-website/docs/pipeline-components/websearch/searchapiwebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/searchapiwebsearch.mdx
@@ -83,7 +83,6 @@ prompt_builder = ChatPromptBuilder(
 )
 llm = OpenAIChatGenerator(
     api_key=Secret.from_token("<your-api-key>"),
-    model="gpt-3.5-turbo",
 )
 
 pipe = Pipeline()

--- a/docs-website/docs/pipeline-components/websearch/serperdevwebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/serperdevwebsearch.mdx
@@ -85,7 +85,6 @@ prompt_builder = ChatPromptBuilder(
 )
 llm = OpenAIChatGenerator(
     api_key=Secret.from_token("<your-api-key>"),
-    model="gpt-3.5-turbo",
 )
 
 pipe = Pipeline()

--- a/docs-website/versioned_docs/version-2.26/concepts/data-classes.mdx
+++ b/docs-website/versioned_docs/version-2.26/concepts/data-classes.mdx
@@ -197,7 +197,7 @@ from haystack.dataclasses import StreamingChunk, ToolCallDelta, ReasoningContent
 chunk = StreamingChunk(
     content="Hello world",
     start=True,
-    meta={"model": "gpt-3.5-turbo"},
+    meta={"model": "gpt-5-mini"},
 )
 
 ## Tool call chunk

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/connectors/weaveconnector.mdx
@@ -59,7 +59,7 @@ from haystack_integrations.components.connectors.weave import WeaveConnector
 
 pipe = Pipeline()
 pipe.add_component("prompt_builder", ChatPromptBuilder())
-pipe.add_component("llm", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+pipe.add_component("llm", OpenAIChatGenerator())
 pipe.connect("prompt_builder.prompt", "llm.messages")
 
 connector = WeaveConnector(pipeline_name="test_pipeline")

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -125,7 +125,7 @@ generator = LlamaCppChatGenerator(
 )
 messages = [ChatMessage.from_user("Who is the best American actor?")]
 result = generator.run(messages, generation_kwargs={"max_tokens": 128})
-generated_reply = result["replies"][0].content
+generated_reply = result["replies"][0].text
 print(generated_reply)
 ```
 

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/joiners/answerjoiner.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/joiners/answerjoiner.mdx
@@ -50,7 +50,7 @@ messages = [
 
 pipe = Pipeline()
 pipe.add_component("gpt-4o", OpenAIChatGenerator(model="gpt-4o"))
-pipe.add_component("llama", OpenAIChatGenerator(model="gpt-3.5-turbo"))
+pipe.add_component("llama", OpenAIChatGenerator())
 pipe.add_component("aba", AnswerBuilder())
 pipe.add_component("abb", AnswerBuilder())
 pipe.add_component("joiner", AnswerJoiner())

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/retrievers/opensearchbm25retriever.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/retrievers/opensearchbm25retriever.mdx
@@ -151,7 +151,7 @@ GeneratedAnswer(
   documents=[
     Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, content: 'There are over 7,000 languages spoken around the world today.', score: 7.179112),
     Document(id=7f225626ad1019b273326fbaf11308edfca6d663308a4a3533ec7787367d59a2, content: 'In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the ph...', score: 1.1426818)],
-  meta={'model': 'gpt-3.5-turbo-0613', 'index': 0, 'finish_reason': 'stop', 'usage': {'prompt_tokens': 86, 'completion_tokens': 13, 'total_tokens': 99}})
+  meta={'model': 'gpt-5-mini', 'index': 0, 'finish_reason': 'stop', 'usage': {'prompt_tokens': 86, 'completion_tokens': 13, 'total_tokens': 99}})
 ```
 
 ## Additional References

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/websearch/firecrawlwebsearch.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/websearch/firecrawlwebsearch.mdx
@@ -102,5 +102,5 @@ query = "What is Haystack by deepset?"
 
 result = pipe.run(data={"search": {"query": query}, "prompt_builder": {"query": query}})
 
-print(result["llm"]["replies"][0].content)
+print(result["llm"]["replies"][0].text)
 ```

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/websearch/searchapiwebsearch.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/websearch/searchapiwebsearch.mdx
@@ -83,7 +83,6 @@ prompt_builder = ChatPromptBuilder(
 )
 llm = OpenAIChatGenerator(
     api_key=Secret.from_token("<your-api-key>"),
-    model="gpt-3.5-turbo",
 )
 
 pipe = Pipeline()

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/websearch/serperdevwebsearch.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/websearch/serperdevwebsearch.mdx
@@ -85,7 +85,6 @@ prompt_builder = ChatPromptBuilder(
 )
 llm = OpenAIChatGenerator(
     api_key=Secret.from_token("<your-api-key>"),
-    model="gpt-3.5-turbo",
 )
 
 pipe = Pipeline()


### PR DESCRIPTION
### Proposed Changes:
- `ChatMessage.content` has been removed long time ago. `ChatMessage.text` should be used instead. Replaced
- GPT-3.5-Turbo is a very old model. Where possible, I avoided using the model name, to have less maintenance efforts in the future

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
