### PR TITLE
docs: Add `pip install pre-commit` instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,12 @@ $ hatch version
 2.3.0-rc0
 ```
 
+Next, you need to install the pre-commit package with:
+
+```bash
+pip install pre-commit
+```
+
 Last, install the pre-commit hooks with:
 
 ```bash


### PR DESCRIPTION
### Related Issues

- I went through the steps and got an error at installing pre-commit hooks, because of missing `pip install pre-commit` instructions step in the docs

### Proposed Changes:

adding the `pip install` instructions step to the md file

### How did you test it?

Running the command in my terminal and making sure that installing the hooks as per the instructions then worked
