### PR TITLE
build: switch to trusted publishing

### DIFF
--- a/.github/workflows/nightly_testpypi_release.yml
+++ b/.github/workflows/nightly_testpypi_release.yml
@@ -12,6 +12,9 @@ env:
 jobs:
   nightly-release:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     # Always build from main for consistency (scheduled and manual runs)
     steps:
       - name: Checkout main
@@ -39,7 +42,4 @@ jobs:
         run: hatch build
 
       - name: Publish to PyPI
-        env:
-          HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.HAYSTACK_AI_PYPI_TOKEN }}
-        run: hatch publish -y
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -13,6 +13,9 @@ env:
 jobs:
   release-on-pypi:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout
@@ -25,7 +28,4 @@ jobs:
         run: hatch build
 
       - name: Publish on PyPi
-        env:
-          HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.HAYSTACK_AI_PYPI_TOKEN }}
-        run: hatch publish -y
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0


### PR DESCRIPTION
### Related Issues

Part of https://github.com/deepset-ai/haystack-private/issues/299

### Proposed Changes:

This PR stops the pypi release workflows from using a secret token and instead uses trusted publishing.
To make this work, I created an environment called pypi. Specifying a GitHub environment is optional, but strongly encouraged.
Further, I added permissions: `id-token: write`. This permission is mandatory for Trusted Publishing. ( see https://docs.pypi.org/trusted-publishers/using-a-publisher/)
I added the action pypa/gh-action-pypi-publish for publishing release and used the commit hash of the latest release. https://github.com/pypa/gh-action-pypi-publish/pkgs/container/gh-action-pypi-publish/505464737?tag=release-v1.13

In the haystack repository, only nightly_testpypi_release.yml and pypi_release.yml used the token. Once this PR is done and a manual pre-release worked, I'll apply open a PR with similar changes in haystack-core-integrations and haystack-experimental.

In pypi, I added two publishers to trusted publishing. One for each workflow.

### How did you test it?

Haven't tested it. My plan is to trigger a pre-release manually after the PR got merged.

### Notes for the reviewer

My understanding is that with this PR the PyPI Action publishes all the build artifacts in the dist/ folder which is populated by the previous `hatch build` command. If I am not mistaken GitHub's OIDC identity provider doesn't work with our previous `hatch publish` command. That's why I replaced it. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
