### PR TITLE
Add Claude Code GitHub workflows (org-member gated)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,45 @@
+name: Claude Code Review
+# For deepset-ai org members: runs automatically on every PR
+# For external contributors: runs when a maintainer adds the 'claude-review' label
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  claude-review:
+    if: |
+      (
+        github.event_name == 'pull_request' &&
+        !github.event.pull_request.head.repo.fork &&
+        (
+          github.event.pull_request.author_association == 'MEMBER' ||
+          github.event.pull_request.author_association == 'OWNER' ||
+          github.event.pull_request.author_association == 'COLLABORATOR'
+        )
+      ) || (
+        github.event_name == 'pull_request_target' &&
+        github.event.label.name == 'claude-review'
+      )
+    runs-on: ubuntu-slim
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_PR_REVIEWS }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,60 @@
+name: Claude Code
+# Only deepset-ai org members (MEMBER, OWNER, COLLABORATOR) can trigger @claude
+# The 'issues' trigger is intentionally omitted for this public repo to prevent
+# external users from triggering the action.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      ) || (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      ) || (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        (
+          github.event.review.author_association == 'MEMBER' ||
+          github.event.review.author_association == 'OWNER' ||
+          github.event.review.author_association == 'COLLABORATOR'
+        )
+      )
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1.0.93
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_PR_REVIEWS }}
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows for Claude Code integration, designed for a public open-source repo with cost and security controls.

### What's included

- **`claude-code-review.yml`** — Automatic AI PR reviews
- **`claude.yml`** — `@claude` mention support in comments/reviews

### Security & cost model

#### Auto-reviews (`claude-code-review.yml`)
- **deepset-ai org members** (`MEMBER`, `OWNER`, `COLLABORATOR`): triggered automatically on every PR opened from a non-fork branch
- **External contributors**: only triggered when a maintainer explicitly adds the `claude-review` label — no automatic API calls for fork PRs
- Fork PRs are explicitly excluded from the `pull_request` trigger to avoid wasted runner minutes

#### `@claude` mentions (`claude.yml`)
- Only `MEMBER`, `OWNER`, or `COLLABORATOR` author associations can trigger the action
- Each event type (`issue_comment`, `pull_request_review_comment`, `pull_request_review`) checks the correct association field to avoid null access
- The `issues` trigger is intentionally omitted — any external user could open an issue with `@claude` in it

#### Secret safety
- `pull_request_target` + `labeled` (for external PR reviews): runs in base branch context with secret access, but **does not check out fork code** — Claude reads the PR diff via GitHub API only
- `pull_request` (for internal reviews): secrets are not available for fork PRs by GitHub's design anyway

### Required secret
`ANTHROPIC_API_KEY_PR_REVIEWS` — should be available at org level already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)