### PR TITLE
docs: add YAML example to PromptBuilder documentation

### DIFF
--- a/docs-website/docs/pipeline-components/builders/promptbuilder.mdx
+++ b/docs-website/docs/pipeline-components/builders/promptbuilder.mdx
@@ -257,6 +257,45 @@ p.run(
 Note that `language_template` introduces `answer_language` variable which is not bound to any pipeline variable. If not set otherwise, it would use its default value, "English". In this example, we overwrite its value to "German".
 The `template_variables` allows you to overwrite pipeline variables (such as documents) as well.
 
+### In YAML
+
+This is the YAML representation of the RAG pipeline shown above. It renders a custom prompt template by filling it with the contents of retrieved documents and a query, then sends the rendered prompt to a generator.
+
+```yaml
+components:
+  llm:
+    init_parameters:
+      api_base_url: null
+      api_key:
+        env_vars:
+        - OPENAI_API_KEY
+        strict: true
+        type: env_var
+      generation_kwargs: {}
+      http_client_kwargs: null
+      max_retries: null
+      model: gpt-5-mini
+      organization: null
+      streaming_callback: null
+      system_prompt: null
+      timeout: null
+    type: haystack.components.generators.openai.OpenAIGenerator
+  prompt_builder:
+    init_parameters:
+      required_variables: null
+      template: "\n    Given these documents, answer the question.\\nDocuments:\n\
+        \    {% for doc in documents %}\n        {{ doc.content }}\n    {% endfor\
+        \ %}\n\n    \\nQuestion: {{query}}\n    \\nAnswer:\n    "
+      variables: null
+    type: haystack.components.builders.prompt_builder.PromptBuilder
+connection_type_validation: true
+connections:
+- receiver: llm.prompt
+  sender: prompt_builder.prompt
+max_runs_per_component: 100
+metadata: {}
+```
+
 ## Additional References
 
 🧑‍🍳 Cookbooks:


### PR DESCRIPTION
### Related Issues

- fixes #11133 

### Proposed Changes:

- Added a YAML representation of the RAG pipeline to the `PromptBuilder` documentation.
- Included an introductory sentence explaining how the pipeline renders a custom prompt template using retrieved documents and sends it to a generator.
- Used the `#### In YAML` heading level to ensure the documentation hierarchy remains consistent with the other "In a pipeline" subsections.

### How did you test it?

- Manual verification: Confirmed the YAML connection mapping (`prompt_builder.prompt` -> `llm.prompt`) matches the Python pipeline logic.
- Structure check: Verified that the new heading level (`####`) correctly nests the YAML example as a subsection within the "In a pipeline" category.

### Notes for the reviewer

The indentation and structure of the YAML were cross-referenced with other recently updated components to ensure a uniform look and feel across the documentation.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings. *(N/A for documentation changes)*
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `docs:`
- [x] I have documented my code.
- [x] I have added a release note file.
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.