### PR TITLE
docs: add YAML example for agent pipeline configuration in documentation

### DIFF
--- a/docs-website/docs/pipeline-components/agents-1/agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent.mdx
@@ -244,6 +244,117 @@ agent_output = extraction_agent.run(
 print(agent_output["database_agent"]["messages"][-1].text)
 ```
 
+### In YAML
+The example pipeline below fetches a webpage, converts its HTML to text, and builds a chat prompt combining the page content with a user query.
+The `Agent` then answers the question based on the provided content and can use its web search tool to find additional information if needed.
+
+```yaml
+components:
+  agent:
+    init_parameters:
+      chat_generator:
+        init_parameters:
+          api_base_url: null
+          api_key:
+            env_vars:
+            - OPENAI_API_KEY
+            strict: true
+            type: env_var
+          generation_kwargs: {}
+          http_client_kwargs: null
+          max_retries: null
+          model: gpt-4o-mini
+          organization: null
+          streaming_callback: null
+          timeout: null
+          tools: null
+          tools_strict: false
+        type: haystack.components.generators.chat.openai.OpenAIChatGenerator
+      confirmation_strategies: null
+      exit_conditions:
+      - text
+      max_agent_steps: 5
+      raise_on_tool_invocation_failure: false
+      required_variables: null
+      state_schema: {}
+      streaming_callback: null
+      system_prompt: You are a helpful assistant. Use the web search tool to find
+        information when needed.
+      tool_invoker_kwargs: null
+      tools:
+      - data:
+          component:
+            init_parameters:
+              allowed_domains: null
+              api_key:
+                env_vars:
+                - SERPERDEV_API_KEY
+                strict: true
+                type: env_var
+              exclude_subdomains: false
+              search_params: {}
+              top_k: 3
+            type: haystack.components.websearch.serper_dev.SerperDevWebSearch
+          description: Search the web for current information on any topic
+          inputs_from_state: null
+          name: web_search
+          outputs_to_state: null
+          outputs_to_string: null
+          parameters: null
+        type: haystack.tools.component_tool.ComponentTool
+      user_prompt: null
+    type: haystack.components.agents.agent.Agent
+  converter:
+    init_parameters:
+      extraction_kwargs: {}
+      store_full_path: false
+    type: haystack.components.converters.html.HTMLToDocument
+  fetcher:
+    init_parameters:
+      client_kwargs:
+        follow_redirects: true
+        timeout: 3
+      http2: false
+      raise_on_failure: true
+      request_headers: {}
+      retry_attempts: 2
+      timeout: 3
+      user_agents:
+      - haystack/LinkContentFetcher/2.27.0rc0
+    type: haystack.components.fetchers.link_content.LinkContentFetcher
+  prompt_builder:
+    init_parameters:
+      required_variables:
+      - docs
+      - query
+      template:
+      - content:
+        - text: 'Based on the following content:
+
+            {% for doc in docs %}
+
+            {{ doc.content }}
+
+            {% endfor %}
+
+            Answer this question: {{ query }}'
+        meta: {}
+        name: null
+        role: user
+      variables: null
+    type: haystack.components.builders.chat_prompt_builder.ChatPromptBuilder
+connection_type_validation: true
+connections:
+- receiver: converter.sources
+  sender: fetcher.streams
+- receiver: prompt_builder.docs
+  sender: converter.documents
+- receiver: agent.messages
+  sender: prompt_builder.prompt
+max_runs_per_component: 100
+metadata: {}
+```
+
 ## Additional References
 
 🧑‍🍳 Cookbook: [Build a GitHub Issue Resolver Agent](https://haystack.deepset.ai/cookbook/github_issue_resolver_agent)

--- a/docs-website/versioned_docs/version-2.27/pipeline-components/agents-1/agent.mdx
+++ b/docs-website/versioned_docs/version-2.27/pipeline-components/agents-1/agent.mdx
@@ -244,6 +244,117 @@ agent_output = extraction_agent.run(
 print(agent_output["database_agent"]["messages"][-1].text)
 ```
 
+### In YAML
+The example pipeline below fetches a webpage, converts its HTML to text, and builds a chat prompt combining the page content with a user query.
+The `Agent` then answers the question based on the provided content and can use its web search tool to find additional information if needed.
+
+```yaml
+components:
+  agent:
+    init_parameters:
+      chat_generator:
+        init_parameters:
+          api_base_url: null
+          api_key:
+            env_vars:
+            - OPENAI_API_KEY
+            strict: true
+            type: env_var
+          generation_kwargs: {}
+          http_client_kwargs: null
+          max_retries: null
+          model: gpt-4o-mini
+          organization: null
+          streaming_callback: null
+          timeout: null
+          tools: null
+          tools_strict: false
+        type: haystack.components.generators.chat.openai.OpenAIChatGenerator
+      confirmation_strategies: null
+      exit_conditions:
+      - text
+      max_agent_steps: 5
+      raise_on_tool_invocation_failure: false
+      required_variables: null
+      state_schema: {}
+      streaming_callback: null
+      system_prompt: You are a helpful assistant. Use the web search tool to find
+        information when needed.
+      tool_invoker_kwargs: null
+      tools:
+      - data:
+          component:
+            init_parameters:
+              allowed_domains: null
+              api_key:
+                env_vars:
+                - SERPERDEV_API_KEY
+                strict: true
+                type: env_var
+              exclude_subdomains: false
+              search_params: {}
+              top_k: 3
+            type: haystack.components.websearch.serper_dev.SerperDevWebSearch
+          description: Search the web for current information on any topic
+          inputs_from_state: null
+          name: web_search
+          outputs_to_state: null
+          outputs_to_string: null
+          parameters: null
+        type: haystack.tools.component_tool.ComponentTool
+      user_prompt: null
+    type: haystack.components.agents.agent.Agent
+  converter:
+    init_parameters:
+      extraction_kwargs: {}
+      store_full_path: false
+    type: haystack.components.converters.html.HTMLToDocument
+  fetcher:
+    init_parameters:
+      client_kwargs:
+        follow_redirects: true
+        timeout: 3
+      http2: false
+      raise_on_failure: true
+      request_headers: {}
+      retry_attempts: 2
+      timeout: 3
+      user_agents:
+      - haystack/LinkContentFetcher/2.27.0rc0
+    type: haystack.components.fetchers.link_content.LinkContentFetcher
+  prompt_builder:
+    init_parameters:
+      required_variables:
+      - docs
+      - query
+      template:
+      - content:
+        - text: 'Based on the following content:
+
+            {% for doc in docs %}
+
+            {{ doc.content }}
+
+            {% endfor %}
+
+            Answer this question: {{ query }}'
+        meta: {}
+        name: null
+        role: user
+      variables: null
+    type: haystack.components.builders.chat_prompt_builder.ChatPromptBuilder
+connection_type_validation: true
+connections:
+- receiver: converter.sources
+  sender: fetcher.streams
+- receiver: prompt_builder.docs
+  sender: converter.documents
+- receiver: agent.messages
+  sender: prompt_builder.prompt
+max_runs_per_component: 100
+metadata: {}
+```
+
 ## Additional References
 
 🧑‍🍳 Cookbook: [Build a GitHub Issue Resolver Agent](https://haystack.deepset.ai/cookbook/github_issue_resolver_agent)


### PR DESCRIPTION
### Related Issues

- partially addresses #11083

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add a pipeline YAML example to the Agent documentation page. The example shows a pipeline that fetches a webpage, converts it to text, builds a prompt, and passes it to an Agent equipped with a `SerperDevWebSearch` `ComponentTool`.

The change is applied to both unstable docs and the versioned v2.27 docs.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Verified that the YAML loads correctly via `Pipeline.loads()`.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
