### PR TITLE
Add OSOP workflow example — RAG pipeline in portable format

### DIFF
--- a/examples/osop-rag-pipeline/README.md
+++ b/examples/osop-rag-pipeline/README.md
@@ -1,0 +1,41 @@
+# Haystack RAG Pipeline — OSOP Workflow Example
+
+This directory contains a portable [OSOP](https://github.com/osopcloud/osop-spec) workflow definition for a typical Haystack RAG (Retrieval-Augmented Generation) pipeline.
+
+## What is OSOP?
+
+**OSOP** (Open Standard for Orchestration Protocols) is a YAML-based format for describing multi-step workflows in a tool-agnostic way. It lets you define pipelines, agent workflows, and automation flows that can be understood by any compatible runtime — including Haystack, LangChain, Prefect, and others.
+
+Think of it as the **OpenAPI of workflows**: a single `.osop` file describes what your pipeline does, so teams can share, review, and port workflows across tools.
+
+## Pipeline Overview
+
+The `haystack-rag-pipeline.osop` file describes a standard RAG pipeline:
+
+```
+User Query → Query Embedder → Document Retriever → Prompt Builder → Answer Generator → Response
+```
+
+| Step | OSOP Node Type | Haystack Equivalent |
+|------|---------------|---------------------|
+| User Query | `human` | Pipeline input |
+| Query Embedder | `agent` | `OpenAITextEmbedder` |
+| Document Retriever | `db` | `QdrantEmbeddingRetriever` |
+| Prompt Builder | `system` | `PromptBuilder` |
+| Answer Generator | `agent` | `OpenAIGenerator` |
+| Response | `api` | Pipeline output |
+
+## Usage
+
+The `.osop` file is a standalone YAML document. You can:
+
+- **Read it** to understand the pipeline at a glance
+- **Validate it** with the [OSOP CLI](https://github.com/osopcloud/osop): `osop validate haystack-rag-pipeline.osop`
+- **Visualize it** with the [OSOP Editor](https://github.com/osopcloud/osop-editor)
+- **Use it as a reference** when building the equivalent Haystack pipeline in Python
+
+## Links
+
+- [OSOP Spec](https://github.com/osopcloud/osop-spec)
+- [OSOP CLI](https://github.com/osopcloud/osop)
+- [Haystack Documentation](https://docs.haystack.deepset.ai/)

--- a/examples/osop-rag-pipeline/haystack-rag-pipeline.osop
+++ b/examples/osop-rag-pipeline/haystack-rag-pipeline.osop
@@ -1,0 +1,66 @@
+# Haystack RAG Pipeline in OSOP Format
+osop_version: "1.0"
+id: haystack-rag-pipeline
+name: Haystack RAG Pipeline
+description: A retrieval-augmented generation pipeline using Haystack components, defined in portable OSOP format.
+tags: [haystack, rag, pipeline, nlp]
+
+nodes:
+  - id: query-input
+    type: human
+    name: User Query
+    description: User submits a natural language question.
+
+  - id: query-embedder
+    type: agent
+    name: Query Embedder
+    description: Convert the user query into a vector embedding.
+    runtime:
+      provider: openai
+      model: text-embedding-3-small
+
+  - id: retriever
+    type: db
+    name: Document Retriever
+    description: Search the document store for relevant passages using vector similarity.
+    runtime:
+      config:
+        top_k: 5
+        store: qdrant
+
+  - id: prompt-builder
+    type: system
+    name: Prompt Builder
+    description: Combine retrieved documents with the query into a structured prompt.
+
+  - id: generator
+    type: agent
+    name: Answer Generator
+    description: Generate a grounded answer using retrieved context.
+    runtime:
+      provider: openai
+      model: gpt-4
+      config:
+        temperature: 0.3
+
+  - id: answer-output
+    type: api
+    name: Response
+    description: Return the generated answer with source citations.
+
+edges:
+  - from: query-input
+    to: query-embedder
+    mode: sequential
+  - from: query-embedder
+    to: retriever
+    mode: sequential
+  - from: retriever
+    to: prompt-builder
+    mode: sequential
+  - from: prompt-builder
+    to: generator
+    mode: sequential
+  - from: generator
+    to: answer-output
+    mode: sequential


### PR DESCRIPTION
## Summary

- Adds a portable **OSOP** (Open Standard for Orchestration Protocols) workflow definition for a typical Haystack RAG pipeline
- Includes a `.osop` YAML file describing the pipeline (query embedding, vector retrieval, prompt building, answer generation) and a README explaining the mapping to Haystack components
- Files are additive only — no existing files modified

## What is OSOP?

[OSOP](https://github.com/osopcloud/osop-spec) is a YAML-based standard for describing multi-step workflows in a tool-agnostic way — like OpenAPI, but for workflows. A single `.osop` file can be validated, visualized, and used as a portable reference across different orchestration tools.

## Files Added

- `examples/osop-rag-pipeline/haystack-rag-pipeline.osop` — The workflow definition
- `examples/osop-rag-pipeline/README.md` — Explanation with Haystack component mapping

## Test plan

- [x] Files are valid YAML
- [x] No existing files modified
- [x] README includes clear mapping between OSOP nodes and Haystack components