### PR TITLE
fix(super_component): only expose run_async when wrapped pipeline is AsyncPipeline

### DIFF
--- a/haystack/core/super_component/super_component.py
+++ b/haystack/core/super_component/super_component.py
@@ -5,7 +5,7 @@
 import functools
 from pathlib import Path
 from types import new_class
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from haystack import logging
 from haystack.core.component.component import component
@@ -70,6 +70,15 @@ class _SuperComponent:
         self.pipeline: Pipeline | AsyncPipeline = pipeline
         self._warmed_up = False
 
+        # ``run_async`` is exposed only when the wrapped pipeline can actually run asynchronously.
+        # It is attached per-instance from ``__init__`` rather than living at the class level so
+        # that ``ComponentMeta.__call__`` (which does ``hasattr(instance, "run_async")`` to set
+        # ``__haystack_supports_async__``) sees it only for ``AsyncPipeline``-backed instances.
+        # Otherwise an outer ``AsyncPipeline`` would route the component to ``run_async`` and
+        # crash with ``TypeError: Pipeline is not an AsyncPipeline``. See GitHub issue #9435.
+        if isinstance(pipeline, AsyncPipeline):
+            self.run_async = self._run_async  # type: ignore[method-assign]
+
         # Determine input types based on pipeline and mapping
         pipeline_inputs = self.pipeline.inputs()
         resolved_input_mapping = (
@@ -129,9 +138,22 @@ class _SuperComponent:
         # Collecting the component names from output_mapping
         return {self._split_component_path(path)[0] for path in self.output_mapping.keys()}
 
-    async def run_async(self, **kwargs: Any) -> dict[str, Any]:
+    if TYPE_CHECKING:
+        # Type-only declaration so callers (and downstream typing) can refer to
+        # ``SuperComponent.run_async``. The runtime attribute is bound per-instance
+        # in ``__init__`` only when the wrapped pipeline is an ``AsyncPipeline``;
+        # this keeps ``ComponentMeta`` from advertising async support for sync
+        # pipelines while still presenting a stable public typing surface. See #9435.
+        async def run_async(self, **kwargs: Any) -> dict[str, Any]: ...
+
+    async def _run_async(self, **kwargs: Any) -> dict[str, Any]:
         """
         Runs the wrapped pipeline with the provided inputs async.
+
+        This implementation is exposed as the public ``run_async`` method only when the wrapped
+        pipeline is an :class:`AsyncPipeline`. The ``__init__`` binds ``self.run_async`` to this
+        method in that case; otherwise the attribute is simply absent so that the component is not
+        advertised as async-capable. See GitHub issue #9435.
 
         Steps:
         1. Maps the inputs from kwargs to pipeline component inputs

--- a/releasenotes/notes/fix-super-component-async-only-when-async-pipeline-cb5c00d6c8cedc34.yaml
+++ b/releasenotes/notes/fix-super-component-async-only-when-async-pipeline-cb5c00d6c8cedc34.yaml
@@ -1,0 +1,16 @@
+---
+fixes:
+  - |
+    Fix ``SuperComponent`` (and ``@super_component``-decorated classes) to only advertise
+    asynchronous support when the wrapped pipeline is an ``AsyncPipeline``. Previously,
+    ``SuperComponent`` always defined ``run_async`` and ``__haystack_supports_async__`` was
+    always ``True``, so:
+
+    - Calling ``run_async`` on a ``SuperComponent`` wrapping a sync ``Pipeline`` raised
+      ``TypeError: Pipeline is not an AsyncPipeline. run_async is not supported.``
+    - Adding such a ``SuperComponent`` to an outer ``AsyncPipeline`` made the outer pipeline
+      route to ``run_async`` and crash with the same error.
+
+    ``run_async`` is now bound on the instance only when the wrapped pipeline is an
+    ``AsyncPipeline``, so ``hasattr(super_component, "run_async")`` and
+    ``__haystack_supports_async__`` correctly reflect the wrapped pipeline's capability.

--- a/test/core/super_component/test_super_component.py
+++ b/test/core/super_component/test_super_component.py
@@ -252,6 +252,48 @@ class TestSuperComponent:
         assert "final_answers" in result
         assert isinstance(result["final_answers"][0], GeneratedAnswer)
 
+    def test_sync_pipeline_does_not_advertise_async_support(self, rag_pipeline):
+        """
+        SuperComponent wrapping a sync Pipeline must NOT advertise async support, otherwise an
+        AsyncPipeline that contains it will route to ``run_async`` and crash. Reported in
+        https://github.com/deepset-ai/haystack/issues/9435.
+        """
+        wrapper = SuperComponent(pipeline=rag_pipeline)
+        assert wrapper.__haystack_supports_async__ is False
+        assert not hasattr(wrapper, "run_async")
+
+    def test_async_pipeline_advertises_async_support(self, async_rag_pipeline):
+        """SuperComponent wrapping an AsyncPipeline must advertise async support."""
+        wrapper = SuperComponent(pipeline=async_rag_pipeline)
+        assert wrapper.__haystack_supports_async__ is True
+        assert hasattr(wrapper, "run_async")
+
+    @pytest.mark.asyncio
+    async def test_super_component_with_sync_pipeline_inside_async_pipeline(self, rag_pipeline):
+        """
+        Regression test for https://github.com/deepset-ai/haystack/issues/9435.
+
+        A SuperComponent wrapping a sync Pipeline used to expose ``run_async`` and set
+        ``__haystack_supports_async__ = True``, which made an outer AsyncPipeline route to
+        ``run_async`` and raise ``TypeError: Pipeline is not an AsyncPipeline.``
+        After the fix, the outer AsyncPipeline must fall back to running the SuperComponent
+        synchronously in a worker thread.
+        """
+        input_mapping = {"search_query": ["retriever.query", "prompt_builder.query", "answer_builder.query"]}
+        output_mapping = {"answer_builder.answers": "final_answers"}
+        wrapper = SuperComponent(
+            pipeline=rag_pipeline, input_mapping=input_mapping, output_mapping=output_mapping
+        )
+
+        outer = AsyncPipeline()
+        outer.add_component("wrapper", wrapper)
+        outer.warm_up()
+
+        result = await outer.run_async(data={"wrapper": {"search_query": "What is the capital of France?"}})
+        assert "wrapper" in result
+        assert "final_answers" in result["wrapper"]
+        assert isinstance(result["wrapper"]["final_answers"][0], GeneratedAnswer)
+
     def test_wrapper_serialization(self, document_store):
         """Test serialization and deserialization of pipeline wrapper."""
         pipeline = Pipeline()


### PR DESCRIPTION
## Summary

`SuperComponent` declared `async def run_async(...)` at the class level, so `ComponentMeta.__call__`'s post-`__init__` `hasattr(instance, \"run_async\")` check set `__haystack_supports_async__ = True` for every instance — including those wrapping a sync `Pipeline`. Two visible failures resulted:

1. Calling `wrapper.run_async(...)` on a sync-pipeline-backed `SuperComponent` raised `TypeError: Pipeline is not an AsyncPipeline...`.
2. Putting such a `SuperComponent` inside an outer `AsyncPipeline` made `AsyncPipeline._run_component_async` dispatch to `run_async`, and the whole outer pipeline crashed with `PipelineRuntimeError`.

Fixes #9435

## Fix

`haystack/core/super_component/super_component.py`:

- Renamed the class-level method from `run_async` to `_run_async`. The metaclass no longer sees a class-level `run_async` and therefore no longer marks every `SuperComponent` as async-capable.
- `__init__` binds `self.run_async = self._run_async` per-instance only when `isinstance(pipeline, AsyncPipeline)`. Sync-pipeline-backed instances simply do not have a `run_async` attribute.
- Added a `TYPE_CHECKING` stub for `run_async` so the static typing surface (used by the existing tests and downstream users) is preserved while the runtime attribute is bound lazily.

## Test

`test/core/super_component/test_super_component.py`:

- `test_sync_pipeline_does_not_advertise_async_support` — `__haystack_supports_async__` is False and `run_async` attribute is absent.
- `test_async_pipeline_advertises_async_support` — positive control.
- `test_super_component_with_sync_pipeline_inside_async_pipeline` — the regression scenario, runs `outer.run_async(...)` and verifies it succeeds.

All three RED before the patch, GREEN after. Existing tests `test_super_component_run_async` and `test_super_component_async_serialization_deserialization` still pass.

Locally on `darwin/arm64`:
- `pytest test/core/super_component/ test/core/component/` → 123 passed.
- Three pre-existing failures in `test_pipeline_base.py` (`test_show_in_notebook`, `test_find_super_components`, `test_merge_super_component_pipelines`) are unrelated and reproduce on `main` without this patch.

## Risk notes

`hasattr(super_component, \"run_async\")` now returns False for sync-pipeline-backed `SuperComponent`s. Any caller that previously hit the broken `run_async` (which always raised `TypeError`) will now hit `AttributeError` instead — strictly an improvement. The `@super_component` decorator path goes through `_SuperComponent.__init__` so it inherits the fix automatically.