### PR TITLE
fix: avoid mutating Document.from_dict input

### DIFF
--- a/haystack/dataclasses/document.py
+++ b/haystack/dataclasses/document.py
@@ -149,6 +149,7 @@ class Document(metaclass=_BackwardCompatible):  # noqa: PLW1641
 
         The `blob` field is converted to its original type.
         """
+        data = data.copy()
         if blob := data.get("blob"):
             data["blob"] = ByteStream.from_dict(blob)
         if sparse_embedding := data.get("sparse_embedding"):

--- a/releasenotes/notes/document-from-dict-copy-input-9b7d2a8e6f4c1d03.yaml
+++ b/releasenotes/notes/document-from-dict-copy-input-9b7d2a8e6f4c1d03.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Prevent `Document.from_dict()` from mutating the input dictionary during deserialization.

--- a/releasenotes/notes/document-from-dict-copy-input-9b7d2a8e6f4c1d03.yaml
+++ b/releasenotes/notes/document-from-dict-copy-input-9b7d2a8e6f4c1d03.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Prevent `Document.from_dict()` from mutating the input dictionary during deserialization.
+    Prevent ``Document.from_dict()`` from mutating the input dictionary during deserialization.

--- a/test/dataclasses/test_document.py
+++ b/test/dataclasses/test_document.py
@@ -259,6 +259,16 @@ def test_from_dict_does_not_mutate_input():
     assert data == original_data
 
 
+def test_from_dict_does_not_mutate_input_with_explicit_meta():
+    data = {"content": "test text", "meta": {"date": "10-10-2023", "type": "article"}, "score": 0.812}
+    original_data = deepcopy(data)
+
+    assert Document.from_dict(data) == Document(
+        content="test text", meta={"date": "10-10-2023", "type": "article"}, score=0.812
+    )
+    assert data == original_data
+
+
 def test_from_dict_with_legacy_fields():
     assert Document.from_dict(
         {

--- a/test/dataclasses/test_document.py
+++ b/test/dataclasses/test_document.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
+from copy import deepcopy
 from dataclasses import replace
 
 import pytest
@@ -213,7 +214,7 @@ def test_from_dict():
     assert Document.from_dict({}) == Document()
 
 
-def from_from_dict_with_parameters():
+def test_from_dict_with_parameters():
     blob_data = b"some bytes"
     assert Document.from_dict(
         {
@@ -232,6 +233,30 @@ def from_from_dict_with_parameters():
         embedding=[0.1, 0.2, 0.3],
         sparse_embedding=SparseEmbedding(indices=[0, 2, 4], values=[0.1, 0.2, 0.3]),
     )
+
+
+def test_from_dict_does_not_mutate_input():
+    blob_data = b"some bytes"
+    data = {
+        "content": "test text",
+        "blob": {"data": list(blob_data), "mime_type": "text/markdown"},
+        "score": 0.812,
+        "embedding": [0.1, 0.2, 0.3],
+        "sparse_embedding": {"indices": [0, 2, 4], "values": [0.1, 0.2, 0.3]},
+        "date": "10-10-2023",
+        "type": "article",
+    }
+    original_data = deepcopy(data)
+
+    assert Document.from_dict(data) == Document(
+        content="test text",
+        blob=ByteStream(blob_data, mime_type="text/markdown"),
+        score=0.812,
+        embedding=[0.1, 0.2, 0.3],
+        sparse_embedding=SparseEmbedding(indices=[0, 2, 4], values=[0.1, 0.2, 0.3]),
+        meta={"date": "10-10-2023", "type": "article"},
+    )
+    assert data == original_data
 
 
 def test_from_dict_with_legacy_fields():


### PR DESCRIPTION
### Related Issues

- None found. This fixes a small deserialization side effect in `Document.from_dict()`.

### Proposed Changes:

`Document.from_dict()` previously mutated the dictionary passed by the caller while converting serialized `blob` and `sparse_embedding` values and while unflattening metadata. This PR copies the input mapping before those transformations so callers can safely reuse their serialized document data after deserialization.

It also renames an existing intended test from `from_from_dict_with_parameters` to `test_from_dict_with_parameters` so pytest collects it, and adds a regression test for preserving the input dictionary.

### How did you test it?

- `hatch run test:unit test/dataclasses/test_document.py`
- `hatch run fmt-check haystack/dataclasses/document.py test/dataclasses/test_document.py`
- `hatch run reno lint`
- `git diff --check`

### Notes for the reviewer

This PR was prepared with an AI assistant. I reviewed the changes and ran the relevant focused checks.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [ ] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
