### PR TITLE
Use dedicated Anthropic API key for public repo Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@5fb899572b81d2bb648d4d187173a2f423a9677c # v1.0.96
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_PR_REVIEWS }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_PR_REVIEWS_PUBLIC_REPOS }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,6 +55,6 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@5fb899572b81d2bb648d4d187173a2f423a9677c # v1.0.96
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_PR_REVIEWS }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_PR_REVIEWS_PUBLIC_REPOS }}
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary

Switches both Claude workflows to use a dedicated secret for public repos:

`ANTHROPIC_API_KEY_PR_REVIEWS` → `ANTHROPIC_API_KEY_PR_REVIEWS_PUBLIC_REPOS`

This allows independent cost tracking and budget control for the public haystack repo vs internal repos.

No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)