### PR TITLE
docs: add chatpromptbuilder yaml

### DIFF
--- a/docs-website/docs/pipeline-components/builders/chatpromptbuilder.mdx
+++ b/docs-website/docs/pipeline-components/builders/chatpromptbuilder.mdx
@@ -407,6 +407,44 @@ res = pipe.run(
 print(res)
 ```
 
+### In YAML
+
+This is the YAML representation of the pipeline shown above. It dynamically constructs a prompt and generates an answer using a chat model.
+
+```yaml
+components:
+  llm:
+    init_parameters:
+      api_base_url: null
+      api_key:
+        env_vars:
+        - OPENAI_API_KEY
+        strict: true
+        type: env_var
+      generation_kwargs: {}
+      http_client_kwargs: null
+      max_retries: null
+      model: gpt-4o-mini
+      organization: null
+      streaming_callback: null
+      timeout: null
+      tools: null
+      tools_strict: false
+    type: haystack.components.generators.chat.openai.OpenAIChatGenerator
+  prompt_builder:
+    init_parameters:
+      required_variables: null
+      template: null
+      variables: null
+    type: haystack.components.builders.chat_prompt_builder.ChatPromptBuilder
+connection_type_validation: true
+connections:
+- receiver: llm.messages
+  sender: prompt_builder.prompt
+max_runs_per_component: 100
+metadata: {}
+```
+
 ## Additional References
 
 🧑‍🍳 Cookbook: [Advanced Prompt Customization for Anthropic](https://haystack.deepset.ai/cookbook/prompt_customization_for_anthropic)

--- a/releasenotes/notes/add-yaml-chatpromptbuilder-docs-20654ffbf7faaa43.yaml
+++ b/releasenotes/notes/add-yaml-chatpromptbuilder-docs-20654ffbf7faaa43.yaml
@@ -1,3 +1,0 @@
----
-docs:
-  - Added a YAML representation of the conversational pipeline to the ChatPromptBuilder documentation.

--- a/releasenotes/notes/add-yaml-chatpromptbuilder-docs-20654ffbf7faaa43.yaml
+++ b/releasenotes/notes/add-yaml-chatpromptbuilder-docs-20654ffbf7faaa43.yaml
@@ -1,0 +1,3 @@
+---
+docs:
+  - Added a YAML representation of the conversational pipeline to the ChatPromptBuilder documentation.


### PR DESCRIPTION
### Related Issues

- fixes #11132 

### Proposed Changes:

- Added a YAML representation of the conversational pipeline to the `ChatPromptBuilder` documentation.
- Included an introductory sentence explaining that the pipeline dynamically constructs prompts and generates answers using a chat model.
- Ensured the YAML example is consistent with the Python code block demonstrating the integration of `ChatPromptBuilder` and `OpenAIChatGenerator`.

### How did you test it?

- Manual verification: Verified the YAML structure against standard Haystack serialization formats.
- Confirmed that the YAML correctly maps the `prompt_builder.prompt` output to the `llm.messages` input as shown in the Python example.

### Notes for the reviewer

The YAML example was placed at the end of the "Usage" section to match the documentation pattern of other components recently updated with YAML examples.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings. *(N/A for documentation changes)*
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `docs:`
- [x] I have documented my code.
- [x] I have added a release note file.
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.