### PR TITLE
chore: Add context7.json for docs indexing

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/deepset-ai/haystack",
+  "public_key": "pk_NBN5TVMCHF3kizc2thzwX"
+}


### PR DESCRIPTION
### Related Issues

- Related to #9885 
- This is to get [context7](https://context7.com/deepset-ai/haystack) to properly index Haystack documentation. Last update of Haystack docs was 7 months ago and only api reference seems up to date. Was a suggestion by Vladimir when I talked with him about Haystack Docs MCP

### Proposed Changes:

- Add context7.json to claim ownership of our docs on context7

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
