### PR TITLE
Add FERPAMetadataRetriever component for regulated higher-education RAG

### DIFF
--- a/haystack/components/retrievers/__init__.py
+++ b/haystack/components/retrievers/__init__.py
@@ -9,6 +9,7 @@ from lazy_imports import LazyImporter
 
 _import_structure = {
     "auto_merging_retriever": ["AutoMergingRetriever"],
+    "ferpa_metadata_retriever": ["FERPAMetadataRetriever"],
     "filter_retriever": ["FilterRetriever"],
     "in_memory": ["InMemoryBM25Retriever", "InMemoryEmbeddingRetriever"],
     "multi_query_embedding_retriever": ["MultiQueryEmbeddingRetriever"],
@@ -18,6 +19,7 @@ _import_structure = {
 
 if TYPE_CHECKING:
     from .auto_merging_retriever import AutoMergingRetriever as AutoMergingRetriever
+    from .ferpa_metadata_retriever import FERPAMetadataRetriever as FERPAMetadataRetriever
     from .filter_retriever import FilterRetriever as FilterRetriever
     from .in_memory import InMemoryBM25Retriever as InMemoryBM25Retriever
     from .in_memory import InMemoryEmbeddingRetriever as InMemoryEmbeddingRetriever

--- a/haystack/components/retrievers/ferpa_metadata_retriever.py
+++ b/haystack/components/retrievers/ferpa_metadata_retriever.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack import Document, component, default_from_dict, default_to_dict
+from haystack.document_stores.types import DocumentStore
+
+
+@component
+class FERPAMetadataRetriever:
+    """
+    Retrieves documents that match both a ``student_id`` and an ``institution_id``
+    metadata constraint, enforcing FERPA (Family Educational Rights and Privacy Act)
+    identity boundaries in retrieval-augmented generation pipelines.
+
+    This component is designed for higher-education AI systems where student records
+    stored in the document store must not cross student or institution boundaries
+    during retrieval. The identity filter is applied **at the document store query**,
+    before any ranking or scoring occurs, so that unauthorized documents are never
+    surfaced in the result set regardless of their semantic similarity to the query.
+
+    The component builds a compound ``AND`` filter from the provided identity fields
+    and delegates to the document store's ``filter_documents`` method, which applies
+    the filter using the same metadata index used by all other retrievers. This makes
+    the enforcement consistent with any other metadata-based access control already
+    in place on the store.
+
+    **FERPA compliance note:** This component enforces the identity isolation layer
+    of a FERPA-compliant RAG pipeline. Callers are also responsible for:
+
+    - Verifying that the ``student_id`` and ``institution_id`` values originate from
+      an authenticated session, not from user-supplied query parameters.
+    - Logging each retrieval event as required by 34 CFR § 99.32 (disclosure records).
+    - Restricting retrieval to authorized document categories (e.g., excluding
+      counseling notes if the session does not carry that permission).
+
+    ### Usage example
+
+    ```python
+    from haystack import Document
+    from haystack.components.retrievers import FERPAMetadataRetriever
+    from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+    docs = [
+        Document(
+            content="Alice is enrolled full-time, 15 credit hours.",
+            meta={"student_id": "stu-alice", "institution_id": "univ-east", "category": "academic_record"},
+        ),
+        Document(
+            content="Bob is enrolled part-time, 6 credit hours.",
+            meta={"student_id": "stu-bob", "institution_id": "univ-east", "category": "academic_record"},
+        ),
+        Document(
+            content="Carol is enrolled at West University.",
+            meta={"student_id": "stu-carol", "institution_id": "univ-west", "category": "academic_record"},
+        ),
+    ]
+
+    doc_store = InMemoryDocumentStore()
+    doc_store.write_documents(docs)
+
+    retriever = FERPAMetadataRetriever(
+        document_store=doc_store,
+        student_id="stu-alice",
+        institution_id="univ-east",
+    )
+
+    # Returns only Alice's document at univ-east.
+    # Bob's document (different student) and Carol's document
+    # (different institution) are excluded.
+    result = retriever.run()
+    print(result["documents"])
+    ```
+
+    The ``student_id`` and ``institution_id`` can also be supplied at run time,
+    which allows the same component instance to serve different authenticated
+    sessions in a pipeline:
+
+    ```python
+    retriever = FERPAMetadataRetriever(document_store=doc_store)
+    result = retriever.run(student_id="stu-alice", institution_id="univ-east")
+    ```
+    """
+
+    def __init__(
+        self,
+        document_store: DocumentStore,
+        student_id: str | None = None,
+        institution_id: str | None = None,
+        student_id_field: str = "student_id",
+        institution_id_field: str = "institution_id",
+    ) -> None:
+        """
+        Create the FERPAMetadataRetriever component.
+
+        :param document_store:
+            An instance of a Document Store to use with the Retriever.
+        :param student_id:
+            The student identifier to filter on. Documents whose ``student_id``
+            metadata field does not match this value are excluded. If ``None``,
+            the value must be supplied at run time.
+        :param institution_id:
+            The institution identifier to filter on. Documents whose
+            ``institution_id`` metadata field does not match this value are
+            excluded. If ``None``, the value must be supplied at run time.
+        :param student_id_field:
+            The name of the metadata field that holds the student identifier.
+            Defaults to ``"student_id"``. Override if your document store uses
+            a different field name (e.g., ``"learner_id"`` or ``"user_id"``).
+        :param institution_id_field:
+            The name of the metadata field that holds the institution identifier.
+            Defaults to ``"institution_id"``. Override if your document store uses
+            a different field name (e.g., ``"org_id"`` or ``"tenant_id"``).
+        """
+        self.document_store = document_store
+        self.student_id = student_id
+        self.institution_id = institution_id
+        self.student_id_field = student_id_field
+        self.institution_id_field = institution_id_field
+
+    def _get_telemetry_data(self) -> dict[str, Any]:
+        """
+        Data that is sent to Posthog for usage analytics.
+        """
+        return {"document_store": type(self.document_store).__name__}
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            document_store=self.document_store,
+            student_id=self.student_id,
+            institution_id=self.institution_id,
+            student_id_field=self.student_id_field,
+            institution_id_field=self.institution_id_field,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "FERPAMetadataRetriever":
+        """
+        Deserializes the component from a dictionary.
+
+        :param data:
+            The dictionary to deserialize from.
+        :returns:
+            The deserialized component.
+        """
+        return default_from_dict(cls, data)
+
+    def _build_filter(self, student_id: str, institution_id: str) -> dict[str, Any]:
+        """
+        Build a compound AND filter matching both identity fields.
+
+        :param student_id: The student identifier value to filter on.
+        :param institution_id: The institution identifier value to filter on.
+        :returns:
+            A Haystack filter dict with an AND operator over both conditions.
+        """
+        return {
+            "operator": "AND",
+            "conditions": [
+                {"field": f"meta.{self.student_id_field}", "operator": "==", "value": student_id},
+                {"field": f"meta.{self.institution_id_field}", "operator": "==", "value": institution_id},
+            ],
+        }
+
+    @component.output_types(documents=list[Document])
+    def run(
+        self,
+        student_id: str | None = None,
+        institution_id: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Run the FERPAMetadataRetriever.
+
+        Retrieves documents from the document store that match both the
+        ``student_id`` and ``institution_id`` identity constraints. Values
+        supplied at run time take precedence over those provided at
+        initialization.
+
+        :param student_id:
+            The student identifier to filter on at run time. If not supplied,
+            the value from initialization is used. One of the two must be set.
+        :param institution_id:
+            The institution identifier to filter on at run time. If not
+            supplied, the value from initialization is used. One of the two
+            must be set.
+        :raises ValueError:
+            If neither an initialization-time nor a run-time value is available
+            for ``student_id`` or ``institution_id``.
+        :returns:
+            A dict with a single key ``"documents"`` containing the list of
+            documents that satisfy both identity constraints.
+        """
+        resolved_student_id = student_id or self.student_id
+        resolved_institution_id = institution_id or self.institution_id
+
+        if not resolved_student_id:
+            msg = (
+                "FERPAMetadataRetriever requires a student_id. "
+                "Provide it at initialization or at run time."
+            )
+            raise ValueError(msg)
+
+        if not resolved_institution_id:
+            msg = (
+                "FERPAMetadataRetriever requires an institution_id. "
+                "Provide it at initialization or at run time."
+            )
+            raise ValueError(msg)
+
+        filters = self._build_filter(
+            student_id=resolved_student_id,
+            institution_id=resolved_institution_id,
+        )
+        return {"documents": self.document_store.filter_documents(filters=filters)}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self,
+        student_id: str | None = None,
+        institution_id: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Asynchronously run the FERPAMetadataRetriever.
+
+        See :meth:`run` for full parameter and return value documentation.
+
+        :raises ValueError:
+            If neither an initialization-time nor a run-time value is available
+            for ``student_id`` or ``institution_id``.
+        :returns:
+            A dict with a single key ``"documents"`` containing the list of
+            documents that satisfy both identity constraints.
+        """
+        resolved_student_id = student_id or self.student_id
+        resolved_institution_id = institution_id or self.institution_id
+
+        if not resolved_student_id:
+            msg = (
+                "FERPAMetadataRetriever requires a student_id. "
+                "Provide it at initialization or at run time."
+            )
+            raise ValueError(msg)
+
+        if not resolved_institution_id:
+            msg = (
+                "FERPAMetadataRetriever requires an institution_id. "
+                "Provide it at initialization or at run time."
+            )
+            raise ValueError(msg)
+
+        filters = self._build_filter(
+            student_id=resolved_student_id,
+            institution_id=resolved_institution_id,
+        )
+        # type: ignore[attr-defined] — filter_documents_async not in Protocol but exists in implementations
+        out_documents = await self.document_store.filter_documents_async(filters=filters)  # type: ignore[attr-defined]
+        return {"documents": out_documents}

--- a/test/components/retrievers/test_ferpa_metadata_retriever.py
+++ b/test/components/retrievers/test_ferpa_metadata_retriever.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack import Pipeline
+from haystack.components.retrievers.ferpa_metadata_retriever import FERPAMetadataRetriever
+from haystack.dataclasses import Document
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack.testing.factory import document_store_class
+
+
+@pytest.fixture()
+def sample_docs():
+    """Documents representing records from two students at two institutions."""
+    alice_east = [
+        Document(
+            content="Alice is enrolled full-time, 15 credit hours.",
+            meta={"student_id": "stu-alice", "institution_id": "univ-east", "category": "academic_record"},
+        ),
+        Document(
+            content="Alice: tuition balance $0.",
+            meta={"student_id": "stu-alice", "institution_id": "univ-east", "category": "financial_record"},
+        ),
+    ]
+    bob_east = [
+        Document(
+            content="Bob is enrolled part-time, 6 credit hours.",
+            meta={"student_id": "stu-bob", "institution_id": "univ-east", "category": "academic_record"},
+        ),
+    ]
+    carol_west = [
+        Document(
+            content="Carol is enrolled at West University, 12 credit hours.",
+            meta={"student_id": "stu-carol", "institution_id": "univ-west", "category": "academic_record"},
+        ),
+    ]
+    all_docs = alice_east + bob_east + carol_west
+    return {
+        "alice_east": alice_east,
+        "bob_east": bob_east,
+        "carol_west": carol_west,
+        "all_docs": all_docs,
+    }
+
+
+@pytest.fixture()
+def sample_document_store(sample_docs):
+    doc_store = InMemoryDocumentStore()
+    doc_store.write_documents(sample_docs["all_docs"])
+    return doc_store
+
+
+class TestFERPAMetadataRetriever:
+    @classmethod
+    def _documents_equal(cls, docs1: list[Document], docs2: list[Document]) -> bool:
+        docs1.sort(key=lambda x: x.id)
+        docs2.sort(key=lambda x: x.id)
+        return docs1 == docs2
+
+    # ------------------------------------------------------------------
+    # Initialization
+    # ------------------------------------------------------------------
+
+    def test_init_default(self, sample_document_store):
+        retriever = FERPAMetadataRetriever(sample_document_store)
+        assert retriever.student_id is None
+        assert retriever.institution_id is None
+        assert retriever.student_id_field == "student_id"
+        assert retriever.institution_id_field == "institution_id"
+
+    def test_init_with_identity(self, sample_document_store):
+        retriever = FERPAMetadataRetriever(
+            sample_document_store,
+            student_id="stu-alice",
+            institution_id="univ-east",
+        )
+        assert retriever.student_id == "stu-alice"
+        assert retriever.institution_id == "univ-east"
+
+    def test_init_with_custom_field_names(self, sample_document_store):
+        retriever = FERPAMetadataRetriever(
+            sample_document_store,
+            student_id="stu-alice",
+            institution_id="univ-east",
+            student_id_field="learner_id",
+            institution_id_field="org_id",
+        )
+        assert retriever.student_id_field == "learner_id"
+        assert retriever.institution_id_field == "org_id"
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def test_to_dict(self):
+        FakeStore = document_store_class("FakeStore", bases=(InMemoryDocumentStore,))
+        doc_store = FakeStore()
+        doc_store.to_dict = lambda: {"type": "FakeStore", "init_parameters": {}}
+
+        component = FERPAMetadataRetriever(
+            document_store=doc_store,
+            student_id="stu-alice",
+            institution_id="univ-east",
+        )
+        data = component.to_dict()
+        assert data == {
+            "type": "haystack.components.retrievers.ferpa_metadata_retriever.FERPAMetadataRetriever",
+            "init_parameters": {
+                "document_store": {"type": "FakeStore", "init_parameters": {}},
+                "student_id": "stu-alice",
+                "institution_id": "univ-east",
+                "student_id_field": "student_id",
+                "institution_id_field": "institution_id",
+            },
+        }
+
+    def test_from_dict(self):
+        valid_data = {
+            "type": "haystack.components.retrievers.ferpa_metadata_retriever.FERPAMetadataRetriever",
+            "init_parameters": {
+                "document_store": {
+                    "type": "haystack.document_stores.in_memory.document_store.InMemoryDocumentStore",
+                    "init_parameters": {},
+                },
+                "student_id": "stu-alice",
+                "institution_id": "univ-east",
+                "student_id_field": "student_id",
+                "institution_id_field": "institution_id",
+            },
+        }
+        component = FERPAMetadataRetriever.from_dict(valid_data)
+        assert isinstance(component.document_store, InMemoryDocumentStore)
+        assert component.student_id == "stu-alice"
+        assert component.institution_id == "univ-east"
+
+    # ------------------------------------------------------------------
+    # Filter construction
+    # ------------------------------------------------------------------
+
+    def test_build_filter_structure(self, sample_document_store):
+        retriever = FERPAMetadataRetriever(sample_document_store)
+        f = retriever._build_filter("stu-alice", "univ-east")
+        assert f["operator"] == "AND"
+        conditions = {c["field"]: c for c in f["conditions"]}
+        assert "meta.student_id" in conditions
+        assert conditions["meta.student_id"]["value"] == "stu-alice"
+        assert "meta.institution_id" in conditions
+        assert conditions["meta.institution_id"]["value"] == "univ-east"
+
+    def test_build_filter_custom_field_names(self, sample_document_store):
+        retriever = FERPAMetadataRetriever(
+            sample_document_store,
+            student_id_field="learner_id",
+            institution_id_field="org_id",
+        )
+        f = retriever._build_filter("stu-alice", "univ-east")
+        fields = [c["field"] for c in f["conditions"]]
+        assert "meta.learner_id" in fields
+        assert "meta.org_id" in fields
+
+    # ------------------------------------------------------------------
+    # Retrieval — identity enforcement
+    # ------------------------------------------------------------------
+
+    def test_retrieval_with_init_identity(self, sample_document_store, sample_docs):
+        retriever = FERPAMetadataRetriever(
+            sample_document_store,
+            student_id="stu-alice",
+            institution_id="univ-east",
+        )
+        result = retriever.run()
+
+        assert "documents" in result
+        assert TestFERPAMetadataRetriever._documents_equal(
+            result["documents"], sample_docs["alice_east"]
+        )
+
+    def test_retrieval_with_runtime_identity(self, sample_document_store, sample_docs):
+        retriever = FERPAMetadataRetriever(sample_document_store)
+        result = retriever.run(student_id="stu-alice", institution_id="univ-east")
+
+        assert "documents" in result
+        assert TestFERPAMetadataRetriever._documents_equal(
+            result["documents"], sample_docs["alice_east"]
+        )
+
+    def test_runtime_identity_overrides_init(self, sample_document_store, sample_docs):
+        # Init with Alice; run with Bob — Bob's docs should be returned.
+        retriever = FERPAMetadataRetriever(
+            sample_document_store,
+            student_id="stu-alice",
+            institution_id="univ-east",
+        )
+        result = retriever.run(student_id="stu-bob", institution_id="univ-east")
+
+        assert "documents" in result
+        assert TestFERPAMetadataRetriever._documents_equal(
+            result["documents"], sample_docs["bob_east"]
+        )
+
+    def test_cross_student_isolation(self, sample_document_store, sample_docs):
+        """Bob's records must not be returned when querying for Alice."""
+        retriever = FERPAMetadataRetriever(
+            sample_document_store,
+            student_id="stu-alice",
+            institution_id="univ-east",
+        )
+        result = retriever.run()
+
+        returned_ids = {doc.meta["student_id"] for doc in result["documents"]}
+        assert "stu-bob" not in returned_ids
+        assert "stu-carol" not in returned_ids
+
+    def test_cross_institution_isolation(self, sample_document_store, sample_docs):
+        """
+        Carol's records at univ-west must not appear when querying the univ-east
+        store, even if there happens to be a student at univ-east with the same ID.
+        """
+        retriever = FERPAMetadataRetriever(
+            sample_document_store,
+            student_id="stu-carol",
+            institution_id="univ-east",  # note: carol is at univ-west
+        )
+        result = retriever.run()
+
+        assert result["documents"] == []
+
+    def test_no_results_for_unknown_student(self, sample_document_store):
+        retriever = FERPAMetadataRetriever(
+            sample_document_store,
+            student_id="stu-unknown",
+            institution_id="univ-east",
+        )
+        result = retriever.run()
+        assert result["documents"] == []
+
+    # ------------------------------------------------------------------
+    # Validation errors
+    # ------------------------------------------------------------------
+
+    def test_missing_student_id_raises(self, sample_document_store):
+        retriever = FERPAMetadataRetriever(
+            sample_document_store,
+            institution_id="univ-east",
+        )
+        with pytest.raises(ValueError, match="student_id"):
+            retriever.run()
+
+    def test_missing_institution_id_raises(self, sample_document_store):
+        retriever = FERPAMetadataRetriever(
+            sample_document_store,
+            student_id="stu-alice",
+        )
+        with pytest.raises(ValueError, match="institution_id"):
+            retriever.run()
+
+    def test_missing_both_raises(self, sample_document_store):
+        retriever = FERPAMetadataRetriever(sample_document_store)
+        with pytest.raises(ValueError):
+            retriever.run()
+
+    # ------------------------------------------------------------------
+    # Pipeline integration
+    # ------------------------------------------------------------------
+
+    @pytest.mark.integration
+    def test_run_in_pipeline(self, sample_document_store, sample_docs):
+        retriever = FERPAMetadataRetriever(
+            sample_document_store,
+            student_id="stu-alice",
+            institution_id="univ-east",
+        )
+
+        pipeline = Pipeline()
+        pipeline.add_component("ferpa_retriever", retriever)
+        result = pipeline.run(data={"ferpa_retriever": {}})
+
+        assert "ferpa_retriever" in result
+        docs = result["ferpa_retriever"]["documents"]
+        assert TestFERPAMetadataRetriever._documents_equal(docs, sample_docs["alice_east"])
+
+    @pytest.mark.integration
+    def test_run_in_pipeline_with_runtime_identity(self, sample_document_store, sample_docs):
+        retriever = FERPAMetadataRetriever(sample_document_store)
+
+        pipeline = Pipeline()
+        pipeline.add_component("ferpa_retriever", retriever)
+
+        result = pipeline.run(
+            data={"ferpa_retriever": {"student_id": "stu-bob", "institution_id": "univ-east"}}
+        )
+        docs = result["ferpa_retriever"]["documents"]
+        assert TestFERPAMetadataRetriever._documents_equal(docs, sample_docs["bob_east"])


### PR DESCRIPTION
## Summary

This PR adds a `FERPAMetadataRetriever` component to `haystack/components/retrievers/` that enforces FERPA (Family Educational Rights and Privacy Act) identity boundaries in retrieval-augmented generation pipelines for higher-education deployments.

## Problem

Higher-education teams building RAG systems on Haystack need to ensure that student records do not cross identity or institutional boundaries during retrieval. The naive approach — retrieval followed by post-filtering — is insufficient for regulated environments: unauthorized documents enter the candidate pool and reach the scoring layer before being discarded, leaving a gap if the post-filter has a defect.

The correct approach is to apply the identity constraint **at the document store query** (pre-filter), so unauthorized documents never enter the retrieval pipeline regardless of their semantic similarity to the query. Haystack's `FilterRetriever` provides the mechanism; this component wraps it with FERPA-specific semantics, validation, and documentation.

## What this adds

**`haystack/components/retrievers/ferpa_metadata_retriever.py`**

- `FERPAMetadataRetriever` — a `@component`-decorated retriever that accepts `student_id` and `institution_id` (at init or run time) and builds a compound AND filter over those metadata fields before querying the document store
- Configurable field names (`student_id_field`, `institution_id_field`) for deployments using non-standard naming
- `run()` and `run_async()` both implemented
- `to_dict()` / `from_dict()` serialization following existing patterns
- Pipeline-compatible: identity can be injected at run time from an upstream authentication component

**`test/components/retrievers/test_ferpa_metadata_retriever.py`**

16 tests covering:
- Initialization with and without identity values
- Custom metadata field names
- Serialization round-trip
- Filter structure (AND operator, `meta.` field prefix)
- Cross-student isolation (Alice's query cannot return Bob's records)
- Cross-institution isolation (univ-east query cannot return univ-west records)
- Runtime identity override (run-time values take precedence over init-time)
- Missing-identity `ValueError` for both fields
- Pipeline integration with init-time and run-time identity

## Design notes

The component enforces identity at query time rather than post-retrieval because:

1. Documents never enter the candidate set — no semantic ranking of unauthorized content occurs
2. The behavior is deterministic — a cross-identity result cannot appear regardless of embedding similarity
3. The approach is consistent with how student information systems already implement field-level access control

The component addresses the retrieval-layer isolation requirement only. Callers remain responsible for session authentication, document category authorization (e.g., excluding counseling notes), and 34 CFR § 99.32 disclosure logging.

## FERPA context

FERPA (20 U.S.C. § 1232g; 34 CFR Part 99) governs access to education records in US higher-education institutions. Its requirements are directly analogous to HIPAA's minimum-necessary standard for healthcare records and GLBA's safeguards rule for financial records — the same retrieval-layer pattern applies to all three.

## Checklist

- [x] Component follows `@component` decorator pattern used throughout `haystack/components/retrievers/`
- [x] `run()` and `run_async()` both implemented with `@component.output_types`
- [x] `to_dict()` / `from_dict()` serialization implemented
- [x] Exported from `haystack/components/retrievers/__init__.py` via `_import_structure`
- [x] 16 tests including cross-student/institution isolation and pipeline integration
- [x] SPDX license headers present