### PR TITLE
docs: add Context7 verification file for docs site

### DIFF
--- a/docs-website/static/docs/context7.json
+++ b/docs-website/static/docs/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/websites/haystack_deepset_ai",
+  "public_key": "pk_NBN5TVMCHF3kizc2thzwX"
+}


### PR DESCRIPTION
### Related Issues

Similar to PRs in Haystack and Hayhooks, this PR temporarily adds a file for claiming ownership of https://context7.com/websites/haystack_deepset_ai
- https://github.com/deepset-ai/haystack/pull/11008
- https://github.com/deepset-ai/haystack/pull/11014
- https://github.com/deepset-ai/hayhooks/pull/244

This allows us to configure context7 for Hayhooks via the context7 web UI. I will delete the temporary file right after claiming ownership is completed.

### Proposed Changes:

- Adds `static/docs/context7.json` so it is served at `https://docs.haystack.deepset.ai/docs/context7.json`

### How did you test it?
Vercel preview shows the file as expected: https://haystack-docs-git-feat-add-context7-json-deepset-ai.vercel.app/docs/context7.json


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)