### PR TITLE
docs(ollama): add streaming-with-tools example to OllamaChatGenerator reference

### DIFF
--- a/docs-website/docs/pipeline-components/generators/ollamachatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/ollamachatgenerator.mdx
@@ -130,10 +130,6 @@ print(assistant_message.tool_calls)
 # -> [ToolCall(tool_name='get_weather', arguments={'city': 'Berlin'}, ...)]
 ```
 
-:::tip[What to expect when tools fire]
-When the model emits a tool call rather than free-form text, streamed chunks carry `tool_calls` deltas and `chunk.content` is empty. The final `replies[0].text` will be `None`, and `replies[0].tool_calls` holds the reconstructed call list. Plain text streaming and tool calling are mutually exclusive within a single generation step.
-:::
-
 You can use the built-in `print_streaming_chunk` callback (which handles both text tokens and tool events) instead of writing your own.
 
 ## Usage

--- a/docs-website/docs/pipeline-components/generators/ollamachatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/ollamachatgenerator.mdx
@@ -88,6 +88,54 @@ See our [Streaming Support](guides-to-generators/choosing-the-right-generator.md
 
 Give preference to `print_streaming_chunk` by default. Write a custom callback only if you need a specific transport (for example, SSE/WebSocket) or custom UI formatting.
 
+### Streaming with Tools
+
+You can combine streaming with tool calling. Pass both `tools` and `streaming_callback`; when the model decides to invoke a tool, the streamed chunks carry tool-call deltas instead of text tokens, and the final reconstructed `ChatMessage` exposes the resolved `tool_calls` list on `replies[0]`.
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack.dataclasses.streaming_chunk import StreamingChunk
+from haystack.tools import create_tool_from_function
+from haystack_integrations.components.generators.ollama import OllamaChatGenerator
+
+
+def get_weather(city: str) -> str:
+    """Get current weather for a city."""
+    return f"Sunny, 22°C in {city}"
+
+
+def callback(chunk: StreamingChunk) -> None:
+    if chunk.tool_calls:
+        print(f"[tool delta] {chunk.tool_calls}")
+    elif chunk.content:
+        print(chunk.content, end="", flush=True)
+
+
+generator = OllamaChatGenerator(
+    model="llama3.1:8b",
+    generation_kwargs={"temperature": 0.0},
+    tools=[create_tool_from_function(get_weather)],
+    streaming_callback=callback,
+)
+
+response = generator.run(
+    messages=[ChatMessage.from_user(
+        "What's the weather in Berlin? Use the get_weather tool."
+    )]
+)
+
+# Final reconstructed message: tool_calls populated, text is None
+assistant_message = response["replies"][0]
+print(assistant_message.tool_calls)
+# -> [ToolCall(tool_name='get_weather', arguments={'city': 'Berlin'}, ...)]
+```
+
+:::tip[What to expect when tools fire]
+When the model emits a tool call rather than free-form text, streamed chunks carry `tool_calls` deltas and `chunk.content` is empty. The final `replies[0].text` will be `None`, and `replies[0].tool_calls` holds the reconstructed call list. Plain text streaming and tool calling are mutually exclusive within a single generation step.
+:::
+
+You can use the built-in `print_streaming_chunk` callback (which handles both text tokens and tool events) instead of writing your own.
+
 ## Usage
 
 1. You need a running instance of Ollama. The installation instructions are [in the Ollama GitHub repository](https://github.com/jmorganca/ollama).

--- a/docs-website/versioned_docs/version-2.28/pipeline-components/generators/ollamachatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.28/pipeline-components/generators/ollamachatgenerator.mdx
@@ -87,6 +87,50 @@ See our [Streaming Support](guides-to-generators/choosing-the-right-generator.md
 
 Give preference to `print_streaming_chunk` by default. Write a custom callback only if you need a specific transport (for example, SSE/WebSocket) or custom UI formatting.
 
+### Streaming with Tools
+
+You can combine streaming with tool calling. Pass both `tools` and `streaming_callback`; when the model decides to invoke a tool, the streamed chunks carry tool-call deltas instead of text tokens, and the final reconstructed `ChatMessage` exposes the resolved `tool_calls` list on `replies[0]`.
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack.dataclasses.streaming_chunk import StreamingChunk
+from haystack.tools import create_tool_from_function
+from haystack_integrations.components.generators.ollama import OllamaChatGenerator
+
+
+def get_weather(city: str) -> str:
+    """Get current weather for a city."""
+    return f"Sunny, 22°C in {city}"
+
+
+def callback(chunk: StreamingChunk) -> None:
+    if chunk.tool_calls:
+        print(f"[tool delta] {chunk.tool_calls}")
+    elif chunk.content:
+        print(chunk.content, end="", flush=True)
+
+
+generator = OllamaChatGenerator(
+    model="llama3.1:8b",
+    generation_kwargs={"temperature": 0.0},
+    tools=[create_tool_from_function(get_weather)],
+    streaming_callback=callback,
+)
+
+response = generator.run(
+    messages=[ChatMessage.from_user(
+        "What's the weather in Berlin? Use the get_weather tool."
+    )]
+)
+
+# Final reconstructed message: tool_calls populated, text is None
+assistant_message = response["replies"][0]
+print(assistant_message.tool_calls)
+# -> [ToolCall(tool_name='get_weather', arguments={'city': 'Berlin'}, ...)]
+```
+
+You can use the built-in `print_streaming_chunk` callback (which handles both text tokens and tool events) instead of writing your own.
+
 ## Usage
 
 1. You need a running instance of Ollama. The installation instructions are [in the Ollama GitHub repository](https://github.com/jmorganca/ollama).

--- a/releasenotes/notes/streaming-with-tools-ollamachatgenerator-docs-8e339d62f38ebd06.yaml
+++ b/releasenotes/notes/streaming-with-tools-ollamachatgenerator-docs-8e339d62f38ebd06.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Document the combined use of streaming and tool calling in ``OllamaChatGenerator``: pass both ``streaming_callback`` and ``tools`` to receive ``tool_calls`` deltas through the streaming callback, and read the reconstructed call list from ``replies[0].tool_calls`` once the run returns. The component reference page now includes an executable example and notes that, within a single generation step, streamed text tokens and tool-call deltas are mutually exclusive (when the model invokes a tool, ``chunk.content`` is empty and ``replies[0].text`` is ``None``).

--- a/releasenotes/notes/streaming-with-tools-ollamachatgenerator-docs-8e339d62f38ebd06.yaml
+++ b/releasenotes/notes/streaming-with-tools-ollamachatgenerator-docs-8e339d62f38ebd06.yaml
@@ -1,4 +1,0 @@
----
-enhancements:
-  - |
-    Document the combined use of streaming and tool calling in ``OllamaChatGenerator``: pass both ``streaming_callback`` and ``tools`` to receive ``tool_calls`` deltas through the streaming callback, and read the reconstructed call list from ``replies[0].tool_calls`` once the run returns. The component reference page now includes an executable example and notes that, within a single generation step, streamed text tokens and tool-call deltas are mutually exclusive (when the model invokes a tool, ``chunk.content`` is empty and ``replies[0].text`` is ``None``).


### PR DESCRIPTION
### Related Issues

- fixes deepset-ai/haystack-core-integrations#3263 (follow-up; landing-page example landed in deepset-ai/haystack-integrations#473)

### Proposed Changes:

Adds a `### Streaming with Tools` section to the `OllamaChatGenerator` reference page (`docs-website/docs/pipeline-components/generators/ollamachatgenerator.mdx`), between the existing `### Streaming` section and the `## Usage` heading.

The section includes:
- An executable example combining `streaming_callback` and `tools` on `OllamaChatGenerator`.
- A behavioral note: within a single generation step, streamed text tokens and tool-call deltas are mutually exclusive. When the model invokes a tool, `chunk.content` is empty in the streamed chunks, and the final `replies[0].text` is `None` while `replies[0].tool_calls` carries the reconstructed call list.

### How did you test it?

Manually verified against `OllamaChatGenerator + llama3.1:8b` on Ollama, with two spike scripts:

1. **Primary spike** (directive prompt invoking `get_weather`): 2 chunks fired (1 carrying the tool-call delta, 1 closing). `replies[0].tool_calls = [ToolCall(tool_name='get_weather', arguments={'city': 'Berlin'}, ...)]`. `replies[0].text` is `None`. `meta.finish_reason: stop`.

2. **Backfill spike** (mutual-exclusivity check): six prompts spanning directive / ambiguous / arithmetic / unrelated-topic / literary. Across all six, never observed text content and tool-call deltas in the same chunk, nor text and `tool_calls` together in the final `ChatMessage`. The arithmetic prompt ("What is 2+2?") produced 99 chunks of pure text (98 text-chunks, 0 tool-chunks), confirming text streaming works as expected when the model elects not to use a tool.

The change is documentation-only and does not introduce code changes; no unit-test additions apply.

### Notes for the reviewer

- The PR follows up on deepset-ai/haystack-core-integrations#3263 and the companion PR deepset-ai/haystack-integrations#473 (which adds a separate, simpler tool-calling example to the integration landing page). I authored both.
- Conventional commit title: `docs(ollama): ...`.
- Release note: `releasenotes/notes/streaming-with-tools-ollamachatgenerator-docs-8e339d62f38ebd06.yaml` (single-entry `enhancements`, RST inline code, matches the shape of prior docs-only release notes).

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes (deepset-ai/haystack-core-integrations#3263 thread updated when each PR opened).
- [ ] I have added unit tests and updated the docstrings. — N/A, docs-only PR.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `docs:`.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [ ] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue. — Not run; this PR touches only `docs-website/docs/.../*.mdx` and `releasenotes/notes/*.yaml`. Happy to run pre-commit if a maintainer flags anything.