### PR TITLE
fix: avoid in-place mutation of ExtractedAnswer in ExtractiveReader

### DIFF
--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -323,7 +323,7 @@ class ExtractiveReader:
 
     def _add_answer_page_number(self, answer: ExtractedAnswer) -> ExtractedAnswer:
         if answer.meta is None:
-            answer.meta = {}
+            answer = replace(answer, meta={})
 
         if answer.document_offset is None:
             return answer

--- a/releasenotes/notes/fix-extractive-reader-inplace-mutation-53436ea625324943.yaml
+++ b/releasenotes/notes/fix-extractive-reader-inplace-mutation-53436ea625324943.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed in-place mutation of ``ExtractedAnswer.meta`` in
+    ``ExtractiveReader._add_answer_page_number`` when the answer's ``meta``
+    was ``None``. Now uses ``dataclasses.replace`` to avoid triggering the
+    dataclass mutation warning.

--- a/test/components/readers/test_extractive.py
+++ b/test/components/readers/test_extractive.py
@@ -486,6 +486,26 @@ def test_add_answer_page_number_returns_same_answer(mock_reader: ExtractiveReade
         assert "page_number must be int" in caplog.text
 
 
+def test_add_answer_page_number_with_none_meta(mock_reader: ExtractiveReader):
+    # when answer.meta is None, it should be initialized to {} without triggering a mutation warning
+    document = Document(content="I thought a lot about this. The answer is 42.", meta={"page_number": 5})
+    answer = ExtractedAnswer(
+        data="42",
+        query="What is the answer?",
+        document=document,
+        score=1.0,
+        document_offset=ExtractedAnswer.Span(42, 44),
+        meta=None,
+    )
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = mock_reader._add_answer_page_number(answer=answer)
+    assert result.meta is not None
+    assert "answer_page_number" in result.meta
+
+
 def test_add_answer_page_number_with_form_feed(mock_reader: ExtractiveReader):
     document = Document(
         content="I thought a lot about this. \f And this document is long. \f The answer is 42.",

--- a/test/components/readers/test_extractive.py
+++ b/test/components/readers/test_extractive.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import warnings
 from math import ceil, exp
 from unittest.mock import Mock, patch
 
@@ -497,7 +498,6 @@ def test_add_answer_page_number_with_none_meta(mock_reader: ExtractiveReader):
         document_offset=ExtractedAnswer.Span(42, 44),
         meta=None,
     )
-    import warnings
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")


### PR DESCRIPTION
### Related Issues
- Related to #10564 (epic) and #10659 (closed sweep that missed this site)

### Proposed Changes
`ExtractiveReader._add_answer_page_number` did `answer.meta = {}` when the
incoming answer had `meta=None`. That triggers the in-place mutation warning
added in #10650. Replaced with `dataclasses.replace(answer, meta={})`.

The earlier sweep in #10659 caught `extractive.py:393` but missed line 323,
so this fills that gap.

### How did you test it?
Added `test_add_answer_page_number_with_none_meta` which calls the method
with `meta=None` inside `warnings.simplefilter("error")`, so any mutation
warning fails the test. Also ran `hatch run test:unit test/components/readers/test_extractive.py`
locally.

### Notes for the reviewer
While looking around I noticed a few sites that mutate dict contents on
input parameters (e.g. `doc.meta["x"] = y`). The current warning only catches
attribute reassignment, so these don't fire it:

- `haystack/components/preprocessors/hierarchical_document_splitter.py:78`
  mutates `document.meta` on an input `Document`
- `haystack/components/generators/chat/hugging_face_api.py:617,688`
  mutates `message.meta["usage"]` on an input `ChatMessage`
- `haystack/components/audio/whisper_remote.py:155` mutates `source.meta`
  (This one is probably fine since `source` is constructed two lines above but just mentioning it)

Not sure if dict-content mutations are in scope for #10564. Happy to open
follow-up PRs if any of these are worth fixing.

### Checklist
- [x] Read contributing guidelines and code of conduct
- [x] Added unit tests
- [x] Conventional commit title (`fix:`)
- [x] Release note added
- [x] Ran pre-commit hooks / quality checks locally
