### PR TITLE
docs: update opensearch version

### DIFF
--- a/docs-website/docs/document-stores/opensearch-document-store.mdx
+++ b/docs-website/docs/document-stores/opensearch-document-store.mdx
@@ -31,8 +31,14 @@ OpenSearch provides support for vector similarity comparisons and approximate ne
 If you have Docker set up, we recommend pulling the Docker image and running it.
 
 ```shell
-docker pull opensearchproject/opensearch:2.11.0
-docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms1024m -Xmx1024m" opensearchproject/opensearch:2.11.0
+docker pull opensearchproject/opensearch:3.5.0
+docker run \
+    -p 9200:9200 \
+    -p 9600:9600 \
+    -e "discovery.type=single-node" \
+    -e "ES_JAVA_OPTS=-Xms1024m -Xmx1024m" \
+    -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=SecureHaystack*2026" \
+    opensearchproject/opensearch:3.5.0
 ```
 
 As an alternative, you can go to [OpenSearch integration GitHub](https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/opensearch) and start a Docker container running OpenSearch using the provided `docker-compose.yml`:
@@ -57,7 +63,7 @@ document_store = OpenSearchDocumentStore(
     hosts="http://localhost:9200",
     use_ssl=True,
     verify_certs=False,
-    http_auth=("admin", "admin"),
+    http_auth=("admin", "SecureHaystack*2026"),
 )
 document_store.write_documents(
     [Document(content="This is first"), Document(content="This is second")],

--- a/docs-website/versioned_docs/version-2.26/document-stores/opensearch-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.26/document-stores/opensearch-document-store.mdx
@@ -31,8 +31,14 @@ OpenSearch provides support for vector similarity comparisons and approximate ne
 If you have Docker set up, we recommend pulling the Docker image and running it.
 
 ```shell
-docker pull opensearchproject/opensearch:2.11.0
-docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms1024m -Xmx1024m" opensearchproject/opensearch:2.11.0
+docker pull opensearchproject/opensearch:3.5.0
+docker run \
+    -p 9200:9200 \
+    -p 9600:9600 \
+    -e "discovery.type=single-node" \
+    -e "ES_JAVA_OPTS=-Xms1024m -Xmx1024m" \
+    -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=SecureHaystack*2026" \
+    opensearchproject/opensearch:3.5.0
 ```
 
 As an alternative, you can go to [OpenSearch integration GitHub](https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/opensearch) and start a Docker container running OpenSearch using the provided `docker-compose.yml`:
@@ -57,7 +63,7 @@ document_store = OpenSearchDocumentStore(
     hosts="http://localhost:9200",
     use_ssl=True,
     verify_certs=False,
-    http_auth=("admin", "admin"),
+    http_auth=("admin", "SecureHaystack*2026"),
 )
 document_store.write_documents(
     [Document(content="This is first"), Document(content="This is second")],


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR updates the OpenSearch Docker examples in the documentation from version 2.11.0 to 3.5.0 given that 2.11. is over two and a half years old.

OpenSearch 3.x requires setting `OPENSEARCH_INITIAL_ADMIN_PASSWORD`, so the Docker run command and the Python code snippet were updated accordingly. The Docker command was also reformatted for readability using line continuations.


### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
