### PR TITLE
docs: add yaml example to document cleaner documentation

### DIFF
--- a/docs-website/docs/pipeline-components/preprocessors/documentcleaner.mdx
+++ b/docs-website/docs/pipeline-components/preprocessors/documentcleaner.mdx
@@ -91,3 +91,61 @@ p.connect("splitter.documents", "writer.documents")
 
 p.run({"text_file_converter": {"sources": your_files}})
 ```
+
+### In YAML
+```yaml
+components:
+  cleaner:
+    init_parameters:
+      ascii_only: false
+      keep_id: false
+      remove_empty_lines: true
+      remove_extra_whitespaces: true
+      remove_regex: null
+      remove_repeated_substrings: false
+      remove_substrings: null
+      replace_regexes: null
+      strip_whitespaces: false
+      unicode_normalization: null
+    type: haystack.components.preprocessors.document_cleaner.DocumentCleaner
+  splitter:
+    init_parameters:
+      extend_abbreviations: true
+      language: en
+      respect_sentence_boundary: false
+      skip_empty_documents: true
+      split_by: sentence
+      split_length: 1
+      split_overlap: 0
+      split_threshold: 0
+      use_split_rules: true
+    type: haystack.components.preprocessors.document_splitter.DocumentSplitter
+  text_file_converter:
+    init_parameters:
+      encoding: utf-8
+      store_full_path: false
+    type: haystack.components.converters.txt.TextFileToDocument
+  writer:
+    init_parameters:
+      document_store:
+        init_parameters:
+          bm25_algorithm: BM25L
+          bm25_parameters: {}
+          bm25_tokenization_regex: (?u)\\b\\w+\\b
+          embedding_similarity_function: dot_product
+          index: 64e4f9ab-87fb-47fd-b390-dabcfda61447
+          return_embedding: true
+        type: haystack.document_stores.in_memory.document_store.InMemoryDocumentStore
+      policy: NONE
+    type: haystack.components.writers.document_writer.DocumentWriter
+connection_type_validation: true
+connections:
+- receiver: cleaner.documents
+  sender: text_file_converter.documents
+- receiver: splitter.documents
+  sender: cleaner.documents
+- receiver: writer.documents
+  sender: splitter.documents
+max_runs_per_component: 100
+metadata: {}
+```


### PR DESCRIPTION
Related to #11083: This PR adds a YAML pipeline configuration example to the Document Cleaner documentation. This YAML representation can be used to instantiate the pipeline using `Pipeline.loads()` and provides users with a practical example of YAML-based pipeline configuration as an alternative to programmatic creation.

### Testing
I instantiated the pipeline from the YAML with `Pipeline.loads()` and run it without error. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
