### PR TITLE
fix: Fix appending `None` to a list in State when the source key is missing

### DIFF
--- a/haystack/components/tools/tool_invoker.py
+++ b/haystack/components/tools/tool_invoker.py
@@ -459,6 +459,13 @@ class ToolInvoker:
         for state_key, config in tool.outputs_to_state.items():
             # Get the source key from the output config, otherwise use the entire result
             source_key = config.get("source", None)
+
+            # If a source key is specified but absent from the result, skip this mapping to avoid passing a None value
+            # to state. This can be a common scenario with PipelineTool wrapping a pipeline that has conditional
+            # branches where not all outputs are always produced even if defined in outputs_to_state.
+            if source_key and source_key not in result:
+                continue
+
             output_value = result.get(source_key) if source_key else result
 
             # Merge other outputs into the state

--- a/releasenotes/notes/fix-merge-tool-outputs-absent-source-key-bc3e13be9f3aacea.yaml
+++ b/releasenotes/notes/fix-merge-tool-outputs-absent-source-key-bc3e13be9f3aacea.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix ``ToolInvoker._merge_tool_outputs`` silently appending ``None`` to list-typed state when a
+    tool's ``outputs_to_state`` source key is absent from the tool result. This is a common scenario
+    with ``PipelineTool`` wrapping a pipeline that has conditional branches where not all outputs are
+    always produced even if defined in ``outputs_to_state``. The mapping is now skipped entirely when
+    the source key is not present in the result dict.

--- a/test/components/tools/test_tool_invoker.py
+++ b/test/components/tools/test_tool_invoker.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from haystack import Pipeline
+from haystack import Document, Pipeline
 from haystack.components.agents.state import State
 from haystack.components.builders.prompt_builder import PromptBuilder
 from haystack.components.generators.chat.openai import OpenAIChatGenerator
@@ -1061,6 +1061,30 @@ class TestToolInvokerUtilities:
             tool=weather_tool, result={"weather": "sunny", "temperature": 14, "unit": "celsius"}, state=state
         )
         assert state.data == {"all_weather_results": {"weather": "sunny", "temperature": 14, "unit": "celsius"}}
+
+    def test_merge_tool_outputs_source_key_absent_does_not_corrupt_list_state(self):
+        """
+        Simulates a PipelineTool wrapping a pipeline with a conditional branch that may not execute, resulting in the
+        source key being absent from the tool result. The test verifies that in this case, the existing list in state
+        is not corrupted by appending None.
+        """
+        tool = Tool(
+            name="retrieval",
+            description="mock",
+            parameters={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+            function=lambda query: {},
+            outputs_to_state={"documents": {"source": "documents_output"}},
+        )
+        invoker = ToolInvoker(tools=[tool])
+        existing_doc = Document(content="from first call")
+        state = State(schema={"documents": {"type": list[Document]}})
+        state.set("documents", [existing_doc])
+
+        # Tool result where the source key is absent (document extraction branch did not execute)
+        invoker._merge_tool_outputs(tool=tool, result={"result": "no web results found"}, state=state)
+
+        assert state.data["documents"] == [existing_doc]
+        assert None not in state.data["documents"]
 
     def test_merge_tool_outputs_with_output_mapping_and_handler(self):
         handler = lambda _, new: f"{new}"  # noqa: E731


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/10981

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fix `ToolInvoker._merge_tool_outputs` silently appending `None` to list-typed state when a tool's `outputs_to_state` source key is absent from the tool result. This is a common scenario with `PipelineTool` wrapping a pipeline that has conditional branches where not all outputs are always produced even if defined in `outputs_to_state`. The mapping is now skipped entirely when the source key is not present in the result dict.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added a new unit test based on what was described in the issue

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

I decided not to update `merge_lists` since the fix in ToolInvoker prevents `None` from reaching `merge_lists`. It's also possible that `None` is an intended to be passed to `merge_lists` which is still allowed if the source key is present in the tool dict and the value it points to is `None`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
