### PR TITLE
docs(brave): add BraveWebSearch component page and websearch entry

### DIFF
--- a/docs-website/docs/pipeline-components/websearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch.mdx
@@ -11,6 +11,7 @@ Use these components to look up answers on the internet.
 
 | Name                                           | Description                        |
 | --- | --- |
+| [BraveWebSearch](websearch/bravewebsearch.mdx) | Search engine using the Brave Search API. |
 | [FirecrawlWebSearch](websearch/firecrawlwebsearch.mdx) | Search engine using the Firecrawl API. |
 | [SearchApiWebSearch](websearch/searchapiwebsearch.mdx) | Search engine using Search API.    |
 | [SerperDevWebSearch](websearch/serperdevwebsearch.mdx) | Search engine using SerperDev API. |

--- a/docs-website/docs/pipeline-components/websearch/bravewebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/bravewebsearch.mdx
@@ -1,0 +1,103 @@
+---
+title: "BraveWebSearch"
+id: bravewebsearch
+slug: "/bravewebsearch"
+description: "Search engine using the Brave Search API."
+---
+
+# BraveWebSearch
+
+Search the web using the Brave Search API.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | Before a [`ChatPromptBuilder`](../builders/chatpromptbuilder.mdx) or right at the beginning of an indexing pipeline |
+| **Mandatory init variables** | `api_key`: The Brave Search API key. Can be set with the `BRAVE_API_KEY` env var. |
+| **Mandatory run variables** | `query`: A string with your search query. |
+| **Output variables** | `documents`: A list of Haystack Documents containing search result content and metadata. <br /> <br />`links`: A list of strings of resulting URLs. |
+| **API reference** | [Brave Search API](/reference/integrations-brave) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/brave/src/haystack_integrations/components/websearch/brave/brave_websearch.py |
+
+</div>
+
+## Overview
+
+When you give `BraveWebSearch` a query, it uses the [Brave Search API](https://brave.com/search/api/) to search the web and return relevant content as Haystack `Document` objects. It also returns a list of the source URLs.
+
+Brave Search is an independent search engine with its own web index. It is a great fit for RAG pipelines that need reliable, privacy-focused web results without depending on Google or Bing.
+
+`BraveWebSearch` requires a Brave Search API key to work. By default, it looks for a `BRAVE_API_KEY` environment variable. Alternatively, you can pass an `api_key` directly during initialization.
+
+## Usage
+
+### On its own
+
+Here is a quick example of how `BraveWebSearch` searches the web based on a query and returns a list of Documents.
+
+```python
+from haystack_integrations.components.websearch.brave import BraveWebSearch
+from haystack.utils import Secret
+
+web_search = BraveWebSearch(
+    api_key=Secret.from_env_var("BRAVE_API_KEY"),
+    top_k=5,
+)
+query = "What is Haystack by deepset?"
+
+response = web_search.run(query=query)
+
+for doc in response["documents"]:
+    print(doc.content)
+```
+
+### In a pipeline
+
+Here is an example of a Retrieval-Augmented Generation (RAG) pipeline that uses `BraveWebSearch` to look up an answer on the web.
+
+```python
+from haystack import Pipeline
+from haystack.utils import Secret
+from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack_integrations.components.websearch.brave import BraveWebSearch
+from haystack.dataclasses import ChatMessage
+
+web_search = BraveWebSearch(
+    api_key=Secret.from_env_var("BRAVE_API_KEY"),
+    top_k=3,
+)
+
+prompt_template = [
+    ChatMessage.from_system("You are a helpful assistant."),
+    ChatMessage.from_user(
+        "Given the information below:\n"
+        "{% for document in documents %}{{ document.content }}\n{% endfor %}\n"
+        "Answer the following question: {{ query }}.\nAnswer:",
+    ),
+]
+
+prompt_builder = ChatPromptBuilder(
+    template=prompt_template,
+    required_variables={"query", "documents"},
+)
+
+llm = OpenAIChatGenerator(
+    api_key=Secret.from_env_var("OPENAI_API_KEY"),
+)
+
+pipe = Pipeline()
+pipe.add_component("search", web_search)
+pipe.add_component("prompt_builder", prompt_builder)
+pipe.add_component("llm", llm)
+
+pipe.connect("search.documents", "prompt_builder.documents")
+pipe.connect("prompt_builder.prompt", "llm.messages")
+
+query = "What is Haystack by deepset?"
+
+result = pipe.run(data={"search": {"query": query}, "prompt_builder": {"query": query}})
+
+print(result["llm"]["replies"][0].text)
+```

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -623,6 +623,7 @@ export default {
             id: 'pipeline-components/websearch'
           },
           items: [
+            'pipeline-components/websearch/bravewebsearch',
             'pipeline-components/websearch/firecrawlwebsearch',
             'pipeline-components/websearch/searchapiwebsearch',
             'pipeline-components/websearch/serperdevwebsearch',

--- a/docs-website/versioned_docs/version-2.28/pipeline-components/websearch.mdx
+++ b/docs-website/versioned_docs/version-2.28/pipeline-components/websearch.mdx
@@ -11,6 +11,7 @@ Use these components to look up answers on the internet.
 
 | Name                                           | Description                        |
 | --- | --- |
+| [BraveWebSearch](websearch/bravewebsearch.mdx) | Search engine using the Brave Search API. |
 | [FirecrawlWebSearch](websearch/firecrawlwebsearch.mdx) | Search engine using the Firecrawl API. |
 | [SearchApiWebSearch](websearch/searchapiwebsearch.mdx) | Search engine using Search API.    |
 | [SerperDevWebSearch](websearch/serperdevwebsearch.mdx) | Search engine using SerperDev API. |

--- a/docs-website/versioned_docs/version-2.28/pipeline-components/websearch/bravewebsearch.mdx
+++ b/docs-website/versioned_docs/version-2.28/pipeline-components/websearch/bravewebsearch.mdx
@@ -1,0 +1,103 @@
+---
+title: "BraveWebSearch"
+id: bravewebsearch
+slug: "/bravewebsearch"
+description: "Search engine using the Brave Search API."
+---
+
+# BraveWebSearch
+
+Search the web using the Brave Search API.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | Before a [`ChatPromptBuilder`](../builders/chatpromptbuilder.mdx) or right at the beginning of an indexing pipeline |
+| **Mandatory init variables** | `api_key`: The Brave Search API key. Can be set with the `BRAVE_API_KEY` env var. |
+| **Mandatory run variables** | `query`: A string with your search query. |
+| **Output variables** | `documents`: A list of Haystack Documents containing search result content and metadata. <br /> <br />`links`: A list of strings of resulting URLs. |
+| **API reference** | [Brave Search API](/reference/integrations-brave) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/brave/src/haystack_integrations/components/websearch/brave/brave_websearch.py |
+
+</div>
+
+## Overview
+
+When you give `BraveWebSearch` a query, it uses the [Brave Search API](https://brave.com/search/api/) to search the web and return relevant content as Haystack `Document` objects. It also returns a list of the source URLs.
+
+Brave Search is an independent search engine with its own web index. It is a great fit for RAG pipelines that need reliable, privacy-focused web results without depending on Google or Bing.
+
+`BraveWebSearch` requires a Brave Search API key to work. By default, it looks for a `BRAVE_API_KEY` environment variable. Alternatively, you can pass an `api_key` directly during initialization.
+
+## Usage
+
+### On its own
+
+Here is a quick example of how `BraveWebSearch` searches the web based on a query and returns a list of Documents.
+
+```python
+from haystack_integrations.components.websearch.brave import BraveWebSearch
+from haystack.utils import Secret
+
+web_search = BraveWebSearch(
+    api_key=Secret.from_env_var("BRAVE_API_KEY"),
+    top_k=5,
+)
+query = "What is Haystack by deepset?"
+
+response = web_search.run(query=query)
+
+for doc in response["documents"]:
+    print(doc.content)
+```
+
+### In a pipeline
+
+Here is an example of a Retrieval-Augmented Generation (RAG) pipeline that uses `BraveWebSearch` to look up an answer on the web.
+
+```python
+from haystack import Pipeline
+from haystack.utils import Secret
+from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack_integrations.components.websearch.brave import BraveWebSearch
+from haystack.dataclasses import ChatMessage
+
+web_search = BraveWebSearch(
+    api_key=Secret.from_env_var("BRAVE_API_KEY"),
+    top_k=3,
+)
+
+prompt_template = [
+    ChatMessage.from_system("You are a helpful assistant."),
+    ChatMessage.from_user(
+        "Given the information below:\n"
+        "{% for document in documents %}{{ document.content }}\n{% endfor %}\n"
+        "Answer the following question: {{ query }}.\nAnswer:",
+    ),
+]
+
+prompt_builder = ChatPromptBuilder(
+    template=prompt_template,
+    required_variables={"query", "documents"},
+)
+
+llm = OpenAIChatGenerator(
+    api_key=Secret.from_env_var("OPENAI_API_KEY"),
+)
+
+pipe = Pipeline()
+pipe.add_component("search", web_search)
+pipe.add_component("prompt_builder", prompt_builder)
+pipe.add_component("llm", llm)
+
+pipe.connect("search.documents", "prompt_builder.documents")
+pipe.connect("prompt_builder.prompt", "llm.messages")
+
+query = "What is Haystack by deepset?"
+
+result = pipe.run(data={"search": {"query": query}, "prompt_builder": {"query": query}})
+
+print(result["llm"]["replies"][0].text)
+```

--- a/docs-website/versioned_sidebars/version-2.28-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.28-sidebars.json
@@ -597,6 +597,7 @@
             "id": "pipeline-components/websearch"
           },
           "items": [
+            "pipeline-components/websearch/bravewebsearch",
             "pipeline-components/websearch/firecrawlwebsearch",
             "pipeline-components/websearch/searchapiwebsearch",
             "pipeline-components/websearch/serperdevwebsearch",


### PR DESCRIPTION
## Related Issues

deepset-ai/haystack-core-integrations#3236

## Proposed Changes

- New page: `docs-website/docs/pipeline-components/websearch/bravewebsearch.mdx`
- Added BraveWebSearch row to `docs-website/docs/pipeline-components/websearch.mdx`
- Updated `docs-website/sidebars.js` with the new page entry
- Mirrored all changes in `versioned_docs/version-2.28`

## How did you test it?

Followed the same structure as the existing `tavilywebsearch.mdx` page (PR #10954).

## Notes for the reviewer

This is the docs PR for the Brave Search integration, which is already merged and released in `haystack-core-integrations`. The companion integration tile PR is at deepset-ai/haystack-integrations.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) guidelines
- [x] I have updated the documentation if needed