### PR TITLE
fix: ignore embeddings in generated document ids

### DIFF
--- a/haystack/dataclasses/document.py
+++ b/haystack/dataclasses/document.py
@@ -114,8 +114,9 @@ class Document(metaclass=_BackwardCompatible):  # noqa: PLW1641
         blob = self.blob.data if self.blob is not None else None
         mime_type = self.blob.mime_type if self.blob is not None else None
         meta = self.meta or {}
-        embedding = self.embedding if self.embedding is not None else None
-        sparse_embedding = self.sparse_embedding.to_dict() if self.sparse_embedding is not None else ""
+        # Keep legacy placeholders so documents without embeddings preserve their generated IDs.
+        embedding = None
+        sparse_embedding = ""
         data = f"{text}{dataframe}{blob!r}{mime_type}{meta}{embedding}{sparse_embedding}"
         return hashlib.sha256(data.encode("utf-8")).hexdigest()
 

--- a/releasenotes/notes/document-id-ignore-embeddings-23608df0c560d41c.yaml
+++ b/releasenotes/notes/document-id-ignore-embeddings-23608df0c560d41c.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    ``Document`` instances created without an explicit ``id`` no longer include dense or sparse embeddings when
+    generating their default ID. If your application depends on embedding-specific document IDs, pass an explicit
+    ``id`` when creating those documents.
+fixes:
+  - |
+    Generated ``Document`` IDs now ignore dense and sparse embeddings so equivalent source documents keep stable
+    identities across embedding model or embedding value changes.

--- a/test/dataclasses/test_document.py
+++ b/test/dataclasses/test_document.py
@@ -51,7 +51,7 @@ def test_init_with_parameters():
         embedding=[0.1, 0.2, 0.3],
         sparse_embedding=sparse_embedding,
     )
-    assert doc.id == "1aa43af57c1dbc317241bf55d3067049f334d3b458d95dc72f71a7111f6c1a56"
+    assert doc.id == "b97b952e9dbe218b6104150256054958ec9e08c0ee6257f199311570e6292cd1"
     assert doc.content == "test text"
     assert doc.blob is not None
     assert doc.blob.data == blob_data
@@ -71,7 +71,7 @@ def test_init_with_legacy_fields():
         score=0.812,
         embedding=[0.1, 0.2, 0.3],  # type: ignore
     )
-    assert doc.id == "18fc2c114825872321cf5009827ca162f54d3be50ab9e9ffa027824b6ec223af"
+    assert doc.id == "f63a61aeda788a9deb6f83bf52388ab254c085c3df40b324e13c3f5112efd485"
     assert doc.content == "test text"
     assert doc.blob == None
     assert doc.meta == {}
@@ -94,7 +94,7 @@ def test_init_with_legacy_field():
         embedding=[0.1, 0.2, 0.3],
         meta={"date": "10-10-2023", "type": "article"},
     )
-    assert doc.id == "a2c0321b34430cc675294611e55529fceb56140ca3202f1c59a43a8cecac1f43"
+    assert doc.id == "2ca95e84e2cfc1b790a6ee09bf1e18088f76422211fed334071df88b0f247de7"
     assert doc.content == "test text"
     assert doc.meta == {"date": "10-10-2023", "type": "article"}
     assert doc.score == 0.812
@@ -120,6 +120,22 @@ def test_basic_equality_id():
     doc2 = replace(doc2, id="5678")
 
     assert doc1 != doc2
+
+
+def test_generated_id_ignores_embedding():
+    doc1 = Document(content="test text", embedding=[0.1, 0.2, 0.3])
+    doc2 = Document(content="test text", embedding=[0.4, 0.5, 0.6])
+    doc3 = Document(content="test text")
+
+    assert doc1.id == doc2.id == doc3.id
+
+
+def test_generated_id_ignores_sparse_embedding():
+    doc1 = Document(content="test text", sparse_embedding=SparseEmbedding(indices=[0, 2], values=[0.1, 0.2]))
+    doc2 = Document(content="test text", sparse_embedding=SparseEmbedding(indices=[1, 3], values=[0.3, 0.4]))
+    doc3 = Document(content="test text")
+
+    assert doc1.id == doc2.id == doc3.id
 
 
 def test_to_dict():


### PR DESCRIPTION
### Related Issues

- fixes deepset-ai/haystack-private-deprioritized#1

### Proposed Changes:

Generated `Document` IDs no longer include dense or sparse embeddings. Equivalent source documents now keep a stable default ID even if embeddings are added later or recomputed with different values.

The hash input keeps the existing `None`/empty-string placeholders for embeddings so documents that do not have embeddings preserve their current generated IDs.

### How did you test it?

- `hatch run test:unit test/dataclasses/test_document.py`
- `hatch run test:unit test/document_stores/test_in_memory.py`
- `hatch run fmt-check haystack/dataclasses/document.py test/dataclasses/test_document.py`
- `hatch run reno lint`
- `git diff --check`

### Notes for the reviewer

This PR focuses only on the issue's embedding part. It does not implement the broader `id_hash_keys` customization discussion.

AI assistance disclosure: this PR was fully generated with an AI assistant, then reviewed and validated locally with the checks above.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [ ] I have run full pre-commit hooks. I ran the focused project checks listed above instead.
