### PR TITLE
test: adding Mixin filter async tests and using them in `InMemoryDocumentStore` tests

### DIFF
--- a/haystack/testing/document_store_async.py
+++ b/haystack/testing/document_store_async.py
@@ -10,7 +10,7 @@ import pytest
 from haystack.dataclasses import Document
 from haystack.document_stores.errors import DuplicateDocumentError
 from haystack.document_stores.types import DocumentStore, DuplicatePolicy
-from haystack.testing.document_store import AssertDocumentsEqualMixin
+from haystack.testing.document_store import AssertDocumentsEqualMixin, FilterableDocsFixtureMixin
 
 
 class AsyncDocumentStore(DocumentStore, Protocol):
@@ -550,3 +550,49 @@ class GetMetadataFieldUniqueValuesAsyncTest:
         assert set(values) == {"A", "B", "C"}
         if isinstance(result, tuple) and len(result) >= 2 and isinstance(result[1], int):
             assert result[1] == 3
+
+
+class FilterDocumentsAsyncTest(AssertDocumentsEqualMixin, FilterableDocsFixtureMixin):
+    """
+    Smoke tests for the async filter_documents_async() path.
+
+    These tests verify that the async plumbing works correctly with no filters,
+    a simple equality filter, and a compound AND filter. Full filter logic correctness
+    is covered by FilterDocumentsTest — the sync and async paths share the same
+    filter translation layer, so only the async dispatch needs smoke-testing here.
+    """
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_no_filters_async(document_store: AsyncDocumentStore):
+        """Verify the async path returns all documents when no filter is applied."""
+        docs = [Document(content="first doc"), Document(content="second doc"), Document(content="third doc")]
+        await document_store.write_documents_async(docs)
+        result = await document_store.filter_documents_async()
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_filter_simple_async(self, document_store: AsyncDocumentStore, filterable_docs: list[Document]):
+        """One equality filter — confirms async plumbing works with a filter."""
+        await document_store.write_documents_async(filterable_docs)
+        result = await document_store.filter_documents_async(
+            filters={"field": "meta.number", "operator": "==", "value": 2}
+        )
+        self.assert_documents_are_equal(result, [d for d in filterable_docs if d.meta.get("number") == 2])
+
+    @pytest.mark.asyncio
+    async def test_filter_compound_async(self, document_store: AsyncDocumentStore, filterable_docs: list[Document]):
+        """One AND filter — verifies compound filters aren't broken by the async path."""
+        await document_store.write_documents_async(filterable_docs)
+        result = await document_store.filter_documents_async(
+            filters={
+                "operator": "AND",
+                "conditions": [
+                    {"field": "meta.number", "operator": "==", "value": 2},
+                    {"field": "meta.name", "operator": "==", "value": "name_0"},
+                ],
+            }
+        )
+        self.assert_documents_are_equal(
+            result, [d for d in filterable_docs if d.meta.get("number") == 2 and d.meta.get("name") == "name_0"]
+        )

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -29,6 +29,7 @@ from haystack.testing.document_store import (
 from haystack.testing.document_store_async import (
     CountDocumentsAsyncTest,
     DeleteDocumentsAsyncTest,
+    FilterDocumentsAsyncTest,
     GetMetadataFieldMinMaxAsyncTest,
     GetMetadataFieldsInfoAsyncTest,
     GetMetadataFieldUniqueValuesAsyncTest,
@@ -46,6 +47,7 @@ class TestMemoryDocumentStore(
     CountDocumentsByFilterTest,
     CountUniqueMetadataByFilterAsyncTest,
     CountUniqueMetadataByFilterTest,
+    FilterDocumentsAsyncTest,
     FilterableDocsFixtureMixin,
     GetMetadataFieldMinMaxTest,
     GetMetadataFieldUniqueValuesTest,


### PR DESCRIPTION
### Related Issues

- fixes #10922 

### Proposed Changes:

A new class `FilterDocumentsAsyncTest` with 3 tests:

- test_no_filters_async: Verifies the async path returns all docs with no filter
- test_filter_simple_async: One equality filter — confirms async plumbing works with a filter
- test_filter_compound_async: One AND filter — verifies compound filters aren't broken by the async path
- InMemoryDocumenStore imports the class to test async calls to filter

### How did you test it?

- unit tests, integration tests, manual verification, instructions for manual tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
