### PR TITLE
test: use Qwen3-VL-8B-Instruct for HF API test_live_run_with_tools

### DIFF
--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -832,13 +832,13 @@ class TestHuggingFaceAPIChatGenerator:
         """
         We test the round trip: generate tool call, pass tool message, generate response.
 
-        The model used here (Qwen/Qwen3-Next-80B-A3B-Instruct) is not gated and kept in a warm state.
+        The model used here (Qwen/Qwen3-VL-8B-Instruct) is not gated and kept in a warm state.
         """
 
         chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "Qwen/Qwen3-Next-80B-A3B-Instruct", "provider": "together"},
+            api_params={"model": "Qwen/Qwen3-VL-8B-Instruct", "provider": "together"},
             generation_kwargs={"temperature": 0.5},
         )
 


### PR DESCRIPTION
### Related Issues

- failing tests due to previous model unavailable: https://github.com/deepset-ai/haystack/actions/runs/23928118362/job/69789262608

### Proposed Changes:
- use Qwen3-VL-8B-Instruct instead

### How did you test it?
CI

### Notes for the reviewer
Had a hard time choosing an instruct model (thinking makes the test slow), not gated, with good support for tool calling and served by HF API provides.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
