### PR TITLE
docs: update llama.cpp repo links from ggerganov to ggml-org

### DIFF
--- a/docs-website/docs/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/docs/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -20,7 +20,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/llamacppgenerator.mdx
@@ -20,7 +20,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.20/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.20/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.20/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.20/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.21/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.21/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.21/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.21/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.22/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.22/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.22/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.22/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.23/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.23/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.23/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.23/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.24/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.24/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.24/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.24/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.25/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.25/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.25/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.25/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 


### PR DESCRIPTION
Part of #10960

The `llama.cpp` repository was moved from `ggerganov/llama.cpp` to `ggml-org/llama.cpp` (see [announcement](https://github.com/ggerganov/llama.cpp/discussions/11801)).

This PR updates all references in the documentation pages — both the current docs and versioned docs (v2.18 through v2.26) — for `LlamaCppGenerator` and `LlamaCppChatGenerator`.

**Files changed:**
- `docs-website/docs/pipeline-components/generators/llamacppchatgenerator.mdx`
- `docs-website/docs/pipeline-components/generators/llamacppgenerator.mdx`
- All versioned equivalents (v2.18–v2.26)