### PR TITLE
feat: Enhance agent snapshot serialization with error handling for non-serializable inputs

### DIFF
--- a/haystack/core/pipeline/breakpoint.py
+++ b/haystack/core/pipeline/breakpoint.py
@@ -375,13 +375,32 @@ def _create_agent_snapshot(
     :param agent_breakpoint: AgentBreakpoint object containing breakpoints
     :return: An AgentSnapshot containing the agent's state and component visits.
     """
+    try:
+        serialized_chat_generator = _serialize_value_with_schema(
+            _deepcopy_with_exceptions(component_inputs["chat_generator"])
+        )
+    except Exception as error:
+        logger.warning(
+            "Failed to serialize the agent's chat_generator inputs. "
+            "The inputs in the snapshot will be replaced with an empty dictionary. Error: {e}",
+            e=error,
+        )
+        serialized_chat_generator = {}
+
+    try:
+        serialized_tool_invoker = _serialize_value_with_schema(
+            _deepcopy_with_exceptions(component_inputs["tool_invoker"])
+        )
+    except Exception as error:
+        logger.warning(
+            "Failed to serialize the agent's tool_invoker inputs. "
+            "The inputs in the snapshot will be replaced with an empty dictionary. Error: {e}",
+            e=error,
+        )
+        serialized_tool_invoker = {}
+
     return AgentSnapshot(
-        component_inputs={
-            "chat_generator": _serialize_value_with_schema(
-                _deepcopy_with_exceptions(component_inputs["chat_generator"])
-            ),
-            "tool_invoker": _serialize_value_with_schema(_deepcopy_with_exceptions(component_inputs["tool_invoker"])),
-        },
+        component_inputs={"chat_generator": serialized_chat_generator, "tool_invoker": serialized_tool_invoker},
         component_visits=component_visits,
         break_point=agent_breakpoint,
         timestamp=datetime.now(),

--- a/releasenotes/notes/error-handling-agent-snapshot-bd5adfd458e9981a.yaml
+++ b/releasenotes/notes/error-handling-agent-snapshot-bd5adfd458e9981a.yaml
@@ -1,7 +1,7 @@
 ---
 enhancements:
   - |
-    Made `_create_agent_snapshot` robust towards serialization errors. If serializing
+    Made ``_create_agent_snapshot`` robust towards serialization errors. If serializing
     agent component inputs fails, a warning is logged and an empty dictionary is used
     as a fallback, preventing the serialization error from masking the real pipeline
     runtime error.

--- a/releasenotes/notes/error-handling-agent-snapshot-bd5adfd458e9981a.yaml
+++ b/releasenotes/notes/error-handling-agent-snapshot-bd5adfd458e9981a.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Made `_create_agent_snapshot` robust towards serialization errors. If serializing
+    agent component inputs fails, a warning is logged and an empty dictionary is used
+    as a fallback, preventing the serialization error from masking the real pipeline
+    runtime error.

--- a/test/core/pipeline/test_breakpoint.py
+++ b/test/core/pipeline/test_breakpoint.py
@@ -12,6 +12,7 @@ from haystack.core.errors import BreakpointException
 from haystack.core.pipeline import Pipeline
 from haystack.core.pipeline.breakpoint import (
     HAYSTACK_PIPELINE_SNAPSHOT_SAVE_ENABLED,
+    _create_agent_snapshot,
     _create_pipeline_snapshot,
     _is_snapshot_save_enabled,
     _save_pipeline_snapshot,
@@ -19,7 +20,7 @@ from haystack.core.pipeline.breakpoint import (
     load_pipeline_snapshot,
 )
 from haystack.dataclasses import ChatMessage
-from haystack.dataclasses.breakpoints import Breakpoint, PipelineSnapshot, PipelineState
+from haystack.dataclasses.breakpoints import AgentBreakpoint, Breakpoint, PipelineSnapshot, PipelineState
 
 
 def test_transform_json_structure_unwraps_sender_value():
@@ -237,6 +238,74 @@ class TestCreatePipelineSnapshot:
 
         assert any("Failed to serialize the inputs of the current pipeline state" in msg for msg in caplog.messages)
         assert any("Failed to serialize original input data for `pipeline.run`." in msg for msg in caplog.messages)
+
+
+class TestCreateAgentSnapshot:
+    def test_create_agent_snapshot_non_serializable_chat_generator(self, caplog):
+        class NonSerializable:
+            def to_dict(self):
+                raise TypeError("Cannot serialize")
+
+        agent_breakpoint = AgentBreakpoint(
+            agent_name="agent", break_point=Breakpoint(component_name="chat_generator", visit_count=1)
+        )
+
+        with caplog.at_level(logging.WARNING):
+            snapshot = _create_agent_snapshot(
+                component_visits={"chat_generator": 1, "tool_invoker": 0},
+                agent_breakpoint=agent_breakpoint,
+                component_inputs={"chat_generator": {"messages": NonSerializable()}, "tool_invoker": {"messages": []}},
+            )
+
+        assert snapshot.component_inputs["chat_generator"] == {}
+        assert snapshot.component_inputs["tool_invoker"] != {}
+        assert "Failed to serialize the agent's chat_generator inputs" in caplog.text
+
+    def test_create_agent_snapshot_non_serializable_tool_invoker(self, caplog):
+        class NonSerializable:
+            def to_dict(self):
+                raise TypeError("Cannot serialize")
+
+        agent_breakpoint = AgentBreakpoint(
+            agent_name="agent", break_point=Breakpoint(component_name="chat_generator", visit_count=1)
+        )
+
+        with caplog.at_level(logging.WARNING):
+            snapshot = _create_agent_snapshot(
+                component_visits={"chat_generator": 1, "tool_invoker": 0},
+                agent_breakpoint=agent_breakpoint,
+                component_inputs={"chat_generator": {"messages": []}, "tool_invoker": {"messages": NonSerializable()}},
+            )
+
+        assert snapshot.component_inputs["tool_invoker"] == {}
+        assert snapshot.component_inputs["chat_generator"] != {}
+        assert "Failed to serialize the agent's tool_invoker inputs" in caplog.text
+
+    def test_create_agent_snapshot_both_non_serializable(self, caplog):
+        class NonSerializable:
+            def to_dict(self):
+                raise TypeError("Cannot serialize")
+
+        agent_breakpoint = AgentBreakpoint(
+            agent_name="agent", break_point=Breakpoint(component_name="chat_generator", visit_count=1)
+        )
+
+        with caplog.at_level(logging.WARNING):
+            snapshot = _create_agent_snapshot(
+                component_visits={"chat_generator": 1, "tool_invoker": 0},
+                agent_breakpoint=agent_breakpoint,
+                component_inputs={
+                    "chat_generator": {"messages": NonSerializable()},
+                    "tool_invoker": {"messages": NonSerializable()},
+                },
+            )
+
+        assert snapshot.component_inputs["chat_generator"] == {}
+        assert snapshot.component_inputs["tool_invoker"] == {}
+        assert "Failed to serialize the agent's chat_generator inputs" in caplog.text
+        assert "Failed to serialize the agent's tool_invoker inputs" in caplog.text
+        assert snapshot.component_visits == {"chat_generator": 1, "tool_invoker": 0}
+        assert snapshot.break_point == agent_breakpoint
 
 
 def test_save_pipeline_snapshot_raises_on_failure(tmp_path, caplog, monkeypatch):


### PR DESCRIPTION
### Related Issues

- fixes #10642

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

`_create_agent_snapshot` called `_serialize_value_with_schema()` without error handling. If serialization failed (e.g. due to non-serializable objects), the resulting `SerializationError` would mask the real pipeline runtime error (e.g. `PipelineRuntimeError`).

This PR wraps each `_serialize_value_with_schema()` call for `chat_generator` and `tool_invoker` inputs in try-except blocks. On failure, a warning is logged and an empty dictionary is used as a fallback, matching the existing pattern in `_create_pipeline_snapshot`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added three unit tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
