### PR TITLE
fix: remove unnecessary type ignores in HuggingFaceAPIDocumentEmbedder

### DIFF
--- a/haystack/components/embedders/hugging_face_api_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_document_embedder.py
@@ -272,12 +272,7 @@ class HuggingFaceAPIDocumentEmbedder:
         ):
             batch = texts_to_embed[i : i + batch_size]
 
-            np_embeddings = self._client.feature_extraction(
-                # this method does not officially support list of strings, but works as expected
-                text=batch,  # type: ignore[arg-type]
-                truncate=truncate,
-                normalize=normalize,
-            )
+            np_embeddings = self._client.feature_extraction(text=batch, truncate=truncate, normalize=normalize)
 
             if np_embeddings.ndim != 2 or np_embeddings.shape[0] != len(batch):
                 raise ValueError(f"Expected embedding shape ({batch_size}, embedding_dim), got {np_embeddings.shape}")
@@ -298,10 +293,7 @@ class HuggingFaceAPIDocumentEmbedder:
         async def _runner(batch: list[str]) -> list[list[float]]:
             async with sem:
                 np_embeddings = await self._async_client.feature_extraction(
-                    # this method does not officially support list of strings, but works as expected
-                    text=batch,  # type: ignore[arg-type]
-                    truncate=truncate,
-                    normalize=normalize,
+                    text=batch, truncate=truncate, normalize=normalize
                 )
 
                 if np_embeddings.ndim != 2 or np_embeddings.shape[0] != len(batch):


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This PR removes unnecessary `# type: ignore[arg-type]` annotations from `HuggingFaceAPIDocumentEmbedder`. With the newest release of Hugging Face Hub client, [`feature_extraction` allows `list[str]` for the `text` parameter](https://github.com/huggingface/huggingface_hub/blob/3d199070555cc5a73703a131383d5bccd49ea4a0/src/huggingface_hub/inference/_client.py#L1026).

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
```
hatch run test:types 
```

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
