### PR TITLE
fix: single-quote YAML strings with backslashes for safe round-tripping

### DIFF
--- a/haystack/marshal/yaml.py
+++ b/haystack/marshal/yaml.py
@@ -19,8 +19,22 @@ class YamlDumper(yaml.SafeDumper):
         """Represent a Python tuple."""
         return self.represent_sequence("tag:yaml.org,2002:python/tuple", data)
 
+    def represent_str(self, data: str) -> yaml.ScalarNode:
+        """Represent a string, using single-quoted style for strings containing backslashes.
+
+        This ensures that backslash sequences (e.g. ``\\b``, ``\\w``) in regex
+        patterns and file paths are preserved literally during YAML round-tripping.
+        Without this, a plain scalar like ``remove_regex: \\b\\w+\\b`` may be
+        misinterpreted on some YAML / Python versions, causing
+        ``ReaderError`` or ``SyntaxWarning`` on load (#11093).
+        """
+        if "\\" in data:
+            return self.represent_scalar("tag:yaml.org,2002:str", data, style="'")
+        return self.represent_scalar("tag:yaml.org,2002:str", data)
+
 
 YamlDumper.add_representer(tuple, YamlDumper.represent_tuple)
+YamlDumper.add_representer(str, YamlDumper.represent_str)
 YamlLoader.add_constructor("tag:yaml.org,2002:python/tuple", YamlLoader.construct_python_tuple)
 
 

--- a/haystack/marshal/yaml.py
+++ b/haystack/marshal/yaml.py
@@ -29,7 +29,9 @@ class YamlDumper(yaml.SafeDumper):
         ``ReaderError`` or ``SyntaxWarning`` on load (#11093).
         """
         if "\\" in data:
-            return self.represent_scalar("tag:yaml.org,2002:str", data, style="'")
+            return self.represent_scalar(
+                "tag:yaml.org,2002:str", data, style="'"
+            )
         return self.represent_scalar("tag:yaml.org,2002:str", data)
 
 

--- a/releasenotes/notes/fix-yaml-backslash-roundtrip-d5ecc900d.yaml
+++ b/releasenotes/notes/fix-yaml-backslash-roundtrip-d5ecc900d.yaml
@@ -1,8 +1,8 @@
 ---
 fixes:
   - |
-    Fixed YAML serialization of strings containing backslashes (e.g. regex patterns like `\b\w+\b`,
-    Windows paths like `C:\Users\file`). Such strings are now emitted as single-quoted YAML scalars,
+    Fixed YAML serialization of strings containing backslashes (e.g. regex patterns like ``\b\w+\b``,
+    Windows paths like ``C:\Users\file``). Such strings are now emitted as single-quoted YAML scalars,
     preventing misinterpretation of backslash sequences as YAML escape characters on load.
-    This fixes `ReaderError: unacceptable character #x0008` and `SyntaxWarning` issues
+    This fixes ``ReaderError: unacceptable character #x0008`` and ``SyntaxWarning`` issues
     when round-tripping pipelines that contain regex parameters. Fixes #11093.

--- a/releasenotes/notes/fix-yaml-backslash-roundtrip-d5ecc900d.yaml
+++ b/releasenotes/notes/fix-yaml-backslash-roundtrip-d5ecc900d.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed YAML serialization of strings containing backslashes (e.g. regex patterns like `\b\w+\b`,
+    Windows paths like `C:\Users\file`). Such strings are now emitted as single-quoted YAML scalars,
+    preventing misinterpretation of backslash sequences as YAML escape characters on load.
+    This fixes `ReaderError: unacceptable character #x0008` and `SyntaxWarning` issues
+    when round-tripping pipelines that contain regex parameters. Fixes #11093.

--- a/test/marshal/test_yaml.py
+++ b/test/marshal/test_yaml.py
@@ -59,3 +59,58 @@ def test_yaml_unmarshal(yaml_data, serialized_yaml_str):
     marshaller = YamlMarshaller()
     unmarshalled = marshaller.unmarshal(serialized_yaml_str)
     assert unmarshalled == yaml_data
+
+
+class TestYamlBackslashRoundtrip:
+    """Strings with backslashes must round-trip correctly through YAML.
+
+    Regression test for #11093: regex patterns and file paths containing
+    backslash sequences must survive YAML round-tripping.
+    """
+
+    def test_single_backslash_sequence(self):
+        m = YamlMarshaller()
+        data = {"regex": r"\b\w+\b"}
+        assert m.unmarshal(m.marshal(data)) == data
+
+    def test_complex_regex(self):
+        m = YamlMarshaller()
+        data = {"regex": r"(?u)\b\w+\b"}
+        assert m.unmarshal(m.marshal(data)) == data
+
+    def test_windows_path(self):
+        m = YamlMarshaller()
+        data = {"path": r"C:\Users\test\file.txt"}
+        assert m.unmarshal(m.marshal(data)) == data
+
+    def test_no_backslash_unchanged(self):
+        m = YamlMarshaller()
+        data = {"text": "hello world"}
+        dumped = m.marshal(data)
+        # Plain scalars should not be quoted when no backslash is present
+        assert "hello world" in dumped
+        assert m.unmarshal(dumped) == data
+
+    def test_backslash_string_is_single_quoted(self):
+        m = YamlMarshaller()
+        data = {"regex": r"\s+"}
+        dumped = m.marshal(data)
+        # Single-quoted scalars use ' as delimiter to prevent escape interpretation
+        assert "'\\s+'" in dumped or "'\\\\s+'" in dumped
+
+    def test_pipe_roundtrip_with_regex(self):
+        """Full Pipeline round-trip with components that use regex parameters."""
+        from haystack import Pipeline
+        from haystack.components.preprocessors import DocumentCleaner
+
+        pipe = Pipeline()
+        cleaner = DocumentCleaner(remove_regex=r"\b\w+\b", replace_regexes={r"\n\n+": "\n"})
+        pipe.add_component("cleaner", cleaner)
+
+        yaml_str = pipe.dumps()
+        loaded = Pipeline.loads(yaml_str)
+
+        # Check regex was preserved
+        loaded_cleaner = loaded.graph.nodes["cleaner"]["instance"]
+        assert loaded_cleaner.remove_regex == r"\b\w+\b"
+        assert r"\n\n+" in loaded_cleaner.replace_regexes


### PR DESCRIPTION
### Related Issues

- fixes #11093

### Proposed Changes:

When serializing pipelines containing regex patterns (e.g. \`\b\w+\b\`) or file paths with backslashes, PyYAML emits plain scalars that can be misinterpreted as YAML escape sequences on load. On Python 3.13+ this produces \`SyntaxWarning\`, and on some configurations it causes \`ReaderError: unacceptable character #x0008\`.

**Fix:** Override \`YamlDumper.represent_str\` to emit single-quoted YAML scalars for any string containing a backslash. In single-quoted YAML scalars, no escape sequences are interpreted, so the round-trip is always safe.

Before:


After:


Strings without backslashes continue to be emitted as plain scalars (no change).

### How did you test it?

- Added 6 new unit tests in \`test/marshal/test_yaml.py\`:
  - Single backslash sequence round-trip
  - Complex regex round-trip
  - Windows path round-trip
  - No-backslash strings unchanged
  - Single-quote style verification
  - Full Pipeline round-trip with DocumentCleaner regex parameters
- All 9 tests pass (3 existing + 6 new)

### Notes for the reviewer

This is a minimal, targeted fix. An alternative approach would be to always quote all strings, but that would make the YAML output significantly more verbose for no additional safety benefit.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I have used conventional commit type \`fix:\` for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file.
- [x] I have run pre-commit hooks and fixed any issue.
