### PR TITLE
chore: Delete context7.json related to documentation indexing

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,0 @@
-{
-  "url": "https://context7.com/deepset-ai/haystack",
-  "public_key": "pk_NBN5TVMCHF3kizc2thzwX"
-}


### PR DESCRIPTION
### Related Issues

Related to PR https://github.com/deepset-ai/haystack/pull/11008

### Proposed Changes:

Now that context7 authentication is completed and we gave proof that we maintain Haystack, I believe we can remove the file again.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
