### PR TITLE
docs(snippets): replace HTML comments with JSX comments for strict MDX compatibility

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -38,9 +38,6 @@ const config = {
   },
 
   markdown: {
-    mdx1Compat: {
-      comments: true,
-    },
     hooks: {
       onBrokenMarkdownLinks: 'throw',
     },

--- a/docs-website/reference/haystack-api/audio_api.md
+++ b/docs-website/reference/haystack-api/audio_api.md
@@ -18,7 +18,7 @@ For the supported audio formats, languages, and other parameters, see the
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.audio import LocalWhisperTranscriber

--- a/docs-website/reference/haystack-api/connectors_api.md
+++ b/docs-website/reference/haystack-api/connectors_api.md
@@ -20,7 +20,7 @@ pass input arguments to this component.
 
 Example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.utils import Secret
@@ -167,7 +167,7 @@ variable in the code.
 
 Usage example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 import json

--- a/docs-website/reference/haystack-api/converters_api.md
+++ b/docs-website/reference/haystack-api/converters_api.md
@@ -20,7 +20,7 @@ and a Document Intelligence or Cognitive Services resource. For help with settin
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 import os
@@ -379,7 +379,7 @@ Converts files to FileContent objects to be included in ChatMessage objects.
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.converters import FileToFileContent
@@ -537,7 +537,7 @@ Documents are expected to have metadata containing:
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack import Document
@@ -1741,7 +1741,7 @@ see the [official documentation](https://github.com/apache/tika-docker/blob/main
 
 Usage example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.converters.tika import TikaDocumentConverter

--- a/docs-website/reference/haystack-api/embedders_api.md
+++ b/docs-website/reference/haystack-api/embedders_api.md
@@ -16,7 +16,7 @@ Calculates document embeddings using OpenAI models deployed on Azure.
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack import Document
@@ -139,7 +139,7 @@ Embeds strings using OpenAI models deployed on Azure.
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.embedders import AzureOpenAITextEmbedder
@@ -257,7 +257,7 @@ Use it with the following Hugging Face APIs:
 
 #### With free serverless inference API
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.embedders import HuggingFaceAPIDocumentEmbedder
@@ -278,7 +278,7 @@ print(result["documents"][0].embedding)
 
 #### With paid inference endpoints
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.embedders import HuggingFaceAPIDocumentEmbedder
@@ -299,7 +299,7 @@ print(result["documents"][0].embedding)
 
 #### With self-hosted text embeddings inference
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.embedders import HuggingFaceAPIDocumentEmbedder
@@ -443,7 +443,7 @@ Use it with the following Hugging Face APIs:
 
 #### With free serverless inference API
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.embedders import HuggingFaceAPITextEmbedder
@@ -460,7 +460,7 @@ print(text_embedder.run("I love pizza!"))
 
 #### With paid inference endpoints
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.embedders import HuggingFaceAPITextEmbedder
@@ -476,7 +476,7 @@ print(text_embedder.run("I love pizza!"))
 
 #### With self-hosted text embeddings inference
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.embedders import HuggingFaceAPITextEmbedder
@@ -600,7 +600,7 @@ The embedding of each Document is stored in the `embedding` field of the Documen
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack import Document
@@ -756,7 +756,7 @@ Computes document embeddings using OpenAI models.
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack import Document
@@ -902,7 +902,7 @@ You can use it to embed user query and send it to an embedding Retriever.
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.embedders import OpenAITextEmbedder
@@ -1042,7 +1042,7 @@ and send them to DocumentWriter to write into a Document Store.
 
 ### Usage example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack import Document
@@ -1195,7 +1195,7 @@ and send them to DocumentWriter to write a into a Document Store.
 
 ### Usage example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack import Document
@@ -1328,7 +1328,7 @@ You can use it to embed user query and send it to a sparse embedding retriever.
 
 Usage example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.embedders import SentenceTransformersSparseTextEmbedder
@@ -1451,7 +1451,7 @@ You can use it to embed user query and send it to an embedding retriever.
 
 Usage example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.embedders import SentenceTransformersTextEmbedder

--- a/docs-website/reference/haystack-api/extractors_api.md
+++ b/docs-website/reference/haystack-api/extractors_api.md
@@ -467,7 +467,7 @@ in the documents.
 
 Usage example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack import Document

--- a/docs-website/reference/haystack-api/generators_api.md
+++ b/docs-website/reference/haystack-api/generators_api.md
@@ -27,7 +27,7 @@ For details on OpenAI API parameters, see
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.generators import AzureOpenAIGenerator
@@ -170,7 +170,7 @@ For details on OpenAI API parameters, see
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.generators.chat import AzureOpenAIChatGenerator
@@ -388,7 +388,7 @@ For details on OpenAI API parameters, see
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.generators.chat import AzureOpenAIResponsesChatGenerator
@@ -701,7 +701,7 @@ format for input and output. Use it to generate text with Hugging Face APIs:
 
 #### With the serverless inference API (Inference Providers) - free tier available
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.generators.chat import HuggingFaceAPIChatGenerator
@@ -727,7 +727,7 @@ print(result)
 
 #### With the serverless inference API (Inference Providers) and text+image input
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.generators.chat import HuggingFaceAPIChatGenerator
@@ -756,7 +756,7 @@ print(result)
 
 #### With paid inference endpoints
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.generators.chat import HuggingFaceAPIChatGenerator
@@ -776,7 +776,7 @@ print(result)
 
 #### With self-hosted text generation inference
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.generators.chat import HuggingFaceAPIChatGenerator
@@ -955,7 +955,7 @@ LLMs running locally may need powerful hardware.
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
@@ -1876,7 +1876,7 @@ Use the `HuggingFaceAPIChatGenerator` component, which supports the `chat_comple
 
 #### With Hugging Face Inference Endpoints
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.generators import HuggingFaceAPIGenerator
@@ -1892,7 +1892,7 @@ print(result)
 
 #### With self-hosted text generation inference
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.generators import HuggingFaceAPIGenerator
@@ -1910,7 +1910,7 @@ Be aware that this example might not work as the Hugging Face Inference API no l
 `text_generation` endpoint. Use the `HuggingFaceAPIChatGenerator` for generative models through the
 `chat_completion` endpoint.
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.generators import HuggingFaceAPIGenerator

--- a/docs-website/reference/haystack-api/image_converters_api.md
+++ b/docs-website/reference/haystack-api/image_converters_api.md
@@ -24,7 +24,7 @@ Documents are expected to have metadata containing:
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack import Document

--- a/docs-website/reference/haystack-api/rankers_api.md
+++ b/docs-website/reference/haystack-api/rankers_api.md
@@ -29,7 +29,7 @@ It can be used with a Text Embeddings Inference (TEI) API endpoint:
 
 Usage example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack import Document

--- a/docs-website/reference/haystack-api/routers_api.md
+++ b/docs-website/reference/haystack-api/routers_api.md
@@ -867,7 +867,7 @@ The labels are specific to each model and can be found it its description on Hug
 
 ### Usage example
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.core.pipeline import Pipeline

--- a/docs-website/reference/haystack-api/tools_api.md
+++ b/docs-website/reference/haystack-api/tools_api.md
@@ -35,7 +35,7 @@ Below is an example of creating a ComponentTool from an existing SerperDevWebSea
 
 ## Usage Example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack import component, Pipeline

--- a/docs-website/reference/haystack-api/utils_api.md
+++ b/docs-website/reference/haystack-api/utils_api.md
@@ -945,7 +945,7 @@ Executes an HTTP request with a configurable exponential backoff retry on failur
 
 Usage example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.utils import request_with_retry

--- a/docs-website/reference/haystack-api/websearch_api.md
+++ b/docs-website/reference/haystack-api/websearch_api.md
@@ -14,7 +14,7 @@ Uses [SearchApi](https://www.searchapi.io/) to search the web for relevant docum
 
 Usage example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.websearch import SearchApiWebSearch
@@ -138,7 +138,7 @@ See the [Serper Dev website](https://serper.dev/) for more details.
 
 Usage example:
 
-<!-- test-ignore -->
+{/* test-ignore */}
 
 ```python
 from haystack.components.websearch import SerperDevWebSearch

--- a/docs-website/scripts/test_python_snippets.py
+++ b/docs-website/scripts/test_python_snippets.py
@@ -9,11 +9,11 @@ Background tester for Python code snippets embedded in Docusaurus Markdown/MDX f
 Features:
 - Recursively scans specified directories for .md and .mdx files
 - Extracts triple-backtick fenced blocks labeled with "python" or "py"
-- Skips blocks preceded by an immediate "<!-- test-ignore -->" marker
+- Skips blocks preceded by an immediate "{/* test-ignore */}" marker
 - Supports markers above a block:
-  - "<!-- test-run -->" to force running even if heuristically considered a concept
-  - "<!-- test-concept -->" to force skipping as illustrative
-  - "<!-- test-require-files: path1 path2 -->" to require files to exist (skip if missing)
+  - "{/* test-run */}" to force running even if heuristically considered a concept
+  - "{/* test-concept */}" to force skipping as illustrative
+  - "{/* test-require-files: path1 path2 */}" to require files to exist (skip if missing)
 - Optionally skips blocks containing unsafe patterns
 - Executes each snippet in isolation via a temporary file using a Python subprocess
 - Times out long-running snippets
@@ -31,13 +31,13 @@ Usage:
   python scripts/test_python_snippets.py docs/overview/intro.mdx docs/concepts/components.mdx
 
   # Force-run a snippet without imports via marker above the block
-  <!-- test-run -->
+  {/* test-run */}
   ```python
   print("hello world")
   ```
 
   # Mark an illustrative snippet to skip
-  <!-- test-concept -->
+  {/* test-concept */}
   ```python
   @dataclass
   class Foo:
@@ -45,7 +45,7 @@ Usage:
   ```
 
   # Require fixtures; snippet will be skipped if files are missing
-  <!-- test-require-files: assets/dog.jpg data/example.json -->
+  {/* test-require-files: assets/dog.jpg data/example.json */}
   ```python
   from haystack.dataclasses import ByteStream
   image = ByteStream.from_file_path("assets/dog.jpg")
@@ -68,10 +68,10 @@ from pathlib import Path
 
 FENCE_START_RE = re.compile(r"^\s*```(?P<lang>[^\n\r]*)\s*$")
 FENCE_END_RE = re.compile(r"^\s*```\s*$")
-TEST_IGNORE_MARK = "<!-- test-ignore -->"
-TEST_CONCEPT_MARK = "<!-- test-concept -->"
-TEST_RUN_MARK = "<!-- test-run -->"
-TEST_REQUIRE_FILES_PREFIX = "<!-- test-require-files:"
+TEST_IGNORE_MARK = "{/* test-ignore */}"
+TEST_CONCEPT_MARK = "{/* test-concept */}"
+TEST_RUN_MARK = "{/* test-run */}"
+TEST_REQUIRE_FILES_PREFIX = "{/* test-require-files:"
 
 
 UNSAFE_PATTERNS = [
@@ -168,7 +168,7 @@ def extract_python_snippets(file_path: str, repo_root: str) -> list[Snippet]:
             if prev == "":
                 j -= 1
                 continue
-            if prev.startswith("<!--") and prev.endswith("-->"):
+            if prev.startswith("{/*") and prev.endswith("*/}"):
                 markers.append(prev)
                 j -= 1
                 continue
@@ -186,7 +186,7 @@ def extract_python_snippets(file_path: str, repo_root: str) -> list[Snippet]:
         if TEST_RUN_MARK in markers:
             pending_forced_run = True
         for marker in markers:
-            if marker.startswith(TEST_REQUIRE_FILES_PREFIX) and marker.endswith("-->"):
+            if marker.startswith(TEST_REQUIRE_FILES_PREFIX) and marker.endswith("*/}"):
                 content = marker[len(TEST_REQUIRE_FILES_PREFIX) : -3].strip()
                 if content:
                     pending_requires_files.extend(content.split())

--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -40,7 +40,7 @@ class LocalWhisperTranscriber:
     [GitHub repository](https://github.com/openai/whisper).
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.audio import LocalWhisperTranscriber
 

--- a/haystack/components/connectors/openapi.py
+++ b/haystack/components/connectors/openapi.py
@@ -24,7 +24,7 @@ class OpenAPIConnector:
     pass input arguments to this component.
 
     Example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.utils import Secret
     from haystack.components.connectors.openapi import OpenAPIConnector

--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -171,7 +171,7 @@ class OpenAPIServiceConnector:
     variable in the code.
 
     Usage example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     import json
     import httpx

--- a/haystack/components/converters/azure.py
+++ b/haystack/components/converters/azure.py
@@ -38,7 +38,7 @@ class AzureOCRDocumentConverter:
     [Azure documentation](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/quickstarts/get-started-sdks-rest-api).
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     import os
     from datetime import datetime

--- a/haystack/components/converters/file_to_file_content.py
+++ b/haystack/components/converters/file_to_file_content.py
@@ -22,7 +22,7 @@ class FileToFileContent:
     Converts files to FileContent objects to be included in ChatMessage objects.
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.converters import FileToFileContent
 

--- a/haystack/components/converters/image/document_to_image.py
+++ b/haystack/components/converters/image/document_to_image.py
@@ -34,7 +34,7 @@ class DocumentToImageContent:
     - For PDF files, a `page_number` key specifying which page to extract
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack import Document
     from haystack.components.converters.image.document_to_image import DocumentToImageContent

--- a/haystack/components/converters/tika.py
+++ b/haystack/components/converters/tika.py
@@ -60,7 +60,7 @@ class TikaDocumentConverter:
     see the [official documentation](https://github.com/apache/tika-docker/blob/main/README.md#usage).
 
     Usage example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.converters.tika import TikaDocumentConverter
     from datetime import datetime

--- a/haystack/components/embedders/azure_document_embedder.py
+++ b/haystack/components/embedders/azure_document_embedder.py
@@ -21,7 +21,7 @@ class AzureOpenAIDocumentEmbedder(OpenAIDocumentEmbedder):
     Calculates document embeddings using OpenAI models deployed on Azure.
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack import Document
     from haystack.components.embedders import AzureOpenAIDocumentEmbedder

--- a/haystack/components/embedders/azure_text_embedder.py
+++ b/haystack/components/embedders/azure_text_embedder.py
@@ -19,7 +19,7 @@ class AzureOpenAITextEmbedder(OpenAITextEmbedder):
     Embeds strings using OpenAI models deployed on Azure.
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.embedders import AzureOpenAITextEmbedder
 

--- a/haystack/components/embedders/hugging_face_api_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_document_embedder.py
@@ -36,7 +36,7 @@ class HuggingFaceAPIDocumentEmbedder:
     ### Usage examples
 
     #### With free serverless inference API
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.embedders import HuggingFaceAPIDocumentEmbedder
     from haystack.utils import Secret
@@ -55,7 +55,7 @@ class HuggingFaceAPIDocumentEmbedder:
     ```
 
     #### With paid inference endpoints
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.embedders import HuggingFaceAPIDocumentEmbedder
     from haystack.utils import Secret
@@ -74,7 +74,7 @@ class HuggingFaceAPIDocumentEmbedder:
     ```
 
     #### With self-hosted text embeddings inference
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.embedders import HuggingFaceAPIDocumentEmbedder
     from haystack.dataclasses import Document

--- a/haystack/components/embedders/hugging_face_api_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_text_embedder.py
@@ -29,7 +29,7 @@ class HuggingFaceAPITextEmbedder:
     ### Usage examples
 
     #### With free serverless inference API
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.embedders import HuggingFaceAPITextEmbedder
     from haystack.utils import Secret
@@ -44,7 +44,7 @@ class HuggingFaceAPITextEmbedder:
     ```
 
     #### With paid inference endpoints
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.embedders import HuggingFaceAPITextEmbedder
     from haystack.utils import Secret
@@ -58,7 +58,7 @@ class HuggingFaceAPITextEmbedder:
     ```
 
     #### With self-hosted text embeddings inference
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.embedders import HuggingFaceAPITextEmbedder
     from haystack.utils import Secret

--- a/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
+++ b/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
@@ -32,7 +32,7 @@ class SentenceTransformersDocumentImageEmbedder:
     The embedding of each Document is stored in the `embedding` field of the Document.
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack import Document
     from haystack.components.embedders.image import SentenceTransformersDocumentImageEmbedder

--- a/haystack/components/embedders/openai_document_embedder.py
+++ b/haystack/components/embedders/openai_document_embedder.py
@@ -24,7 +24,7 @@ class OpenAIDocumentEmbedder:
     Computes document embeddings using OpenAI models.
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack import Document
     from haystack.components.embedders import OpenAIDocumentEmbedder

--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -21,7 +21,7 @@ class OpenAITextEmbedder:
     You can use it to embed user query and send it to an embedding Retriever.
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.embedders import OpenAITextEmbedder
 

--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -25,7 +25,7 @@ class SentenceTransformersDocumentEmbedder:
     and send them to DocumentWriter to write into a Document Store.
 
     ### Usage example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack import Document
     from haystack.components.embedders import SentenceTransformersDocumentEmbedder

--- a/haystack/components/embedders/sentence_transformers_sparse_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_sparse_document_embedder.py
@@ -25,7 +25,7 @@ class SentenceTransformersSparseDocumentEmbedder:
     and send them to DocumentWriter to write a into a Document Store.
 
     ### Usage example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack import Document
     from haystack.components.embedders import SentenceTransformersSparseDocumentEmbedder

--- a/haystack/components/embedders/sentence_transformers_sparse_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_sparse_text_embedder.py
@@ -22,7 +22,7 @@ class SentenceTransformersSparseTextEmbedder:
     You can use it to embed user query and send it to a sparse embedding retriever.
 
     Usage example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.embedders import SentenceTransformersSparseTextEmbedder
 

--- a/haystack/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_text_embedder.py
@@ -21,7 +21,7 @@ class SentenceTransformersTextEmbedder:
     You can use it to embed user query and send it to an embedding retriever.
 
     Usage example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.embedders import SentenceTransformersTextEmbedder
 

--- a/haystack/components/extractors/named_entity_extractor.py
+++ b/haystack/components/extractors/named_entity_extractor.py
@@ -88,7 +88,7 @@ class NamedEntityExtractor:
     in the documents.
 
     Usage example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack import Document
     from haystack.components.extractors.named_entity_extractor import NamedEntityExtractor

--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -33,7 +33,7 @@ class AzureOpenAIGenerator(OpenAIGenerator):
 
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.generators import AzureOpenAIGenerator
     from haystack.utils import Secret

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -42,7 +42,7 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
     [OpenAI documentation](https://platform.openai.com/docs/api-reference/chat).
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.generators.chat import AzureOpenAIChatGenerator
     from haystack.dataclasses import ChatMessage

--- a/haystack/components/generators/chat/azure_responses.py
+++ b/haystack/components/generators/chat/azure_responses.py
@@ -34,7 +34,7 @@ class AzureOpenAIResponsesChatGenerator(OpenAIResponsesChatGenerator):
     [OpenAI documentation](https://platform.openai.com/docs/api-reference/responses).
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.generators.chat import AzureOpenAIResponsesChatGenerator
     from haystack.dataclasses import ChatMessage

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -263,7 +263,7 @@ class HuggingFaceAPIChatGenerator:
     ### Usage examples
 
     #### With the serverless inference API (Inference Providers) - free tier available
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.generators.chat import HuggingFaceAPIChatGenerator
     from haystack.dataclasses import ChatMessage
@@ -287,7 +287,7 @@ class HuggingFaceAPIChatGenerator:
     ```
 
     #### With the serverless inference API (Inference Providers) and text+image input
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.generators.chat import HuggingFaceAPIChatGenerator
     from haystack.dataclasses import ChatMessage, ImageContent
@@ -314,7 +314,7 @@ class HuggingFaceAPIChatGenerator:
     ```
 
     #### With paid inference endpoints
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.generators.chat import HuggingFaceAPIChatGenerator
     from haystack.dataclasses import ChatMessage
@@ -332,7 +332,7 @@ class HuggingFaceAPIChatGenerator:
     ```
 
     #### With self-hosted text generation inference
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.generators.chat import HuggingFaceAPIChatGenerator
     from haystack.dataclasses import ChatMessage

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -95,7 +95,7 @@ class HuggingFaceLocalChatGenerator:
     LLMs running locally may need powerful hardware.
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
     from haystack.dataclasses import ChatMessage

--- a/haystack/components/generators/hugging_face_api.py
+++ b/haystack/components/generators/hugging_face_api.py
@@ -50,7 +50,7 @@ class HuggingFaceAPIGenerator:
     ### Usage examples
 
     #### With Hugging Face Inference Endpoints
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.generators import HuggingFaceAPIGenerator
     from haystack.utils import Secret
@@ -64,7 +64,7 @@ class HuggingFaceAPIGenerator:
     ```
 
     #### With self-hosted text generation inference
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.generators import HuggingFaceAPIGenerator
 
@@ -81,7 +81,7 @@ class HuggingFaceAPIGenerator:
     `text_generation` endpoint. Use the `HuggingFaceAPIChatGenerator` for generative models through the
     `chat_completion` endpoint.
 
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.generators import HuggingFaceAPIGenerator
     from haystack.utils import Secret

--- a/haystack/components/rankers/hugging_face_tei.py
+++ b/haystack/components/rankers/hugging_face_tei.py
@@ -38,7 +38,7 @@ class HuggingFaceTEIRanker:
     - [Hugging Face Inference Endpoints](https://huggingface.co/inference-endpoints)
 
     Usage example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack import Document
     from haystack.components.rankers import HuggingFaceTEIRanker

--- a/haystack/components/routers/transformers_text_router.py
+++ b/haystack/components/routers/transformers_text_router.py
@@ -22,7 +22,7 @@ class TransformersTextRouter:
     The labels are specific to each model and can be found it its description on Hugging Face.
 
     ### Usage example
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.core.pipeline import Pipeline
     from haystack.components.routers import TransformersTextRouter

--- a/haystack/components/websearch/searchapi.py
+++ b/haystack/components/websearch/searchapi.py
@@ -24,7 +24,7 @@ class SearchApiWebSearch:
     Uses [SearchApi](https://www.searchapi.io/) to search the web for relevant documents.
 
     Usage example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.websearch import SearchApiWebSearch
     from haystack.utils import Secret

--- a/haystack/components/websearch/serper_dev.py
+++ b/haystack/components/websearch/serper_dev.py
@@ -27,7 +27,7 @@ class SerperDevWebSearch:
     See the [Serper Dev website](https://serper.dev/) for more details.
 
     Usage example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.components.websearch import SerperDevWebSearch
     from haystack.utils import Secret

--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -59,7 +59,7 @@ class ComponentTool(Tool):
     Below is an example of creating a ComponentTool from an existing SerperDevWebSearch component.
 
     ## Usage Example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack import component, Pipeline
     from haystack.tools import ComponentTool

--- a/haystack/utils/requests_utils.py
+++ b/haystack/utils/requests_utils.py
@@ -18,7 +18,7 @@ def request_with_retry(
     Executes an HTTP request with a configurable exponential backoff retry on failures.
 
     Usage example:
-    <!-- test-ignore -->
+    {/* test-ignore */}
     ```python
     from haystack.utils import request_with_retry
 


### PR DESCRIPTION
## What does this PR do?

Closes #11104.

Replaces all `<!-- test-ignore -->` HTML comment markers in Python docstrings and generated API reference docs with JSX comments `{/* test-ignore */}` to be compatible with strict MDX parsing in Docusaurus v4.

**Changes:**
- `haystack/**/*.py` (31 files): `<!-- test-ignore -->` → `{/* test-ignore */}` in docstring usage examples
- `docs-website/reference/haystack-api/*.md` (13 files): same replacement in generated API reference docs
- `docs-website/scripts/test_python_snippets.py`: update `TEST_IGNORE_MARK`, `TEST_CONCEPT_MARK`, `TEST_RUN_MARK`, `TEST_REQUIRE_FILES_PREFIX` constants + detection logic (`startswith`/`endswith` checks) + docstring examples
- `docs-website/docusaurus.config.js`: remove `mdx1Compat: { comments: true }` compatibility shim

After this change the docs site can run with strict MDX and the `mdx1Compat.comments` workaround is no longer needed.

## Before submitting

- [x] This PR fixes a bug (non-breaking change that fixes an issue)
- [ ] This PR is a new feature
- [ ] This PR is a breaking change

## Testing

The `test_python_snippets.py` script will correctly detect the new JSX marker format since all constants and detection logic have been updated consistently.