### PR TITLE
docs: update llama.cpp links from ggerganov to ggml-org

### DIFF
--- a/docs-website/docs/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/docs/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -20,7 +20,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/generators/llamacppgenerator.mdx
@@ -20,7 +20,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.20/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.20/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.20/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.20/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.21/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.21/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.21/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.21/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.22/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.22/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.22/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.22/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.23/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.23/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.23/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.23/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.24/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.24/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.24/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.24/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.25/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.25/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.25/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.25/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/generators/llamacppchatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/generators/llamacppchatgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` enables chat completion using an LLM running o
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format, which can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf). `LlamaCppChatGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/generators/llamacppgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/generators/llamacppgenerator.mdx
@@ -24,7 +24,7 @@ description: "`LlamaCppGenerator` provides an interface to generate text using a
 
 ## Overview
 
-[Llama.cpp](https://github.com/ggerganov/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
+[Llama.cpp](https://github.com/ggml-org/llama.cpp) is a library written in C/C++ for efficient inference of Large Language Models. It leverages the efficient quantized GGUF format, dramatically reducing memory requirements and accelerating inference. This means it is possible to run LLMs efficiently on standard machines (even without GPUs).
 
 `Llama.cpp` uses the quantized binary file of the LLM in GGUF format that can be downloaded from [Hugging Face](https://huggingface.co/models?library=gguf).  `LlamaCppGenerator` supports models running on `Llama.cpp`  by taking the path to the locally saved GGUF file as `model` parameter at initialization.
 


### PR DESCRIPTION
### Related Issues

- fixes #10960

### Proposed Changes:

The llama.cpp repository was moved from `ggerganov/llama.cpp` to `ggml-org/llama.cpp`. While GitHub redirects still work, the documentation should point to the canonical URL.

Updated all 20 occurrences across docs-website (current and versioned docs) from `https://github.com/ggerganov/llama.cpp` to `https://github.com/ggml-org/llama.cpp`.

### How did you test it?

Verified with grep that no `ggerganov/llama.cpp` references remain in the codebase, and that `ggml-org/llama.cpp` is the correct current location.

### Notes for the reviewer

Only documentation link updates, no code changes.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `docs:`
- [x] I have documented my code.
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [ ] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.