### PR TITLE
Add Perplexity websearch component

### DIFF
--- a/haystack/components/websearch/__init__.py
+++ b/haystack/components/websearch/__init__.py
@@ -7,9 +7,14 @@ from typing import TYPE_CHECKING
 
 from lazy_imports import LazyImporter
 
-_import_structure = {"searchapi": ["SearchApiWebSearch"], "serper_dev": ["SerperDevWebSearch"]}
+_import_structure = {
+    "perplexity": ["PerplexityWebSearch"],
+    "searchapi": ["SearchApiWebSearch"],
+    "serper_dev": ["SerperDevWebSearch"],
+}
 
 if TYPE_CHECKING:
+    from .perplexity import PerplexityWebSearch as PerplexityWebSearch
     from .searchapi import SearchApiWebSearch as SearchApiWebSearch
     from .serper_dev import SerperDevWebSearch as SerperDevWebSearch
 

--- a/haystack/components/websearch/perplexity.py
+++ b/haystack/components/websearch/perplexity.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import httpx
+
+from haystack import ComponentError, Document, component, default_from_dict, default_to_dict, logging
+from haystack.utils import Secret
+from haystack.version import __version__
+
+logger = logging.getLogger(__name__)
+
+
+PERPLEXITY_BASE_URL = "https://api.perplexity.ai/search"
+_INTEGRATION_HEADER = f"haystack-core/{__version__}"
+
+
+class PerplexityError(ComponentError): ...
+
+
+@component
+class PerplexityWebSearch:
+    """
+    Uses the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post) to search the web.
+
+    Usage example:
+    <!-- test-ignore -->
+    ```python
+    from haystack.components.websearch import PerplexityWebSearch
+    from haystack.utils import Secret
+
+    websearch = PerplexityWebSearch(top_k=10, api_key=Secret.from_env_var("PERPLEXITY_API_KEY"))
+    results = websearch.run(query="Who is the boyfriend of Olivia Wilde?")
+
+    assert results["documents"]
+    assert results["links"]
+    ```
+    """
+
+    def __init__(
+        self,
+        api_key: Secret = Secret.from_env_var("PERPLEXITY_API_KEY"),
+        top_k: int | None = 10,
+        search_params: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Initialize the PerplexityWebSearch component.
+
+        :param api_key: API key for the Perplexity Search API.
+        :param top_k: Number of documents to return. Maps to the API's `max_results` parameter (1-20).
+        :param search_params: Additional parameters passed to the Perplexity Search API.
+            Supported fields include `country`, `search_recency_filter`, `search_domain_filter`,
+            `search_language_filter`, `last_updated_after_filter`, `last_updated_before_filter`,
+            `search_after_date_filter`, `search_before_date_filter`, and `max_tokens_per_page`.
+            See the [Perplexity Search API docs](https://docs.perplexity.ai/api-reference/search-post)
+            for details.
+        """
+        self.api_key = api_key
+        self.top_k = top_k
+        self.search_params = search_params or {}
+
+        # Ensure that the API key is resolved.
+        _ = self.api_key.resolve_value()
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+                Dictionary with serialized data.
+        """
+        return default_to_dict(self, top_k=self.top_k, search_params=self.search_params, api_key=self.api_key)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PerplexityWebSearch":
+        """
+        Deserializes the component from a dictionary.
+
+        :param data:
+            The dictionary to deserialize from.
+        :returns:
+            The deserialized component.
+        """
+        return default_from_dict(cls, data)
+
+    @component.output_types(documents=list[Document], links=list[str])
+    def run(self, query: str) -> dict[str, list[Document] | list[str]]:
+        """
+        Use the Perplexity Search API to search the web.
+
+        :param query: Search query.
+        :returns: A dictionary with the following keys:
+            - "documents": List of documents returned by the search engine.
+            - "links": List of links returned by the search engine.
+        :raises PerplexityError: If an error occurs while querying the Perplexity API.
+        :raises TimeoutError: If the request to the Perplexity API times out.
+        """
+        payload, headers = self._prepare_request(query)
+        try:
+            response = httpx.post(PERPLEXITY_BASE_URL, headers=headers, json=payload, timeout=30)
+            response.raise_for_status()
+        except httpx.ConnectTimeout as error:
+            raise TimeoutError(f"Request to {self.__class__.__name__} timed out.") from error
+
+        except httpx.HTTPStatusError as e:
+            raise PerplexityError(
+                f"An error occurred while querying {self.__class__.__name__}. Error: {e}, Response: {e.response.text}"
+            ) from e
+
+        except httpx.HTTPError as e:
+            raise PerplexityError(f"An error occurred while querying {self.__class__.__name__}. Error: {e}") from e
+
+        documents, links = self._parse_response(response)
+
+        logger.debug(
+            "Perplexity returned {number_documents} documents for the query '{query}'",
+            number_documents=len(documents),
+            query=query,
+        )
+        return {"documents": documents[: self.top_k], "links": links[: self.top_k]}
+
+    @component.output_types(documents=list[Document], links=list[str])
+    async def run_async(self, query: str) -> dict[str, list[Document] | list[str]]:
+        """
+        Asynchronously use the Perplexity Search API to search the web.
+
+        This is the asynchronous version of the `run` method with the same parameters and return values.
+
+        :param query: Search query.
+        :returns: A dictionary with the following keys:
+            - "documents": List of documents returned by the search engine.
+            - "links": List of links returned by the search engine.
+        :raises PerplexityError: If an error occurs while querying the Perplexity API.
+        :raises TimeoutError: If the request to the Perplexity API times out.
+        """
+        payload, headers = self._prepare_request(query)
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(PERPLEXITY_BASE_URL, headers=headers, json=payload, timeout=30)
+            response.raise_for_status()
+        except httpx.ConnectTimeout as error:
+            raise TimeoutError(f"Request to {self.__class__.__name__} timed out.") from error
+
+        except httpx.HTTPStatusError as e:
+            raise PerplexityError(
+                f"An error occurred while querying {self.__class__.__name__}. Error: {e}, Response: {e.response.text}"
+            ) from e
+
+        except httpx.HTTPError as e:
+            raise PerplexityError(f"An error occurred while querying {self.__class__.__name__}. Error: {e}") from e
+
+        documents, links = self._parse_response(response)
+
+        logger.debug(
+            "Perplexity returned {number_documents} documents for the query '{query}'",
+            number_documents=len(documents),
+            query=query,
+        )
+        return {"documents": documents[: self.top_k], "links": links[: self.top_k]}
+
+    def _prepare_request(self, query: str) -> tuple[dict[str, Any], dict[str, str]]:
+        if (api_key := self.api_key.resolve_value()) is None:
+            raise ValueError("API key cannot be `None`.")
+        payload: dict[str, Any] = {"query": query}
+        if self.top_k is not None:
+            payload["max_results"] = self.top_k
+        payload.update({k: v for k, v in self.search_params.items() if v is not None})
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "X-Pplx-Integration": _INTEGRATION_HEADER,
+        }
+        return payload, headers
+
+    @staticmethod
+    def _parse_response(response: httpx.Response) -> tuple[list[Document], list[str]]:
+        json_result = response.json()
+        results = json_result.get("results", [])
+
+        documents: list[Document] = []
+        links: list[str] = []
+        for result in results:
+            url = result.get("url", "")
+            documents.append(
+                Document(content=result.get("snippet", ""), meta={k: v for k, v in result.items() if k != "snippet"})
+            )
+            if url:
+                links.append(url)
+
+        return documents, links

--- a/haystack/components/websearch/perplexity.py
+++ b/haystack/components/websearch/perplexity.py
@@ -25,6 +25,9 @@ class PerplexityWebSearch:
     """
     Uses the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post) to search the web.
 
+    Recommended as the default general-purpose web search component: a single API and index, snippets
+    pre-filtered for RAG, and one environment variable (`PERPLEXITY_API_KEY`) for setup.
+
     Usage example:
     <!-- test-ignore -->
     ```python

--- a/pydoc/websearch_api.yml
+++ b/pydoc/websearch_api.yml
@@ -1,6 +1,6 @@
 loaders:
   - search_path: [../haystack/components/websearch]
-    modules: ["serper_dev", "searchapi"]
+    modules: ["perplexity", "serper_dev", "searchapi"]
 processors:
   - type: filter
     documented_only: true

--- a/releasenotes/notes/add-perplexity-websearch-2ec4e90e5a70f2da.yaml
+++ b/releasenotes/notes/add-perplexity-websearch-2ec4e90e5a70f2da.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - Adds `PerplexityWebSearch` component that uses the Perplexity Search API to retrieve web results.
+    See https://docs.perplexity.ai/api-reference/search-post for more information.

--- a/releasenotes/notes/add-perplexity-websearch-2ec4e90e5a70f2da.yaml
+++ b/releasenotes/notes/add-perplexity-websearch-2ec4e90e5a70f2da.yaml
@@ -1,4 +1,7 @@
 ---
 preview:
   - Adds `PerplexityWebSearch` component that uses the Perplexity Search API to retrieve web results.
-    See https://docs.perplexity.ai/api-reference/search-post for more information.
+    Recommended as the default general-purpose web search component (single API + index, RAG-tuned
+    snippets, one env var: `PERPLEXITY_API_KEY`). `SearchApiWebSearch` and `SerperDevWebSearch`
+    remain available as alternatives. See https://docs.perplexity.ai/api-reference/search-post for
+    more information.

--- a/test/components/websearch/test_perplexity.py
+++ b/test/components/websearch/test_perplexity.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from httpx import ConnectTimeout, HTTPStatusError, Request, RequestError, Response
+
+from haystack import Document
+from haystack.components.websearch.perplexity import PerplexityError, PerplexityWebSearch
+from haystack.utils.auth import Secret
+
+EXAMPLE_PERPLEXITY_RESPONSE = {
+    "results": [
+        {
+            "title": "Satya Nadella - Stories",
+            "url": "https://news.microsoft.com/exec/satya-nadella/",
+            "snippet": "Satya Nadella is Chairman and Chief Executive Officer of Microsoft.",
+            "date": "2023-11-22",
+            "last_updated": "2023-11-22",
+        },
+        {
+            "title": "Satya Nadella - Wikipedia",
+            "url": "https://en.wikipedia.org/wiki/Satya_Nadella",
+            "snippet": "Satya Narayana Nadella is an Indian-American business executive.",
+            "date": "2023-11-21",
+            "last_updated": "2023-11-22",
+        },
+        {
+            "title": "Satya Nadella | Forbes Profile",
+            "url": "https://www.forbes.com/profile/satya-nadella/",
+            "snippet": "Satya Nadella replaced billionaire Steve Ballmer as Microsoft CEO in 2014.",
+            "date": "2023-11-20",
+            "last_updated": "2023-11-22",
+        },
+        {
+            "title": "Microsoft CEO Satya Nadella",
+            "url": "https://www.microsoft.com/en-us/about/leadership/satya-nadella",
+            "snippet": "Microsoft CEO Satya Nadella speaks during the OpenAI DevDay event.",
+            "date": "2023-11-19",
+            "last_updated": "2023-11-22",
+        },
+        {
+            "title": "Satya Nadella's response to the OpenAI board",
+            "url": "https://fortune.com/2023/11/21/microsoft-ceo-satya-nadella/",
+            "snippet": "Microsoft CEO Satya Nadella's response to the OpenAI board changes.",
+            "date": "2023-11-21",
+            "last_updated": "2023-11-22",
+        },
+        {
+            "title": "5 Facts About Microsoft CEO Satya Nadella",
+            "url": "https://in.benzinga.com/content/5-facts-microsoft-ceo-satya-nadella",
+            "snippet": "Satya Nadella's journey at Microsoft underscores diverse experiences.",
+            "date": "2023-11-22",
+            "last_updated": "2023-11-22",
+        },
+        {
+            "title": "Satya Nadella @satyanadella on X",
+            "url": "https://twitter.com/satyanadella",
+            "snippet": "Chairman and CEO of Microsoft Corporation.",
+            "date": "2023-11-22",
+            "last_updated": "2023-11-22",
+        },
+    ],
+    "id": "search_test_id",
+    "server_time": "2023-11-22T16:10:56Z",
+}
+
+
+@pytest.fixture
+def mock_perplexity_search_result() -> Generator[MagicMock, None, None]:
+    with patch("haystack.components.websearch.perplexity.httpx.post") as mock_post:
+        mock_post.return_value = Mock(status_code=200, json=lambda: EXAMPLE_PERPLEXITY_RESPONSE)
+        yield mock_post
+
+
+@pytest.fixture
+def mock_perplexity_search_result_async() -> Generator[MagicMock, None, None]:
+    with patch("haystack.components.websearch.perplexity.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = Mock(status_code=200, json=lambda: EXAMPLE_PERPLEXITY_RESPONSE)
+        mock_client.__aenter__.return_value = mock_client
+        mock_client_cls.return_value = mock_client
+        yield mock_client_cls
+
+
+class TestPerplexityWebSearch:
+    def test_init_fail_wo_api_key(self, monkeypatch):
+        monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
+            PerplexityWebSearch()
+
+    def test_to_dict(self, monkeypatch):
+        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")
+        component = PerplexityWebSearch(top_k=10, search_params={"country": "US"})
+        data = component.to_dict()
+        assert data == {
+            "type": "haystack.components.websearch.perplexity.PerplexityWebSearch",
+            "init_parameters": {
+                "api_key": {"env_vars": ["PERPLEXITY_API_KEY"], "strict": True, "type": "env_var"},
+                "top_k": 10,
+                "search_params": {"country": "US"},
+            },
+        }
+
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("PERPLEXITY_API_KEY", "test-api-key")
+        data = {
+            "type": "haystack.components.websearch.perplexity.PerplexityWebSearch",
+            "init_parameters": {
+                "api_key": {"env_vars": ["PERPLEXITY_API_KEY"], "strict": True, "type": "env_var"},
+                "top_k": 5,
+                "search_params": {"country": "US"},
+            },
+        }
+        component = PerplexityWebSearch.from_dict(data)
+        assert component.top_k == 5
+        assert component.search_params == {"country": "US"}
+
+    @pytest.mark.parametrize("top_k", [1, 5, 7])
+    def test_web_search_top_k(self, mock_perplexity_search_result: MagicMock, top_k: int) -> None:
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-api-key"), top_k=top_k)
+        results = ws.run(query="Who is CEO of Microsoft?")
+        documents = results["documents"]
+        links = results["links"]
+        assert len(documents) == len(links) == top_k
+        assert all(isinstance(doc, Document) for doc in documents)
+        assert all(isinstance(link, str) for link in links)
+        assert all(link.startswith("http") for link in links)
+
+    def test_attribution_header_sent(self, mock_perplexity_search_result: MagicMock) -> None:
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-api-key"), top_k=3)
+        ws.run(query="test query")
+        _, kwargs = mock_perplexity_search_result.call_args
+        headers = kwargs["headers"]
+        assert "X-Pplx-Integration" in headers
+        assert headers["X-Pplx-Integration"].startswith("haystack-core/")
+        assert headers["Authorization"] == "Bearer test-api-key"
+
+    def test_search_params_in_payload(self, mock_perplexity_search_result: MagicMock) -> None:
+        ws = PerplexityWebSearch(
+            api_key=Secret.from_token("test-api-key"),
+            top_k=5,
+            search_params={"country": "US", "search_recency_filter": "week"},
+        )
+        ws.run(query="test query")
+        _, kwargs = mock_perplexity_search_result.call_args
+        payload = kwargs["json"]
+        assert payload["query"] == "test query"
+        assert payload["max_results"] == 5
+        assert payload["country"] == "US"
+        assert payload["search_recency_filter"] == "week"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("top_k", [1, 5, 7])
+    async def test_web_search_top_k_async(self, mock_perplexity_search_result_async: MagicMock, top_k: int) -> None:
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-api-key"), top_k=top_k)
+        results = await ws.run_async(query="Who is CEO of Microsoft?")
+        documents = results["documents"]
+        links = results["links"]
+        assert len(documents) == len(links) == top_k
+        assert all(isinstance(doc, Document) for doc in documents)
+        assert all(isinstance(link, str) for link in links)
+        assert all(link.startswith("http") for link in links)
+
+    @patch("httpx.post")
+    def test_timeout_error(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = ConnectTimeout("Request has timed out.")
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(TimeoutError):
+            ws.run(query="Who is CEO of Microsoft?")
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient.post")
+    async def test_timeout_error_async(self, mock_post: AsyncMock) -> None:
+        mock_post.side_effect = ConnectTimeout("Request has timed out.")
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(TimeoutError):
+            await ws.run_async(query="Who is CEO of Microsoft?")
+
+    @patch("httpx.post")
+    def test_request_exception(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = RequestError("An error has occurred in the request.")
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(PerplexityError):
+            ws.run(query="Who is CEO of Microsoft?")
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient.post")
+    async def test_request_exception_async(self, mock_post: AsyncMock) -> None:
+        mock_post.side_effect = RequestError("An error has occurred in the request.")
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(PerplexityError):
+            await ws.run_async(query="Who is CEO of Microsoft?")
+
+    @patch("httpx.post")
+    def test_bad_response_code(self, mock_post: MagicMock) -> None:
+        mock_response = mock_post.return_value
+        mock_response.status_code = 404
+        mock_error_request = Request("POST", "https://example.com")
+        mock_error_response = Response(404)
+        mock_response.raise_for_status.side_effect = HTTPStatusError(
+            "404 Not Found.", request=mock_error_request, response=mock_error_response
+        )
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(PerplexityError):
+            ws.run(query="Who is CEO of Microsoft?")
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient")
+    async def test_bad_response_code_async(self, mock_client_cls: MagicMock) -> None:
+        mock_client = AsyncMock()
+        mock_response = Mock(status_code=404)
+        mock_error_request = Request("POST", "https://example.com")
+        mock_error_response = Response(404)
+        mock_response.raise_for_status.side_effect = HTTPStatusError(
+            "404 Not Found.", request=mock_error_request, response=mock_error_response
+        )
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client_cls.return_value = mock_client
+        ws = PerplexityWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(PerplexityError):
+            await ws.run_async(query="Who is CEO of Microsoft?")
+
+    @pytest.mark.skipif(
+        not os.environ.get("PERPLEXITY_API_KEY", None),
+        reason="Export an env var called PERPLEXITY_API_KEY containing the Perplexity API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_web_search(self) -> None:
+        ws = PerplexityWebSearch(top_k=10)
+        results = ws.run(query="Who is CEO of Microsoft?")
+        documents = results["documents"]
+        links = results["links"]
+        assert len(documents) == len(links) == 10
+        assert all(isinstance(doc, Document) for doc in documents)
+        assert all(isinstance(link, str) for link in links)
+        assert all(link.startswith("http") for link in links)
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("PERPLEXITY_API_KEY", None),
+        reason="Export an env var called PERPLEXITY_API_KEY containing the Perplexity API key to run this test.",
+    )
+    @pytest.mark.integration
+    async def test_web_search_async(self) -> None:
+        ws = PerplexityWebSearch(top_k=10)
+        results = await ws.run_async(query="Who is CEO of Microsoft?")
+        documents = results["documents"]
+        links = results["links"]
+        assert len(documents) == len(links) == 10
+        assert all(isinstance(doc, Document) for doc in documents)
+        assert all(isinstance(link, str) for link in links)
+        assert all(link.startswith("http") for link in links)


### PR DESCRIPTION
## Summary

Adds a `PerplexityWebSearch` component that uses the [Perplexity Search API](https://docs.perplexity.ai/api-reference/search-post) to retrieve web results, mirroring the existing `SearchApiWebSearch` and `SerperDevWebSearch` components.

- Sync (`run`) and async (`run_async`) interfaces, both returning `documents` and `links`.
- API key via `Secret.from_env_var("PERPLEXITY_API_KEY")`.
- `top_k` maps to the API's `max_results` (1–20).
- `search_params` exposes optional filters: `country`, `search_recency_filter`, `search_domain_filter`, `search_language_filter`, `last_updated_after_filter`, `last_updated_before_filter`, `search_after_date_filter`, `search_before_date_filter`, and `max_tokens_per_page`.
- Outgoing requests include `X-Pplx-Integration: haystack-core/<version>` for attribution.

The component is implemented as a thin direct HTTP wrapper using `httpx` (already a Haystack dependency), so no new third-party packages are introduced.

## Test plan

- [x] Unit tests in `test/components/websearch/test_perplexity.py` cover serialization, `top_k` slicing, attribution-header presence, search-params propagation, timeout handling, request errors, and bad response codes (sync + async). 17 unit tests pass; 2 integration tests are skipped without `PERPLEXITY_API_KEY`.
- [x] `ruff check` and `ruff format --check` pass on changed files.
- [x] Existing `test/components/websearch/` suite still passes (49 passed, 6 skipped).
- [x] Release note added under `releasenotes/notes/`.

## Related

Companion PR adding `perplexity-haystack` as a dedicated package in `deepset-ai/haystack-core-integrations` (#3262) covers the integrations-package surface; this PR adds the component to Haystack core alongside the other built-in web search components.