### PR TITLE
docs: remove Context7 verification file

### DIFF
--- a/docs-website/static/docs/context7.json
+++ b/docs-website/static/docs/context7.json
@@ -1,4 +1,0 @@
-{
-  "url": "https://context7.com/websites/haystack_deepset_ai",
-  "public_key": "pk_NBN5TVMCHF3kizc2thzwX"
-}


### PR DESCRIPTION
### Related Issues

- Context7 authentication was successfully completed and the verification file is no longer needed

### Proposed Changes:

- Reverts #11288 (commit 6c5b587b7c344a12e8d0d0d60852e701e1896325)

### How did you test it?
Vercel preview does not show the file any longer, which is expected: https://haystack-docs-git-revert-context7-verification-file-deepset-ai.vercel.app/docs/context7.json


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)