### PR TITLE
chore: Add type checking to test/human_in_the_loop, test/evaluation, test/document_stores and test/dataclasses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ integration-only-slow = 'pytest --maxfail=5 -m "integration and slow" {args:test
 all = 'pytest {args:test}'
 
 # TODO We want to eventually type the whole test folder
-types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/}"
+types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/human_in_the_loop test/evaluation test/document_stores test/dataclasses}"
 
 [tool.hatch.envs.e2e]
 template = "test"

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -4,6 +4,7 @@
 
 import json
 import warnings
+from collections.abc import Sequence
 
 import pytest
 
@@ -306,7 +307,7 @@ class TestChatMessage:
 
     def test_from_assistant_with_invalid_reasoning(self):
         with pytest.raises(TypeError):
-            ChatMessage.from_assistant(text="text", reasoning=123)
+            ChatMessage.from_assistant(text="text", reasoning=123)  # type: ignore[arg-type]
 
     def test_from_user_with_valid_content(self):
         text = "I have a question."
@@ -354,7 +355,7 @@ class TestChatMessage:
         assert message.texts == [""]
 
     def test_from_user_with_content_parts(self, base64_image_string, base64_pdf_string):
-        content_parts = [
+        content_parts: list[TextContent | ImageContent | FileContent | str] = [
             TextContent(text="text"),
             ImageContent(base64_image=base64_image_string),
             FileContent(base64_data=base64_pdf_string),
@@ -393,7 +394,7 @@ class TestChatMessage:
     def test_from_user_with_content_parts_fails_unsupported_parts(self):
         with pytest.raises(TypeError):
             ChatMessage.from_user(
-                content_parts=["text part", ToolCall(id="123", tool_name="mytool", arguments={"a": 1})]
+                content_parts=["text part", ToolCall(id="123", tool_name="mytool", arguments={"a": 1})]  # type: ignore[list-item]
             )
 
     def test_from_user_with_content_parts_fails_with_empty_parts(self):
@@ -442,7 +443,10 @@ class TestChatMessage:
         assert not message.reasoning
 
     def test_from_tool_with_valid_mixed_content(self, base64_image_string):
-        tool_result = [TextContent(text="Hello"), ImageContent(base64_image=base64_image_string, mime_type="image/png")]
+        tool_result: list[TextContent | ImageContent] = [
+            TextContent(text="Hello"),
+            ImageContent(base64_image=base64_image_string, mime_type="image/png"),
+        ]
         message = ChatMessage.from_tool(
             tool_result=tool_result, origin=ToolCall(tool_name="mytool", arguments={}), error=False
         )
@@ -472,7 +476,10 @@ class TestChatMessage:
         assert len(message) == 2
 
     def test_mixed_content(self):
-        content = [TextContent(text="Hello"), ToolCall(id="123", tool_name="mytool", arguments={"a": 1})]
+        content: list[TextContent | ToolCall] = [
+            TextContent(text="Hello"),
+            ToolCall(id="123", tool_name="mytool", arguments={"a": 1}),
+        ]
 
         message = ChatMessage(_role=ChatRole.ASSISTANT, _content=content)
 
@@ -485,16 +492,16 @@ class TestChatMessage:
 
     def test_from_function_class_method_removed(self):
         with pytest.raises(AttributeError):
-            ChatMessage.from_function("Result of function invocation", "my_function")
+            ChatMessage.from_function("Result of function invocation", "my_function")  # type: ignore[attr-defined]
 
     def test_chat_message_content_attribute_removed(self):
         message = ChatMessage.from_user(text="This is a message")
         with pytest.raises(AttributeError):
-            message.content
+            message.content  # type: ignore[attr-defined]
 
     def test_chat_message_init_parameters_removed(self):
         with pytest.raises(TypeError):
-            ChatMessage(role="irrelevant", content="This is a message")
+            ChatMessage(role="irrelevant", content="This is a message")  # type: ignore[call-arg]
 
     def test_no_warning_on_init(self):
         with warnings.catch_warnings():
@@ -572,7 +579,7 @@ class TestChatMessageSerde:
         text_content = TextContent(text="Hello")
         invalid_content = "invalid"
 
-        message = ChatMessage(_role=ChatRole.ASSISTANT, _content=[text_content, invalid_content])
+        message = ChatMessage(_role=ChatRole.ASSISTANT, _content=[text_content, invalid_content])  # type: ignore[list-item]
 
         with pytest.raises(TypeError):
             message.to_dict()
@@ -888,7 +895,7 @@ class TestToOpenaiDictFormat:
         assert openai_msg == {"role": "tool", "content": "result"}
 
     def test_to_openai_dict_format_tool_message_list_with_unsupported_image(self, base64_image_string):
-        tool_result = [
+        tool_result: Sequence[TextContent | ImageContent] = [
             TextContent(text="first result"),
             ImageContent(base64_image=base64_image_string, mime_type="image/png"),
         ]
@@ -940,6 +947,7 @@ class TestFromOpenaiDictFormat:
         openai_msg = {"role": "tool", "content": "The weather is sunny", "tool_call_id": "call_123"}
         message = ChatMessage.from_openai_dict_format(openai_msg)
         assert message.role.value == "tool"
+        assert message.tool_call_result is not None
         assert message.tool_call_result.result == "The weather is sunny"
         assert message.tool_call_result.origin.id == "call_123"
 
@@ -951,6 +959,7 @@ class TestFromOpenaiDictFormat:
         }
         message = ChatMessage.from_openai_dict_format(openai_msg)
         assert message.role.value == "tool"
+        assert message.tool_call_result is not None
         assert message.tool_call_result.result == [TextContent(text="first result"), TextContent(text="second result")]
         assert message.tool_call_result.origin.id == "call_123"
 
@@ -958,6 +967,7 @@ class TestFromOpenaiDictFormat:
         openai_msg = {"role": "tool", "content": "The weather is sunny"}
         message = ChatMessage.from_openai_dict_format(openai_msg)
         assert message.role.value == "tool"
+        assert message.tool_call_result is not None
         assert message.tool_call_result.result == "The weather is sunny"
         assert message.tool_call_result.origin.id is None
 

--- a/test/dataclasses/test_document.py
+++ b/test/dataclasses/test_document.py
@@ -37,7 +37,7 @@ def test_init():
 
 def test_init_with_wrong_parameters():
     with pytest.raises(TypeError):
-        Document(text="")
+        Document(text="")  # type: ignore[call-arg]
 
 
 def test_init_with_parameters():
@@ -53,6 +53,7 @@ def test_init_with_parameters():
     )
     assert doc.id == "1aa43af57c1dbc317241bf55d3067049f334d3b458d95dc72f71a7111f6c1a56"
     assert doc.content == "test text"
+    assert doc.blob is not None
     assert doc.blob.data == blob_data
     assert doc.blob.mime_type == "text/markdown"
     assert doc.meta == {"text": "test text"}
@@ -88,7 +89,7 @@ def test_init_with_legacy_field():
     doc = Document(
         content="test text",
         content_type="text",  # type: ignore
-        id_hash_keys=["content"],  # type: ignore
+        id_hash_keys=["content"],
         score=0.812,
         embedding=[0.1, 0.2, 0.3],
         meta={"date": "10-10-2023", "type": "article"},
@@ -265,7 +266,7 @@ def test_from_dict_with_legacy_field_and_flat_meta():
     ) == Document(
         content="test text",
         content_type="text",  # type: ignore
-        id_hash_keys=["content"],  # type: ignore
+        id_hash_keys=["content"],
         score=0.812,
         embedding=[0.1, 0.2, 0.3],
         meta={"date": "10-10-2023", "type": "article"},

--- a/test/dataclasses/test_streaming_chunk.py
+++ b/test/dataclasses/test_streaming_chunk.py
@@ -15,6 +15,7 @@ from haystack.dataclasses import (
     ToolCallDelta,
     ToolCallResult,
 )
+from haystack.dataclasses.streaming_chunk import FinishReason
 
 
 @component
@@ -22,8 +23,8 @@ class ExampleComponent:
     def __init__(self):
         self.name = "test_component"
 
-    def run(self) -> str:
-        return "Test content"
+    def run(self) -> dict[str, str]:
+        return {"test": "Test content"}
 
 
 def test_create_chunk_with_content_and_metadata():
@@ -143,7 +144,7 @@ def test_create_chunk_with_finish_reason_and_meta():
 
 def test_finish_reason_standard_values():
     """Test all standard finish_reason values including the new Haystack-specific ones."""
-    standard_values = ["stop", "length", "tool_calls", "content_filter", "tool_call_results"]
+    standard_values: list[FinishReason] = ["stop", "length", "tool_calls", "content_filter", "tool_call_results"]
 
     for value in standard_values:
         chunk = StreamingChunk(content="Test content", finish_reason=value)
@@ -271,8 +272,10 @@ def test_from_dict_tool_call_result():
     assert chunk.content == ""
     assert chunk.meta == {"key": "value"}
     assert chunk.index == 0
+    assert chunk.component_info is not None
     assert chunk.component_info.type == "test_streaming_chunk.ExampleComponent"
     assert chunk.component_info.name == "test_component"
+    assert chunk.tool_call_result is not None
     assert chunk.tool_call_result.result == "output"
     assert chunk.tool_call_result.error is False
     assert chunk.tool_call_result.origin.id == "123"
@@ -298,8 +301,10 @@ def test_from_dict_tool_calls():
     assert chunk.content == ""
     assert chunk.meta == {"key": "value"}
     assert chunk.index == 0
+    assert chunk.component_info is not None
     assert chunk.component_info.type == "test_streaming_chunk.ExampleComponent"
     assert chunk.component_info.name == "test_component"
+    assert chunk.tool_calls is not None
     assert chunk.tool_calls[0].tool_name == "test_tool"
     assert chunk.tool_calls[0].index == 0
     assert chunk.finish_reason == "tool_calls"
@@ -325,8 +330,10 @@ def test_from_dict_reasoning():
     assert chunk.content == ""
     assert chunk.meta == {"key": "value"}
     assert chunk.index == 0
+    assert chunk.component_info is not None
     assert chunk.component_info.type == "test_streaming_chunk.ExampleComponent"
     assert chunk.component_info.name == "test_component"
+    assert chunk.reasoning is not None
     assert chunk.reasoning.reasoning_text == "thinking"
     assert chunk.reasoning.extra["step"] == 1
     assert chunk.finish_reason == "stop"

--- a/test/document_stores/test_filter_policy.py
+++ b/test/document_stores/test_filter_policy.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Literal
+
 import pytest
 
 from haystack.document_stores.types import FilterPolicy, apply_filter_policy
@@ -168,7 +170,7 @@ def test_merge_comparison_filters_with_same_field():
 
 
 @pytest.mark.parametrize("logical_operator", ["AND", "OR", "NOT"])
-def test_merge_with_custom_logical_operator(logical_operator: str):
+def test_merge_with_custom_logical_operator(logical_operator: Literal["AND", "OR", "NOT"]) -> None:
     """
     Merging with a custom logical operator
 

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -6,6 +6,7 @@ import asyncio
 import gc
 import logging
 import tempfile
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -126,12 +127,12 @@ class TestMemoryDocumentStore(
         }
         store = InMemoryDocumentStore.from_dict(data)
         mock_regex.compile.assert_called_with("custom_regex")
-        assert store.tokenizer
+        assert store.tokenizer is not None
         assert store.bm25_algorithm == "BM25Plus"
         assert store.bm25_parameters == {"key": "value"}
         assert store.index == "my_cool_index"
 
-    def test_save_to_disk_and_load_from_disk(self, in_memory_doc_store, tmp_dir: str):
+    def test_save_to_disk_and_load_from_disk(self, in_memory_doc_store: InMemoryDocumentStore, tmp_dir: str) -> None:
         docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]
         in_memory_doc_store.write_documents(docs)
         tmp_dir = tmp_dir + "/in_memory_doc_store.json"
@@ -144,7 +145,7 @@ class TestMemoryDocumentStore(
 
     def test_invalid_bm25_algorithm(self):
         with pytest.raises(ValueError, match="BM25 algorithm 'invalid' is not supported"):
-            InMemoryDocumentStore(bm25_algorithm="invalid")
+            InMemoryDocumentStore(bm25_algorithm="invalid")  # type: ignore[arg-type]
 
     def test_write_documents(self, document_store):
         docs = [Document(id="1")]
@@ -152,7 +153,7 @@ class TestMemoryDocumentStore(
         with pytest.raises(DuplicateDocumentError):
             document_store.write_documents(docs)
 
-    def test_bm25_retrieval(self, document_store: InMemoryDocumentStore):
+    def test_bm25_retrieval(self, document_store: InMemoryDocumentStore) -> None:
         # Tests if the bm25_retrieval method returns the correct document based on the input query.
         docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]
         document_store.write_documents(docs)
@@ -160,7 +161,9 @@ class TestMemoryDocumentStore(
         assert len(results) == 1
         assert results[0].content == "Haystack supports multiple languages"
 
-    def test_bm25_retrieval_with_empty_document_store(self, document_store: InMemoryDocumentStore, caplog):
+    def test_bm25_retrieval_with_empty_document_store(
+        self, document_store: InMemoryDocumentStore, caplog: pytest.LogCaptureFixture
+    ) -> None:
         caplog.set_level(logging.INFO)
         # Tests if the bm25_retrieval method correctly returns an empty list when there are no documents in the
         # DocumentStore.
@@ -168,14 +171,14 @@ class TestMemoryDocumentStore(
         assert len(results) == 0
         assert "No documents found for BM25 retrieval. Returning empty list." in caplog.text
 
-    def test_bm25_retrieval_empty_query(self, document_store: InMemoryDocumentStore):
+    def test_bm25_retrieval_empty_query(self, document_store: InMemoryDocumentStore) -> None:
         # Tests if the bm25_retrieval method returns a document when the query is an empty string.
         docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]
         document_store.write_documents(docs)
         with pytest.raises(ValueError, match="Query should be a non-empty string"):
             document_store.bm25_retrieval(query="", top_k=1)
 
-    def test_bm25_retrieval_with_different_top_k(self, document_store: InMemoryDocumentStore):
+    def test_bm25_retrieval_with_different_top_k(self, document_store: InMemoryDocumentStore) -> None:
         # Tests if the bm25_retrieval method correctly changes the number of returned documents
         # based on the top_k parameter.
         docs = [
@@ -206,7 +209,7 @@ class TestMemoryDocumentStore(
         assert len(results) == 1
         assert results[0].content == "Python is a popular programming language"
 
-    def test_bm25_retrieval_with_two_queries(self, document_store: InMemoryDocumentStore):
+    def test_bm25_retrieval_with_two_queries(self, document_store: InMemoryDocumentStore) -> None:
         # Tests if the bm25_retrieval method returns different documents for different queries.
         docs = [
             Document(content="Javascript is a popular programming language"),
@@ -225,7 +228,7 @@ class TestMemoryDocumentStore(
 
     # Test a query, add a new document and make sure results are appropriately updated
 
-    def test_bm25_retrieval_with_updated_docs(self, document_store: InMemoryDocumentStore):
+    def test_bm25_retrieval_with_updated_docs(self, document_store: InMemoryDocumentStore) -> None:
         # Tests if the bm25_retrieval method correctly updates the retrieved documents when new
         # documents are added to the DocumentStore.
         docs = [Document(content="Hello world")]
@@ -244,7 +247,7 @@ class TestMemoryDocumentStore(
         assert len(results) == 1
         assert results[0].content == "Python is a popular programming language"
 
-    def test_bm25_retrieval_with_scale_score(self, document_store: InMemoryDocumentStore):
+    def test_bm25_retrieval_with_scale_score(self, document_store: InMemoryDocumentStore) -> None:
         docs = [Document(content="Python programming"), Document(content="Java programming")]
         document_store.write_documents(docs)
 
@@ -284,13 +287,13 @@ class TestMemoryDocumentStore(
 
         results1 = document_store.bm25_retrieval(query="Haystack installation", top_k=10, scale_score=False)
         assert len(results1) == 3
-        assert all(res.score < 0.0 for res in results1)
+        assert all(res.score < 0.0 for res in results1 if res.score)
 
         results2 = document_store.bm25_retrieval(query="Haystack installation", top_k=10, scale_score=True)
         assert len(results2) == 3
-        assert all(0.0 <= res.score <= 1.0 for res in results2)
+        assert all(0.0 <= res.score <= 1.0 for res in results2 if res.score)
 
-    def test_bm25_retrieval_default_filter(self, document_store: InMemoryDocumentStore):
+    def test_bm25_retrieval_default_filter(self, document_store: InMemoryDocumentStore) -> None:
         docs = [Document(), Document(content="Gardening"), Document(content="Bird watching")]
         document_store.write_documents(docs)
         results = document_store.bm25_retrieval(query="doesn't matter, top_k is 10", top_k=10)
@@ -355,7 +358,7 @@ class TestMemoryDocumentStore(
         with pytest.raises(ValueError, match="query_embedding should be a non-empty list of floats"):
             in_memory_doc_store.embedding_retrieval(query_embedding=[])
         with pytest.raises(ValueError, match="query_embedding should be a non-empty list of floats"):
-            in_memory_doc_store.embedding_retrieval(query_embedding=["invalid", "list", "of", "strings"])  # type: ignore
+            in_memory_doc_store.embedding_retrieval(query_embedding=["invalid", "list", "of", "strings"])
 
     def test_embedding_retrieval_no_embeddings(self, in_memory_doc_store, caplog):
         caplog.set_level(logging.WARNING)
@@ -496,14 +499,14 @@ class TestMemoryDocumentStore(
     # Test async/await methods and concurrency
 
     @pytest.mark.asyncio
-    async def test_write_documents_async(self, document_store: InMemoryDocumentStore):
+    async def test_write_documents_async(self, document_store: InMemoryDocumentStore) -> None:
         docs = [Document(id="1")]
         assert await document_store.write_documents_async(docs) == 1
         with pytest.raises(DuplicateDocumentError):
             await document_store.write_documents_async(docs)
 
     @pytest.mark.asyncio
-    async def test_filter_documents(self, document_store: InMemoryDocumentStore):
+    async def test_filter_documents(self, document_store: InMemoryDocumentStore) -> None:
         filterable_docs = [Document(content="1", meta={"number": -10}), Document(content="2", meta={"number": 100})]
         await document_store.write_documents_async(filterable_docs)
         result = await document_store.filter_documents_async(
@@ -514,7 +517,7 @@ class TestMemoryDocumentStore(
         )
 
     @pytest.mark.asyncio
-    async def test_bm25_retrieval_async(self, document_store: InMemoryDocumentStore):
+    async def test_bm25_retrieval_async(self, document_store: InMemoryDocumentStore) -> None:
         # Tests if the bm25_retrieval method returns the correct document based on the input query.
         docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]
         await document_store.write_documents_async(docs)
@@ -537,7 +540,7 @@ class TestMemoryDocumentStore(
         assert results[0].content == "Haystack supports multiple languages"
 
     @pytest.mark.asyncio
-    async def test_concurrent_bm25_retrievals(self, document_store: InMemoryDocumentStore):
+    async def test_concurrent_bm25_retrievals(self, document_store: InMemoryDocumentStore) -> None:
         # Test multiple concurrent BM25 retrievals
         docs = [
             Document(content="Python is a popular programming language"),
@@ -587,7 +590,7 @@ class TestMemoryDocumentStore(
             assert result[0].content == expected
 
     @pytest.mark.asyncio
-    async def test_mixed_concurrent_operations(self, document_store: InMemoryDocumentStore):
+    async def test_mixed_concurrent_operations(self, document_store: InMemoryDocumentStore) -> None:
         # Test a mix of concurrent operations including writes and retrievals
         docs = [
             Document(content="First document"),
@@ -603,7 +606,7 @@ class TestMemoryDocumentStore(
             document_store.bm25_retrieval_async(query="Fourth", top_k=1),
             document_store.filter_documents_async(),
         ]
-        results = await asyncio.gather(*tasks)
+        results = cast(tuple[list[Document], int, list[Document], list[Document]], await asyncio.gather(*tasks))
 
         # Verify results
         assert len(results[0]) == 1  # First retrieval
@@ -612,7 +615,7 @@ class TestMemoryDocumentStore(
         assert len(results[3]) == 4  # Filter operation
 
     @pytest.mark.asyncio
-    async def test_concurrent_operations_with_errors(self, document_store: InMemoryDocumentStore):
+    async def test_concurrent_operations_with_errors(self, document_store: InMemoryDocumentStore) -> None:
         # Test concurrent operations where some might fail
         docs = [Document(content="Test document")]
         await document_store.write_documents_async(docs)
@@ -629,7 +632,7 @@ class TestMemoryDocumentStore(
             await asyncio.gather(*tasks)
 
     @pytest.mark.asyncio
-    async def test_concurrent_operations_with_large_dataset(self, document_store: InMemoryDocumentStore):
+    async def test_concurrent_operations_with_large_dataset(self, document_store: InMemoryDocumentStore) -> None:
         # Test concurrent operations with a larger dataset
         # Create 100 documents with different content
         docs = [Document(content=f"Document {i} content") for i in range(100)]

--- a/test/evaluation/test_eval_run_result.py
+++ b/test/evaluation/test_eval_run_result.py
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any
+
 import pytest
+from pandas import DataFrame
 
 from haystack.evaluation import EvaluationRunResult
 
 
 def test_init_results_evaluator():
-    data = {
+    data: dict[str, dict[str, Any]] = {
         "inputs": {
             "query_id": ["53c3b3e6", "225f87f7"],
             "question": ["What is the capital of France?", "What is the capital of Spain?"],
@@ -70,7 +73,7 @@ def test_init_results_evaluator():
 
 
 def test_score_report():
-    data = {
+    data: dict[str, dict[str, Any]] = {
         "inputs": {
             "query_id": ["53c3b3e6", "225f87f7"],
             "question": ["What is the capital of France?", "What is the capital of Spain?"],
@@ -107,7 +110,7 @@ def test_score_report():
 
 
 def test_to_df():
-    data = {
+    data: dict[str, dict[str, Any]] = {
         "inputs": {
             "query_id": ["53c3b3e6", "225f87f7", "53c3b3e6", "225f87f7"],
             "question": [
@@ -154,7 +157,7 @@ def test_to_df():
 
 
 def test_comparative_individual_scores_report():
-    data_1 = {
+    data_1: dict[str, dict[str, Any]] = {
         "inputs": {
             "query_id": ["53c3b3e6", "225f87f7"],
             "question": ["What is the capital of France?", "What is the capital of Spain?"],
@@ -172,7 +175,7 @@ def test_comparative_individual_scores_report():
         },
     }
 
-    data_2 = {
+    data_2: dict[str, dict[str, Any]] = {
         "inputs": {
             "query_id": ["53c3b3e6", "225f87f7"],
             "question": ["What is the capital of France?", "What is the capital of Spain?"],
@@ -194,6 +197,7 @@ def test_comparative_individual_scores_report():
     result2 = EvaluationRunResult("testing_pipeline_2", inputs=data_2["inputs"], results=data_2["metrics"])
     results = result1.comparative_detailed_report(result2, keep_columns=["predicted_answer"])
 
+    assert isinstance(results, DataFrame)
     assert list(results.keys()) == [
         "query_id",
         "question",

--- a/test/evaluation/test_eval_run_result.py
+++ b/test/evaluation/test_eval_run_result.py
@@ -5,7 +5,6 @@
 from typing import Any
 
 import pytest
-from pandas import DataFrame
 
 from haystack.evaluation import EvaluationRunResult
 
@@ -197,7 +196,7 @@ def test_comparative_individual_scores_report():
     result2 = EvaluationRunResult("testing_pipeline_2", inputs=data_2["inputs"], results=data_2["metrics"])
     results = result1.comparative_detailed_report(result2, keep_columns=["predicted_answer"])
 
-    assert isinstance(results, DataFrame)
+    assert isinstance(results, dict)
     assert list(results.keys()) == [
         "query_id",
         "question",


### PR DESCRIPTION
### Related Issues

- partially addresses #10396

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds type checking to test/human_in_the_loop, test/evaluation, test/document_stores and test/dataclasses.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Re-ran unit, integration and type checking tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
