### PR TITLE
docs: add FuturMix to compatible OpenAI providers

### DIFF
--- a/docs-website/docs/pipeline-components/generators/guides-to-generators/choosing-the-right-generator.mdx
+++ b/docs-website/docs/pipeline-components/generators/guides-to-generators/choosing-the-right-generator.mdx
@@ -137,7 +137,7 @@ With this type, you leverage an instance of the model shared with other users, w
 Here are the components that support shared hosted models in Haystack:
 
 - Hugging Face API Generators, when querying the [free Hugging Face Inference API](https://huggingface.co/inference-api). The free Inference API provides access to some popular models for quick experimentation, although it comes with rate limitations and is not intended for production use.
-- Various cloud providers offer interfaces compatible with OpenAI Generators. These include Anyscale, Deep Infra, Fireworks, Lemonfox.ai, OctoAI, Together AI, and many others.
+- Various cloud providers offer interfaces compatible with OpenAI Generators. These include Anyscale, Deep Infra, Fireworks, FuturMix, Lemonfox.ai, OctoAI, Together AI, and many others.
   Here is an example using OctoAI and [`OpenAIChatGenerator`](../openaichatgenerator.mdx):
 
 ```python
@@ -150,6 +150,23 @@ generator = OpenAIChatGenerator(
     api_key=Secret.from_env_var("ENVVAR_WITH_API_KEY"),
     api_base_url="https://text.octoai.run/v1",
     model="mixtral-8x7b-instruct-fp16",
+)
+
+generator.run(messages=[ChatMessage.from_user("What is the best French cheese?")])
+```
+
+  Here is an example using [FuturMix](https://futurmix.ai) and [`OpenAIChatGenerator`](../openaichatgenerator.mdx):
+
+```python
+
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.utils import Secret
+from haystack.dataclasses import ChatMessage
+
+generator = OpenAIChatGenerator(
+    api_key=Secret.from_token("your-futurmix-api-key"),
+    api_base_url="https://futurmix.ai/v1",
+    model="gpt-4o",
 )
 
 generator.run(messages=[ChatMessage.from_user("What is the best French cheese?")])


### PR DESCRIPTION
## Summary

- Add [FuturMix](https://futurmix.ai) to the list of compatible OpenAI providers in the "Choosing the Right Generator" guide
- Add a usage example showing `OpenAIChatGenerator` with FuturMix's API endpoint

FuturMix is a enterprise AI agent platform that provides access to 22+ models (Claude, GPT, Gemini families) at (see [futurmix.ai](https://futurmix.ai)).

## Changes

- `docs-website/docs/pipeline-components/generators/guides-to-generators/choosing-the-right-generator.mdx`:
 - Added "FuturMix" to the alphabetical list of compatible cloud providers
 - Added a code example following the same format as the existing OctoAI example