### PR TITLE
docs: Add `pip install pre-commit` instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,11 @@ $ cd haystack
 $ hatch version
 2.3.0-rc0
 ```
+Next, you need to install the pre-commit package with:
+
+```bash
+pip install pre-commit
+```
 
 Last, install the pre-commit hooks with:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ $ hatch --version
 Hatch, version 1.14.1
 ```
 
-You can create a new virtual environment for Haystack with `hatch` by running:
+You create a new virtual environment for Haystack with `hatch` by running:
 
 ```console
 $ hatch shell
@@ -220,19 +220,24 @@ If everything worked, you should be able to do something like this (the output m
 
 ```console
 $ cd haystack
+
+$ hatch shell
+You are about to enter a new shell, exit as you usually would e.g. by typing `exit` or pressing `ctrl+d`...
+
 $ hatch version
 2.3.0-rc0
-```
-Next, you need to install the pre-commit package with:
-
-```bash
-pip install pre-commit
 ```
 
 Last, install the pre-commit hooks with:
 
 ```bash
 pre-commit install
+```
+
+Note: It is important to run `pre-commit install` inside the virtual environment created with `hatch shell`. If you don't, you'll get an error message like this:
+
+```bash
+pre-commit: command not found
 ```
 
 This utility will run some tasks right before all `git commit` operations. From now on, your `git commit` output for

--- a/docs-website/docs/overview/installation.mdx
+++ b/docs-website/docs/overview/installation.mdx
@@ -47,20 +47,5 @@ ImportError: "Haystack failed to import the optional dependency 'pypdf'. Run 'pi
 
 ## Contributing to Haystack
 
-If you would like to contribute to the Haystack, check our [Contributor Guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) first.
-
-To be able to make changes to Haystack code, install with the following commands:
-
-```shell
-## Clone the repo
-git clone https://github.com/deepset-ai/haystack.git
-
-## Move into the cloned folder
-cd haystack
-
-## Upgrade pip
-pip install --upgrade pip
-
-## Install Haystack in editable mode
-pip install -e '.[dev]'
-```
+If you would like to contribute to the Haystack, check our [Contributor Guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) first
+and follow the instructions [here](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#setting-up-your-development-environment) to set up your development environment.

--- a/docs-website/versioned_docs/version-2.27/overview/installation.mdx
+++ b/docs-website/versioned_docs/version-2.27/overview/installation.mdx
@@ -47,20 +47,5 @@ ImportError: "Haystack failed to import the optional dependency 'pypdf'. Run 'pi
 
 ## Contributing to Haystack
 
-If you would like to contribute to the Haystack, check our [Contributor Guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) first.
-
-To be able to make changes to Haystack code, install with the following commands:
-
-```shell
-## Clone the repo
-git clone https://github.com/deepset-ai/haystack.git
-
-## Move into the cloned folder
-cd haystack
-
-## Upgrade pip
-pip install --upgrade pip
-
-## Install Haystack in editable mode
-pip install -e '.[dev]'
-```
+If you would like to contribute to the Haystack, check our [Contributor Guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) first
+and follow the instructions [here](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#setting-up-your-development-environment) to set up your development environment.


### PR DESCRIPTION
### Related Issues

 I went through the steps and got an error at installing pre-commit hooks, because of the missing pip install pre-commit instructions step in the docs

### Proposed Changes:

adding the `pip install pre-commit` instructions step to the CONTRIBUTIONS.md file

### How did you test it?

Running the command in my terminal and making sure that installing the hooks as the next step per the instructions then worked.