### PR TITLE
docs: add YAML example to DocumentSplitter documentation

### DIFF
--- a/docs-website/docs/pipeline-components/preprocessors/documentsplitter.mdx
+++ b/docs-website/docs/pipeline-components/preprocessors/documentsplitter.mdx
@@ -95,3 +95,64 @@ path = "path/to/your/files"
 files = list(Path(path).glob("*.md"))
 p.run({"text_file_converter": {"sources": files}})
 ```
+
+### In YAML
+
+This is the YAML representation of the indexing pipeline shown above. It reads text files, cleans the text, splits it into individual sentences, and writes them to an in-memory document store.
+
+```yaml
+components:
+  cleaner:
+    init_parameters:
+      ascii_only: false
+      keep_id: false
+      remove_empty_lines: true
+      remove_extra_whitespaces: true
+      remove_regex: null
+      remove_repeated_substrings: false
+      remove_substrings: null
+      replace_regexes: null
+      strip_whitespaces: false
+      unicode_normalization: null
+    type: haystack.components.preprocessors.document_cleaner.DocumentCleaner
+  splitter:
+    init_parameters:
+      extend_abbreviations: true
+      language: en
+      respect_sentence_boundary: false
+      skip_empty_documents: true
+      split_by: sentence
+      split_length: 1
+      split_overlap: 0
+      split_threshold: 0
+      use_split_rules: true
+    type: haystack.components.preprocessors.document_splitter.DocumentSplitter
+  text_file_converter:
+    init_parameters:
+      encoding: utf-8
+      store_full_path: false
+    type: haystack.components.converters.txt.TextFileToDocument
+  writer:
+    init_parameters:
+      document_store:
+        init_parameters:
+          bm25_algorithm: BM25L
+          bm25_parameters: {}
+          bm25_tokenization_regex: (?u)\\b\\w+\\b
+          embedding_similarity_function: dot_product
+          index: 64e4f9ab-87fb-47fd-b390-dabcfda61447
+          return_embedding: true
+        type: haystack.document_stores.in_memory.document_store.InMemoryDocumentStore
+      policy: NONE
+    type: haystack.components.writers.document_writer.DocumentWriter
+connection_type_validation: true
+connections:
+- receiver: cleaner.documents
+  sender: text_file_converter.documents
+- receiver: splitter.documents
+  sender: cleaner.documents
+- receiver: writer.documents
+  sender: splitter.documents
+max_runs_per_component: 100
+metadata: {}
+```

--- a/releasenotes/notes/add-yaml-splitter-docs-149e44f86c20f032.yaml
+++ b/releasenotes/notes/add-yaml-splitter-docs-149e44f86c20f032.yaml
@@ -1,0 +1,3 @@
+---
+docs:
+  - Added a YAML representation of the indexing pipeline to the DocumentSplitter documentation.

--- a/releasenotes/notes/add-yaml-splitter-docs-149e44f86c20f032.yaml
+++ b/releasenotes/notes/add-yaml-splitter-docs-149e44f86c20f032.yaml
@@ -1,3 +1,0 @@
----
-docs:
-  - Added a YAML representation of the indexing pipeline to the DocumentSplitter documentation.


### PR DESCRIPTION
### Related Issues

- fixes #11131 

### Proposed Changes:

-Added a YAML representation of the indexing pipeline to the DocumentSplitter documentation.
-Included a brief introductory description for the YAML example to provide context on the pipeline's workflow (loading, cleaning, splitting, and writing).
-Ensured the YAML example precisely matches the Python pipeline example provided in the same document for consistency.

### How did you test it?

-Manual verification: Verified that the YAML structure correctly represents the Python example above it.
-Cross-referenced the YAML format with recently merged PRs for other preprocessors (like DocumentCleaner) to ensure stylistic consistency with the rest of the documentation.

### Notes for the reviewer

-The YAML example was added directly after the "In a pipeline" Python code block, adhering to the standard documentation layout used across the Haystack repository.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings. *(N/A for documentation changes)*
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `docs:`
- [x] I have documented my code.
- [x] I have added a release note file. *(Note: Pure documentation changes are usually labeled as `ignore-for-release-notes` by maintainers, but they may ask you to add one if they prefer.)*
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
