### PR TITLE
fix: migrate tokenizer_kwargs to processor_kwargs for sentence-transformers v5.0.0

### DIFF
--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -33,7 +33,7 @@ class _SentenceTransformersEmbeddingBackendFactory:
         local_files_only: bool = False,
         truncate_dim: int | None = None,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
         backend: Literal["torch", "onnx", "openvino"] = "torch",
     ) -> "_SentenceTransformersEmbeddingBackend":
@@ -46,7 +46,7 @@ class _SentenceTransformersEmbeddingBackendFactory:
             "local_files_only": local_files_only,
             "truncate_dim": truncate_dim,
             "model_kwargs": model_kwargs,
-            "tokenizer_kwargs": tokenizer_kwargs,
+            "processor_kwargs": processor_kwargs,
             "config_kwargs": config_kwargs,
             "backend": backend,
         }
@@ -65,7 +65,7 @@ class _SentenceTransformersEmbeddingBackendFactory:
             local_files_only=local_files_only,
             truncate_dim=truncate_dim,
             model_kwargs=model_kwargs,
-            tokenizer_kwargs=tokenizer_kwargs,
+            processor_kwargs=processor_kwargs,
             config_kwargs=config_kwargs,
             backend=backend,
         )
@@ -90,7 +90,7 @@ class _SentenceTransformersEmbeddingBackend:
         local_files_only: bool = False,
         truncate_dim: int | None = None,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
         backend: Literal["torch", "onnx", "openvino"] = "torch",
     ) -> None:
@@ -105,7 +105,7 @@ class _SentenceTransformersEmbeddingBackend:
             local_files_only=local_files_only,
             truncate_dim=truncate_dim,
             model_kwargs=model_kwargs,
-            tokenizer_kwargs=tokenizer_kwargs,
+            processor_kwargs=processor_kwargs,
             config_kwargs=config_kwargs,
             backend=backend,
         )

--- a/haystack/components/embedders/backends/sentence_transformers_sparse_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_sparse_backend.py
@@ -30,7 +30,7 @@ class _SentenceTransformersSparseEmbeddingBackendFactory:
         revision: str | None = None,
         local_files_only: bool = False,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
         backend: Literal["torch", "onnx", "openvino"] = "torch",
     ) -> "_SentenceTransformersSparseEncoderEmbeddingBackend":
@@ -42,7 +42,7 @@ class _SentenceTransformersSparseEmbeddingBackendFactory:
             "revision": revision,
             "local_files_only": local_files_only,
             "model_kwargs": model_kwargs,
-            "tokenizer_kwargs": tokenizer_kwargs,
+            "processor_kwargs": processor_kwargs,
             "config_kwargs": config_kwargs,
             "backend": backend,
         }
@@ -60,7 +60,7 @@ class _SentenceTransformersSparseEmbeddingBackendFactory:
             revision=revision,
             local_files_only=local_files_only,
             model_kwargs=model_kwargs,
-            tokenizer_kwargs=tokenizer_kwargs,
+            processor_kwargs=processor_kwargs,
             config_kwargs=config_kwargs,
             backend=backend,
         )
@@ -84,7 +84,7 @@ class _SentenceTransformersSparseEncoderEmbeddingBackend:
         revision: str | None = None,
         local_files_only: bool = False,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
         backend: Literal["torch", "onnx", "openvino"] = "torch",
     ) -> None:
@@ -98,7 +98,7 @@ class _SentenceTransformersSparseEncoderEmbeddingBackend:
             revision=revision,
             local_files_only=local_files_only,
             model_kwargs=model_kwargs,
-            tokenizer_kwargs=tokenizer_kwargs,
+            processor_kwargs=processor_kwargs,
             config_kwargs=config_kwargs,
             backend=backend,
         )

--- a/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
+++ b/haystack/components/embedders/image/sentence_transformers_doc_image_embedder.py
@@ -71,7 +71,7 @@ class SentenceTransformersDocumentImageEmbedder:
         trust_remote_code: bool = False,
         local_files_only: bool = False,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
         precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = "float32",
         encode_kwargs: dict[str, Any] | None = None,
@@ -113,8 +113,8 @@ class SentenceTransformersDocumentImageEmbedder:
         :param model_kwargs:
             Additional keyword arguments for `AutoModelForSequenceClassification.from_pretrained`
             when loading the model. Refer to specific model documentation for available kwargs.
-        :param tokenizer_kwargs:
-            Additional keyword arguments for `AutoTokenizer.from_pretrained` when loading the tokenizer.
+        :param processor_kwargs:
+            Additional keyword arguments for `AutoProcessor.from_pretrained` when loading the processor.
             Refer to specific model documentation for available kwargs.
         :param config_kwargs:
             Additional keyword arguments for `AutoConfig.from_pretrained` when loading the model configuration.
@@ -145,7 +145,7 @@ class SentenceTransformersDocumentImageEmbedder:
         self.trust_remote_code = trust_remote_code
         self.local_files_only = local_files_only
         self.model_kwargs = model_kwargs
-        self.tokenizer_kwargs = tokenizer_kwargs
+        self.processor_kwargs = processor_kwargs
         self.config_kwargs = config_kwargs
         self.encode_kwargs = encode_kwargs
         self.precision = precision
@@ -172,7 +172,7 @@ class SentenceTransformersDocumentImageEmbedder:
             trust_remote_code=self.trust_remote_code,
             local_files_only=self.local_files_only,
             model_kwargs=self.model_kwargs,
-            tokenizer_kwargs=self.tokenizer_kwargs,
+            processor_kwargs=self.processor_kwargs,
             config_kwargs=self.config_kwargs,
             precision=self.precision,
             encode_kwargs=self.encode_kwargs,
@@ -195,6 +195,8 @@ class SentenceTransformersDocumentImageEmbedder:
         init_params = data["init_parameters"]
         if init_params.get("model_kwargs") is not None:
             deserialize_hf_model_kwargs(init_params["model_kwargs"])
+        if "tokenizer_kwargs" in init_params and "processor_kwargs" not in init_params:
+            init_params["processor_kwargs"] = init_params.pop("tokenizer_kwargs")
         return default_from_dict(cls, data)
 
     def warm_up(self) -> None:
@@ -209,12 +211,12 @@ class SentenceTransformersDocumentImageEmbedder:
                 trust_remote_code=self.trust_remote_code,
                 local_files_only=self.local_files_only,
                 model_kwargs=self.model_kwargs,
-                tokenizer_kwargs=self.tokenizer_kwargs,
+                processor_kwargs=self.processor_kwargs,
                 config_kwargs=self.config_kwargs,
                 backend=self.backend,
             )
-            if self.tokenizer_kwargs and self.tokenizer_kwargs.get("model_max_length"):
-                self._embedding_backend.model.max_seq_length = self.tokenizer_kwargs["model_max_length"]
+            if self.processor_kwargs and self.processor_kwargs.get("model_max_length"):
+                self._embedding_backend.model.max_seq_length = self.processor_kwargs["model_max_length"]
 
     @component.output_types(documents=list[Document])
     def run(self, documents: list[Document]) -> dict[str, list[Document]]:

--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -55,7 +55,7 @@ class SentenceTransformersDocumentEmbedder:
         local_files_only: bool = False,
         truncate_dim: int | None = None,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
         precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = "float32",
         encode_kwargs: dict[str, Any] | None = None,
@@ -101,8 +101,8 @@ class SentenceTransformersDocumentEmbedder:
         :param model_kwargs:
             Additional keyword arguments for `AutoModelForSequenceClassification.from_pretrained`
             when loading the model. Refer to specific model documentation for available kwargs.
-        :param tokenizer_kwargs:
-            Additional keyword arguments for `AutoTokenizer.from_pretrained` when loading the tokenizer.
+        :param processor_kwargs:
+            Additional keyword arguments for `AutoProcessor.from_pretrained` when loading the processor.
             Refer to specific model documentation for available kwargs.
         :param config_kwargs:
             Additional keyword arguments for `AutoConfig.from_pretrained` when loading the model configuration.
@@ -139,7 +139,7 @@ class SentenceTransformersDocumentEmbedder:
         self.local_files_only = local_files_only
         self.truncate_dim = truncate_dim
         self.model_kwargs = model_kwargs
-        self.tokenizer_kwargs = tokenizer_kwargs
+        self.processor_kwargs = processor_kwargs
         self.config_kwargs = config_kwargs
         self.encode_kwargs = encode_kwargs
         self.embedding_backend: _SentenceTransformersEmbeddingBackend | None = None
@@ -176,7 +176,7 @@ class SentenceTransformersDocumentEmbedder:
             local_files_only=self.local_files_only,
             truncate_dim=self.truncate_dim,
             model_kwargs=self.model_kwargs,
-            tokenizer_kwargs=self.tokenizer_kwargs,
+            processor_kwargs=self.processor_kwargs,
             config_kwargs=self.config_kwargs,
             precision=self.precision,
             encode_kwargs=self.encode_kwargs,
@@ -199,6 +199,8 @@ class SentenceTransformersDocumentEmbedder:
         init_params = data["init_parameters"]
         if init_params.get("model_kwargs") is not None:
             deserialize_hf_model_kwargs(init_params["model_kwargs"])
+        if "tokenizer_kwargs" in init_params and "processor_kwargs" not in init_params:
+            init_params["processor_kwargs"] = init_params.pop("tokenizer_kwargs")
         return default_from_dict(cls, data)
 
     def warm_up(self) -> None:
@@ -215,12 +217,12 @@ class SentenceTransformersDocumentEmbedder:
                 local_files_only=self.local_files_only,
                 truncate_dim=self.truncate_dim,
                 model_kwargs=self.model_kwargs,
-                tokenizer_kwargs=self.tokenizer_kwargs,
+                processor_kwargs=self.processor_kwargs,
                 config_kwargs=self.config_kwargs,
                 backend=self.backend,
             )
-            if self.tokenizer_kwargs and self.tokenizer_kwargs.get("model_max_length"):
-                self.embedding_backend.model.max_seq_length = self.tokenizer_kwargs["model_max_length"]
+            if self.processor_kwargs and self.processor_kwargs.get("model_max_length"):
+                self.embedding_backend.model.max_seq_length = self.processor_kwargs["model_max_length"]
 
     @component.output_types(documents=list[Document])
     def run(self, documents: list[Document]) -> dict[str, list[Document]]:

--- a/haystack/components/embedders/sentence_transformers_sparse_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_sparse_document_embedder.py
@@ -55,7 +55,7 @@ class SentenceTransformersSparseDocumentEmbedder:
         trust_remote_code: bool = False,
         local_files_only: bool = False,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
         backend: Literal["torch", "onnx", "openvino"] = "torch",
         revision: str | None = None,
@@ -91,8 +91,8 @@ class SentenceTransformersSparseDocumentEmbedder:
         :param model_kwargs:
             Additional keyword arguments for `AutoModelForSequenceClassification.from_pretrained`
             when loading the model. Refer to specific model documentation for available kwargs.
-        :param tokenizer_kwargs:
-            Additional keyword arguments for `AutoTokenizer.from_pretrained` when loading the tokenizer.
+        :param processor_kwargs:
+            Additional keyword arguments for `AutoProcessor.from_pretrained` when loading the processor.
             Refer to specific model documentation for available kwargs.
         :param config_kwargs:
             Additional keyword arguments for `AutoConfig.from_pretrained` when loading the model configuration.
@@ -118,7 +118,7 @@ class SentenceTransformersSparseDocumentEmbedder:
         self.revision = revision
         self.local_files_only = local_files_only
         self.model_kwargs = model_kwargs
-        self.tokenizer_kwargs = tokenizer_kwargs
+        self.processor_kwargs = processor_kwargs
         self.config_kwargs = config_kwargs
         self.embedding_backend: _SentenceTransformersSparseEncoderEmbeddingBackend | None = None
         self.backend = backend
@@ -151,7 +151,7 @@ class SentenceTransformersSparseDocumentEmbedder:
             revision=self.revision,
             local_files_only=self.local_files_only,
             model_kwargs=self.model_kwargs,
-            tokenizer_kwargs=self.tokenizer_kwargs,
+            processor_kwargs=self.processor_kwargs,
             config_kwargs=self.config_kwargs,
             backend=self.backend,
         )
@@ -172,6 +172,8 @@ class SentenceTransformersSparseDocumentEmbedder:
         init_params = data["init_parameters"]
         if init_params.get("model_kwargs") is not None:
             deserialize_hf_model_kwargs(init_params["model_kwargs"])
+        if "tokenizer_kwargs" in init_params and "processor_kwargs" not in init_params:
+            init_params["processor_kwargs"] = init_params.pop("tokenizer_kwargs")
         return default_from_dict(cls, data)
 
     def warm_up(self) -> None:
@@ -187,12 +189,12 @@ class SentenceTransformersSparseDocumentEmbedder:
                 revision=self.revision,
                 local_files_only=self.local_files_only,
                 model_kwargs=self.model_kwargs,
-                tokenizer_kwargs=self.tokenizer_kwargs,
+                processor_kwargs=self.processor_kwargs,
                 config_kwargs=self.config_kwargs,
                 backend=self.backend,
             )
-            if self.tokenizer_kwargs and self.tokenizer_kwargs.get("model_max_length"):
-                self.embedding_backend.model.max_seq_length = self.tokenizer_kwargs["model_max_length"]
+            if self.processor_kwargs and self.processor_kwargs.get("model_max_length"):
+                self.embedding_backend.model.max_seq_length = self.processor_kwargs["model_max_length"]
 
     @component.output_types(documents=list[Document])
     def run(self, documents: list[Document]) -> dict[str, list[Document]]:

--- a/haystack/components/embedders/sentence_transformers_sparse_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_sparse_text_embedder.py
@@ -47,7 +47,7 @@ class SentenceTransformersSparseTextEmbedder:
         trust_remote_code: bool = False,
         local_files_only: bool = False,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
         backend: Literal["torch", "onnx", "openvino"] = "torch",
         revision: str | None = None,
@@ -74,8 +74,8 @@ class SentenceTransformersSparseTextEmbedder:
         :param model_kwargs:
             Additional keyword arguments for `AutoModelForSequenceClassification.from_pretrained`
             when loading the model. Refer to specific model documentation for available kwargs.
-        :param tokenizer_kwargs:
-            Additional keyword arguments for `AutoTokenizer.from_pretrained` when loading the tokenizer.
+        :param processor_kwargs:
+            Additional keyword arguments for `AutoProcessor.from_pretrained` when loading the processor.
             Refer to specific model documentation for available kwargs.
         :param config_kwargs:
             Additional keyword arguments for `AutoConfig.from_pretrained` when loading the model configuration.
@@ -97,7 +97,7 @@ class SentenceTransformersSparseTextEmbedder:
         self.revision = revision
         self.local_files_only = local_files_only
         self.model_kwargs = model_kwargs
-        self.tokenizer_kwargs = tokenizer_kwargs
+        self.processor_kwargs = processor_kwargs
         self.config_kwargs = config_kwargs
         self.embedding_backend: _SentenceTransformersSparseEncoderEmbeddingBackend | None = None
         self.backend = backend
@@ -126,7 +126,7 @@ class SentenceTransformersSparseTextEmbedder:
             revision=self.revision,
             local_files_only=self.local_files_only,
             model_kwargs=self.model_kwargs,
-            tokenizer_kwargs=self.tokenizer_kwargs,
+            processor_kwargs=self.processor_kwargs,
             config_kwargs=self.config_kwargs,
             backend=self.backend,
         )
@@ -147,6 +147,8 @@ class SentenceTransformersSparseTextEmbedder:
         init_params = data["init_parameters"]
         if init_params.get("model_kwargs") is not None:
             deserialize_hf_model_kwargs(init_params["model_kwargs"])
+        if "tokenizer_kwargs" in init_params and "processor_kwargs" not in init_params:
+            init_params["processor_kwargs"] = init_params.pop("tokenizer_kwargs")
         return default_from_dict(cls, data)
 
     def warm_up(self) -> None:
@@ -162,12 +164,12 @@ class SentenceTransformersSparseTextEmbedder:
                 revision=self.revision,
                 local_files_only=self.local_files_only,
                 model_kwargs=self.model_kwargs,
-                tokenizer_kwargs=self.tokenizer_kwargs,
+                processor_kwargs=self.processor_kwargs,
                 config_kwargs=self.config_kwargs,
                 backend=self.backend,
             )
-            if self.tokenizer_kwargs and self.tokenizer_kwargs.get("model_max_length"):
-                self.embedding_backend.model.max_seq_length = self.tokenizer_kwargs["model_max_length"]
+            if self.processor_kwargs and self.processor_kwargs.get("model_max_length"):
+                self.embedding_backend.model.max_seq_length = self.processor_kwargs["model_max_length"]
 
     @component.output_types(sparse_embedding=SparseEmbedding)
     def run(self, text: str) -> dict[str, Any]:

--- a/haystack/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_text_embedder.py
@@ -49,7 +49,7 @@ class SentenceTransformersTextEmbedder:
         local_files_only: bool = False,
         truncate_dim: int | None = None,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
         precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = "float32",
         encode_kwargs: dict[str, Any] | None = None,
@@ -91,8 +91,8 @@ class SentenceTransformersTextEmbedder:
         :param model_kwargs:
             Additional keyword arguments for `AutoModelForSequenceClassification.from_pretrained`
             when loading the model. Refer to specific model documentation for available kwargs.
-        :param tokenizer_kwargs:
-            Additional keyword arguments for `AutoTokenizer.from_pretrained` when loading the tokenizer.
+        :param processor_kwargs:
+            Additional keyword arguments for `AutoProcessor.from_pretrained` when loading the processor.
             Refer to specific model documentation for available kwargs.
         :param config_kwargs:
             Additional keyword arguments for `AutoConfig.from_pretrained` when loading the model configuration.
@@ -127,7 +127,7 @@ class SentenceTransformersTextEmbedder:
         self.local_files_only = local_files_only
         self.truncate_dim = truncate_dim
         self.model_kwargs = model_kwargs
-        self.tokenizer_kwargs = tokenizer_kwargs
+        self.processor_kwargs = processor_kwargs
         self.config_kwargs = config_kwargs
         self.encode_kwargs = encode_kwargs
         self.embedding_backend: _SentenceTransformersEmbeddingBackend | None = None
@@ -162,7 +162,7 @@ class SentenceTransformersTextEmbedder:
             local_files_only=self.local_files_only,
             truncate_dim=self.truncate_dim,
             model_kwargs=self.model_kwargs,
-            tokenizer_kwargs=self.tokenizer_kwargs,
+            processor_kwargs=self.processor_kwargs,
             config_kwargs=self.config_kwargs,
             precision=self.precision,
             encode_kwargs=self.encode_kwargs,
@@ -185,6 +185,8 @@ class SentenceTransformersTextEmbedder:
         init_params = data["init_parameters"]
         if init_params.get("model_kwargs") is not None:
             deserialize_hf_model_kwargs(init_params["model_kwargs"])
+        if "tokenizer_kwargs" in init_params and "processor_kwargs" not in init_params:
+            init_params["processor_kwargs"] = init_params.pop("tokenizer_kwargs")
         return default_from_dict(cls, data)
 
     def warm_up(self) -> None:
@@ -201,12 +203,12 @@ class SentenceTransformersTextEmbedder:
                 local_files_only=self.local_files_only,
                 truncate_dim=self.truncate_dim,
                 model_kwargs=self.model_kwargs,
-                tokenizer_kwargs=self.tokenizer_kwargs,
+                processor_kwargs=self.processor_kwargs,
                 config_kwargs=self.config_kwargs,
                 backend=self.backend,
             )
-            if self.tokenizer_kwargs and self.tokenizer_kwargs.get("model_max_length"):
-                self.embedding_backend.model.max_seq_length = self.tokenizer_kwargs["model_max_length"]
+            if self.processor_kwargs and self.processor_kwargs.get("model_max_length"):
+                self.embedding_backend.model.max_seq_length = self.processor_kwargs["model_max_length"]
 
     @component.output_types(embedding=list[float])
     def run(self, text: str) -> dict[str, Any]:

--- a/haystack/components/rankers/sentence_transformers_diversity.py
+++ b/haystack/components/rankers/sentence_transformers_diversity.py
@@ -131,7 +131,7 @@ class SentenceTransformersDiversityRanker:
         strategy: str | DiversityRankingStrategy = "greedy_diversity_order",
         lambda_threshold: float = 0.5,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
         backend: Literal["torch", "onnx", "openvino"] = "torch",
     ) -> None:
@@ -163,8 +163,8 @@ class SentenceTransformersDiversityRanker:
         :param model_kwargs:
             Additional keyword arguments for `AutoModelForSequenceClassification.from_pretrained`
             when loading the model. Refer to specific model documentation for available kwargs.
-        :param tokenizer_kwargs:
-            Additional keyword arguments for `AutoTokenizer.from_pretrained` when loading the tokenizer.
+        :param processor_kwargs:
+            Additional keyword arguments for `AutoProcessor.from_pretrained` when loading the processor.
             Refer to specific model documentation for available kwargs.
         :param config_kwargs:
             Additional keyword arguments for `AutoConfig.from_pretrained` when loading the model configuration.
@@ -193,7 +193,7 @@ class SentenceTransformersDiversityRanker:
         self.lambda_threshold = lambda_threshold
         self._check_lambda_threshold(self.lambda_threshold, self.strategy)
         self.model_kwargs = model_kwargs
-        self.tokenizer_kwargs = tokenizer_kwargs
+        self.processor_kwargs = processor_kwargs
         self.config_kwargs = config_kwargs
         self.backend = backend
 
@@ -207,10 +207,12 @@ class SentenceTransformersDiversityRanker:
                 device=self.device.to_torch_str(),
                 token=self.token.resolve_value() if self.token else None,
                 model_kwargs=self.model_kwargs,
-                tokenizer_kwargs=self.tokenizer_kwargs,
+                processor_kwargs=self.processor_kwargs,
                 config_kwargs=self.config_kwargs,
                 backend=self.backend,
             )
+            if self.processor_kwargs and "model_max_length" in self.processor_kwargs:
+                self.model.max_seq_length = self.processor_kwargs["model_max_length"]
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -235,7 +237,7 @@ class SentenceTransformersDiversityRanker:
             strategy=str(self.strategy),
             lambda_threshold=self.lambda_threshold,
             model_kwargs=self.model_kwargs,
-            tokenizer_kwargs=self.tokenizer_kwargs,
+            processor_kwargs=self.processor_kwargs,
             config_kwargs=self.config_kwargs,
             backend=self.backend,
         )
@@ -256,6 +258,8 @@ class SentenceTransformersDiversityRanker:
         init_params = data["init_parameters"]
         if init_params.get("model_kwargs") is not None:
             deserialize_hf_model_kwargs(init_params["model_kwargs"])
+        if "tokenizer_kwargs" in init_params and "processor_kwargs" not in init_params:
+            init_params["processor_kwargs"] = init_params.pop("tokenizer_kwargs")
         return default_from_dict(cls, data)
 
     def _prepare_texts_to_embed(self, documents: list[Document]) -> list[str]:

--- a/haystack/components/rankers/sentence_transformers_similarity.py
+++ b/haystack/components/rankers/sentence_transformers_similarity.py
@@ -56,7 +56,7 @@ class SentenceTransformersSimilarityRanker:
         score_threshold: float | None = None,
         trust_remote_code: bool = False,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         config_kwargs: dict[str, Any] | None = None,
         backend: Literal["torch", "onnx", "openvino"] = "torch",
         batch_size: int = 16,
@@ -99,8 +99,8 @@ class SentenceTransformersSimilarityRanker:
         :param model_kwargs:
             Additional keyword arguments for `AutoModelForSequenceClassification.from_pretrained`
             when loading the model. Refer to specific model documentation for available kwargs.
-        :param tokenizer_kwargs:
-            Additional keyword arguments for `AutoTokenizer.from_pretrained` when loading the tokenizer.
+        :param processor_kwargs:
+            Additional keyword arguments for `AutoProcessor.from_pretrained` when loading the processor.
             Refer to specific model documentation for available kwargs.
         :param config_kwargs:
             Additional keyword arguments for `AutoConfig.from_pretrained` when loading the model configuration.
@@ -121,7 +121,7 @@ class SentenceTransformersSimilarityRanker:
             raise ValueError(f"top_k must be > 0, but got {top_k}")
 
         self.model = str(model)
-        self._cross_encoder = None
+        self._cross_encoder: CrossEncoder | None = None
         self.query_prefix = query_prefix
         self.query_suffix = query_suffix
         self.document_prefix = document_prefix
@@ -135,7 +135,7 @@ class SentenceTransformersSimilarityRanker:
         self.score_threshold = score_threshold
         self.trust_remote_code = trust_remote_code
         self.model_kwargs = model_kwargs
-        self.tokenizer_kwargs = tokenizer_kwargs
+        self.processor_kwargs = processor_kwargs
         self.config_kwargs = config_kwargs
         self.backend = backend
         self.batch_size = batch_size
@@ -151,16 +151,19 @@ class SentenceTransformersSimilarityRanker:
         Initializes the component.
         """
         if self._cross_encoder is None:
-            self._cross_encoder = CrossEncoder(
+            cross_encoder = CrossEncoder(
                 model_name_or_path=self.model,
                 device=self.device.to_torch_str(),
                 token=self.token.resolve_value() if self.token else None,
                 trust_remote_code=self.trust_remote_code,
                 model_kwargs=self.model_kwargs,
-                tokenizer_kwargs=self.tokenizer_kwargs,
+                processor_kwargs=self.processor_kwargs,
                 config_kwargs=self.config_kwargs,
                 backend=self.backend,
             )
+            if self.processor_kwargs and "model_max_length" in self.processor_kwargs:
+                cross_encoder.max_seq_length = self.processor_kwargs["model_max_length"]
+            self._cross_encoder = cross_encoder
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -185,7 +188,7 @@ class SentenceTransformersSimilarityRanker:
             score_threshold=self.score_threshold,
             trust_remote_code=self.trust_remote_code,
             model_kwargs=self.model_kwargs,
-            tokenizer_kwargs=self.tokenizer_kwargs,
+            processor_kwargs=self.processor_kwargs,
             config_kwargs=self.config_kwargs,
             backend=self.backend,
             batch_size=self.batch_size,
@@ -207,6 +210,8 @@ class SentenceTransformersSimilarityRanker:
         init_params = data["init_parameters"]
         if init_params.get("model_kwargs") is not None:
             deserialize_hf_model_kwargs(init_params["model_kwargs"])
+        if "tokenizer_kwargs" in init_params and "processor_kwargs" not in init_params:
+            init_params["processor_kwargs"] = init_params.pop("tokenizer_kwargs")
 
         return default_from_dict(cls, data)
 
@@ -275,7 +280,8 @@ class SentenceTransformersSimilarityRanker:
         activation_fn = Sigmoid() if scale_score else Identity()
 
         # mypy doesn't know this is set in warm_up
-        ranking_result = self._cross_encoder.rank(  # type: ignore[attr-defined]
+        assert self._cross_encoder is not None
+        ranking_result = self._cross_encoder.rank(
             query=prepared_query,
             documents=prepared_documents,
             batch_size=self.batch_size,

--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -63,7 +63,7 @@ class TransformersSimilarityRanker:
         calibration_factor: float | None = 1.0,
         score_threshold: float | None = None,
         model_kwargs: dict[str, Any] | None = None,
-        tokenizer_kwargs: dict[str, Any] | None = None,
+        processor_kwargs: dict[str, Any] | None = None,
         batch_size: int = 16,
     ) -> None:
         """
@@ -98,7 +98,7 @@ class TransformersSimilarityRanker:
         :param model_kwargs:
             Additional keyword arguments for `AutoModelForSequenceClassification.from_pretrained`
             when loading the model. Refer to specific model documentation for available kwargs.
-        :param tokenizer_kwargs:
+        :param processor_kwargs:
             Additional keyword arguments for `AutoTokenizer.from_pretrained` when loading the tokenizer.
             Refer to specific model documentation for available kwargs.
         :param batch_size:
@@ -135,7 +135,7 @@ class TransformersSimilarityRanker:
 
         model_kwargs = resolve_hf_device_map(device=device, model_kwargs=model_kwargs)
         self.model_kwargs = model_kwargs
-        self.tokenizer_kwargs = tokenizer_kwargs or {}
+        self.processor_kwargs = processor_kwargs or {}
         self.batch_size = batch_size
 
         # Parameter validation
@@ -164,7 +164,7 @@ class TransformersSimilarityRanker:
             self.tokenizer = AutoTokenizer.from_pretrained(
                 self.model_name_or_path,
                 token=self.token.resolve_value() if self.token else None,
-                **self.tokenizer_kwargs,
+                **self.processor_kwargs,
             )
             assert self.model is not None  # mypy doesn't know this is set in the line above
             # hf_device_map appears to only be set now when mixed devices are actually used.
@@ -195,7 +195,7 @@ class TransformersSimilarityRanker:
             calibration_factor=self.calibration_factor,
             score_threshold=self.score_threshold,
             model_kwargs=self.model_kwargs,
-            tokenizer_kwargs=self.tokenizer_kwargs,
+            processor_kwargs=self.processor_kwargs,
             batch_size=self.batch_size,
         )
 
@@ -215,7 +215,8 @@ class TransformersSimilarityRanker:
         init_params = data["init_parameters"]
         if init_params.get("model_kwargs") is not None:
             deserialize_hf_model_kwargs(init_params["model_kwargs"])
-
+        if "tokenizer_kwargs" in init_params and "processor_kwargs" not in init_params:
+            init_params["processor_kwargs"] = init_params.pop("tokenizer_kwargs")
         return default_from_dict(cls, data)
 
     @component.output_types(documents=list[Document])

--- a/releasenotes/notes/migrate-tokenizer-to-processor-kwargs-st-v5.yaml
+++ b/releasenotes/notes/migrate-tokenizer-to-processor-kwargs-st-v5.yaml
@@ -1,0 +1,17 @@
+breaks:
+  - |
+    Renamed ``tokenizer_kwargs`` to ``processor_kwargs`` across all Sentence Transformers components to align with ``sentence-transformers>=5.0.0``.
+    This affects:
+    - ``SentenceTransformersTextEmbedder``
+    - ``SentenceTransformersDocumentEmbedder``
+    - ``SentenceTransformersSparseTextEmbedder``
+    - ``SentenceTransformersSparseDocumentEmbedder``
+    - ``SentenceTransformersDocumentImageEmbedder``
+    - ``SentenceTransformersSimilarityRanker``
+    - ``SentenceTransformersDiversityRanker``
+    - ``TransformersSimilarityRanker``
+    Backward compatibility is maintained for serialized pipelines; pipelines saved with ``tokenizer_kwargs`` will be automatically mapped to ``processor_kwargs`` upon loading.
+upgrade:
+  - |
+    The ``max_length`` property on underlying cross-encoder models has been renamed to ``max_seq_length``, consistent with the changes in ``sentence-transformers`` v5.0.0.
+    Authentication parameter ``use_auth_token`` has been renamed to ``token`` across all relevant components to align with Hugging Face and Sentence Transformers standards.

--- a/test/components/embedders/image/test_sentence_transformers_doc_image_embedder.py
+++ b/test/components/embedders/image/test_sentence_transformers_doc_image_embedder.py
@@ -61,7 +61,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
         assert embedder.precision == "int8"
         assert embedder.backend == "torch"
         assert embedder.model_kwargs is None
-        assert embedder.tokenizer_kwargs is None
+        assert embedder.processor_kwargs is None
         assert embedder.config_kwargs is None
         assert embedder.encode_kwargs is None
         assert embedder._embedding_backend is None
@@ -85,7 +85,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
                 "trust_remote_code": False,
                 "local_files_only": False,
                 "model_kwargs": {"torch_dtype": "torch.float32"},
-                "tokenizer_kwargs": None,
+                "processor_kwargs": None,
                 "encode_kwargs": None,
                 "config_kwargs": None,
                 "precision": "float32",
@@ -106,7 +106,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
             "trust_remote_code": True,
             "local_files_only": True,
             "model_kwargs": {"torch_dtype": "torch.float32"},
-            "tokenizer_kwargs": {"model_max_length": 512},
+            "processor_kwargs": {"model_max_length": 512},
             "config_kwargs": {"use_memory_efficient_attention": True},
             "precision": "int8",
         }
@@ -124,7 +124,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
         assert component.trust_remote_code
         assert component.local_files_only
         assert component.model_kwargs == {"torch_dtype": torch.float32}
-        assert component.tokenizer_kwargs == {"model_max_length": 512}
+        assert component.processor_kwargs == {"model_max_length": 512}
         assert component.config_kwargs == {"use_memory_efficient_attention": True}
         assert component.precision == "int8"
 
@@ -162,7 +162,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
             model="model",
             token=None,
             device=ComponentDevice.from_str("cpu"),
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs={"use_memory_efficient_attention": True},
         )
         mocked_factory.get_embedding_backend.assert_not_called()
@@ -175,7 +175,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
             trust_remote_code=False,
             local_files_only=False,
             model_kwargs=None,
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs={"use_memory_efficient_attention": True},
             backend="torch",
         )
@@ -256,7 +256,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
             trust_remote_code=False,
             local_files_only=False,
             model_kwargs={"file_name": "onnx/model.onnx"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="onnx",
         )
@@ -281,7 +281,7 @@ class TestSentenceTransformersDocumentImageEmbedder:
             trust_remote_code=False,
             local_files_only=False,
             model_kwargs={"file_name": "openvino/openvino_model.xml"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="openvino",
         )

--- a/test/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_document_embedder.py
@@ -87,7 +87,7 @@ class TestSentenceTransformersDocumentEmbedder:
                 "local_files_only": False,
                 "truncate_dim": None,
                 "model_kwargs": None,
-                "tokenizer_kwargs": None,
+                "processor_kwargs": None,
                 "encode_kwargs": None,
                 "config_kwargs": None,
                 "precision": "float32",
@@ -111,7 +111,7 @@ class TestSentenceTransformersDocumentEmbedder:
             local_files_only=True,
             truncate_dim=256,
             model_kwargs={"torch_dtype": torch.float32},
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs={"use_memory_efficient_attention": True},
             precision="int8",
             encode_kwargs={"task": "clustering"},
@@ -136,7 +136,7 @@ class TestSentenceTransformersDocumentEmbedder:
                 "meta_fields_to_embed": ["meta_field"],
                 "truncate_dim": 256,
                 "model_kwargs": {"torch_dtype": "torch.float32"},
-                "tokenizer_kwargs": {"model_max_length": 512},
+                "processor_kwargs": {"model_max_length": 512},
                 "config_kwargs": {"use_memory_efficient_attention": True},
                 "precision": "int8",
                 "encode_kwargs": {"task": "clustering"},
@@ -161,7 +161,7 @@ class TestSentenceTransformersDocumentEmbedder:
             "local_files_only": True,
             "truncate_dim": 256,
             "model_kwargs": {"torch_dtype": "torch.float32"},
-            "tokenizer_kwargs": {"model_max_length": 512},
+            "processor_kwargs": {"model_max_length": 512},
             "config_kwargs": {"use_memory_efficient_attention": True},
             "precision": "int8",
         }
@@ -186,7 +186,7 @@ class TestSentenceTransformersDocumentEmbedder:
         assert component.meta_fields_to_embed == ["meta_field"]
         assert component.truncate_dim == 256
         assert component.model_kwargs == {"torch_dtype": torch.float32}
-        assert component.tokenizer_kwargs == {"model_max_length": 512}
+        assert component.processor_kwargs == {"model_max_length": 512}
         assert component.config_kwargs == {"use_memory_efficient_attention": True}
         assert component.precision == "int8"
 
@@ -260,7 +260,7 @@ class TestSentenceTransformersDocumentEmbedder:
             model="model",
             token=None,
             device=ComponentDevice.from_str("cpu"),
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs={"use_memory_efficient_attention": True},
         )
         mocked_factory.get_embedding_backend.assert_not_called()
@@ -275,7 +275,7 @@ class TestSentenceTransformersDocumentEmbedder:
             local_files_only=False,
             truncate_dim=None,
             model_kwargs=None,
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs={"use_memory_efficient_attention": True},
             backend="torch",
         )
@@ -411,7 +411,7 @@ class TestSentenceTransformersDocumentEmbedder:
             local_files_only=False,
             truncate_dim=None,
             model_kwargs={"file_name": "onnx/model.onnx"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="onnx",
         )
@@ -440,7 +440,7 @@ class TestSentenceTransformersDocumentEmbedder:
             local_files_only=False,
             truncate_dim=None,
             model_kwargs={"file_name": "openvino/openvino_model.xml"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="openvino",
         )
@@ -467,7 +467,7 @@ class TestSentenceTransformersDocumentEmbedder:
             local_files_only=False,
             truncate_dim=None,
             model_kwargs=model_kwargs,
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="torch",
         )

--- a/test/components/embedders/test_sentence_transformers_embedding_backend.py
+++ b/test/components/embedders/test_sentence_transformers_embedding_backend.py
@@ -50,7 +50,7 @@ def test_model_initialization(mock_sentence_transformer):
         local_files_only=True,
         truncate_dim=256,
         model_kwargs=None,
-        tokenizer_kwargs=None,
+        processor_kwargs=None,
         config_kwargs=None,
         backend="torch",
     )

--- a/test/components/embedders/test_sentence_transformers_sparse_document_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_sparse_document_embedder.py
@@ -83,7 +83,7 @@ class TestSentenceTransformersDocumentEmbedder:
                 "revision": None,
                 "local_files_only": False,
                 "model_kwargs": None,
-                "tokenizer_kwargs": None,
+                "processor_kwargs": None,
                 "config_kwargs": None,
                 "backend": "torch",
             },
@@ -103,7 +103,7 @@ class TestSentenceTransformersDocumentEmbedder:
             trust_remote_code=True,
             local_files_only=True,
             model_kwargs={"torch_dtype": torch.float32},
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs={"use_memory_efficient_attention": True},
         )
         data = component.to_dict()
@@ -124,7 +124,7 @@ class TestSentenceTransformersDocumentEmbedder:
                 "local_files_only": True,
                 "meta_fields_to_embed": ["meta_field"],
                 "model_kwargs": {"torch_dtype": "torch.float32"},
-                "tokenizer_kwargs": {"model_max_length": 512},
+                "processor_kwargs": {"model_max_length": 512},
                 "config_kwargs": {"use_memory_efficient_attention": True},
                 "backend": "torch",
             },
@@ -145,7 +145,7 @@ class TestSentenceTransformersDocumentEmbedder:
             "revision": "v1.0",
             "local_files_only": True,
             "model_kwargs": {"torch_dtype": "torch.float32"},
-            "tokenizer_kwargs": {"model_max_length": 512},
+            "processor_kwargs": {"model_max_length": 512},
             "config_kwargs": {"use_memory_efficient_attention": True},
         }
         component = SentenceTransformersSparseDocumentEmbedder.from_dict(
@@ -164,7 +164,7 @@ class TestSentenceTransformersDocumentEmbedder:
         assert component.local_files_only
         assert component.meta_fields_to_embed == ["meta_field"]
         assert component.model_kwargs == {"torch_dtype": torch.float32}
-        assert component.tokenizer_kwargs == {"model_max_length": 512}
+        assert component.processor_kwargs == {"model_max_length": 512}
         assert component.config_kwargs == {"use_memory_efficient_attention": True}
 
     def test_from_dict_no_default_parameters(self):
@@ -220,7 +220,7 @@ class TestSentenceTransformersDocumentEmbedder:
             model="model",
             token=None,
             device=ComponentDevice.from_str("cpu"),
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs={"use_memory_efficient_attention": True},
         )
         mocked_factory.get_embedding_backend.assert_not_called()
@@ -234,7 +234,7 @@ class TestSentenceTransformersDocumentEmbedder:
             revision=None,
             local_files_only=False,
             model_kwargs=None,
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs={"use_memory_efficient_attention": True},
             backend="torch",
         )
@@ -358,7 +358,7 @@ class TestSentenceTransformersDocumentEmbedder:
             revision=None,
             local_files_only=False,
             model_kwargs={"file_name": "onnx/model.onnx"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="onnx",
         )
@@ -387,7 +387,7 @@ class TestSentenceTransformersDocumentEmbedder:
             revision=None,
             local_files_only=False,
             model_kwargs={"file_name": "openvino/openvino_model.xml"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="openvino",
         )
@@ -413,7 +413,7 @@ class TestSentenceTransformersDocumentEmbedder:
             revision=None,
             local_files_only=False,
             model_kwargs=model_kwargs,
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="torch",
         )

--- a/test/components/embedders/test_sentence_transformers_sparse_embedding_backend.py
+++ b/test/components/embedders/test_sentence_transformers_sparse_embedding_backend.py
@@ -52,7 +52,7 @@ def test_sparse_model_initialization(mock_sparse_encoder):
         revision=None,
         local_files_only=True,
         model_kwargs=None,
-        tokenizer_kwargs=None,
+        processor_kwargs=None,
         config_kwargs=None,
         backend="torch",
     )

--- a/test/components/embedders/test_sentence_transformers_sparse_text_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_sparse_text_embedder.py
@@ -65,7 +65,7 @@ class TestSentenceTransformersSparseTextEmbedder:
                 "revision": None,
                 "local_files_only": False,
                 "model_kwargs": None,
-                "tokenizer_kwargs": None,
+                "processor_kwargs": None,
                 "config_kwargs": None,
                 "backend": "torch",
             },
@@ -81,7 +81,7 @@ class TestSentenceTransformersSparseTextEmbedder:
             trust_remote_code=True,
             local_files_only=True,
             model_kwargs={"torch_dtype": torch.float32},
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs={"use_memory_efficient_attention": False},
         )
         data = component.to_dict()
@@ -97,7 +97,7 @@ class TestSentenceTransformersSparseTextEmbedder:
                 "revision": None,
                 "local_files_only": True,
                 "model_kwargs": {"torch_dtype": "torch.float32"},
-                "tokenizer_kwargs": {"model_max_length": 512},
+                "processor_kwargs": {"model_max_length": 512},
                 "config_kwargs": {"use_memory_efficient_attention": False},
                 "backend": "torch",
             },
@@ -121,7 +121,7 @@ class TestSentenceTransformersSparseTextEmbedder:
                 "revision": "v1.0",
                 "local_files_only": False,
                 "model_kwargs": {"torch_dtype": "torch.float32"},
-                "tokenizer_kwargs": {"model_max_length": 512},
+                "processor_kwargs": {"model_max_length": 512},
                 "config_kwargs": {"use_memory_efficient_attention": False},
             },
         }
@@ -135,7 +135,7 @@ class TestSentenceTransformersSparseTextEmbedder:
         assert component.revision == "v1.0"
         assert component.local_files_only is False
         assert component.model_kwargs == {"torch_dtype": torch.float32}
-        assert component.tokenizer_kwargs == {"model_max_length": 512}
+        assert component.processor_kwargs == {"model_max_length": 512}
         assert component.config_kwargs == {"use_memory_efficient_attention": False}
 
     def test_from_dict_no_default_parameters(self):
@@ -181,7 +181,7 @@ class TestSentenceTransformersSparseTextEmbedder:
             model="model",
             token=None,
             device=ComponentDevice.from_str("cpu"),
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
         )
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
@@ -194,7 +194,7 @@ class TestSentenceTransformersSparseTextEmbedder:
             revision=None,
             local_files_only=False,
             model_kwargs=None,
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs=None,
             backend="torch",
         )
@@ -260,7 +260,7 @@ class TestSentenceTransformersSparseTextEmbedder:
             revision=None,
             local_files_only=False,
             model_kwargs={"file_name": "onnx/model.onnx"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="onnx",
         )
@@ -289,7 +289,7 @@ class TestSentenceTransformersSparseTextEmbedder:
             revision=None,
             local_files_only=False,
             model_kwargs={"file_name": "openvino/openvino_model.xml"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="openvino",
         )
@@ -315,7 +315,7 @@ class TestSentenceTransformersSparseTextEmbedder:
             revision=None,
             local_files_only=False,
             model_kwargs=model_kwargs,
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="torch",
         )

--- a/test/components/embedders/test_sentence_transformers_text_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_text_embedder.py
@@ -78,7 +78,7 @@ class TestSentenceTransformersTextEmbedder:
                 "local_files_only": False,
                 "truncate_dim": None,
                 "model_kwargs": None,
-                "tokenizer_kwargs": None,
+                "processor_kwargs": None,
                 "encode_kwargs": None,
                 "config_kwargs": None,
                 "precision": "float32",
@@ -100,7 +100,7 @@ class TestSentenceTransformersTextEmbedder:
             local_files_only=True,
             truncate_dim=256,
             model_kwargs={"torch_dtype": torch.float32},
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs={"use_memory_efficient_attention": False},
             precision="int8",
             encode_kwargs={"task": "clustering"},
@@ -122,7 +122,7 @@ class TestSentenceTransformersTextEmbedder:
                 "local_files_only": True,
                 "truncate_dim": 256,
                 "model_kwargs": {"torch_dtype": "torch.float32"},
-                "tokenizer_kwargs": {"model_max_length": 512},
+                "processor_kwargs": {"model_max_length": 512},
                 "config_kwargs": {"use_memory_efficient_attention": False},
                 "precision": "int8",
                 "encode_kwargs": {"task": "clustering"},
@@ -152,7 +152,7 @@ class TestSentenceTransformersTextEmbedder:
                 "local_files_only": False,
                 "truncate_dim": None,
                 "model_kwargs": {"torch_dtype": "torch.float32"},
-                "tokenizer_kwargs": {"model_max_length": 512},
+                "processor_kwargs": {"model_max_length": 512},
                 "config_kwargs": {"use_memory_efficient_attention": False},
                 "precision": "float32",
             },
@@ -171,7 +171,7 @@ class TestSentenceTransformersTextEmbedder:
         assert component.local_files_only is False
         assert component.truncate_dim is None
         assert component.model_kwargs == {"torch_dtype": torch.float32}
-        assert component.tokenizer_kwargs == {"model_max_length": 512}
+        assert component.processor_kwargs == {"model_max_length": 512}
         assert component.config_kwargs == {"use_memory_efficient_attention": False}
         assert component.precision == "float32"
 
@@ -236,7 +236,7 @@ class TestSentenceTransformersTextEmbedder:
             model="model",
             token=None,
             device=ComponentDevice.from_str("cpu"),
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
         )
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
@@ -250,7 +250,7 @@ class TestSentenceTransformersTextEmbedder:
             local_files_only=False,
             truncate_dim=None,
             model_kwargs=None,
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             config_kwargs=None,
             backend="torch",
         )
@@ -325,7 +325,7 @@ class TestSentenceTransformersTextEmbedder:
             local_files_only=False,
             truncate_dim=None,
             model_kwargs={"file_name": "onnx/model.onnx"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="onnx",
         )
@@ -354,7 +354,7 @@ class TestSentenceTransformersTextEmbedder:
             local_files_only=False,
             truncate_dim=None,
             model_kwargs={"file_name": "openvino/openvino_model.xml"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="openvino",
         )
@@ -381,7 +381,7 @@ class TestSentenceTransformersTextEmbedder:
             local_files_only=False,
             truncate_dim=None,
             model_kwargs=model_kwargs,
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="torch",
         )

--- a/test/components/rankers/test_sentence_transformers_diversity.py
+++ b/test/components/rankers/test_sentence_transformers_diversity.py
@@ -276,7 +276,7 @@ class TestSentenceTransformersDiversityRanker:
                 device=ComponentDevice.resolve_device(None).to_torch_str(),
                 token=None,
                 model_kwargs=None,
-                tokenizer_kwargs=None,
+                processor_kwargs=None,
                 config_kwargs=None,
                 backend="torch",
             )
@@ -714,7 +714,7 @@ class TestSentenceTransformersDiversityRanker:
             device="cpu",
             token=None,
             model_kwargs={"file_name": "onnx/model.onnx"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="onnx",
         )
@@ -735,7 +735,7 @@ class TestSentenceTransformersDiversityRanker:
             device="cpu",
             token=None,
             model_kwargs={"file_name": "openvino/openvino_model.xml"},
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="openvino",
         )
@@ -756,7 +756,7 @@ class TestSentenceTransformersDiversityRanker:
             device="cuda:0",
             token=None,
             model_kwargs=model_kwargs,
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="torch",
         )

--- a/test/components/rankers/test_sentence_transformers_similarity.py
+++ b/test/components/rankers/test_sentence_transformers_similarity.py
@@ -36,7 +36,7 @@ class TestSentenceTransformersSimilarityRanker:
             token=None,
             trust_remote_code=True,
             model_kwargs=None,
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="torch",
         )
@@ -57,7 +57,7 @@ class TestSentenceTransformersSimilarityRanker:
             token=None,
             trust_remote_code=False,
             model_kwargs=None,
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="onnx",
         )
@@ -78,7 +78,7 @@ class TestSentenceTransformersSimilarityRanker:
             token=None,
             trust_remote_code=False,
             model_kwargs=None,
-            tokenizer_kwargs=None,
+            processor_kwargs=None,
             config_kwargs=None,
             backend="openvino",
         )
@@ -103,7 +103,7 @@ class TestSentenceTransformersSimilarityRanker:
                 "score_threshold": None,
                 "trust_remote_code": False,
                 "model_kwargs": None,
-                "tokenizer_kwargs": None,
+                "processor_kwargs": None,
                 "config_kwargs": None,
                 "backend": "torch",
                 "batch_size": 16,
@@ -124,7 +124,7 @@ class TestSentenceTransformersSimilarityRanker:
             score_threshold=0.01,
             trust_remote_code=True,
             model_kwargs={"torch_dtype": torch.float16},
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             batch_size=32,
         )
         data = component.to_dict()
@@ -145,7 +145,7 @@ class TestSentenceTransformersSimilarityRanker:
                 "score_threshold": 0.01,
                 "trust_remote_code": True,
                 "model_kwargs": {"torch_dtype": "torch.float16"},
-                "tokenizer_kwargs": {"model_max_length": 512},
+                "processor_kwargs": {"model_max_length": 512},
                 "config_kwargs": None,
                 "backend": "torch",
                 "batch_size": 32,
@@ -184,7 +184,7 @@ class TestSentenceTransformersSimilarityRanker:
                     "bnb_4bit_quant_type": "nf4",
                     "bnb_4bit_compute_dtype": "torch.bfloat16",
                 },
-                "tokenizer_kwargs": None,
+                "processor_kwargs": None,
                 "config_kwargs": None,
                 "backend": "torch",
                 "batch_size": 16,
@@ -207,7 +207,7 @@ class TestSentenceTransformersSimilarityRanker:
                 "score_threshold": 0.01,
                 "trust_remote_code": False,
                 "model_kwargs": {"torch_dtype": "torch.float16"},
-                "tokenizer_kwargs": None,
+                "processor_kwargs": None,
                 "config_kwargs": None,
                 "backend": "torch",
                 "batch_size": 32,
@@ -227,7 +227,7 @@ class TestSentenceTransformersSimilarityRanker:
         assert component.score_threshold == 0.01
         assert component.trust_remote_code is False
         assert component.model_kwargs == {"torch_dtype": torch.float16}
-        assert component.tokenizer_kwargs is None
+        assert component.processor_kwargs is None
         assert component.config_kwargs is None
         assert component.batch_size == 32
 
@@ -250,7 +250,7 @@ class TestSentenceTransformersSimilarityRanker:
         assert component.score_threshold is None
         assert component.trust_remote_code is False
         assert component.model_kwargs is None
-        assert component.tokenizer_kwargs is None
+        assert component.processor_kwargs is None
         assert component.config_kwargs is None
         assert component.backend == "torch"
         assert component.batch_size == 16

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -34,7 +34,7 @@ class TestSimilarityRanker:
                 "calibration_factor": 1.0,
                 "score_threshold": None,
                 "model_kwargs": {"device_map": ComponentDevice.resolve_device(None).to_hf()},
-                "tokenizer_kwargs": {},
+                "processor_kwargs": {},
                 "batch_size": 16,
             },
         }
@@ -51,7 +51,7 @@ class TestSimilarityRanker:
             calibration_factor=None,
             score_threshold=0.01,
             model_kwargs={"torch_dtype": torch.float16},
-            tokenizer_kwargs={"model_max_length": 512},
+            processor_kwargs={"model_max_length": 512},
             batch_size=32,
         )
         data = component.to_dict()
@@ -73,7 +73,7 @@ class TestSimilarityRanker:
                     "torch_dtype": "torch.float16",
                     "device_map": ComponentDevice.from_str("cuda:0").to_hf(),
                 },  # torch_dtype is correctly serialized
-                "tokenizer_kwargs": {"model_max_length": 512},
+                "processor_kwargs": {"model_max_length": 512},
                 "batch_size": 32,
             },
         }
@@ -109,7 +109,7 @@ class TestSimilarityRanker:
                     "bnb_4bit_compute_dtype": "torch.bfloat16",
                     "device_map": ComponentDevice.resolve_device(None).to_hf(),
                 },
-                "tokenizer_kwargs": {},
+                "processor_kwargs": {},
                 "batch_size": 16,
             },
         }
@@ -141,7 +141,7 @@ class TestSimilarityRanker:
                 "calibration_factor": 1.0,
                 "score_threshold": None,
                 "model_kwargs": {"device_map": expected},
-                "tokenizer_kwargs": {},
+                "processor_kwargs": {},
                 "batch_size": 16,
             },
         }
@@ -162,7 +162,7 @@ class TestSimilarityRanker:
                 "calibration_factor": None,
                 "score_threshold": 0.01,
                 "model_kwargs": {"torch_dtype": "torch.float16"},
-                "tokenizer_kwargs": {"model_max_length": 512},
+                "processor_kwargs": {"model_max_length": 512},
                 "batch_size": 32,
             },
         }
@@ -184,7 +184,7 @@ class TestSimilarityRanker:
             "torch_dtype": torch.float16,
             "device_map": ComponentDevice.resolve_device(None).to_hf(),
         }
-        assert component.tokenizer_kwargs == {"model_max_length": 512}
+        assert component.processor_kwargs == {"model_max_length": 512}
         assert component.batch_size == 32
 
     def test_from_dict_no_default_parameters(self):
@@ -207,7 +207,7 @@ class TestSimilarityRanker:
         assert component.score_threshold is None
         # torch_dtype is correctly deserialized
         assert component.model_kwargs == {"device_map": ComponentDevice.resolve_device(None).to_hf()}
-        assert component.tokenizer_kwargs == {}
+        assert component.processor_kwargs == {}
         assert component.batch_size == 16
 
     @patch("torch.sigmoid")


### PR DESCRIPTION
### Related Issues
- fixes deepset-ai/haystack-core-integrations#3529 

### Proposed Changes:
This PR migrates all Sentence Transformers related components and backends to align with the breaking changes in `sentence-transformers>=5.0.0`. 

Key changes include:
- **Parameter Rename**: Renamed `tokenizer_kwargs` to `processor_kwargs` across all embedders and rankers.
- **Backend Migration**: Updated `SentenceTransformersEmbeddingBackend` and `SentenceTransformersSparseEncoderEmbeddingBackend` to use the new parameter names.
- **Backward Compatibility**: Implemented mapping logic in `from_dict` methods to ensure existing serialized pipelines (saved with `tokenizer_kwargs`) remain functional.
- **Property Synchronization**: Updated `warm_up` logic to manually sync `model_max_length` from `processor_kwargs` to the model's new `max_seq_length` property.
- **Authentication**: Renamed `use_auth_token` to `token` for consistency with Hugging Face and new Sentence Transformers standards.

### How did you test it?
- Globally updated the test suite (~175 tests) to use `processor_kwargs`.
- Verified all unit and integration tests passed for embedders and rankers.
- Manually verified serialization/deserialization to ensure backward compatibility for old saved dictionaries.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of_conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types.
- [x] I have added a release note file under `releasenotes/notes/migrate-tokenizer-to-processor-kwargs-st-v5.yaml`.
