### PR TITLE
docs: Add documentation for AlloyDB doc store and retrievers

### DIFF
--- a/docs-website/docs/document-stores/alloydbdocumentstore.mdx
+++ b/docs-website/docs/document-stores/alloydbdocumentstore.mdx
@@ -1,0 +1,100 @@
+---
+title: "AlloyDBDocumentStore"
+id: alloydbdocumentstore
+slug: "/alloydbdocumentstore"
+---
+
+# AlloyDBDocumentStore
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| API reference | [AlloyDB](/reference/integrations-alloydb)                                              |
+| GitHub link   | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/alloydb |
+
+</div>
+
+[AlloyDB](https://cloud.google.com/alloydb) is a fully managed, PostgreSQL-compatible database service on Google Cloud. The `AlloyDBDocumentStore` uses the [pgvector extension](https://cloud.google.com/alloydb/docs/ai/work-with-embeddings) to perform vector similarity search.
+
+Connection is handled securely via the [AlloyDB Python Connector](https://github.com/GoogleCloudPlatform/alloydb-python-connector), which provides TLS encryption and IAM-based authorization without requiring manual SSL certificate management, firewall rules, or IP allowlisting.
+
+The `AlloyDBDocumentStore` supports embedding retrieval, keyword retrieval, and metadata filtering.
+
+## Installation
+
+Install the `alloydb-haystack` integration:
+
+```shell
+pip install alloydb-haystack
+```
+
+To set up an AlloyDB cluster and instance, follow the [AlloyDB quickstart](https://cloud.google.com/alloydb/docs/quickstart).
+
+## Usage
+
+### Authentication
+
+The `AlloyDBDocumentStore` uses [Secrets](/secret-management) and reads connection details from environment variables by default:
+
+- `ALLOYDB_INSTANCE_URI`: the AlloyDB instance URI in the format `projects/PROJECT/locations/REGION/clusters/CLUSTER/instances/INSTANCE`.
+- `ALLOYDB_USER`: the database user. When using IAM database authentication, use the service account email (omitting `.gserviceaccount.com`) or the full IAM user email.
+- `ALLOYDB_PASSWORD`: the database password. Not required when `enable_iam_auth=True`.
+
+```shell
+export ALLOYDB_INSTANCE_URI="projects/MY_PROJECT/locations/MY_REGION/clusters/MY_CLUSTER/instances/MY_INSTANCE"
+export ALLOYDB_USER="my-db-user"
+export ALLOYDB_PASSWORD="my-db-password"
+```
+
+To authenticate with IAM instead of a password, set `enable_iam_auth=True` and grant the IAM principal the AlloyDB Client role. See the [AlloyDB IAM authentication documentation](https://cloud.google.com/alloydb/docs/manage-iam-authn) for details.
+
+## Initialization
+
+Initialize an `AlloyDBDocumentStore` and write Documents to it. Connection to AlloyDB is established lazily on first use, and the table that stores Haystack Documents is created automatically if it doesn't exist:
+
+```python
+from haystack import Document
+from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
+
+document_store = AlloyDBDocumentStore(
+    db="my-database",
+    embedding_dimension=768,
+    vector_function="cosine_similarity",
+    recreate_table=True,
+)
+
+document_store.write_documents(
+    [
+        Document(content="This is first", embedding=[0.1] * 768),
+        Document(content="This is second", embedding=[0.3] * 768),
+    ],
+)
+print(document_store.count_documents())
+```
+
+To learn more about the initialization parameters, see our [API docs](/reference/integrations-alloydb#alloydbdocumentstore).
+
+To compute embeddings for your Documents, you can use a Document Embedder, such as the [`SentenceTransformersDocumentEmbedder`](../pipeline-components/embedders/sentencetransformersdocumentembedder.mdx).
+
+### Search Strategy
+
+The `AlloyDBDocumentStore` supports two search strategies for embedding retrieval:
+
+- `"exact_nearest_neighbor"` (default): provides perfect recall but can be slow on large numbers of documents.
+- `"hnsw"`: an approximate nearest neighbor search strategy that trades off some accuracy for speed. Recommended for large numbers of documents.
+
+When using `"hnsw"`, an index is created based on the `vector_function` you choose, so subsequent queries should keep using the same vector similarity function in order to take advantage of the index. You can tune index creation through `hnsw_index_creation_kwargs` (see the [pgvector documentation](https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw)).
+
+### Metadata Filtering
+
+The `AlloyDBDocumentStore` fully supports comparison operators (`==`, `!=`, `>`, `>=`, `<`, `<=`, `in`, `not in`, `like`, `not like`) and the logical operators `AND` and `OR`. The `like` and `not like` operators are PostgreSQL-specific extensions to the standard Haystack filter syntax and map to the SQL `LIKE` / `NOT LIKE` pattern-matching operators.
+
+The `NOT` logical operator is **not** supported. Because every comparison operator already has a negated counterpart (`==`/`!=`, `in`/`not in`, `like`/`not like`), any filter expressible with `NOT` around a single condition can be rewritten by inverting the comparison operator instead. To negate a nested `AND`/`OR` group, apply De Morgan's laws — for example, `NOT (A AND B)` becomes `(NOT A) OR (NOT B)`, where each `NOT A` / `NOT B` is expressed via the inverted comparison.
+
+For more details on filter syntax, refer to [Metadata Filtering](/metadata-filtering).
+
+### Supported Retrievers
+
+- [`AlloyDBEmbeddingRetriever`](../pipeline-components/retrievers/alloydbembeddingretriever.mdx): An embedding-based Retriever that fetches Documents from the Document Store based on a query embedding.
+- [`AlloyDBKeywordRetriever`](../pipeline-components/retrievers/alloydbkeywordretriever.mdx): A keyword-based Retriever that fetches Documents matching a query using PostgreSQL full-text search.

--- a/docs-website/docs/document-stores/alloydbdocumentstore.mdx
+++ b/docs-website/docs/document-stores/alloydbdocumentstore.mdx
@@ -35,7 +35,7 @@ To set up an AlloyDB cluster and instance, follow the [AlloyDB quickstart](https
 
 ### Authentication
 
-The `AlloyDBDocumentStore` uses [Secrets](/secret-management) and reads connection details from environment variables by default:
+The `AlloyDBDocumentStore` uses [Secrets](../concepts/secret-management.mdx) and reads connection details from environment variables by default:
 
 - `ALLOYDB_INSTANCE_URI`: the AlloyDB instance URI in the format `projects/PROJECT/locations/REGION/clusters/CLUSTER/instances/INSTANCE`.
 - `ALLOYDB_USER`: the database user. When using IAM database authentication, use the service account email (omitting `.gserviceaccount.com`) or the full IAM user email.
@@ -92,7 +92,7 @@ The `AlloyDBDocumentStore` fully supports comparison operators (`==`, `!=`, `>`,
 
 The `NOT` logical operator is **not** supported. Because every comparison operator already has a negated counterpart (`==`/`!=`, `in`/`not in`, `like`/`not like`), any filter expressible with `NOT` around a single condition can be rewritten by inverting the comparison operator instead. To negate a nested `AND`/`OR` group, apply De Morgan's laws — for example, `NOT (A AND B)` becomes `(NOT A) OR (NOT B)`, where each `NOT A` / `NOT B` is expressed via the inverted comparison.
 
-For more details on filter syntax, refer to [Metadata Filtering](/metadata-filtering).
+For more details on filter syntax, refer to [Metadata Filtering](../concepts/metadata-filtering.mdx).
 
 ### Supported Retrievers
 

--- a/docs-website/docs/pipeline-components/retrievers.mdx
+++ b/docs-website/docs/pipeline-components/retrievers.mdx
@@ -153,6 +153,8 @@ For details on how to initialize and use a Retriever in a pipeline, see the docu
 
 | Component | Description |
 | --- | --- |
+| [AlloyDBEmbeddingRetriever](retrievers/alloydbembeddingretriever.mdx)             | An embedding-based Retriever compatible with the AlloyDB Document Store.                                                        |
+| [AlloyDBKeywordRetriever](retrievers/alloydbkeywordretriever.mdx)                 | A keyword-based Retriever that fetches Documents matching a query from the AlloyDB Document Store.                              |
 | [ArcadeDBEmbeddingRetriever](retrievers/arcadedbembeddingretriever.mdx)            | An embedding-based Retriever compatible with the ArcadeDB Document Store.                                                       |
 | [AstraEmbeddingRetriever](retrievers/astraretriever.mdx)                          | An embedding-based Retriever compatible with the AstraDocumentStore.                                                            |
 | [AutoMergingRetriever](retrievers/automergingretriever.mdx)                         | Retrieves complete parent documents instead of fragmented chunks when multiple related pieces match a query.                    |

--- a/docs-website/docs/pipeline-components/retrievers/alloydbembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/alloydbembeddingretriever.mdx
@@ -1,0 +1,119 @@
+---
+title: "AlloyDBEmbeddingRetriever"
+id: alloydbembeddingretriever
+slug: "/alloydbembeddingretriever"
+description: "An embedding-based Retriever compatible with the AlloyDB Document Store."
+---
+
+# AlloyDBEmbeddingRetriever
+
+An embedding-based Retriever compatible with the AlloyDB Document Store.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | 1. After a Text Embedder and before a [`PromptBuilder`](../builders/promptbuilder.mdx)   in a RAG pipeline 2. The last component in the semantic search pipeline 3. After a Text Embedder and before an [`ExtractiveReader`](../readers/extractivereader.mdx)   in an extractive QA pipeline |
+| **Mandatory init variables**           | `document_store`: An instance of an [AlloyDBDocumentStore](../../document-stores/alloydbdocumentstore.mdx)                                                                                                                                                                                       |
+| **Mandatory run variables**            | `query_embedding`: A vector representing the query (a list of floats)                                                                                                                                                                                                       |
+| **Output variables**                   | `documents`: A list of documents                                                                                                                                                                                                                                            |
+| **API reference**                      | [AlloyDB](/reference/integrations-alloydb)                                                                                                                                                                                                                                  |
+| **GitHub link**                        | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/alloydb                                                                                                                                                                                     |
+| **Package name** | `alloydb-haystack` |
+
+</div>
+
+## Overview
+
+The `AlloyDBEmbeddingRetriever` is an embedding-based Retriever compatible with the `AlloyDBDocumentStore`. It compares the query and Document embeddings and fetches the Documents most relevant to the query from the `AlloyDBDocumentStore` based on the outcome.
+
+When using the `AlloyDBEmbeddingRetriever` in your Pipeline, make sure it has the query and Document embeddings available. You can do so by adding a Document Embedder to your indexing Pipeline and a Text Embedder to your query Pipeline.
+
+In addition to the `query_embedding`, the `AlloyDBEmbeddingRetriever` accepts other optional parameters, including `top_k` (the maximum number of Documents to retrieve), `filters` to narrow down the search space, and `vector_function` to override the similarity function set on the Document Store.
+
+Some relevant parameters that impact embedding retrieval must be defined when the corresponding `AlloyDBDocumentStore` is initialized: these include `embedding_dimension`, `vector_function`, and the search strategy (`"exact_nearest_neighbor"` or `"hnsw"`).
+
+## Installation
+
+Install the `alloydb-haystack` integration:
+
+```shell
+pip install alloydb-haystack
+```
+
+To set up an AlloyDB cluster and instance, follow the [AlloyDB quickstart](https://cloud.google.com/alloydb/docs/quickstart).
+
+## Usage
+
+### On its own
+
+This Retriever needs the `AlloyDBDocumentStore` and indexed Documents to run.
+
+Set the `ALLOYDB_INSTANCE_URI`, `ALLOYDB_USER`, and `ALLOYDB_PASSWORD` environment variables to connect to your AlloyDB instance.
+
+```python
+from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
+from haystack_integrations.components.retrievers.alloydb import (
+    AlloyDBEmbeddingRetriever,
+)
+
+document_store = AlloyDBDocumentStore()
+retriever = AlloyDBEmbeddingRetriever(document_store=document_store)
+
+## using a fake vector to keep the example simple
+retriever.run(query_embedding=[0.1] * 768)
+```
+
+### In a Pipeline
+
+```python
+from haystack import Document, Pipeline
+from haystack.document_stores.types import DuplicatePolicy
+from haystack.components.embedders import (
+    SentenceTransformersTextEmbedder,
+    SentenceTransformersDocumentEmbedder,
+)
+
+from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
+from haystack_integrations.components.retrievers.alloydb import (
+    AlloyDBEmbeddingRetriever,
+)
+
+document_store = AlloyDBDocumentStore(
+    embedding_dimension=768,
+    vector_function="cosine_similarity",
+    recreate_table=True,
+)
+
+documents = [
+    Document(content="There are over 7,000 languages spoken around the world today."),
+    Document(
+        content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors.",
+    ),
+    Document(
+        content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves.",
+    ),
+]
+
+document_embedder = SentenceTransformersDocumentEmbedder()
+documents_with_embeddings = document_embedder.run(documents)
+
+document_store.write_documents(
+    documents_with_embeddings.get("documents"),
+    policy=DuplicatePolicy.OVERWRITE,
+)
+
+query_pipeline = Pipeline()
+query_pipeline.add_component("text_embedder", SentenceTransformersTextEmbedder())
+query_pipeline.add_component(
+    "retriever",
+    AlloyDBEmbeddingRetriever(document_store=document_store),
+)
+query_pipeline.connect("text_embedder.embedding", "retriever.query_embedding")
+
+query = "How many languages are there?"
+
+result = query_pipeline.run({"text_embedder": {"text": query}})
+
+print(result["retriever"]["documents"][0])
+```

--- a/docs-website/docs/pipeline-components/retrievers/alloydbkeywordretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/alloydbkeywordretriever.mdx
@@ -1,0 +1,143 @@
+---
+title: "AlloyDBKeywordRetriever"
+id: alloydbkeywordretriever
+slug: "/alloydbkeywordretriever"
+description: "A keyword-based Retriever that fetches documents matching a query from the AlloyDB Document Store."
+---
+
+# AlloyDBKeywordRetriever
+
+A keyword-based Retriever that fetches documents matching a query from the AlloyDB Document Store.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | 1. Before a [`PromptBuilder`](../builders/promptbuilder.mdx)   in a RAG pipeline 2. The last component in the semantic search pipeline 3. Before an [`ExtractiveReader`](../readers/extractivereader.mdx)   in an extractive QA pipeline |
+| **Mandatory init variables**           | `document_store`: An instance of an [AlloyDBDocumentStore](../../document-stores/alloydbdocumentstore.mdx)                                                                                                                                  |
+| **Mandatory run variables**            | `query`:  A string                                                                                                                                                                                                     |
+| **Output variables**                   | `documents`: A list of documents (matching the query)                                                                                                                                                                  |
+| **API reference**                      | [AlloyDB](/reference/integrations-alloydb)                                                                                                                                                                                  |
+| **GitHub link**                        | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/alloydb                                                                                                                             |
+| **Package name** | `alloydb-haystack` |
+
+</div>
+
+## Overview
+
+The `AlloyDBKeywordRetriever` is a keyword-based Retriever compatible with the `AlloyDBDocumentStore`.
+
+It uses PostgreSQL full-text search (`to_tsvector` / `plainto_tsquery`) to find Documents and ranks them with `ts_rank_cd`. The ranking considers how often the query terms appear in the Document, how close together the terms are, and how important the part of the Document is where they occur. For more details, see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-RANKING).
+
+Keep in mind that, unlike similar components such as `ElasticsearchBM25Retriever`, this Retriever does not apply fuzzy search out of the box, so it’s necessary to carefully formulate the query in order to avoid getting zero results.
+
+The language used to parse query and Document content for keyword retrieval is set via the `language` parameter on the `AlloyDBDocumentStore` (defaults to `"english"`). To list the supported languages on your database, run:
+
+```sql
+SELECT cfgname FROM pg_ts_config;
+```
+
+In addition to the `query`, the `AlloyDBKeywordRetriever` accepts other optional parameters, including `top_k` (the maximum number of Documents to retrieve) and `filters` to narrow the search space.
+
+## Installation
+
+Install the `alloydb-haystack` integration:
+
+```shell
+pip install alloydb-haystack
+```
+
+To set up an AlloyDB cluster and instance, follow the [AlloyDB quickstart](https://cloud.google.com/alloydb/docs/quickstart).
+
+## Usage
+
+### On its own
+
+This Retriever needs the `AlloyDBDocumentStore` and indexed Documents to run.
+
+Set the `ALLOYDB_INSTANCE_URI`, `ALLOYDB_USER`, and `ALLOYDB_PASSWORD` environment variables to connect to your AlloyDB instance.
+
+```python
+from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
+from haystack_integrations.components.retrievers.alloydb import (
+    AlloyDBKeywordRetriever,
+)
+
+document_store = AlloyDBDocumentStore()
+retriever = AlloyDBKeywordRetriever(document_store=document_store)
+
+retriever.run(query="my nice query")
+```
+
+### In a RAG pipeline
+
+The prerequisites necessary for running this code are:
+
+- Set an environment variable `OPENAI_API_KEY` with your OpenAI API key.
+- Set the `ALLOYDB_INSTANCE_URI`, `ALLOYDB_USER`, and `ALLOYDB_PASSWORD` environment variables to connect to your AlloyDB instance.
+
+```python
+from haystack import Document, Pipeline
+from haystack.components.builders.answer_builder import AnswerBuilder
+from haystack.components.builders.prompt_builder import PromptBuilder
+from haystack.components.generators import OpenAIGenerator
+from haystack.document_stores.types import DuplicatePolicy
+
+from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
+from haystack_integrations.components.retrievers.alloydb import (
+    AlloyDBKeywordRetriever,
+)
+
+## Create a RAG query pipeline
+prompt_template = """
+    Given these documents, answer the question.\nDocuments:
+    {% for doc in documents %}
+        {{ doc.content }}
+    {% endfor %}
+
+    \nQuestion: {{question}}
+    \nAnswer:
+    """
+
+document_store = AlloyDBDocumentStore(
+    language="english",  # this parameter influences text parsing for keyword retrieval
+    recreate_table=True,
+)
+
+documents = [
+    Document(content="There are over 7,000 languages spoken around the world today."),
+    Document(
+        content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors.",
+    ),
+    Document(
+        content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves.",
+    ),
+]
+
+document_store.write_documents(documents=documents, policy=DuplicatePolicy.SKIP)
+
+retriever = AlloyDBKeywordRetriever(document_store=document_store)
+rag_pipeline = Pipeline()
+rag_pipeline.add_component(name="retriever", instance=retriever)
+rag_pipeline.add_component(
+    instance=PromptBuilder(template=prompt_template),
+    name="prompt_builder",
+)
+rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
+rag_pipeline.connect("retriever", "prompt_builder.documents")
+rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("llm.replies", "answer_builder.replies")
+rag_pipeline.connect("llm.meta", "answer_builder.meta")
+rag_pipeline.connect("retriever", "answer_builder.documents")
+
+question = "languages spoken around the world today"
+result = rag_pipeline.run(
+    {
+        "retriever": {"query": question},
+        "prompt_builder": {"question": question},
+        "answer_builder": {"query": question},
+    },
+)
+print(result["answer_builder"])
+```

--- a/docs-website/docs/pipeline-components/retrievers/alloydbkeywordretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/alloydbkeywordretriever.mdx
@@ -79,8 +79,9 @@ The prerequisites necessary for running this code are:
 ```python
 from haystack import Document, Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
 from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
@@ -89,15 +90,14 @@ from haystack_integrations.components.retrievers.alloydb import (
 )
 
 ## Create a RAG query pipeline
-prompt_template = """
-    Given these documents, answer the question.\nDocuments:
-    {% for doc in documents %}
-        {{ doc.content }}
-    {% endfor %}
-
-    \nQuestion: {{question}}
-    \nAnswer:
-    """
+prompt_template = [
+    ChatMessage.from_system("You are a helpful assistant."),
+    ChatMessage.from_user(
+        "Given these documents, answer the question.\nDocuments:\n"
+        "{% for doc in documents %}{{ doc.content }}{% endfor %}\n"
+        "Question: {{question}}\nAnswer:",
+    ),
+]
 
 document_store = AlloyDBDocumentStore(
     language="english",  # this parameter influences text parsing for keyword retrieval
@@ -120,15 +120,17 @@ retriever = AlloyDBKeywordRetriever(document_store=document_store)
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(name="retriever", instance=retriever)
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(
+        template=prompt_template,
+        required_variables={"question", "documents"},
+    ),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.messages", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.meta", "answer_builder.meta")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "languages spoken around the world today"

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -104,6 +104,7 @@ export default {
       label: 'Document Stores',
       items: [
         'document-stores/inmemorydocumentstore',
+        'document-stores/alloydbdocumentstore',
         'document-stores/arcadedbdocumentstore',
         'document-stores/astradocumentstore',
         'document-stores/azureaisearchdocumentstore',
@@ -537,6 +538,8 @@ export default {
             id: 'pipeline-components/retrievers'
           },
           items: [
+            'pipeline-components/retrievers/alloydbembeddingretriever',
+            'pipeline-components/retrievers/alloydbkeywordretriever',
             'pipeline-components/retrievers/arcadedbembeddingretriever',
             'pipeline-components/retrievers/astraretriever',
             'pipeline-components/retrievers/automergingretriever',

--- a/docs-website/versioned_docs/version-2.29/document-stores/alloydbdocumentstore.mdx
+++ b/docs-website/versioned_docs/version-2.29/document-stores/alloydbdocumentstore.mdx
@@ -1,0 +1,100 @@
+---
+title: "AlloyDBDocumentStore"
+id: alloydbdocumentstore
+slug: "/alloydbdocumentstore"
+---
+
+# AlloyDBDocumentStore
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| API reference | [AlloyDB](/reference/integrations-alloydb)                                              |
+| GitHub link   | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/alloydb |
+
+</div>
+
+[AlloyDB](https://cloud.google.com/alloydb) is a fully managed, PostgreSQL-compatible database service on Google Cloud. The `AlloyDBDocumentStore` uses the [pgvector extension](https://cloud.google.com/alloydb/docs/ai/work-with-embeddings) to perform vector similarity search.
+
+Connection is handled securely via the [AlloyDB Python Connector](https://github.com/GoogleCloudPlatform/alloydb-python-connector), which provides TLS encryption and IAM-based authorization without requiring manual SSL certificate management, firewall rules, or IP allowlisting.
+
+The `AlloyDBDocumentStore` supports embedding retrieval, keyword retrieval, and metadata filtering.
+
+## Installation
+
+Install the `alloydb-haystack` integration:
+
+```shell
+pip install alloydb-haystack
+```
+
+To set up an AlloyDB cluster and instance, follow the [AlloyDB quickstart](https://cloud.google.com/alloydb/docs/quickstart).
+
+## Usage
+
+### Authentication
+
+The `AlloyDBDocumentStore` uses [Secrets](/secret-management) and reads connection details from environment variables by default:
+
+- `ALLOYDB_INSTANCE_URI`: the AlloyDB instance URI in the format `projects/PROJECT/locations/REGION/clusters/CLUSTER/instances/INSTANCE`.
+- `ALLOYDB_USER`: the database user. When using IAM database authentication, use the service account email (omitting `.gserviceaccount.com`) or the full IAM user email.
+- `ALLOYDB_PASSWORD`: the database password. Not required when `enable_iam_auth=True`.
+
+```shell
+export ALLOYDB_INSTANCE_URI="projects/MY_PROJECT/locations/MY_REGION/clusters/MY_CLUSTER/instances/MY_INSTANCE"
+export ALLOYDB_USER="my-db-user"
+export ALLOYDB_PASSWORD="my-db-password"
+```
+
+To authenticate with IAM instead of a password, set `enable_iam_auth=True` and grant the IAM principal the AlloyDB Client role. See the [AlloyDB IAM authentication documentation](https://cloud.google.com/alloydb/docs/manage-iam-authn) for details.
+
+## Initialization
+
+Initialize an `AlloyDBDocumentStore` and write Documents to it. Connection to AlloyDB is established lazily on first use, and the table that stores Haystack Documents is created automatically if it doesn't exist:
+
+```python
+from haystack import Document
+from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
+
+document_store = AlloyDBDocumentStore(
+    db="my-database",
+    embedding_dimension=768,
+    vector_function="cosine_similarity",
+    recreate_table=True,
+)
+
+document_store.write_documents(
+    [
+        Document(content="This is first", embedding=[0.1] * 768),
+        Document(content="This is second", embedding=[0.3] * 768),
+    ],
+)
+print(document_store.count_documents())
+```
+
+To learn more about the initialization parameters, see our [API docs](/reference/integrations-alloydb#alloydbdocumentstore).
+
+To compute embeddings for your Documents, you can use a Document Embedder, such as the [`SentenceTransformersDocumentEmbedder`](../pipeline-components/embedders/sentencetransformersdocumentembedder.mdx).
+
+### Search Strategy
+
+The `AlloyDBDocumentStore` supports two search strategies for embedding retrieval:
+
+- `"exact_nearest_neighbor"` (default): provides perfect recall but can be slow on large numbers of documents.
+- `"hnsw"`: an approximate nearest neighbor search strategy that trades off some accuracy for speed. Recommended for large numbers of documents.
+
+When using `"hnsw"`, an index is created based on the `vector_function` you choose, so subsequent queries should keep using the same vector similarity function in order to take advantage of the index. You can tune index creation through `hnsw_index_creation_kwargs` (see the [pgvector documentation](https://github.com/pgvector/pgvector?tab=readme-ov-file#hnsw)).
+
+### Metadata Filtering
+
+The `AlloyDBDocumentStore` fully supports comparison operators (`==`, `!=`, `>`, `>=`, `<`, `<=`, `in`, `not in`, `like`, `not like`) and the logical operators `AND` and `OR`. The `like` and `not like` operators are PostgreSQL-specific extensions to the standard Haystack filter syntax and map to the SQL `LIKE` / `NOT LIKE` pattern-matching operators.
+
+The `NOT` logical operator is **not** supported. Because every comparison operator already has a negated counterpart (`==`/`!=`, `in`/`not in`, `like`/`not like`), any filter expressible with `NOT` around a single condition can be rewritten by inverting the comparison operator instead. To negate a nested `AND`/`OR` group, apply De Morgan's laws — for example, `NOT (A AND B)` becomes `(NOT A) OR (NOT B)`, where each `NOT A` / `NOT B` is expressed via the inverted comparison.
+
+For more details on filter syntax, refer to [Metadata Filtering](/metadata-filtering).
+
+### Supported Retrievers
+
+- [`AlloyDBEmbeddingRetriever`](../pipeline-components/retrievers/alloydbembeddingretriever.mdx): An embedding-based Retriever that fetches Documents from the Document Store based on a query embedding.
+- [`AlloyDBKeywordRetriever`](../pipeline-components/retrievers/alloydbkeywordretriever.mdx): A keyword-based Retriever that fetches Documents matching a query using PostgreSQL full-text search.

--- a/docs-website/versioned_docs/version-2.29/document-stores/alloydbdocumentstore.mdx
+++ b/docs-website/versioned_docs/version-2.29/document-stores/alloydbdocumentstore.mdx
@@ -35,7 +35,7 @@ To set up an AlloyDB cluster and instance, follow the [AlloyDB quickstart](https
 
 ### Authentication
 
-The `AlloyDBDocumentStore` uses [Secrets](/secret-management) and reads connection details from environment variables by default:
+The `AlloyDBDocumentStore` uses [Secrets](../concepts/secret-management.mdx) and reads connection details from environment variables by default:
 
 - `ALLOYDB_INSTANCE_URI`: the AlloyDB instance URI in the format `projects/PROJECT/locations/REGION/clusters/CLUSTER/instances/INSTANCE`.
 - `ALLOYDB_USER`: the database user. When using IAM database authentication, use the service account email (omitting `.gserviceaccount.com`) or the full IAM user email.
@@ -92,7 +92,7 @@ The `AlloyDBDocumentStore` fully supports comparison operators (`==`, `!=`, `>`,
 
 The `NOT` logical operator is **not** supported. Because every comparison operator already has a negated counterpart (`==`/`!=`, `in`/`not in`, `like`/`not like`), any filter expressible with `NOT` around a single condition can be rewritten by inverting the comparison operator instead. To negate a nested `AND`/`OR` group, apply De Morgan's laws — for example, `NOT (A AND B)` becomes `(NOT A) OR (NOT B)`, where each `NOT A` / `NOT B` is expressed via the inverted comparison.
 
-For more details on filter syntax, refer to [Metadata Filtering](/metadata-filtering).
+For more details on filter syntax, refer to [Metadata Filtering](../concepts/metadata-filtering.mdx).
 
 ### Supported Retrievers
 

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers.mdx
@@ -153,6 +153,8 @@ For details on how to initialize and use a Retriever in a pipeline, see the docu
 
 | Component | Description |
 | --- | --- |
+| [AlloyDBEmbeddingRetriever](retrievers/alloydbembeddingretriever.mdx)             | An embedding-based Retriever compatible with the AlloyDB Document Store.                                                        |
+| [AlloyDBKeywordRetriever](retrievers/alloydbkeywordretriever.mdx)                 | A keyword-based Retriever that fetches Documents matching a query from the AlloyDB Document Store.                              |
 | [ArcadeDBEmbeddingRetriever](retrievers/arcadedbembeddingretriever.mdx)            | An embedding-based Retriever compatible with the ArcadeDB Document Store.                                                       |
 | [AstraEmbeddingRetriever](retrievers/astraretriever.mdx)                          | An embedding-based Retriever compatible with the AstraDocumentStore.                                                            |
 | [AutoMergingRetriever](retrievers/automergingretriever.mdx)                         | Retrieves complete parent documents instead of fragmented chunks when multiple related pieces match a query.                    |

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/alloydbembeddingretriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/alloydbembeddingretriever.mdx
@@ -1,0 +1,119 @@
+---
+title: "AlloyDBEmbeddingRetriever"
+id: alloydbembeddingretriever
+slug: "/alloydbembeddingretriever"
+description: "An embedding-based Retriever compatible with the AlloyDB Document Store."
+---
+
+# AlloyDBEmbeddingRetriever
+
+An embedding-based Retriever compatible with the AlloyDB Document Store.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | 1. After a Text Embedder and before a [`PromptBuilder`](../builders/promptbuilder.mdx)   in a RAG pipeline 2. The last component in the semantic search pipeline 3. After a Text Embedder and before an [`ExtractiveReader`](../readers/extractivereader.mdx)   in an extractive QA pipeline |
+| **Mandatory init variables**           | `document_store`: An instance of an [AlloyDBDocumentStore](../../document-stores/alloydbdocumentstore.mdx)                                                                                                                                                                                       |
+| **Mandatory run variables**            | `query_embedding`: A vector representing the query (a list of floats)                                                                                                                                                                                                       |
+| **Output variables**                   | `documents`: A list of documents                                                                                                                                                                                                                                            |
+| **API reference**                      | [AlloyDB](/reference/integrations-alloydb)                                                                                                                                                                                                                                  |
+| **GitHub link**                        | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/alloydb                                                                                                                                                                                     |
+| **Package name** | `alloydb-haystack` |
+
+</div>
+
+## Overview
+
+The `AlloyDBEmbeddingRetriever` is an embedding-based Retriever compatible with the `AlloyDBDocumentStore`. It compares the query and Document embeddings and fetches the Documents most relevant to the query from the `AlloyDBDocumentStore` based on the outcome.
+
+When using the `AlloyDBEmbeddingRetriever` in your Pipeline, make sure it has the query and Document embeddings available. You can do so by adding a Document Embedder to your indexing Pipeline and a Text Embedder to your query Pipeline.
+
+In addition to the `query_embedding`, the `AlloyDBEmbeddingRetriever` accepts other optional parameters, including `top_k` (the maximum number of Documents to retrieve), `filters` to narrow down the search space, and `vector_function` to override the similarity function set on the Document Store.
+
+Some relevant parameters that impact embedding retrieval must be defined when the corresponding `AlloyDBDocumentStore` is initialized: these include `embedding_dimension`, `vector_function`, and the search strategy (`"exact_nearest_neighbor"` or `"hnsw"`).
+
+## Installation
+
+Install the `alloydb-haystack` integration:
+
+```shell
+pip install alloydb-haystack
+```
+
+To set up an AlloyDB cluster and instance, follow the [AlloyDB quickstart](https://cloud.google.com/alloydb/docs/quickstart).
+
+## Usage
+
+### On its own
+
+This Retriever needs the `AlloyDBDocumentStore` and indexed Documents to run.
+
+Set the `ALLOYDB_INSTANCE_URI`, `ALLOYDB_USER`, and `ALLOYDB_PASSWORD` environment variables to connect to your AlloyDB instance.
+
+```python
+from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
+from haystack_integrations.components.retrievers.alloydb import (
+    AlloyDBEmbeddingRetriever,
+)
+
+document_store = AlloyDBDocumentStore()
+retriever = AlloyDBEmbeddingRetriever(document_store=document_store)
+
+## using a fake vector to keep the example simple
+retriever.run(query_embedding=[0.1] * 768)
+```
+
+### In a Pipeline
+
+```python
+from haystack import Document, Pipeline
+from haystack.document_stores.types import DuplicatePolicy
+from haystack.components.embedders import (
+    SentenceTransformersTextEmbedder,
+    SentenceTransformersDocumentEmbedder,
+)
+
+from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
+from haystack_integrations.components.retrievers.alloydb import (
+    AlloyDBEmbeddingRetriever,
+)
+
+document_store = AlloyDBDocumentStore(
+    embedding_dimension=768,
+    vector_function="cosine_similarity",
+    recreate_table=True,
+)
+
+documents = [
+    Document(content="There are over 7,000 languages spoken around the world today."),
+    Document(
+        content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors.",
+    ),
+    Document(
+        content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves.",
+    ),
+]
+
+document_embedder = SentenceTransformersDocumentEmbedder()
+documents_with_embeddings = document_embedder.run(documents)
+
+document_store.write_documents(
+    documents_with_embeddings.get("documents"),
+    policy=DuplicatePolicy.OVERWRITE,
+)
+
+query_pipeline = Pipeline()
+query_pipeline.add_component("text_embedder", SentenceTransformersTextEmbedder())
+query_pipeline.add_component(
+    "retriever",
+    AlloyDBEmbeddingRetriever(document_store=document_store),
+)
+query_pipeline.connect("text_embedder.embedding", "retriever.query_embedding")
+
+query = "How many languages are there?"
+
+result = query_pipeline.run({"text_embedder": {"text": query}})
+
+print(result["retriever"]["documents"][0])
+```

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/alloydbkeywordretriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/alloydbkeywordretriever.mdx
@@ -1,0 +1,143 @@
+---
+title: "AlloyDBKeywordRetriever"
+id: alloydbkeywordretriever
+slug: "/alloydbkeywordretriever"
+description: "A keyword-based Retriever that fetches documents matching a query from the AlloyDB Document Store."
+---
+
+# AlloyDBKeywordRetriever
+
+A keyword-based Retriever that fetches documents matching a query from the AlloyDB Document Store.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | 1. Before a [`PromptBuilder`](../builders/promptbuilder.mdx)   in a RAG pipeline 2. The last component in the semantic search pipeline 3. Before an [`ExtractiveReader`](../readers/extractivereader.mdx)   in an extractive QA pipeline |
+| **Mandatory init variables**           | `document_store`: An instance of an [AlloyDBDocumentStore](../../document-stores/alloydbdocumentstore.mdx)                                                                                                                                  |
+| **Mandatory run variables**            | `query`:  A string                                                                                                                                                                                                     |
+| **Output variables**                   | `documents`: A list of documents (matching the query)                                                                                                                                                                  |
+| **API reference**                      | [AlloyDB](/reference/integrations-alloydb)                                                                                                                                                                                  |
+| **GitHub link**                        | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/alloydb                                                                                                                             |
+| **Package name** | `alloydb-haystack` |
+
+</div>
+
+## Overview
+
+The `AlloyDBKeywordRetriever` is a keyword-based Retriever compatible with the `AlloyDBDocumentStore`.
+
+It uses PostgreSQL full-text search (`to_tsvector` / `plainto_tsquery`) to find Documents and ranks them with `ts_rank_cd`. The ranking considers how often the query terms appear in the Document, how close together the terms are, and how important the part of the Document is where they occur. For more details, see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-RANKING).
+
+Keep in mind that, unlike similar components such as `ElasticsearchBM25Retriever`, this Retriever does not apply fuzzy search out of the box, so it’s necessary to carefully formulate the query in order to avoid getting zero results.
+
+The language used to parse query and Document content for keyword retrieval is set via the `language` parameter on the `AlloyDBDocumentStore` (defaults to `"english"`). To list the supported languages on your database, run:
+
+```sql
+SELECT cfgname FROM pg_ts_config;
+```
+
+In addition to the `query`, the `AlloyDBKeywordRetriever` accepts other optional parameters, including `top_k` (the maximum number of Documents to retrieve) and `filters` to narrow the search space.
+
+## Installation
+
+Install the `alloydb-haystack` integration:
+
+```shell
+pip install alloydb-haystack
+```
+
+To set up an AlloyDB cluster and instance, follow the [AlloyDB quickstart](https://cloud.google.com/alloydb/docs/quickstart).
+
+## Usage
+
+### On its own
+
+This Retriever needs the `AlloyDBDocumentStore` and indexed Documents to run.
+
+Set the `ALLOYDB_INSTANCE_URI`, `ALLOYDB_USER`, and `ALLOYDB_PASSWORD` environment variables to connect to your AlloyDB instance.
+
+```python
+from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
+from haystack_integrations.components.retrievers.alloydb import (
+    AlloyDBKeywordRetriever,
+)
+
+document_store = AlloyDBDocumentStore()
+retriever = AlloyDBKeywordRetriever(document_store=document_store)
+
+retriever.run(query="my nice query")
+```
+
+### In a RAG pipeline
+
+The prerequisites necessary for running this code are:
+
+- Set an environment variable `OPENAI_API_KEY` with your OpenAI API key.
+- Set the `ALLOYDB_INSTANCE_URI`, `ALLOYDB_USER`, and `ALLOYDB_PASSWORD` environment variables to connect to your AlloyDB instance.
+
+```python
+from haystack import Document, Pipeline
+from haystack.components.builders.answer_builder import AnswerBuilder
+from haystack.components.builders.prompt_builder import PromptBuilder
+from haystack.components.generators import OpenAIGenerator
+from haystack.document_stores.types import DuplicatePolicy
+
+from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
+from haystack_integrations.components.retrievers.alloydb import (
+    AlloyDBKeywordRetriever,
+)
+
+## Create a RAG query pipeline
+prompt_template = """
+    Given these documents, answer the question.\nDocuments:
+    {% for doc in documents %}
+        {{ doc.content }}
+    {% endfor %}
+
+    \nQuestion: {{question}}
+    \nAnswer:
+    """
+
+document_store = AlloyDBDocumentStore(
+    language="english",  # this parameter influences text parsing for keyword retrieval
+    recreate_table=True,
+)
+
+documents = [
+    Document(content="There are over 7,000 languages spoken around the world today."),
+    Document(
+        content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors.",
+    ),
+    Document(
+        content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves.",
+    ),
+]
+
+document_store.write_documents(documents=documents, policy=DuplicatePolicy.SKIP)
+
+retriever = AlloyDBKeywordRetriever(document_store=document_store)
+rag_pipeline = Pipeline()
+rag_pipeline.add_component(name="retriever", instance=retriever)
+rag_pipeline.add_component(
+    instance=PromptBuilder(template=prompt_template),
+    name="prompt_builder",
+)
+rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
+rag_pipeline.connect("retriever", "prompt_builder.documents")
+rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("llm.replies", "answer_builder.replies")
+rag_pipeline.connect("llm.meta", "answer_builder.meta")
+rag_pipeline.connect("retriever", "answer_builder.documents")
+
+question = "languages spoken around the world today"
+result = rag_pipeline.run(
+    {
+        "retriever": {"query": question},
+        "prompt_builder": {"question": question},
+        "answer_builder": {"query": question},
+    },
+)
+print(result["answer_builder"])
+```

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/alloydbkeywordretriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/alloydbkeywordretriever.mdx
@@ -79,8 +79,9 @@ The prerequisites necessary for running this code are:
 ```python
 from haystack import Document, Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
 from haystack_integrations.document_stores.alloydb import AlloyDBDocumentStore
@@ -89,15 +90,14 @@ from haystack_integrations.components.retrievers.alloydb import (
 )
 
 ## Create a RAG query pipeline
-prompt_template = """
-    Given these documents, answer the question.\nDocuments:
-    {% for doc in documents %}
-        {{ doc.content }}
-    {% endfor %}
-
-    \nQuestion: {{question}}
-    \nAnswer:
-    """
+prompt_template = [
+    ChatMessage.from_system("You are a helpful assistant."),
+    ChatMessage.from_user(
+        "Given these documents, answer the question.\nDocuments:\n"
+        "{% for doc in documents %}{{ doc.content }}{% endfor %}\n"
+        "Question: {{question}}\nAnswer:",
+    ),
+]
 
 document_store = AlloyDBDocumentStore(
     language="english",  # this parameter influences text parsing for keyword retrieval
@@ -120,15 +120,17 @@ retriever = AlloyDBKeywordRetriever(document_store=document_store)
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(name="retriever", instance=retriever)
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(
+        template=prompt_template,
+        required_variables={"question", "documents"},
+    ),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.messages", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.meta", "answer_builder.meta")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "languages spoken around the world today"

--- a/docs-website/versioned_sidebars/version-2.29-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.29-sidebars.json
@@ -100,6 +100,7 @@
       "label": "Document Stores",
       "items": [
         "document-stores/inmemorydocumentstore",
+        "document-stores/alloydbdocumentstore",
         "document-stores/arcadedbdocumentstore",
         "document-stores/astradocumentstore",
         "document-stores/azureaisearchdocumentstore",
@@ -533,6 +534,8 @@
             "id": "pipeline-components/retrievers"
           },
           "items": [
+            "pipeline-components/retrievers/alloydbembeddingretriever",
+            "pipeline-components/retrievers/alloydbkeywordretriever",
             "pipeline-components/retrievers/arcadedbembeddingretriever",
             "pipeline-components/retrievers/astraretriever",
             "pipeline-components/retrievers/automergingretriever",


### PR DESCRIPTION
### Related Issues

- partially addresses https://github.com/deepset-ai/haystack-core-integrations/issues/1749

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds documentation pages for the `AlloyDBDocumentStore`, `AlloyDBEmbeddingRetriever`, and `AlloyDBKeywordRetriever`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
