### PR TITLE
fix: support run_async for sync-backed super components

### DIFF
--- a/haystack/core/super_component/super_component.py
+++ b/haystack/core/super_component/super_component.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import functools
 from pathlib import Path
 from types import new_class
@@ -141,15 +142,20 @@ class _SuperComponent:
         :param kwargs: Keyword arguments matching the SuperComponent's input names
         :returns:
             Dictionary containing the SuperComponent's output values
-        :raises TypeError:
-            If the pipeline is not an AsyncPipeline
         """
-        if not isinstance(self.pipeline, AsyncPipeline):
-            raise TypeError("Pipeline is not an AsyncPipeline. run_async is not supported.")
-
         filtered_inputs = {param: value for param, value in kwargs.items() if value != _delegate_default}
         pipeline_inputs = self._map_explicit_inputs(input_mapping=self.input_mapping, inputs=filtered_inputs)
-        pipeline_outputs = await self.pipeline.run_async(data=pipeline_inputs)
+        include_outputs_from = self._get_include_outputs_from()
+
+        if isinstance(self.pipeline, AsyncPipeline):
+            pipeline_outputs = await self.pipeline.run_async(
+                data=pipeline_inputs, include_outputs_from=include_outputs_from
+            )
+        else:
+            pipeline_outputs = await asyncio.to_thread(
+                self.pipeline.run, data=pipeline_inputs, include_outputs_from=include_outputs_from
+            )
+
         return self._map_explicit_outputs(pipeline_outputs, self.output_mapping)
 
     @staticmethod

--- a/releasenotes/notes/fix-supercomponent-run-async-with-sync-pipeline-81c95a2e1b8d4f1a.yaml
+++ b/releasenotes/notes/fix-supercomponent-run-async-with-sync-pipeline-81c95a2e1b8d4f1a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed ``SuperComponent.run_async`` for sync-backed super components by running the wrapped ``Pipeline`` in a
+    worker thread. This prevents runtime failures for components such as ``DocumentPreprocessor`` when ``run_async``
+    is called.

--- a/test/components/preprocessors/test_document_preprocessor.py
+++ b/test/components/preprocessors/test_document_preprocessor.py
@@ -132,3 +132,20 @@ class TestDocumentPreprocessor:
         processed_docs = result["documents"]
         assert len(processed_docs) == 3  # Should be split into 3 sentences
         assert all("." not in doc.content for doc in processed_docs)  # Each doc should be a single sentence
+
+    @pytest.mark.asyncio
+    async def test_run_async(self, preprocessor: DocumentPreprocessor) -> None:
+        documents = [
+            Document(content="This is a test document. It has multiple sentences."),
+            Document(content="Another test document with some content."),
+        ]
+
+        result = await preprocessor.run_async(documents=documents)
+
+        assert "documents" in result
+        processed_docs = result["documents"]
+        assert len(processed_docs) > len(documents)
+        for doc in processed_docs:
+            assert doc.content.strip() == doc.content
+            assert len(doc.content.split()) <= 3
+            assert doc.id is not None

--- a/test/core/super_component/test_super_component.py
+++ b/test/core/super_component/test_super_component.py
@@ -252,6 +252,16 @@ class TestSuperComponent:
         assert "final_answers" in result
         assert isinstance(result["final_answers"][0], GeneratedAnswer)
 
+    @pytest.mark.asyncio
+    async def test_super_component_run_async_with_sync_pipeline(self, rag_pipeline):
+        input_mapping = {"search_query": ["retriever.query", "prompt_builder.query", "answer_builder.query"]}
+        output_mapping = {"answer_builder.answers": "final_answers"}
+        wrapper = SuperComponent(pipeline=rag_pipeline, input_mapping=input_mapping, output_mapping=output_mapping)
+        wrapper.warm_up()
+        result = await wrapper.run_async(search_query="What is the capital of France?")
+        assert "final_answers" in result
+        assert isinstance(result["final_answers"][0], GeneratedAnswer)
+
     def test_wrapper_serialization(self, document_store):
         """Test serialization and deserialization of pipeline wrapper."""
         pipeline = Pipeline()


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
