### PR TITLE
feat: Add ability to set messages as required in Agent through `required_variables`

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -256,6 +256,7 @@ class Agent:
             List variables that must be provided as input to user_prompt or system_prompt.
             If a variable listed as required is not provided, an exception is raised.
             If set to `"*"`, all variables found in the prompts are required. Optional.
+            You can also include `"messages"` to make the `messages` run-time input required.
         :param exit_conditions: List of conditions that will cause the agent to return.
             Can include "text" if the agent should return when it generates a message without tool calls,
             or tool names that will cause the agent to return once the tool was executed. Defaults to ["text"].
@@ -363,8 +364,12 @@ class Agent:
         """
         required_variables = self.required_variables
 
+        # Check whether required_variables targets any prompt template variables (i.e. not just "messages")
+        has_prompt_required_vars = required_variables == "*" or (
+            isinstance(required_variables, list) and any(v != "messages" for v in required_variables)
+        )
         if (
-            required_variables is not None
+            has_prompt_required_vars
             and self._system_chat_prompt_builder is None
             and self._user_chat_prompt_builder is None
         ):
@@ -405,6 +410,17 @@ class Agent:
                 component.set_input_type(self, name=var_name, type=Any)
             else:
                 component.set_input_type(self, name=var_name, type=Any, default=None)
+
+    def __post_init__(self) -> None:
+        """
+        Called by ComponentMeta after input/output sockets are parsed from the run method signature.
+
+        Used to retroactively make the ``messages`` input required when ``"messages"`` is listed
+        in ``required_variables``, which cannot be done inside ``__init__`` because the socket
+        hasn't been parsed yet at that point.
+        """
+        if isinstance(self.required_variables, list) and "messages" in self.required_variables:
+            component.set_input_type(self, name="messages", type=list[ChatMessage])
 
     def warm_up(self) -> None:
         """

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -261,7 +261,8 @@ class ComponentMeta(type):
                 existing_socket = sockets.get(param_name)
                 if existing_socket is not None and existing_socket != new_socket:
                     raise ComponentError(
-                        "set_input_types()/set_input_type() cannot override the parameters of the 'run' method"
+                        "set_input_types()/set_input_type() cannot override the parameters of the 'run' method.\n"
+                        f"Conflict found for parameter '{param_name}': {existing_socket} vs {new_socket}"
                     )
 
                 sockets[param_name] = new_socket
@@ -321,6 +322,11 @@ class ComponentMeta(type):
 
         ComponentMeta._parse_and_set_input_sockets(cls, instance)
         ComponentMeta._parse_and_set_output_sockets(instance)
+
+        # Call __post_init__ if defined, allowing components to adjust sockets after
+        # the run method signature has been parsed (e.g. to make an existing socket required).
+        if callable(getattr(instance, "__post_init__", None)):
+            instance.__post_init__()
 
         # Since a Component can't be used in multiple Pipelines at the same time
         # we need to know if it's already owned by a Pipeline when adding it to one.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -1392,6 +1392,20 @@ class TestRegisterPromptVariables:
         make_agent(required_variables=["name"])
         assert "The parameter required_variables is provided but neither" in caplog.text
 
+    def test_register_prompt_variables_messages_required(self, make_agent):
+        agent = make_agent(required_variables=["messages"])
+        messages_socket = agent.__haystack_input__._sockets_dict["messages"]
+        assert messages_socket.is_mandatory
+
+    def test_register_prompt_variables_messages_optional_by_default(self, make_agent):
+        agent = make_agent()
+        messages_socket = agent.__haystack_input__._sockets_dict["messages"]
+        assert not messages_socket.is_mandatory
+
+    def test_register_prompt_variables_no_warning_when_only_messages_required(self, make_agent, caplog):
+        make_agent(required_variables=["messages"])
+        assert "The parameter required_variables is provided but neither" not in caplog.text
+
     def test_register_prompt_variables_set_all_variables_as_required(self, make_agent):
         agent = make_agent(user_prompt=_user_msg("Question: {{question}}"), required_variables="*")
         assert agent._user_chat_prompt_builder.required_variables == "*"


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
