### PR TITLE
refactor: restrict OpenAPI $ref resolution to in-document pointers

### DIFF
--- a/haystack/components/converters/openapi_functions.py
+++ b/haystack/components/converters/openapi_functions.py
@@ -233,6 +233,16 @@ class OpenAPIServiceToFunctions:
 
         return parsed_schema
 
+    @staticmethod
+    def _no_external_ref_loader(uri: str, **_: Any) -> Any:
+        # In-document refs (those starting with "#") are resolved by jsonref without invoking
+        # the loader. Anything else points outside the document (file://, http(s)://, ...) and
+        # is rejected to prevent local file disclosure and outbound requests during parsing.
+        raise RuntimeError(
+            f"Refusing to resolve external $ref '{uri}' while parsing OpenAPI spec. "
+            "Only in-document JSON-pointer references (starting with '#') are supported."
+        )
+
     def _parse_openapi_spec(self, content: str) -> dict[str, Any]:
         """
         Parses OpenAPI specification content, supporting both JSON and YAML formats.
@@ -243,7 +253,7 @@ class OpenAPIServiceToFunctions:
         open_api_spec_content = None
         try:
             open_api_spec_content = json.loads(content)
-            return jsonref.replace_refs(open_api_spec_content)
+            return jsonref.replace_refs(open_api_spec_content, loader=self._no_external_ref_loader, proxies=False)
         except json.JSONDecodeError as json_error:
             # heuristic to confirm that the content is likely malformed JSON
             if content.strip().startswith(("{", "[")):
@@ -258,4 +268,4 @@ class OpenAPIServiceToFunctions:
             raise RuntimeError(error_message, content) from e
 
         # Replace references in the object with their resolved values, if any
-        return jsonref.replace_refs(open_api_spec_content)
+        return jsonref.replace_refs(open_api_spec_content, loader=self._no_external_ref_loader, proxies=False)

--- a/releasenotes/notes/openapi-converter-disallow-external-refs-9b1d3f0a7c2e54a1.yaml
+++ b/releasenotes/notes/openapi-converter-disallow-external-refs-9b1d3f0a7c2e54a1.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    `OpenAPIServiceToFunctions` now resolves only in-document JSON-pointer
+    references (those starting with `#`) when parsing OpenAPI specifications.
+    External `$ref` URIs (for example `file://` or `http(s)://`) are no longer
+    fetched during parsing; specs that depend on them will raise a
+    `RuntimeError`. This avoids unintended filesystem access or outbound
+    HTTP requests when the spec content is not fully trusted.

--- a/releasenotes/notes/openapi-converter-disallow-external-refs-9b1d3f0a7c2e54a1.yaml
+++ b/releasenotes/notes/openapi-converter-disallow-external-refs-9b1d3f0a7c2e54a1.yaml
@@ -1,9 +1,9 @@
 ---
 enhancements:
   - |
-    `OpenAPIServiceToFunctions` now resolves only in-document JSON-pointer
-    references (those starting with `#`) when parsing OpenAPI specifications.
-    External `$ref` URIs (for example `file://` or `http(s)://`) are no longer
+    ``OpenAPIServiceToFunctions`` now resolves only in-document JSON-pointer
+    references (those starting with ``#``) when parsing OpenAPI specifications.
+    External ``$ref`` URIs (for example ``file://`` or ``http(s)://``) are no longer
     fetched during parsing; specs that depend on them will raise a
-    `RuntimeError`. This avoids unintended filesystem access or outbound
+    ``RuntimeError``. This avoids unintended filesystem access or outbound
     HTTP requests when the spec content is not fully trusted.


### PR DESCRIPTION
## Summary
- `OpenAPIServiceToFunctions._parse_openapi_spec` was calling `jsonref.replace_refs` with the library default loader, which dispatches arbitrary `$ref` URIs to the filesystem (`file://`) and the network (`http(s)://`).
- Pass an explicit loader that refuses any non-in-document `$ref` and set `proxies=False` so references must resolve eagerly during parsing.
- In-document JSON-pointer references (those starting with `#`) continue to work unchanged.

This is a defensive hardening change for OpenAPI specs whose contents are not fully trusted (e.g. fetched from third-party catalogs, generated by an LLM, or uploaded by end users). Specs that depend on external `$ref` resolution will now raise a `RuntimeError` instead of silently performing filesystem reads or outbound HTTP requests.

## Test plan
- [ ] CI runs `OpenAPIServiceToFunctions` unit tests with the new loader.
- [ ] Manual: a spec containing an in-document `$ref` (e.g. `#/components/schemas/Foo`) still resolves correctly.
- [ ] Manual: a spec containing `$ref: file:///etc/passwd` or `$ref: http://...` raises and does not perform the I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)