### PR TITLE
fix:  pass `documents` as keyword argument in `EmbeddingBasedDocumentSplitter`

### DIFF
--- a/haystack/components/preprocessors/embedding_based_document_splitter.py
+++ b/haystack/components/preprocessors/embedding_based_document_splitter.py
@@ -310,7 +310,7 @@ class EmbeddingBasedDocumentSplitter:
         """
         # Create Document objects for each group
         group_docs = [Document(content=group) for group in sentence_groups]
-        result = self.document_embedder.run(group_docs)
+        result = self.document_embedder.run(documents=group_docs)
         embedded_docs = result["documents"]
         return [doc.embedding for doc in embedded_docs]
 
@@ -320,7 +320,7 @@ class EmbeddingBasedDocumentSplitter:
         """
         # Create Document objects for each group
         group_docs = [Document(content=group) for group in sentence_groups]
-        result = await self.document_embedder.run_async(group_docs)  # type: ignore[attr-defined]
+        result = await self.document_embedder.run_async(documents=group_docs)  # type: ignore[attr-defined]
         embedded_docs = result["documents"]
         return [doc.embedding for doc in embedded_docs]
 


### PR DESCRIPTION
### Related Issues

- fixes https://linear.app/deepset/issue/BUI-422/code-component-embeddingbaseddocumentsplitter-cannot-be-connected-to

`EmbeddingBasedDocumentSplitter._calculate_embeddings`  calls `document_embedder.run` with a positional argument. This fails when the embedder's run() method only accepts **kwargs 
(e.g. deepset Cloud's Code component wrapper) raising:

`TypeError: Code.run() takes 1 positional argument but 2 were given.
`

Note: There is an example pipeline with logs in the linear ticket.
### Proposed Changes:
Changed both call sites to use keyword arguments.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
