### PR TITLE
chore: fix types for mypy 1.20

### DIFF
--- a/haystack/core/type_utils.py
+++ b/haystack/core/type_utils.py
@@ -64,7 +64,7 @@ def _type_name(type_: Any) -> str:
     return f"{name}"
 
 
-def _safe_get_origin(_type: type | UnionType) -> type | None:
+def _safe_get_origin(_type: type | UnionType) -> Any:
     """
     Safely retrieves the origin type of a generic alias or returns the type itself if it's a built-in.
 

--- a/haystack/dataclasses/document.py
+++ b/haystack/dataclasses/document.py
@@ -96,7 +96,7 @@ class Document(metaclass=_BackwardCompatible):  # noqa: PLW1641
         """
         if type(self) != type(other):
             return False
-        return self.to_dict() == other.to_dict()  # type: ignore[attr-defined]
+        return self.to_dict() == other.to_dict()
 
     def __post_init__(self) -> None:
         """

--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -651,16 +651,16 @@ class DeleteAllTest:
         assert document_store.count_documents() == 0
 
     @staticmethod
-    def _delete_all_supports_recreate(document_store: DocumentStore) -> tuple[bool, str | None]:
+    def _delete_all_supports_recreate(document_store: DocumentStore) -> str | None:
         """
-        Return (True, param_name) if delete_all_documents has recreate_index or recreate_collection, else (False, None).
+        Return the recreate parameter name if delete_all_documents supports it, else None.
         """
         sig = inspect.signature(document_store.delete_all_documents)  # type:ignore[attr-defined]
         if "recreate_index" in sig.parameters:
-            return True, "recreate_index"
+            return "recreate_index"
         if "recreate_collection" in sig.parameters:
-            return True, "recreate_collection"
-        return False, None
+            return "recreate_collection"
+        return None
 
     @staticmethod
     def test_delete_all_documents_without_recreate_index(document_store: DocumentStore):
@@ -669,8 +669,8 @@ class DeleteAllTest:
 
         Skipped if the store's delete_all_documents does not have recreate_index or recreate_collection.
         """
-        supports, param_name = DeleteAllTest._delete_all_supports_recreate(document_store)
-        if not supports:
+        param_name = DeleteAllTest._delete_all_supports_recreate(document_store)
+        if param_name is None:
             pytest.skip("delete_all_documents has no recreate_index or recreate_collection parameter")
 
         docs = [Document(id="1", content="A first document"), Document(id="2", content="Second document")]
@@ -691,8 +691,8 @@ class DeleteAllTest:
 
         Skipped if the store's delete_all_documents does not have recreate_index or recreate_collection.
         """
-        supports, param_name = DeleteAllTest._delete_all_supports_recreate(document_store)
-        if not supports:
+        param_name = DeleteAllTest._delete_all_supports_recreate(document_store)
+        if param_name is None:
             pytest.skip("delete_all_documents has no recreate_index or recreate_collection parameter")
 
         docs = [Document(id="1", content="A first document"), Document(id="2", content="Second document")]

--- a/haystack/testing/document_store_async.py
+++ b/haystack/testing/document_store_async.py
@@ -50,16 +50,16 @@ class DeleteAllAsyncTest:
     """
 
     @staticmethod
-    def _delete_all_supports_recreate(document_store: AsyncDocumentStore) -> tuple[bool, str | None]:
+    def _delete_all_supports_recreate(document_store: AsyncDocumentStore) -> str | None:
         """
-        Return (True, param_name) if delete_all_documents_async has recreate_index or recreate_collection.
+        Return the recreate parameter name if delete_all_documents_async supports it, else None.
         """
         sig = inspect.signature(document_store.delete_all_documents_async)  # type:ignore[attr-defined]
         if "recreate_index" in sig.parameters:
-            return True, "recreate_index"
+            return "recreate_index"
         if "recreate_collection" in sig.parameters:
-            return True, "recreate_collection"
-        return False, None
+            return "recreate_collection"
+        return None
 
     @staticmethod
     @pytest.mark.asyncio
@@ -122,8 +122,8 @@ class CountDocumentsAsyncTest:
 
         Skipped if the store's delete_all_documents_async does not have recreate_index or recreate_collection.
         """
-        supports, param_name = DeleteAllAsyncTest._delete_all_supports_recreate(document_store)
-        if not supports or param_name is None:
+        param_name = DeleteAllAsyncTest._delete_all_supports_recreate(document_store)
+        if param_name is None:
             pytest.skip("delete_all_documents_async has no recreate_index or recreate_collection parameter")
 
         docs = [Document(id="1", content="A first document"), Document(id="2", content="Second document")]
@@ -145,8 +145,8 @@ class CountDocumentsAsyncTest:
 
         Skipped if the store's delete_all_documents_async does not have recreate_index or recreate_collection.
         """
-        supports, param_name = DeleteAllAsyncTest._delete_all_supports_recreate(document_store)
-        if not supports or param_name is None:
+        param_name = DeleteAllAsyncTest._delete_all_supports_recreate(document_store)
+        if param_name is None:
             pytest.skip("delete_all_documents_async has no recreate_index or recreate_collection parameter")
 
         docs = [Document(id="1", content="A first document"), Document(id="2", content="Second document")]


### PR DESCRIPTION
### Related Issues

- [Failing mypy checks](https://github.com/deepset-ai/haystack/actions/runs/23842160123/job/69500891249?pr=10993) due to new mypy release: https://pypi.org/project/mypy/1.20.0/

### Proposed Changes:
- cosmetic changes to make mypy happy

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
