### PR TITLE
docs: fix Langfuse Agent tracing snippet

### DIFF
--- a/docs-website/docs/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/docs/pipeline-components/connectors/langfuseconnector.mdx
@@ -126,63 +126,78 @@ from haystack import Pipeline
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
+
 @tool
 def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
-"""Get current weather information for a city."""
-weather_data = {
-  "Berlin": "18°C, partly cloudy",
-  "New York": "22°C, sunny",
-  "Tokyo": "25°C, clear skies"
-}
-return weather_data.get(city, f"Weather information for {city} not available")
+    """Get current weather information for a city."""
+    weather_data = {
+        "Berlin": "18°C, partly cloudy",
+        "New York": "22°C, sunny",
+        "Tokyo": "25°C, clear skies",
+    }
+    return weather_data.get(city, f"Weather information for {city} not available")
+
 
 @tool
-def calculate(operation: Annotated[str, "Mathematical operation: add, subtract, multiply, divide"],
-          a: Annotated[float, "First number"],
-          b: Annotated[float, "Second number"]) -> str:
-"""Perform basic mathematical calculations."""
-if operation == "add":
-  result = a + b
-  elif operation == "subtract":
-  result = a - b
-  elif operation == "multiply":
-  result = a * b
-  elif operation == "divide":
-  if b == 0:
-      return "Error: Division by zero"
-      result = a / b
-  else:
-  return f"Error: Unknown operation '{operation}'"
+def calculate(
+    operation: Annotated[
+        str,
+        "Mathematical operation: add, subtract, multiply, divide",
+    ],
+    a: Annotated[float, "First number"],
+    b: Annotated[float, "Second number"],
+) -> str:
+    """Perform basic mathematical calculations."""
+    if operation == "add":
+        result = a + b
+    elif operation == "subtract":
+        result = a - b
+    elif operation == "multiply":
+        result = a * b
+    elif operation == "divide":
+        if b == 0:
+            return "Error: Division by zero"
+        else:
+            result = a / b
+    else:
+        return f"Error: Unknown operation '{operation}'"
 
-return f"The result of {a} {operation} {b} is {result}"
+    return f"The result of {a} {operation} {b} is {result}"
+
 
 if __name__ == "__main__":
-## Create components
-chat_generator = OpenAIChatGenerator()
+    ## Create components
+    chat_generator = OpenAIChatGenerator()
 
-agent = Agent(
-  chat_generator=chat_generator,
-  tools=[get_weather, calculate],
-  system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
-  exit_conditions=["text"]
-)
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[get_weather, calculate],
+        system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
+        exit_conditions=["text"],
+    )
 
-langfuse_connector = LangfuseConnector("Agent Example")
+    langfuse_connector = LangfuseConnector("Agent Example")
 
-## Create and run pipeline
-pipe = Pipeline()
-pipe.add_component("tracer", langfuse_connector)
-pipe.add_component("agent", agent)
+    ## Create and run pipeline
+    pipe = Pipeline()
+    pipe.add_component("tracer", langfuse_connector)
+    pipe.add_component("agent", agent)
 
-response = pipe.run(
-  data={
-      "agent": {"messages": [ChatMessage.from_user("What's the weather in Berlin and calculate 15 + 27?")]},
-      "tracer": {"invocation_context": {"test": "agent_with_tools"}}
-    }
-)
+    response = pipe.run(
+        data={
+            "agent": {
+                "messages": [
+                    ChatMessage.from_user(
+                        "What's the weather in Berlin and calculate 15 + 27?",
+                    ),
+                ],
+            },
+            "tracer": {"invocation_context": {"test": "agent_with_tools"}},
+        },
+    )
 
-print(response["agent"]["last_message"].text)
-print(response["tracer"]["trace_url"])
+    print(response["agent"]["last_message"].text)
+    print(response["tracer"]["trace_url"])
 ```
 
 ## Advanced Usage

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/connectors/langfuseconnector.mdx
@@ -123,63 +123,78 @@ from haystack import Pipeline
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
+
 @tool
 def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
-"""Get current weather information for a city."""
-weather_data = {
-  "Berlin": "18°C, partly cloudy",
-  "New York": "22°C, sunny",
-  "Tokyo": "25°C, clear skies"
-}
-return weather_data.get(city, f"Weather information for {city} not available")
+    """Get current weather information for a city."""
+    weather_data = {
+        "Berlin": "18°C, partly cloudy",
+        "New York": "22°C, sunny",
+        "Tokyo": "25°C, clear skies",
+    }
+    return weather_data.get(city, f"Weather information for {city} not available")
+
 
 @tool
-def calculate(operation: Annotated[str, "Mathematical operation: add, subtract, multiply, divide"],
-          a: Annotated[float, "First number"],
-          b: Annotated[float, "Second number"]) -> str:
-"""Perform basic mathematical calculations."""
-if operation == "add":
-  result = a + b
-  elif operation == "subtract":
-  result = a - b
-  elif operation == "multiply":
-  result = a * b
-  elif operation == "divide":
-  if b == 0:
-      return "Error: Division by zero"
-      result = a / b
-  else:
-  return f"Error: Unknown operation '{operation}'"
+def calculate(
+    operation: Annotated[
+        str,
+        "Mathematical operation: add, subtract, multiply, divide",
+    ],
+    a: Annotated[float, "First number"],
+    b: Annotated[float, "Second number"],
+) -> str:
+    """Perform basic mathematical calculations."""
+    if operation == "add":
+        result = a + b
+    elif operation == "subtract":
+        result = a - b
+    elif operation == "multiply":
+        result = a * b
+    elif operation == "divide":
+        if b == 0:
+            return "Error: Division by zero"
+        else:
+            result = a / b
+    else:
+        return f"Error: Unknown operation '{operation}'"
 
-return f"The result of {a} {operation} {b} is {result}"
+    return f"The result of {a} {operation} {b} is {result}"
+
 
 if __name__ == "__main__":
-## Create components
-chat_generator = OpenAIChatGenerator()
+    ## Create components
+    chat_generator = OpenAIChatGenerator()
 
-agent = Agent(
-  chat_generator=chat_generator,
-  tools=[get_weather, calculate],
-  system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
-  exit_conditions=["text"]
-)
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[get_weather, calculate],
+        system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
+        exit_conditions=["text"],
+    )
 
-langfuse_connector = LangfuseConnector("Agent Example")
+    langfuse_connector = LangfuseConnector("Agent Example")
 
-## Create and run pipeline
-pipe = Pipeline()
-pipe.add_component("tracer", langfuse_connector)
-pipe.add_component("agent", agent)
+    ## Create and run pipeline
+    pipe = Pipeline()
+    pipe.add_component("tracer", langfuse_connector)
+    pipe.add_component("agent", agent)
 
-response = pipe.run(
-  data={
-      "agent": {"messages": [ChatMessage.from_user("What's the weather in Berlin and calculate 15 + 27?")]},
-      "tracer": {"invocation_context": {"test": "agent_with_tools"}}
-    }
-)
+    response = pipe.run(
+        data={
+            "agent": {
+                "messages": [
+                    ChatMessage.from_user(
+                        "What's the weather in Berlin and calculate 15 + 27?",
+                    ),
+                ],
+            },
+            "tracer": {"invocation_context": {"test": "agent_with_tools"}},
+        },
+    )
 
-print(response["agent"]["last_message"].text)
-print(response["tracer"]["trace_url"])
+    print(response["agent"]["last_message"].text)
+    print(response["tracer"]["trace_url"])
 ```
 
 ## Advanced Usage

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/connectors/langfuseconnector.mdx
@@ -126,63 +126,78 @@ from haystack import Pipeline
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
+
 @tool
 def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
-"""Get current weather information for a city."""
-weather_data = {
-  "Berlin": "18°C, partly cloudy",
-  "New York": "22°C, sunny",
-  "Tokyo": "25°C, clear skies"
-}
-return weather_data.get(city, f"Weather information for {city} not available")
+    """Get current weather information for a city."""
+    weather_data = {
+        "Berlin": "18°C, partly cloudy",
+        "New York": "22°C, sunny",
+        "Tokyo": "25°C, clear skies",
+    }
+    return weather_data.get(city, f"Weather information for {city} not available")
+
 
 @tool
-def calculate(operation: Annotated[str, "Mathematical operation: add, subtract, multiply, divide"],
-          a: Annotated[float, "First number"],
-          b: Annotated[float, "Second number"]) -> str:
-"""Perform basic mathematical calculations."""
-if operation == "add":
-  result = a + b
-  elif operation == "subtract":
-  result = a - b
-  elif operation == "multiply":
-  result = a * b
-  elif operation == "divide":
-  if b == 0:
-      return "Error: Division by zero"
-      result = a / b
-  else:
-  return f"Error: Unknown operation '{operation}'"
+def calculate(
+    operation: Annotated[
+        str,
+        "Mathematical operation: add, subtract, multiply, divide",
+    ],
+    a: Annotated[float, "First number"],
+    b: Annotated[float, "Second number"],
+) -> str:
+    """Perform basic mathematical calculations."""
+    if operation == "add":
+        result = a + b
+    elif operation == "subtract":
+        result = a - b
+    elif operation == "multiply":
+        result = a * b
+    elif operation == "divide":
+        if b == 0:
+            return "Error: Division by zero"
+        else:
+            result = a / b
+    else:
+        return f"Error: Unknown operation '{operation}'"
 
-return f"The result of {a} {operation} {b} is {result}"
+    return f"The result of {a} {operation} {b} is {result}"
+
 
 if __name__ == "__main__":
-## Create components
-chat_generator = OpenAIChatGenerator()
+    ## Create components
+    chat_generator = OpenAIChatGenerator()
 
-agent = Agent(
-  chat_generator=chat_generator,
-  tools=[get_weather, calculate],
-  system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
-  exit_conditions=["text"]
-)
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[get_weather, calculate],
+        system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
+        exit_conditions=["text"],
+    )
 
-langfuse_connector = LangfuseConnector("Agent Example")
+    langfuse_connector = LangfuseConnector("Agent Example")
 
-## Create and run pipeline
-pipe = Pipeline()
-pipe.add_component("tracer", langfuse_connector)
-pipe.add_component("agent", agent)
+    ## Create and run pipeline
+    pipe = Pipeline()
+    pipe.add_component("tracer", langfuse_connector)
+    pipe.add_component("agent", agent)
 
-response = pipe.run(
-  data={
-      "agent": {"messages": [ChatMessage.from_user("What's the weather in Berlin and calculate 15 + 27?")]},
-      "tracer": {"invocation_context": {"test": "agent_with_tools"}}
-    }
-)
+    response = pipe.run(
+        data={
+            "agent": {
+                "messages": [
+                    ChatMessage.from_user(
+                        "What's the weather in Berlin and calculate 15 + 27?",
+                    ),
+                ],
+            },
+            "tracer": {"invocation_context": {"test": "agent_with_tools"}},
+        },
+    )
 
-print(response["agent"]["last_message"].text)
-print(response["tracer"]["trace_url"])
+    print(response["agent"]["last_message"].text)
+    print(response["tracer"]["trace_url"])
 ```
 
 ## Advanced Usage

--- a/docs-website/versioned_docs/version-2.20/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.20/pipeline-components/connectors/langfuseconnector.mdx
@@ -126,63 +126,78 @@ from haystack import Pipeline
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
+
 @tool
 def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
-"""Get current weather information for a city."""
-weather_data = {
-  "Berlin": "18°C, partly cloudy",
-  "New York": "22°C, sunny",
-  "Tokyo": "25°C, clear skies"
-}
-return weather_data.get(city, f"Weather information for {city} not available")
+    """Get current weather information for a city."""
+    weather_data = {
+        "Berlin": "18°C, partly cloudy",
+        "New York": "22°C, sunny",
+        "Tokyo": "25°C, clear skies",
+    }
+    return weather_data.get(city, f"Weather information for {city} not available")
+
 
 @tool
-def calculate(operation: Annotated[str, "Mathematical operation: add, subtract, multiply, divide"],
-          a: Annotated[float, "First number"],
-          b: Annotated[float, "Second number"]) -> str:
-"""Perform basic mathematical calculations."""
-if operation == "add":
-  result = a + b
-  elif operation == "subtract":
-  result = a - b
-  elif operation == "multiply":
-  result = a * b
-  elif operation == "divide":
-  if b == 0:
-      return "Error: Division by zero"
-      result = a / b
-  else:
-  return f"Error: Unknown operation '{operation}'"
+def calculate(
+    operation: Annotated[
+        str,
+        "Mathematical operation: add, subtract, multiply, divide",
+    ],
+    a: Annotated[float, "First number"],
+    b: Annotated[float, "Second number"],
+) -> str:
+    """Perform basic mathematical calculations."""
+    if operation == "add":
+        result = a + b
+    elif operation == "subtract":
+        result = a - b
+    elif operation == "multiply":
+        result = a * b
+    elif operation == "divide":
+        if b == 0:
+            return "Error: Division by zero"
+        else:
+            result = a / b
+    else:
+        return f"Error: Unknown operation '{operation}'"
 
-return f"The result of {a} {operation} {b} is {result}"
+    return f"The result of {a} {operation} {b} is {result}"
+
 
 if __name__ == "__main__":
-## Create components
-chat_generator = OpenAIChatGenerator()
+    ## Create components
+    chat_generator = OpenAIChatGenerator()
 
-agent = Agent(
-  chat_generator=chat_generator,
-  tools=[get_weather, calculate],
-  system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
-  exit_conditions=["text"]
-)
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[get_weather, calculate],
+        system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
+        exit_conditions=["text"],
+    )
 
-langfuse_connector = LangfuseConnector("Agent Example")
+    langfuse_connector = LangfuseConnector("Agent Example")
 
-## Create and run pipeline
-pipe = Pipeline()
-pipe.add_component("tracer", langfuse_connector)
-pipe.add_component("agent", agent)
+    ## Create and run pipeline
+    pipe = Pipeline()
+    pipe.add_component("tracer", langfuse_connector)
+    pipe.add_component("agent", agent)
 
-response = pipe.run(
-  data={
-      "agent": {"messages": [ChatMessage.from_user("What's the weather in Berlin and calculate 15 + 27?")]},
-      "tracer": {"invocation_context": {"test": "agent_with_tools"}}
-    }
-)
+    response = pipe.run(
+        data={
+            "agent": {
+                "messages": [
+                    ChatMessage.from_user(
+                        "What's the weather in Berlin and calculate 15 + 27?",
+                    ),
+                ],
+            },
+            "tracer": {"invocation_context": {"test": "agent_with_tools"}},
+        },
+    )
 
-print(response["agent"]["last_message"].text)
-print(response["tracer"]["trace_url"])
+    print(response["agent"]["last_message"].text)
+    print(response["tracer"]["trace_url"])
 ```
 
 ## Advanced Usage

--- a/docs-website/versioned_docs/version-2.21/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.21/pipeline-components/connectors/langfuseconnector.mdx
@@ -126,63 +126,78 @@ from haystack import Pipeline
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
+
 @tool
 def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
-"""Get current weather information for a city."""
-weather_data = {
-  "Berlin": "18°C, partly cloudy",
-  "New York": "22°C, sunny",
-  "Tokyo": "25°C, clear skies"
-}
-return weather_data.get(city, f"Weather information for {city} not available")
+    """Get current weather information for a city."""
+    weather_data = {
+        "Berlin": "18°C, partly cloudy",
+        "New York": "22°C, sunny",
+        "Tokyo": "25°C, clear skies",
+    }
+    return weather_data.get(city, f"Weather information for {city} not available")
+
 
 @tool
-def calculate(operation: Annotated[str, "Mathematical operation: add, subtract, multiply, divide"],
-          a: Annotated[float, "First number"],
-          b: Annotated[float, "Second number"]) -> str:
-"""Perform basic mathematical calculations."""
-if operation == "add":
-  result = a + b
-  elif operation == "subtract":
-  result = a - b
-  elif operation == "multiply":
-  result = a * b
-  elif operation == "divide":
-  if b == 0:
-      return "Error: Division by zero"
-      result = a / b
-  else:
-  return f"Error: Unknown operation '{operation}'"
+def calculate(
+    operation: Annotated[
+        str,
+        "Mathematical operation: add, subtract, multiply, divide",
+    ],
+    a: Annotated[float, "First number"],
+    b: Annotated[float, "Second number"],
+) -> str:
+    """Perform basic mathematical calculations."""
+    if operation == "add":
+        result = a + b
+    elif operation == "subtract":
+        result = a - b
+    elif operation == "multiply":
+        result = a * b
+    elif operation == "divide":
+        if b == 0:
+            return "Error: Division by zero"
+        else:
+            result = a / b
+    else:
+        return f"Error: Unknown operation '{operation}'"
 
-return f"The result of {a} {operation} {b} is {result}"
+    return f"The result of {a} {operation} {b} is {result}"
+
 
 if __name__ == "__main__":
-## Create components
-chat_generator = OpenAIChatGenerator()
+    ## Create components
+    chat_generator = OpenAIChatGenerator()
 
-agent = Agent(
-  chat_generator=chat_generator,
-  tools=[get_weather, calculate],
-  system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
-  exit_conditions=["text"]
-)
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[get_weather, calculate],
+        system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
+        exit_conditions=["text"],
+    )
 
-langfuse_connector = LangfuseConnector("Agent Example")
+    langfuse_connector = LangfuseConnector("Agent Example")
 
-## Create and run pipeline
-pipe = Pipeline()
-pipe.add_component("tracer", langfuse_connector)
-pipe.add_component("agent", agent)
+    ## Create and run pipeline
+    pipe = Pipeline()
+    pipe.add_component("tracer", langfuse_connector)
+    pipe.add_component("agent", agent)
 
-response = pipe.run(
-  data={
-      "agent": {"messages": [ChatMessage.from_user("What's the weather in Berlin and calculate 15 + 27?")]},
-      "tracer": {"invocation_context": {"test": "agent_with_tools"}}
-    }
-)
+    response = pipe.run(
+        data={
+            "agent": {
+                "messages": [
+                    ChatMessage.from_user(
+                        "What's the weather in Berlin and calculate 15 + 27?",
+                    ),
+                ],
+            },
+            "tracer": {"invocation_context": {"test": "agent_with_tools"}},
+        },
+    )
 
-print(response["agent"]["last_message"].text)
-print(response["tracer"]["trace_url"])
+    print(response["agent"]["last_message"].text)
+    print(response["tracer"]["trace_url"])
 ```
 
 ## Advanced Usage

--- a/docs-website/versioned_docs/version-2.22/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.22/pipeline-components/connectors/langfuseconnector.mdx
@@ -126,63 +126,78 @@ from haystack import Pipeline
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
+
 @tool
 def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
-"""Get current weather information for a city."""
-weather_data = {
-  "Berlin": "18°C, partly cloudy",
-  "New York": "22°C, sunny",
-  "Tokyo": "25°C, clear skies"
-}
-return weather_data.get(city, f"Weather information for {city} not available")
+    """Get current weather information for a city."""
+    weather_data = {
+        "Berlin": "18°C, partly cloudy",
+        "New York": "22°C, sunny",
+        "Tokyo": "25°C, clear skies",
+    }
+    return weather_data.get(city, f"Weather information for {city} not available")
+
 
 @tool
-def calculate(operation: Annotated[str, "Mathematical operation: add, subtract, multiply, divide"],
-          a: Annotated[float, "First number"],
-          b: Annotated[float, "Second number"]) -> str:
-"""Perform basic mathematical calculations."""
-if operation == "add":
-  result = a + b
-  elif operation == "subtract":
-  result = a - b
-  elif operation == "multiply":
-  result = a * b
-  elif operation == "divide":
-  if b == 0:
-      return "Error: Division by zero"
-      result = a / b
-  else:
-  return f"Error: Unknown operation '{operation}'"
+def calculate(
+    operation: Annotated[
+        str,
+        "Mathematical operation: add, subtract, multiply, divide",
+    ],
+    a: Annotated[float, "First number"],
+    b: Annotated[float, "Second number"],
+) -> str:
+    """Perform basic mathematical calculations."""
+    if operation == "add":
+        result = a + b
+    elif operation == "subtract":
+        result = a - b
+    elif operation == "multiply":
+        result = a * b
+    elif operation == "divide":
+        if b == 0:
+            return "Error: Division by zero"
+        else:
+            result = a / b
+    else:
+        return f"Error: Unknown operation '{operation}'"
 
-return f"The result of {a} {operation} {b} is {result}"
+    return f"The result of {a} {operation} {b} is {result}"
+
 
 if __name__ == "__main__":
-## Create components
-chat_generator = OpenAIChatGenerator()
+    ## Create components
+    chat_generator = OpenAIChatGenerator()
 
-agent = Agent(
-  chat_generator=chat_generator,
-  tools=[get_weather, calculate],
-  system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
-  exit_conditions=["text"]
-)
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[get_weather, calculate],
+        system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
+        exit_conditions=["text"],
+    )
 
-langfuse_connector = LangfuseConnector("Agent Example")
+    langfuse_connector = LangfuseConnector("Agent Example")
 
-## Create and run pipeline
-pipe = Pipeline()
-pipe.add_component("tracer", langfuse_connector)
-pipe.add_component("agent", agent)
+    ## Create and run pipeline
+    pipe = Pipeline()
+    pipe.add_component("tracer", langfuse_connector)
+    pipe.add_component("agent", agent)
 
-response = pipe.run(
-  data={
-      "agent": {"messages": [ChatMessage.from_user("What's the weather in Berlin and calculate 15 + 27?")]},
-      "tracer": {"invocation_context": {"test": "agent_with_tools"}}
-    }
-)
+    response = pipe.run(
+        data={
+            "agent": {
+                "messages": [
+                    ChatMessage.from_user(
+                        "What's the weather in Berlin and calculate 15 + 27?",
+                    ),
+                ],
+            },
+            "tracer": {"invocation_context": {"test": "agent_with_tools"}},
+        },
+    )
 
-print(response["agent"]["last_message"].text)
-print(response["tracer"]["trace_url"])
+    print(response["agent"]["last_message"].text)
+    print(response["tracer"]["trace_url"])
 ```
 
 ## Advanced Usage

--- a/docs-website/versioned_docs/version-2.23/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.23/pipeline-components/connectors/langfuseconnector.mdx
@@ -126,63 +126,78 @@ from haystack import Pipeline
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
+
 @tool
 def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
-"""Get current weather information for a city."""
-weather_data = {
-  "Berlin": "18°C, partly cloudy",
-  "New York": "22°C, sunny",
-  "Tokyo": "25°C, clear skies"
-}
-return weather_data.get(city, f"Weather information for {city} not available")
+    """Get current weather information for a city."""
+    weather_data = {
+        "Berlin": "18°C, partly cloudy",
+        "New York": "22°C, sunny",
+        "Tokyo": "25°C, clear skies",
+    }
+    return weather_data.get(city, f"Weather information for {city} not available")
+
 
 @tool
-def calculate(operation: Annotated[str, "Mathematical operation: add, subtract, multiply, divide"],
-          a: Annotated[float, "First number"],
-          b: Annotated[float, "Second number"]) -> str:
-"""Perform basic mathematical calculations."""
-if operation == "add":
-  result = a + b
-  elif operation == "subtract":
-  result = a - b
-  elif operation == "multiply":
-  result = a * b
-  elif operation == "divide":
-  if b == 0:
-      return "Error: Division by zero"
-      result = a / b
-  else:
-  return f"Error: Unknown operation '{operation}'"
+def calculate(
+    operation: Annotated[
+        str,
+        "Mathematical operation: add, subtract, multiply, divide",
+    ],
+    a: Annotated[float, "First number"],
+    b: Annotated[float, "Second number"],
+) -> str:
+    """Perform basic mathematical calculations."""
+    if operation == "add":
+        result = a + b
+    elif operation == "subtract":
+        result = a - b
+    elif operation == "multiply":
+        result = a * b
+    elif operation == "divide":
+        if b == 0:
+            return "Error: Division by zero"
+        else:
+            result = a / b
+    else:
+        return f"Error: Unknown operation '{operation}'"
 
-return f"The result of {a} {operation} {b} is {result}"
+    return f"The result of {a} {operation} {b} is {result}"
+
 
 if __name__ == "__main__":
-## Create components
-chat_generator = OpenAIChatGenerator()
+    ## Create components
+    chat_generator = OpenAIChatGenerator()
 
-agent = Agent(
-  chat_generator=chat_generator,
-  tools=[get_weather, calculate],
-  system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
-  exit_conditions=["text"]
-)
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[get_weather, calculate],
+        system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
+        exit_conditions=["text"],
+    )
 
-langfuse_connector = LangfuseConnector("Agent Example")
+    langfuse_connector = LangfuseConnector("Agent Example")
 
-## Create and run pipeline
-pipe = Pipeline()
-pipe.add_component("tracer", langfuse_connector)
-pipe.add_component("agent", agent)
+    ## Create and run pipeline
+    pipe = Pipeline()
+    pipe.add_component("tracer", langfuse_connector)
+    pipe.add_component("agent", agent)
 
-response = pipe.run(
-  data={
-      "agent": {"messages": [ChatMessage.from_user("What's the weather in Berlin and calculate 15 + 27?")]},
-      "tracer": {"invocation_context": {"test": "agent_with_tools"}}
-    }
-)
+    response = pipe.run(
+        data={
+            "agent": {
+                "messages": [
+                    ChatMessage.from_user(
+                        "What's the weather in Berlin and calculate 15 + 27?",
+                    ),
+                ],
+            },
+            "tracer": {"invocation_context": {"test": "agent_with_tools"}},
+        },
+    )
 
-print(response["agent"]["last_message"].text)
-print(response["tracer"]["trace_url"])
+    print(response["agent"]["last_message"].text)
+    print(response["tracer"]["trace_url"])
 ```
 
 ## Advanced Usage

--- a/docs-website/versioned_docs/version-2.24/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.24/pipeline-components/connectors/langfuseconnector.mdx
@@ -126,63 +126,78 @@ from haystack import Pipeline
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
+
 @tool
 def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
-"""Get current weather information for a city."""
-weather_data = {
-  "Berlin": "18°C, partly cloudy",
-  "New York": "22°C, sunny",
-  "Tokyo": "25°C, clear skies"
-}
-return weather_data.get(city, f"Weather information for {city} not available")
+    """Get current weather information for a city."""
+    weather_data = {
+        "Berlin": "18°C, partly cloudy",
+        "New York": "22°C, sunny",
+        "Tokyo": "25°C, clear skies",
+    }
+    return weather_data.get(city, f"Weather information for {city} not available")
+
 
 @tool
-def calculate(operation: Annotated[str, "Mathematical operation: add, subtract, multiply, divide"],
-          a: Annotated[float, "First number"],
-          b: Annotated[float, "Second number"]) -> str:
-"""Perform basic mathematical calculations."""
-if operation == "add":
-  result = a + b
-  elif operation == "subtract":
-  result = a - b
-  elif operation == "multiply":
-  result = a * b
-  elif operation == "divide":
-  if b == 0:
-      return "Error: Division by zero"
-      result = a / b
-  else:
-  return f"Error: Unknown operation '{operation}'"
+def calculate(
+    operation: Annotated[
+        str,
+        "Mathematical operation: add, subtract, multiply, divide",
+    ],
+    a: Annotated[float, "First number"],
+    b: Annotated[float, "Second number"],
+) -> str:
+    """Perform basic mathematical calculations."""
+    if operation == "add":
+        result = a + b
+    elif operation == "subtract":
+        result = a - b
+    elif operation == "multiply":
+        result = a * b
+    elif operation == "divide":
+        if b == 0:
+            return "Error: Division by zero"
+        else:
+            result = a / b
+    else:
+        return f"Error: Unknown operation '{operation}'"
 
-return f"The result of {a} {operation} {b} is {result}"
+    return f"The result of {a} {operation} {b} is {result}"
+
 
 if __name__ == "__main__":
-## Create components
-chat_generator = OpenAIChatGenerator()
+    ## Create components
+    chat_generator = OpenAIChatGenerator()
 
-agent = Agent(
-  chat_generator=chat_generator,
-  tools=[get_weather, calculate],
-  system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
-  exit_conditions=["text"]
-)
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[get_weather, calculate],
+        system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
+        exit_conditions=["text"],
+    )
 
-langfuse_connector = LangfuseConnector("Agent Example")
+    langfuse_connector = LangfuseConnector("Agent Example")
 
-## Create and run pipeline
-pipe = Pipeline()
-pipe.add_component("tracer", langfuse_connector)
-pipe.add_component("agent", agent)
+    ## Create and run pipeline
+    pipe = Pipeline()
+    pipe.add_component("tracer", langfuse_connector)
+    pipe.add_component("agent", agent)
 
-response = pipe.run(
-  data={
-      "agent": {"messages": [ChatMessage.from_user("What's the weather in Berlin and calculate 15 + 27?")]},
-      "tracer": {"invocation_context": {"test": "agent_with_tools"}}
-    }
-)
+    response = pipe.run(
+        data={
+            "agent": {
+                "messages": [
+                    ChatMessage.from_user(
+                        "What's the weather in Berlin and calculate 15 + 27?",
+                    ),
+                ],
+            },
+            "tracer": {"invocation_context": {"test": "agent_with_tools"}},
+        },
+    )
 
-print(response["agent"]["last_message"].text)
-print(response["tracer"]["trace_url"])
+    print(response["agent"]["last_message"].text)
+    print(response["tracer"]["trace_url"])
 ```
 
 ## Advanced Usage

--- a/docs-website/versioned_docs/version-2.25/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.25/pipeline-components/connectors/langfuseconnector.mdx
@@ -126,63 +126,78 @@ from haystack import Pipeline
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
+
 @tool
 def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
-"""Get current weather information for a city."""
-weather_data = {
-  "Berlin": "18°C, partly cloudy",
-  "New York": "22°C, sunny",
-  "Tokyo": "25°C, clear skies"
-}
-return weather_data.get(city, f"Weather information for {city} not available")
+    """Get current weather information for a city."""
+    weather_data = {
+        "Berlin": "18°C, partly cloudy",
+        "New York": "22°C, sunny",
+        "Tokyo": "25°C, clear skies",
+    }
+    return weather_data.get(city, f"Weather information for {city} not available")
+
 
 @tool
-def calculate(operation: Annotated[str, "Mathematical operation: add, subtract, multiply, divide"],
-          a: Annotated[float, "First number"],
-          b: Annotated[float, "Second number"]) -> str:
-"""Perform basic mathematical calculations."""
-if operation == "add":
-  result = a + b
-  elif operation == "subtract":
-  result = a - b
-  elif operation == "multiply":
-  result = a * b
-  elif operation == "divide":
-  if b == 0:
-      return "Error: Division by zero"
-      result = a / b
-  else:
-  return f"Error: Unknown operation '{operation}'"
+def calculate(
+    operation: Annotated[
+        str,
+        "Mathematical operation: add, subtract, multiply, divide",
+    ],
+    a: Annotated[float, "First number"],
+    b: Annotated[float, "Second number"],
+) -> str:
+    """Perform basic mathematical calculations."""
+    if operation == "add":
+        result = a + b
+    elif operation == "subtract":
+        result = a - b
+    elif operation == "multiply":
+        result = a * b
+    elif operation == "divide":
+        if b == 0:
+            return "Error: Division by zero"
+        else:
+            result = a / b
+    else:
+        return f"Error: Unknown operation '{operation}'"
 
-return f"The result of {a} {operation} {b} is {result}"
+    return f"The result of {a} {operation} {b} is {result}"
+
 
 if __name__ == "__main__":
-## Create components
-chat_generator = OpenAIChatGenerator()
+    ## Create components
+    chat_generator = OpenAIChatGenerator()
 
-agent = Agent(
-  chat_generator=chat_generator,
-  tools=[get_weather, calculate],
-  system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
-  exit_conditions=["text"]
-)
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[get_weather, calculate],
+        system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
+        exit_conditions=["text"],
+    )
 
-langfuse_connector = LangfuseConnector("Agent Example")
+    langfuse_connector = LangfuseConnector("Agent Example")
 
-## Create and run pipeline
-pipe = Pipeline()
-pipe.add_component("tracer", langfuse_connector)
-pipe.add_component("agent", agent)
+    ## Create and run pipeline
+    pipe = Pipeline()
+    pipe.add_component("tracer", langfuse_connector)
+    pipe.add_component("agent", agent)
 
-response = pipe.run(
-  data={
-      "agent": {"messages": [ChatMessage.from_user("What's the weather in Berlin and calculate 15 + 27?")]},
-      "tracer": {"invocation_context": {"test": "agent_with_tools"}}
-    }
-)
+    response = pipe.run(
+        data={
+            "agent": {
+                "messages": [
+                    ChatMessage.from_user(
+                        "What's the weather in Berlin and calculate 15 + 27?",
+                    ),
+                ],
+            },
+            "tracer": {"invocation_context": {"test": "agent_with_tools"}},
+        },
+    )
 
-print(response["agent"]["last_message"].text)
-print(response["tracer"]["trace_url"])
+    print(response["agent"]["last_message"].text)
+    print(response["tracer"]["trace_url"])
 ```
 
 ## Advanced Usage

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/connectors/langfuseconnector.mdx
@@ -126,63 +126,78 @@ from haystack import Pipeline
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
+
 @tool
 def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
-"""Get current weather information for a city."""
-weather_data = {
-  "Berlin": "18°C, partly cloudy",
-  "New York": "22°C, sunny",
-  "Tokyo": "25°C, clear skies"
-}
-return weather_data.get(city, f"Weather information for {city} not available")
+    """Get current weather information for a city."""
+    weather_data = {
+        "Berlin": "18°C, partly cloudy",
+        "New York": "22°C, sunny",
+        "Tokyo": "25°C, clear skies",
+    }
+    return weather_data.get(city, f"Weather information for {city} not available")
+
 
 @tool
-def calculate(operation: Annotated[str, "Mathematical operation: add, subtract, multiply, divide"],
-          a: Annotated[float, "First number"],
-          b: Annotated[float, "Second number"]) -> str:
-"""Perform basic mathematical calculations."""
-if operation == "add":
-  result = a + b
-  elif operation == "subtract":
-  result = a - b
-  elif operation == "multiply":
-  result = a * b
-  elif operation == "divide":
-  if b == 0:
-      return "Error: Division by zero"
-      result = a / b
-  else:
-  return f"Error: Unknown operation '{operation}'"
+def calculate(
+    operation: Annotated[
+        str,
+        "Mathematical operation: add, subtract, multiply, divide",
+    ],
+    a: Annotated[float, "First number"],
+    b: Annotated[float, "Second number"],
+) -> str:
+    """Perform basic mathematical calculations."""
+    if operation == "add":
+        result = a + b
+    elif operation == "subtract":
+        result = a - b
+    elif operation == "multiply":
+        result = a * b
+    elif operation == "divide":
+        if b == 0:
+            return "Error: Division by zero"
+        else:
+            result = a / b
+    else:
+        return f"Error: Unknown operation '{operation}'"
 
-return f"The result of {a} {operation} {b} is {result}"
+    return f"The result of {a} {operation} {b} is {result}"
+
 
 if __name__ == "__main__":
-## Create components
-chat_generator = OpenAIChatGenerator()
+    ## Create components
+    chat_generator = OpenAIChatGenerator()
 
-agent = Agent(
-  chat_generator=chat_generator,
-  tools=[get_weather, calculate],
-  system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
-  exit_conditions=["text"]
-)
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[get_weather, calculate],
+        system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
+        exit_conditions=["text"],
+    )
 
-langfuse_connector = LangfuseConnector("Agent Example")
+    langfuse_connector = LangfuseConnector("Agent Example")
 
-## Create and run pipeline
-pipe = Pipeline()
-pipe.add_component("tracer", langfuse_connector)
-pipe.add_component("agent", agent)
+    ## Create and run pipeline
+    pipe = Pipeline()
+    pipe.add_component("tracer", langfuse_connector)
+    pipe.add_component("agent", agent)
 
-response = pipe.run(
-  data={
-      "agent": {"messages": [ChatMessage.from_user("What's the weather in Berlin and calculate 15 + 27?")]},
-      "tracer": {"invocation_context": {"test": "agent_with_tools"}}
-    }
-)
+    response = pipe.run(
+        data={
+            "agent": {
+                "messages": [
+                    ChatMessage.from_user(
+                        "What's the weather in Berlin and calculate 15 + 27?",
+                    ),
+                ],
+            },
+            "tracer": {"invocation_context": {"test": "agent_with_tools"}},
+        },
+    )
 
-print(response["agent"]["last_message"].text)
-print(response["tracer"]["trace_url"])
+    print(response["agent"]["last_message"].text)
+    print(response["tracer"]["trace_url"])
 ```
 
 ## Advanced Usage

--- a/docs-website/versioned_docs/version-2.27/pipeline-components/connectors/langfuseconnector.mdx
+++ b/docs-website/versioned_docs/version-2.27/pipeline-components/connectors/langfuseconnector.mdx
@@ -126,63 +126,78 @@ from haystack import Pipeline
 
 from haystack_integrations.components.connectors.langfuse import LangfuseConnector
 
+
 @tool
 def get_weather(city: Annotated[str, "The city to get weather for"]) -> str:
-"""Get current weather information for a city."""
-weather_data = {
-  "Berlin": "18°C, partly cloudy",
-  "New York": "22°C, sunny",
-  "Tokyo": "25°C, clear skies"
-}
-return weather_data.get(city, f"Weather information for {city} not available")
+    """Get current weather information for a city."""
+    weather_data = {
+        "Berlin": "18°C, partly cloudy",
+        "New York": "22°C, sunny",
+        "Tokyo": "25°C, clear skies",
+    }
+    return weather_data.get(city, f"Weather information for {city} not available")
+
 
 @tool
-def calculate(operation: Annotated[str, "Mathematical operation: add, subtract, multiply, divide"],
-          a: Annotated[float, "First number"],
-          b: Annotated[float, "Second number"]) -> str:
-"""Perform basic mathematical calculations."""
-if operation == "add":
-  result = a + b
-  elif operation == "subtract":
-  result = a - b
-  elif operation == "multiply":
-  result = a * b
-  elif operation == "divide":
-  if b == 0:
-      return "Error: Division by zero"
-      result = a / b
-  else:
-  return f"Error: Unknown operation '{operation}'"
+def calculate(
+    operation: Annotated[
+        str,
+        "Mathematical operation: add, subtract, multiply, divide",
+    ],
+    a: Annotated[float, "First number"],
+    b: Annotated[float, "Second number"],
+) -> str:
+    """Perform basic mathematical calculations."""
+    if operation == "add":
+        result = a + b
+    elif operation == "subtract":
+        result = a - b
+    elif operation == "multiply":
+        result = a * b
+    elif operation == "divide":
+        if b == 0:
+            return "Error: Division by zero"
+        else:
+            result = a / b
+    else:
+        return f"Error: Unknown operation '{operation}'"
 
-return f"The result of {a} {operation} {b} is {result}"
+    return f"The result of {a} {operation} {b} is {result}"
+
 
 if __name__ == "__main__":
-## Create components
-chat_generator = OpenAIChatGenerator()
+    ## Create components
+    chat_generator = OpenAIChatGenerator()
 
-agent = Agent(
-  chat_generator=chat_generator,
-  tools=[get_weather, calculate],
-  system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
-  exit_conditions=["text"]
-)
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[get_weather, calculate],
+        system_prompt="You are a helpful assistant with access to weather and calculator tools. Use them when needed.",
+        exit_conditions=["text"],
+    )
 
-langfuse_connector = LangfuseConnector("Agent Example")
+    langfuse_connector = LangfuseConnector("Agent Example")
 
-## Create and run pipeline
-pipe = Pipeline()
-pipe.add_component("tracer", langfuse_connector)
-pipe.add_component("agent", agent)
+    ## Create and run pipeline
+    pipe = Pipeline()
+    pipe.add_component("tracer", langfuse_connector)
+    pipe.add_component("agent", agent)
 
-response = pipe.run(
-  data={
-      "agent": {"messages": [ChatMessage.from_user("What's the weather in Berlin and calculate 15 + 27?")]},
-      "tracer": {"invocation_context": {"test": "agent_with_tools"}}
-    }
-)
+    response = pipe.run(
+        data={
+            "agent": {
+                "messages": [
+                    ChatMessage.from_user(
+                        "What's the weather in Berlin and calculate 15 + 27?",
+                    ),
+                ],
+            },
+            "tracer": {"invocation_context": {"test": "agent_with_tools"}},
+        },
+    )
 
-print(response["agent"]["last_message"].text)
-print(response["tracer"]["trace_url"])
+    print(response["agent"]["last_message"].text)
+    print(response["tracer"]["trace_url"])
 ```
 
 ## Advanced Usage


### PR DESCRIPTION
### Related Issues

- I was doing a Langfuse experiment and tried running the snippet here: https://docs.haystack.deepset.ai/docs/langfuseconnector#with-an-agent. It's broken

### Proposed Changes:
- fix the Agent tracing snippet

### How did you test it?
Vercel

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
