### PR TITLE
test: Add regression test for unintended agent execution

### DIFF
--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -1792,8 +1792,9 @@ class TestAgentWaitsForBlockedPredecessor:
         assert "agent" in result
 
 
-def test_agent_not_triggered_by_injected_streaming_callback(weather_tool):
-    """Regression test for https://github.com/deepset-ai/haystack/issues/11109.
+class TestAgentNotTriggeredByInjectedInput:
+    """
+    Regression test for https://github.com/deepset-ai/haystack/issues/11109.
 
     ConditionalRouter routes to `planning`, BranchJoiner never runs, so Agent.messages
     gets no input. A `streaming_callback` injected via `pipeline.run` data must not
@@ -1801,45 +1802,46 @@ def test_agent_not_triggered_by_injected_streaming_callback(weather_tool):
     `sender=None` entry flips `has_user_input()` to True).
     """
 
-    @component
-    class Planner:
-        @component.output_types(messages=list[ChatMessage], last_role=str)
-        def run(self) -> dict:
-            return {"messages": [ChatMessage.from_assistant("?")], "last_role": "assistant"}
+    def test_agent_not_triggered_by_injected_streaming_callback(self, weather_tool):
+        @component
+        class Planner:
+            @component.output_types(messages=list[ChatMessage], last_role=str)
+            def run(self) -> dict:
+                return {"messages": [ChatMessage.from_assistant("?")], "last_role": "assistant"}
 
-    chat_generator = MockChatGenerator()
-    agent = Agent(chat_generator=chat_generator, tools=[weather_tool])
-    chat_generator.run = MagicMock(return_value={"replies": [ChatMessage.from_assistant("x")]})
+        chat_generator = MockChatGenerator()
+        agent = Agent(chat_generator=chat_generator, tools=[weather_tool])
+        chat_generator.run = MagicMock(return_value={"replies": [ChatMessage.from_assistant("x")]})
 
-    router = ConditionalRouter(
-        routes=[
-            {
-                "condition": "{{ last_role == 'tool' }}",
-                "output": "{{ messages }}",
-                "output_name": "processing",
-                "output_type": list[ChatMessage],
-            },
-            {
-                "condition": "{{ True }}",
-                "output": "{{ messages }}",
-                "output_name": "planning",
-                "output_type": list[ChatMessage],
-            },
-        ],
-        unsafe=True,
-    )
+        router = ConditionalRouter(
+            routes=[
+                {
+                    "condition": "{{ last_role == 'tool' }}",
+                    "output": "{{ messages }}",
+                    "output_name": "processing",
+                    "output_type": list[ChatMessage],
+                },
+                {
+                    "condition": "{{ True }}",
+                    "output": "{{ messages }}",
+                    "output_name": "planning",
+                    "output_type": list[ChatMessage],
+                },
+            ],
+            unsafe=True,
+        )
 
-    pipeline = Pipeline()
-    pipeline.add_component("planner", Planner())
-    pipeline.add_component("router", router)
-    pipeline.add_component("branch_joiner", BranchJoiner(type_=list[ChatMessage]))
-    pipeline.add_component("agent", agent)
-    pipeline.connect("planner.messages", "router.messages")
-    pipeline.connect("planner.last_role", "router.last_role")
-    pipeline.connect("router.processing", "branch_joiner.value")
-    pipeline.connect("branch_joiner.value", "agent.messages")
+        pipeline = Pipeline()
+        pipeline.add_component("planner", Planner())
+        pipeline.add_component("router", router)
+        pipeline.add_component("branch_joiner", BranchJoiner(type_=list[ChatMessage]))
+        pipeline.add_component("agent", agent)
+        pipeline.connect("planner.messages", "router.messages")
+        pipeline.connect("planner.last_role", "router.last_role")
+        pipeline.connect("router.processing", "branch_joiner.value")
+        pipeline.connect("branch_joiner.value", "agent.messages")
 
-    result = pipeline.run(data={"agent": {"streaming_callback": sync_streaming_callback}})
+        result = pipeline.run(data={"agent": {"streaming_callback": sync_streaming_callback}})
 
-    assert "agent" not in result
-    chat_generator.run.assert_not_called()
+        assert "agent" not in result
+        chat_generator.run.assert_not_called()

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -21,8 +21,10 @@ from haystack.components.agents.state import merge_lists
 from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
 from haystack.components.generators.chat.openai import OpenAIChatGenerator
+from haystack.components.joiners.branch import BranchJoiner
 from haystack.components.joiners.list_joiner import ListJoiner
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+from haystack.components.routers.conditional_router import ConditionalRouter
 from haystack.core.component.types import OutputSocket
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.dataclasses.chat_message import ChatRole, TextContent
@@ -1788,3 +1790,56 @@ class TestAgentWaitsForBlockedPredecessor:
             }
         )
         assert "agent" in result
+
+
+def test_agent_not_triggered_by_injected_streaming_callback(weather_tool):
+    """Regression test for https://github.com/deepset-ai/haystack/issues/11109.
+
+    ConditionalRouter routes to `planning`, BranchJoiner never runs, so Agent.messages
+    gets no input. A `streaming_callback` injected via `pipeline.run` data must not
+    by itself trigger the Agent (would happen if `messages` were optional, since any
+    `sender=None` entry flips `has_user_input()` to True).
+    """
+
+    @component
+    class Planner:
+        @component.output_types(messages=list[ChatMessage], last_role=str)
+        def run(self) -> dict:
+            return {"messages": [ChatMessage.from_assistant("?")], "last_role": "assistant"}
+
+    chat_generator = MockChatGenerator()
+    agent = Agent(chat_generator=chat_generator, tools=[weather_tool])
+    chat_generator.run = MagicMock(return_value={"replies": [ChatMessage.from_assistant("x")]})
+
+    router = ConditionalRouter(
+        routes=[
+            {
+                "condition": "{{ last_role == 'tool' }}",
+                "output": "{{ messages }}",
+                "output_name": "processing",
+                "output_type": list[ChatMessage],
+            },
+            {
+                "condition": "{{ True }}",
+                "output": "{{ messages }}",
+                "output_name": "planning",
+                "output_type": list[ChatMessage],
+            },
+        ],
+        unsafe=True,
+    )
+
+    pipeline = Pipeline()
+    pipeline.add_component("planner", Planner())
+    pipeline.add_component("router", router)
+    pipeline.add_component("branch_joiner", BranchJoiner(type_=list[ChatMessage]))
+    pipeline.add_component("agent", agent)
+    pipeline.connect("planner.messages", "router.messages")
+    pipeline.connect("planner.last_role", "router.last_role")
+    pipeline.connect("router.processing", "branch_joiner.value")
+    pipeline.connect("branch_joiner.value", "agent.messages")
+
+    result = pipeline.run(data={"agent": {"streaming_callback": sync_streaming_callback}})
+
+    assert "agent" not in result
+    chat_generator.run.assert_not_called()


### PR DESCRIPTION
### Related Issues

- related to #11109 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This PR adds a regression test for #11109. 

The test sets up a pipeline where a `ConditionalRouter` routes to a `planning` branch, leaving the `BranchJoiner` connected to `Agent.messages` un-triggered. It then runs the pipeline with a `streaming_callback` injected through `pipeline.run(data=...)` for the `agent` component. It asserts that the `Agent` does not run and that the underlying chat generator is never called, i.e. injecting an auxiliary input must not by itself trigger the component.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I ran the test both with the current version of `Agent` and with the version where `messages` is optional (the test fails in this case).

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
