### PR TITLE
fix: keep agent snapshots resumable when runtime-only inputs cannot be serialized

### DIFF
--- a/haystack/core/pipeline/breakpoint.py
+++ b/haystack/core/pipeline/breakpoint.py
@@ -291,37 +291,15 @@ def _create_pipeline_snapshot(
     transformed_original_input_data = _transform_json_structure(original_input_data)
     transformed_inputs = _transform_json_structure({**inputs, component_name: component_inputs})
 
-    try:
-        serialized_inputs = _serialize_value_with_schema(transformed_inputs)
-    except Exception as error:
-        logger.warning(
-            "Failed to serialize the inputs of the current pipeline state. "
-            "The inputs in the snapshot will be replaced with an empty dictionary. Error: {e}",
-            e=error,
-        )
-        serialized_inputs = {}
-
-    try:
-        serialized_original_input_data = _serialize_value_with_schema(transformed_original_input_data)
-    except Exception as error:
-        logger.warning(
-            "Failed to serialize original input data for `pipeline.run`. "
-            "This likely occurred due to non-serializable object types. "
-            "The snapshot will store an empty dictionary instead. Error: {e}",
-            e=error,
-        )
-        serialized_original_input_data = {}
-
-    try:
-        serialized_pipeline_outputs = _serialize_value_with_schema(pipeline_outputs)
-    except Exception as error:
-        logger.warning(
-            "Failed to serialize outputs of the current pipeline state. "
-            "This likely occurred due to non-serializable object types. "
-            "The snapshot will store an empty dictionary instead. Error: {e}",
-            e=error,
-        )
-        serialized_pipeline_outputs = {}
+    serialized_inputs = _serialize_with_field_fallback(
+        transformed_inputs, description="the inputs of the current pipeline state"
+    )
+    serialized_original_input_data = _serialize_with_field_fallback(
+        transformed_original_input_data, description="original input data for `pipeline.run`"
+    )
+    serialized_pipeline_outputs = _serialize_with_field_fallback(
+        pipeline_outputs, description="outputs of the current pipeline state"
+    )
 
     return PipelineSnapshot(
         pipeline_state=PipelineState(
@@ -390,54 +368,72 @@ def _create_agent_snapshot(
     )
 
 
-def _serialize_agent_component_inputs(component_name: str, component_inputs: dict[str, Any]) -> dict[str, Any]:
+def _serialize_with_field_fallback(payload: Any, *, description: str) -> dict[str, Any]:
     """
-    Serialize agent component inputs while preserving resumable fields whenever possible.
+    Serialize a payload and, on failure, retry field-by-field to preserve resumable fields.
 
-    If serializing the whole input mapping fails (for example due to a non-serializable callback),
-    we retry field-by-field and omit only the failing fields. This keeps snapshots resumable when
-    required fields like ``messages`` or ``state`` are still serializable.
+    If the whole payload serializes, the result is returned as-is. Otherwise, and if the payload is a
+    mapping, each top-level field is serialized individually and only the failing fields are omitted.
+    When the payload is not a mapping, or when every field fails to serialize, the helper returns a
+    structurally valid empty-object payload so that the downstream ``_deserialize_value_with_schema``
+    can still load it back instead of raising ``DeserializationError`` on a bare ``{}``.
 
-    :param component_name: Name of the agent sub-component (e.g. ``chat_generator`` or ``tool_invoker``).
-    :param component_inputs: Runtime inputs for that sub-component.
-    :returns: A serialized payload that is always a structurally valid ``{"serialization_schema", "serialized_data"}``
-        pair. When every field fails to serialize, an empty-but-valid object payload is returned so that
-        ``_deserialize_value_with_schema`` can still load it (e.g. when resuming from a ``ToolBreakpoint`` where the
-        sub-component's inputs are not strictly required).
+    :param payload: The value to serialize.
+    :param description: Short human-readable label used in warning messages, for example
+        ``"the agent's chat_generator inputs"`` or ``"the inputs of the current pipeline state"``.
+    :returns: A dict of the form ``{"serialization_schema": ..., "serialized_data": ...}``.
     """
     try:
-        return _serialize_value_with_schema(_deepcopy_with_exceptions(component_inputs))
+        return _serialize_value_with_schema(_deepcopy_with_exceptions(payload))
     except Exception as error:
         logger.warning(
-            "Failed to serialize the agent's {component_name} inputs. "
+            "Failed to serialize {description}. "
             "Haystack will omit only the non-serializable fields when possible. Error: {e}",
-            component_name=component_name,
+            description=description,
             e=error,
         )
 
     serialized_properties: dict[str, Any] = {}
     serialized_data: dict[str, Any] = {}
 
-    for field_name, value in component_inputs.items():
-        try:
-            serialized_value = _serialize_value_with_schema(_deepcopy_with_exceptions(value))
-        except Exception as field_error:
-            logger.warning(
-                "Failed to serialize the agent's {component_name}.{field_name} input. "
-                "The field will be omitted from the snapshot. Error: {e}",
-                component_name=component_name,
-                field_name=field_name,
-                e=field_error,
-            )
-            continue
+    if isinstance(payload, dict):
+        for field_name, value in payload.items():
+            try:
+                serialized_value = _serialize_value_with_schema(_deepcopy_with_exceptions(value))
+            except Exception as field_error:
+                logger.warning(
+                    "Failed to serialize the '{field_name}' field of {description}. "
+                    "The field will be omitted from the snapshot. Error: {e}",
+                    field_name=field_name,
+                    description=description,
+                    e=field_error,
+                )
+                continue
 
-        serialized_properties[field_name] = serialized_value["serialization_schema"]
-        serialized_data[field_name] = serialized_value["serialized_data"]
+            serialized_properties[field_name] = serialized_value["serialization_schema"]
+            serialized_data[field_name] = serialized_value["serialized_data"]
 
     return {
         "serialization_schema": {"type": "object", "properties": serialized_properties},
         "serialized_data": serialized_data,
     }
+
+
+def _serialize_agent_component_inputs(component_name: str, component_inputs: dict[str, Any]) -> dict[str, Any]:
+    """
+    Serialize agent component inputs while preserving resumable fields whenever possible.
+
+    Thin wrapper around :func:`_serialize_with_field_fallback` that supplies an agent-specific label
+    for the warning messages.
+
+    :param component_name: Name of the agent sub-component (e.g. ``chat_generator`` or ``tool_invoker``).
+    :param component_inputs: Runtime inputs for that sub-component.
+    :returns: A serialized payload that is always a structurally valid ``{"serialization_schema",
+        "serialized_data"}`` pair. When every field fails to serialize, an empty-but-valid object
+        payload is returned so that ``_deserialize_value_with_schema`` can still load it (for example
+        when resuming from a ``ToolBreakpoint`` where the sub-component's inputs are not strictly required).
+    """
+    return _serialize_with_field_fallback(component_inputs, description=f"the agent's {component_name} inputs")
 
 
 def _validate_tool_breakpoint_is_valid(agent_breakpoint: AgentBreakpoint, tools: "ToolsType") -> None:

--- a/haystack/core/pipeline/breakpoint.py
+++ b/haystack/core/pipeline/breakpoint.py
@@ -375,29 +375,12 @@ def _create_agent_snapshot(
     :param agent_breakpoint: AgentBreakpoint object containing breakpoints
     :return: An AgentSnapshot containing the agent's state and component visits.
     """
-    try:
-        serialized_chat_generator = _serialize_value_with_schema(
-            _deepcopy_with_exceptions(component_inputs["chat_generator"])
-        )
-    except Exception as error:
-        logger.warning(
-            "Failed to serialize the agent's chat_generator inputs. "
-            "The inputs in the snapshot will be replaced with an empty dictionary. Error: {e}",
-            e=error,
-        )
-        serialized_chat_generator = {}
-
-    try:
-        serialized_tool_invoker = _serialize_value_with_schema(
-            _deepcopy_with_exceptions(component_inputs["tool_invoker"])
-        )
-    except Exception as error:
-        logger.warning(
-            "Failed to serialize the agent's tool_invoker inputs. "
-            "The inputs in the snapshot will be replaced with an empty dictionary. Error: {e}",
-            e=error,
-        )
-        serialized_tool_invoker = {}
+    serialized_chat_generator = _serialize_agent_component_inputs(
+        component_name="chat_generator", component_inputs=component_inputs["chat_generator"]
+    )
+    serialized_tool_invoker = _serialize_agent_component_inputs(
+        component_name="tool_invoker", component_inputs=component_inputs["tool_invoker"]
+    )
 
     return AgentSnapshot(
         component_inputs={"chat_generator": serialized_chat_generator, "tool_invoker": serialized_tool_invoker},
@@ -405,6 +388,56 @@ def _create_agent_snapshot(
         break_point=agent_breakpoint,
         timestamp=datetime.now(),
     )
+
+
+def _serialize_agent_component_inputs(component_name: str, component_inputs: dict[str, Any]) -> dict[str, Any]:
+    """
+    Serialize agent component inputs while preserving resumable fields whenever possible.
+
+    If serializing the whole input mapping fails (for example due to a non-serializable callback),
+    we retry field-by-field and omit only the failing fields. This keeps snapshots resumable when
+    required fields like ``messages`` or ``state`` are still serializable.
+
+    :param component_name: Name of the agent sub-component (e.g. ``chat_generator`` or ``tool_invoker``).
+    :param component_inputs: Runtime inputs for that sub-component.
+    :returns: A serialized payload, or ``{}`` if no fields can be serialized at all.
+    """
+    try:
+        return _serialize_value_with_schema(_deepcopy_with_exceptions(component_inputs))
+    except Exception as error:
+        logger.warning(
+            "Failed to serialize the agent's {component_name} inputs. "
+            "Haystack will omit only the non-serializable fields when possible. Error: {e}",
+            component_name=component_name,
+            e=error,
+        )
+
+    serialized_properties: dict[str, Any] = {}
+    serialized_data: dict[str, Any] = {}
+
+    for field_name, value in component_inputs.items():
+        try:
+            serialized_value = _serialize_value_with_schema(_deepcopy_with_exceptions(value))
+        except Exception as field_error:
+            logger.warning(
+                "Failed to serialize the agent's {component_name}.{field_name} input. "
+                "The field will be omitted from the snapshot. Error: {e}",
+                component_name=component_name,
+                field_name=field_name,
+                e=field_error,
+            )
+            continue
+
+        serialized_properties[field_name] = serialized_value["serialization_schema"]
+        serialized_data[field_name] = serialized_value["serialized_data"]
+
+    if not serialized_properties:
+        return {}
+
+    return {
+        "serialization_schema": {"type": "object", "properties": serialized_properties},
+        "serialized_data": serialized_data,
+    }
 
 
 def _validate_tool_breakpoint_is_valid(agent_breakpoint: AgentBreakpoint, tools: "ToolsType") -> None:

--- a/haystack/core/pipeline/breakpoint.py
+++ b/haystack/core/pipeline/breakpoint.py
@@ -400,7 +400,10 @@ def _serialize_agent_component_inputs(component_name: str, component_inputs: dic
 
     :param component_name: Name of the agent sub-component (e.g. ``chat_generator`` or ``tool_invoker``).
     :param component_inputs: Runtime inputs for that sub-component.
-    :returns: A serialized payload, or ``{}`` if no fields can be serialized at all.
+    :returns: A serialized payload that is always a structurally valid ``{"serialization_schema", "serialized_data"}``
+        pair. When every field fails to serialize, an empty-but-valid object payload is returned so that
+        ``_deserialize_value_with_schema`` can still load it (e.g. when resuming from a ``ToolBreakpoint`` where the
+        sub-component's inputs are not strictly required).
     """
     try:
         return _serialize_value_with_schema(_deepcopy_with_exceptions(component_inputs))
@@ -430,9 +433,6 @@ def _serialize_agent_component_inputs(component_name: str, component_inputs: dic
 
         serialized_properties[field_name] = serialized_value["serialization_schema"]
         serialized_data[field_name] = serialized_value["serialized_data"]
-
-    if not serialized_properties:
-        return {}
 
     return {
         "serialization_schema": {"type": "object", "properties": serialized_properties},

--- a/releasenotes/notes/fix-agent-snapshot-resume-after-fallback-7fd7ff9a0f8f8b87.yaml
+++ b/releasenotes/notes/fix-agent-snapshot-resume-after-fallback-7fd7ff9a0f8f8b87.yaml
@@ -1,11 +1,13 @@
 ---
 fixes:
   - |
-    Preserve resumable agent snapshots when some ``chat_generator`` or ``tool_invoker`` inputs are
-    non-serializable. Haystack now omits only the failing runtime-only fields (for example
-    non-serializable callbacks) instead of replacing the whole payload with an empty dictionary.
-    When every field of a sub-component input fails to serialize, the snapshot still stores a
-    structurally valid empty payload (``{"serialization_schema": {"type": "object", "properties": {}},
-    "serialized_data": {}}``) so that resuming the snapshot does not raise ``DeserializationError`` –
-    for example when resuming from a ``ToolBreakpoint`` where the sub-component's inputs are not
-    strictly required.
+    Preserve resumable snapshots when some inputs or outputs are non-serializable. Haystack now
+    omits only the failing top-level fields (for example non-serializable callbacks or runtime
+    objects) instead of replacing the whole payload with an empty dictionary. This applies both
+    to agent sub-component inputs (``chat_generator`` and ``tool_invoker``) and to pipeline-level
+    ``inputs``, ``original_input_data``, and ``pipeline_outputs`` captured by
+    ``_create_pipeline_snapshot``. When every field fails to serialize, the snapshot still stores
+    a structurally valid empty payload (``{"serialization_schema": {"type": "object", "properties":
+    {}}, "serialized_data": {}}``) so that resuming the snapshot does not raise
+    ``DeserializationError`` — for example when resuming from a ``ToolBreakpoint`` where the
+    sub-component's inputs are not strictly required.

--- a/releasenotes/notes/fix-agent-snapshot-resume-after-fallback-7fd7ff9a0f8f8b87.yaml
+++ b/releasenotes/notes/fix-agent-snapshot-resume-after-fallback-7fd7ff9a0f8f8b87.yaml
@@ -4,3 +4,8 @@ fixes:
     Preserve resumable agent snapshots when some ``chat_generator`` or ``tool_invoker`` inputs are
     non-serializable. Haystack now omits only the failing runtime-only fields (for example
     non-serializable callbacks) instead of replacing the whole payload with an empty dictionary.
+    When every field of a sub-component input fails to serialize, the snapshot still stores a
+    structurally valid empty payload (``{"serialization_schema": {"type": "object", "properties": {}},
+    "serialized_data": {}}``) so that resuming the snapshot does not raise ``DeserializationError`` –
+    for example when resuming from a ``ToolBreakpoint`` where the sub-component's inputs are not
+    strictly required.

--- a/releasenotes/notes/fix-agent-snapshot-resume-after-fallback-7fd7ff9a0f8f8b87.yaml
+++ b/releasenotes/notes/fix-agent-snapshot-resume-after-fallback-7fd7ff9a0f8f8b87.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Preserve resumable agent snapshots when some ``chat_generator`` or ``tool_invoker`` inputs are
+    non-serializable. Haystack now omits only the failing runtime-only fields (for example
+    non-serializable callbacks) instead of replacing the whole payload with an empty dictionary.

--- a/test/components/agents/test_agent_breakpoints.py
+++ b/test/components/agents/test_agent_breakpoints.py
@@ -472,6 +472,40 @@ class TestAgentBreakpoints:
         assert "last_message" in result
         assert len(result["messages"]) > 0
 
+    def test_resume_from_tool_invoker_omits_non_serializable_runtime_callback(self, agent, tmp_path, monkeypatch):
+        monkeypatch.setenv(HAYSTACK_PIPELINE_SNAPSHOT_SAVE_ENABLED, "true")
+        debug_path = str(tmp_path / "debug_snapshots")
+        tool_bp = ToolBreakpoint(component_name="tool_invoker", tool_name="weather_tool", snapshot_file_path=debug_path)
+        agent_breakpoint = AgentBreakpoint(break_point=tool_bp, agent_name="test_agent")
+
+        try:
+            agent.run(
+                messages=[ChatMessage.from_user("What's the weather in Berlin?")],
+                break_point=agent_breakpoint,
+                streaming_callback=lambda chunk: None,
+            )
+        except BreakpointException:
+            pass
+
+        snapshot_files = list(Path(debug_path).glob("test_agent_tool_invoker_*.json"))
+        assert len(snapshot_files) > 0
+        latest_snapshot_file = str(max(snapshot_files, key=os.path.getctime))
+        agent_snapshot = load_pipeline_snapshot(latest_snapshot_file).agent_snapshot
+
+        assert agent_snapshot is not None
+        assert "streaming_callback" not in agent_snapshot.component_inputs["chat_generator"]["serialized_data"]
+        assert "streaming_callback" not in agent_snapshot.component_inputs["tool_invoker"]["serialized_data"]
+        assert "state" in agent_snapshot.component_inputs["tool_invoker"]["serialized_data"]
+
+        result = agent.run(
+            messages=[ChatMessage.from_user("This is actually ignored when resuming from snapshot.")],
+            snapshot=agent_snapshot,
+        )
+
+        assert "messages" in result
+        assert "last_message" in result
+        assert len(result["messages"]) == 4
+
     def test_resume_from_tool_invoker_and_new_breakpoint(self, weather_tool, tmp_path, monkeypatch):
         monkeypatch.setenv(HAYSTACK_PIPELINE_SNAPSHOT_SAVE_ENABLED, "true")
         agent = Agent(

--- a/test/core/pipeline/test_breakpoint.py
+++ b/test/core/pipeline/test_breakpoint.py
@@ -242,6 +242,48 @@ class TestCreatePipelineSnapshot:
         assert any("Failed to serialize the inputs of the current pipeline state" in msg for msg in caplog.messages)
         assert any("Failed to serialize original input data for `pipeline.run`." in msg for msg in caplog.messages)
 
+    def test_create_pipeline_snapshot_non_serializable_inputs_snapshot_is_resumable(self, caplog):
+        """
+        Guards against the same non-resumable snapshot regression fixed at the agent level: when
+        top-level pipeline inputs/outputs contain non-serializable values, the snapshot fields
+        must still round-trip through ``_deserialize_value_with_schema`` instead of failing with
+        ``DeserializationError: ... Got: {}``. Serializable sibling components must stay intact.
+        """
+
+        class NonSerializable:
+            def to_dict(self):
+                raise TypeError("Cannot serialize")
+
+        with caplog.at_level(logging.WARNING):
+            snapshot = _create_pipeline_snapshot(
+                inputs={
+                    "comp1": {"input_value": [{"sender": None, "value": NonSerializable()}]},
+                    "comp2": {"input_value": [{"sender": None, "value": "keep me"}]},
+                },
+                component_inputs={},
+                break_point=Breakpoint(component_name="comp3"),
+                component_visits={"comp1": 1, "comp2": 1, "comp3": 0},
+                original_input_data={"comp1": {"input_value": NonSerializable()}},
+                ordered_component_names=["comp1", "comp2", "comp3"],
+                include_outputs_from=set(),
+                pipeline_outputs={"comp1": {"result": NonSerializable()}},
+            )
+
+        # No DeserializationError on any of the three pipeline-level payloads.
+        deserialized_inputs = _deserialize_value_with_schema(snapshot.pipeline_state.inputs)
+        deserialized_original_input_data = _deserialize_value_with_schema(snapshot.original_input_data)
+        deserialized_outputs = _deserialize_value_with_schema(snapshot.pipeline_state.pipeline_outputs)
+
+        # The non-serializable comp1 field is omitted while the serializable siblings are preserved.
+        assert "comp1" not in deserialized_inputs
+        assert deserialized_inputs["comp2"] == {"input_value": "keep me"}
+        assert deserialized_inputs["comp3"] == {}
+        # original_input_data and pipeline_outputs degrade to empty-but-valid payloads.
+        assert deserialized_original_input_data == {}
+        assert deserialized_outputs == {}
+        assert any("Failed to serialize the inputs of the current pipeline state" in msg for msg in caplog.messages)
+        assert any("Failed to serialize outputs of the current pipeline state" in msg for msg in caplog.messages)
+
 
 class TestCreateAgentSnapshot:
     def test_create_agent_snapshot_non_serializable_chat_generator(self, caplog):

--- a/test/core/pipeline/test_breakpoint.py
+++ b/test/core/pipeline/test_breakpoint.py
@@ -21,6 +21,9 @@ from haystack.core.pipeline.breakpoint import (
 )
 from haystack.dataclasses import ChatMessage
 from haystack.dataclasses.breakpoints import AgentBreakpoint, Breakpoint, PipelineSnapshot, PipelineState
+from haystack.utils import _deserialize_value_with_schema
+
+_EMPTY_OBJECT_PAYLOAD = {"serialization_schema": {"type": "object", "properties": {}}, "serialized_data": {}}
 
 
 def test_transform_json_structure_unwraps_sender_value():
@@ -257,8 +260,8 @@ class TestCreateAgentSnapshot:
                 component_inputs={"chat_generator": {"messages": NonSerializable()}, "tool_invoker": {"messages": []}},
             )
 
-        assert snapshot.component_inputs["chat_generator"] == {}
-        assert snapshot.component_inputs["tool_invoker"] != {}
+        assert snapshot.component_inputs["chat_generator"] == _EMPTY_OBJECT_PAYLOAD
+        assert snapshot.component_inputs["tool_invoker"] != _EMPTY_OBJECT_PAYLOAD
         assert "Failed to serialize the agent's chat_generator inputs" in caplog.text
 
     def test_create_agent_snapshot_non_serializable_tool_invoker(self, caplog):
@@ -277,8 +280,8 @@ class TestCreateAgentSnapshot:
                 component_inputs={"chat_generator": {"messages": []}, "tool_invoker": {"messages": NonSerializable()}},
             )
 
-        assert snapshot.component_inputs["tool_invoker"] == {}
-        assert snapshot.component_inputs["chat_generator"] != {}
+        assert snapshot.component_inputs["tool_invoker"] == _EMPTY_OBJECT_PAYLOAD
+        assert snapshot.component_inputs["chat_generator"] != _EMPTY_OBJECT_PAYLOAD
         assert "Failed to serialize the agent's tool_invoker inputs" in caplog.text
 
     def test_create_agent_snapshot_both_non_serializable(self, caplog):
@@ -300,12 +303,47 @@ class TestCreateAgentSnapshot:
                 },
             )
 
-        assert snapshot.component_inputs["chat_generator"] == {}
-        assert snapshot.component_inputs["tool_invoker"] == {}
+        assert snapshot.component_inputs["chat_generator"] == _EMPTY_OBJECT_PAYLOAD
+        assert snapshot.component_inputs["tool_invoker"] == _EMPTY_OBJECT_PAYLOAD
         assert "Failed to serialize the agent's chat_generator inputs" in caplog.text
         assert "Failed to serialize the agent's tool_invoker inputs" in caplog.text
         assert snapshot.component_visits == {"chat_generator": 1, "tool_invoker": 0}
         assert snapshot.break_point == agent_breakpoint
+
+    def test_create_agent_snapshot_all_fields_non_serializable_payload_is_deserializable(self, caplog):
+        """
+        When every field of a sub-component input fails to serialize, the resulting payload must still be a
+        structurally valid ``{"serialization_schema", "serialized_data"}`` pair so that
+        ``_deserialize_value_with_schema`` can load it back (rather than raising ``DeserializationError`` as it would
+        for a bare ``{}``). This guards against the snapshot being silently non-resumable in the all-fields-fail path.
+        """
+
+        class NonSerializable:
+            def to_dict(self):
+                raise TypeError("Cannot serialize")
+
+        agent_breakpoint = AgentBreakpoint(
+            agent_name="agent", break_point=Breakpoint(component_name="chat_generator", visit_count=1)
+        )
+
+        with caplog.at_level(logging.WARNING):
+            snapshot = _create_agent_snapshot(
+                component_visits={"chat_generator": 1, "tool_invoker": 0},
+                agent_breakpoint=agent_breakpoint,
+                component_inputs={
+                    "chat_generator": {"streaming_callback": NonSerializable()},
+                    "tool_invoker": {"streaming_callback": NonSerializable()},
+                },
+            )
+
+        for component_name in ("chat_generator", "tool_invoker"):
+            payload = snapshot.component_inputs[component_name]
+            assert "serialization_schema" in payload
+            assert "serialized_data" in payload
+            assert payload["serialization_schema"] == {"type": "object", "properties": {}}
+            assert payload["serialized_data"] == {}
+            # Round-trip: deserializer must accept the empty-but-valid payload without raising.
+            assert _deserialize_value_with_schema(payload) == {}
 
 
 def test_save_pipeline_snapshot_raises_on_failure(tmp_path, caplog, monkeypatch):


### PR DESCRIPTION
### Related Issues

- fixes #11126

### Proposed Changes:

The robustness change in #11108 prevents agent snapshot serialization errors from masking the real runtime error, but it can also replace the entire `chat_generator` / `tool_invoker` payload with `{}` when only one runtime-only field is non-serializable (for example a lambda `streaming_callback`).

That makes the saved snapshot non-resumable even though the essential payload (`messages`, `state`, `tools`, etc.) is still serializable.

This PR keeps the scope narrow:
- it preserves the existing #11108 behavior of not masking the original runtime error
- when serializing `chat_generator` or `tool_invoker` inputs fails, it retries field-by-field
- only the non-serializable runtime-only fields are omitted from the snapshot
- resumable fields are kept intact so the saved snapshot can still be resumed

### How did you test it?

- `hatch -e test run pytest test/components/agents/test_agent_breakpoints.py -k 'non_serializable_runtime_callback' -q`
- `hatch -e test run pytest test/core/pipeline/test_breakpoint.py -k 'create_agent_snapshot' -q`
- `hatch -e test run pytest test/components/agents/test_agent_breakpoints.py -k 'resume_from_tool_invoker and not new_breakpoint' -q`
- `hatch run fmt-check haystack/core/pipeline/breakpoint.py test/components/agents/test_agent_breakpoints.py`

### Notes for the reviewer

I intentionally kept this fix local to agent snapshot serialization instead of introducing a broader “non-resumable snapshot” concept.

The regression test covers a concrete user-visible case where a non-serializable runtime callback causes the fallback path to trigger, but the snapshot should still remain resumable because the essential state is serializable.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
