### PR TITLE
feat: expose evaluator row status for LLM evaluators

### DIFF
--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -85,17 +85,20 @@ class ContextRelevanceEvaluator(LLMEvaluator):
     print(result["results"])
     # [{
     #   'relevant_statements': ['Python, created by Guido van Rossum in the late 1980s.'],
-    #    'score': 1.0
+    #   'score': 1.0,
+    #   'status': 'evaluated'
     #  },
     #  {
     #   'relevant_statements': ['The JVM has two primary functions: to allow Java programs to run on any device or
     #                           operating system (known as the "write once, run anywhere" principle), and to manage and
     #                           optimize program memory'],
-    #   'score': 1.0
+    #   'score': 1.0,
+    #   'status': 'evaluated'
     #  },
     #  {
     #   'relevant_statements': [],
-    #   'score': 0.0
+    #   'score': 0.0,
+    #   'status': 'evaluated'
     #  }]
     ```
     """
@@ -171,7 +174,8 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         :returns:
             A dictionary with the following outputs:
                 - `score`: Mean context relevance score over all the provided input questions.
-                - `results`: A list of dictionaries with `relevant_statements` and `score` for each input context.
+                - `results`: A list of dictionaries with `relevant_statements`, `score`, and `status` for each input
+                  context. `status` is `evaluated` for valid results and `error` for failed evaluations.
         """
         result = super(ContextRelevanceEvaluator, self).run(**inputs)  # noqa: UP008
         # Post-process the raw results to calculate relevance metrics and scores
@@ -189,7 +193,8 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         :returns:
             A dictionary with the following outputs:
                 - `score`: Mean context relevance score over all the provided input questions.
-                - `results`: A list of dictionaries with `relevant_statements` and `score` for each input context.
+                - `results`: A list of dictionaries with `relevant_statements`, `score`, and `status` for each input
+                  context. `status` is `evaluated` for valid results and `error` for failed evaluations.
         """
         result = await super(ContextRelevanceEvaluator, self).run_async(**inputs)  # noqa: UP008
         # Post-process the raw results to calculate relevance metrics and scores
@@ -209,8 +214,9 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         """
         for idx, res in enumerate(result["results"]):
             if res is None:
-                result["results"][idx] = {"relevant_statements": [], "score": float("nan")}
+                result["results"][idx] = {"relevant_statements": [], "score": float("nan"), "status": "error"}
                 continue
+            res["status"] = "evaluated"
             if len(res["relevant_statements"]) > 0:
                 res["score"] = 1
             else:

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -83,7 +83,8 @@ class FaithfulnessEvaluator(LLMEvaluator):
     # 0.5
     print(result["results"])
     # [{'statements': ['Python is a high-level general-purpose programming language.',
-    # 'Python was created by George Lucas.'], 'statement_scores': [1, 0], 'score': 0.5}]
+    # 'Python was created by George Lucas.'], 'statement_scores': [1, 0], 'score': 0.5,
+    # 'status': 'evaluated'}]
     ```
     """
 
@@ -164,7 +165,8 @@ class FaithfulnessEvaluator(LLMEvaluator):
             A dictionary with the following outputs:
                 - `score`: Mean faithfulness score over all the provided input answers.
                 - `individual_scores`: A list of faithfulness scores for each input answer.
-                - `results`: A list of dictionaries with `statements` and `statement_scores` for each input answer.
+                - `results`: A list of dictionaries with `statements`, `statement_scores`, `score`, and `status` for
+                  each input answer. `status` is `evaluated` for valid results and `error` for failed evaluations.
         """
         result = super(FaithfulnessEvaluator, self).run(**inputs)  # noqa: UP008
         # Post-process the raw results to calculate relevance metrics and scores
@@ -185,7 +187,8 @@ class FaithfulnessEvaluator(LLMEvaluator):
             A dictionary with the following outputs:
                 - `score`: Mean faithfulness score over all the provided input answers.
                 - `individual_scores`: A list of faithfulness scores for each input answer.
-                - `results`: A list of dictionaries with `statements` and `statement_scores` for each input answer.
+                - `results`: A list of dictionaries with `statements`, `statement_scores`, `score`, and `status` for
+                  each input answer. `status` is `evaluated` for valid results and `error` for failed evaluations.
         """
         result = await super(FaithfulnessEvaluator, self).run_async(**inputs)  # noqa: UP008
         # Post-process the raw results to calculate relevance metrics and scores
@@ -207,8 +210,14 @@ class FaithfulnessEvaluator(LLMEvaluator):
         # calculate average statement faithfulness score per query
         for idx, res in enumerate(result["results"]):
             if res is None:
-                result["results"][idx] = {"statements": [], "statement_scores": [], "score": float("nan")}
+                result["results"][idx] = {
+                    "statements": [],
+                    "statement_scores": [],
+                    "score": float("nan"),
+                    "status": "error",
+                }
                 continue
+            res["status"] = "evaluated"
             if not res["statements"]:
                 res["score"] = 0
             else:

--- a/releasenotes/notes/add-llm-evaluator-row-statuses-78166807b18bc138.yaml
+++ b/releasenotes/notes/add-llm-evaluator-row-statuses-78166807b18bc138.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Adds a ``status`` field to each result produced by ``ContextRelevanceEvaluator`` and ``FaithfulnessEvaluator``.
+    The field is ``evaluated`` for valid results and ``error`` for generation or parsing failures continued with
+    ``raise_on_failure=False``.

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -166,7 +166,10 @@ class TestContextRelevanceEvaluator:
         results = component.run(questions=questions, contexts=contexts)
 
         assert results == {
-            "results": [{"score": 1, "relevant_statements": ["a", "b"]}, {"score": 0, "relevant_statements": []}],
+            "results": [
+                {"score": 1, "relevant_statements": ["a", "b"], "status": "evaluated"},
+                {"score": 0, "relevant_statements": [], "status": "evaluated"},
+            ],
             "score": 0.5,
             "meta": None,
             "individual_scores": [1, 0],
@@ -195,7 +198,10 @@ class TestContextRelevanceEvaluator:
         ]
         results = component.run(questions=questions, contexts=contexts)
         assert results == {
-            "results": [{"score": 1, "relevant_statements": ["a", "b"]}, {"score": 0, "relevant_statements": []}],
+            "results": [
+                {"score": 1, "relevant_statements": ["a", "b"], "status": "evaluated"},
+                {"score": 0, "relevant_statements": [], "status": "evaluated"},
+            ],
             "score": 0.5,
             "meta": None,
             "individual_scores": [1, 0],
@@ -207,13 +213,16 @@ class TestContextRelevanceEvaluator:
         with pytest.raises(ValueError, match="LLM evaluator expected input parameter"):
             component.run()
 
-    def test_run_returns_nan_raise_on_failure_false(self, monkeypatch, caplog):
+    @pytest.mark.parametrize("failure_mode", ["generation", "parsing"])
+    def test_run_returns_nan_raise_on_failure_false(self, monkeypatch, caplog, failure_mode):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = ContextRelevanceEvaluator(raise_on_failure=False)
 
         def chat_generator_run(self, *args, **kwargs):
             if "Python" in kwargs["messages"][0].text:
-                raise Exception("OpenAI API request failed.")
+                if failure_mode == "generation":
+                    raise Exception("OpenAI API request failed.")
+                return {"replies": [ChatMessage.from_assistant("not valid JSON")]}
             return {"replies": [ChatMessage.from_assistant('{"relevant_statements": ["c", "d"], "score": 1}')]}
 
         monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
@@ -236,11 +245,27 @@ class TestContextRelevanceEvaluator:
             results = component.run(questions=questions, contexts=contexts)
 
         assert results["score"] == 1
-        assert results["results"][0] == {"relevant_statements": ["c", "d"], "score": 1}
+        assert results["results"][0] == {"relevant_statements": ["c", "d"], "score": 1, "status": "evaluated"}
         assert results["results"][1]["relevant_statements"] == []
         assert math.isnan(results["results"][1]["score"])
+        assert results["results"][1]["status"] == "error"
 
         assert "1 query(s) failed and were excluded from the score." in caplog.text
+
+    def test_run_all_failures_returns_nan_and_error_statuses(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = ContextRelevanceEvaluator(raise_on_failure=False)
+
+        def chat_generator_run(self, *args, **kwargs):
+            raise Exception("OpenAI API request failed.")
+
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
+
+        results = component.run(questions=["q1", "q2"], contexts=[["c1"], ["c2"]])
+
+        assert math.isnan(results["score"])
+        assert all(math.isnan(score) for score in results["individual_scores"])
+        assert [result["status"] for result in results["results"]] == ["error", "error"]
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),
@@ -256,7 +281,7 @@ class TestContextRelevanceEvaluator:
 
         required_fields = {"results"}
         assert all(field in result for field in required_fields)
-        nested_required_fields = {"score", "relevant_statements"}
+        nested_required_fields = {"score", "relevant_statements", "status"}
         assert all(field in result["results"][0] for field in nested_required_fields)
 
         assert "meta" in result
@@ -289,20 +314,26 @@ class TestContextRelevanceEvaluatorAsync:
         results = await component.run_async(questions=questions, contexts=contexts)
 
         assert results == {
-            "results": [{"score": 1, "relevant_statements": ["a", "b"]}, {"score": 0, "relevant_statements": []}],
+            "results": [
+                {"score": 1, "relevant_statements": ["a", "b"], "status": "evaluated"},
+                {"score": 0, "relevant_statements": [], "status": "evaluated"},
+            ],
             "score": 0.5,
             "meta": None,
             "individual_scores": [1, 0],
         }
 
     @pytest.mark.asyncio
-    async def test_run_async_returns_nan_raise_on_failure_false(self, monkeypatch, caplog):
+    @pytest.mark.parametrize("failure_mode", ["generation", "parsing"])
+    async def test_run_async_returns_nan_raise_on_failure_false(self, monkeypatch, caplog, failure_mode):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = ContextRelevanceEvaluator(raise_on_failure=False)
 
         async def chat_generator_run_async(self, *args, **kwargs):
             if "Python" in kwargs["messages"][0].text:
-                raise Exception("OpenAI API request failed.")
+                if failure_mode == "generation":
+                    raise Exception("OpenAI API request failed.")
+                return {"replies": [ChatMessage.from_assistant("not valid JSON")]}
             return {"replies": [ChatMessage.from_assistant('{"relevant_statements": ["c", "d"], "score": 1}')]}
 
         monkeypatch.setattr(
@@ -316,9 +347,10 @@ class TestContextRelevanceEvaluatorAsync:
             results = await component.run_async(questions=questions, contexts=contexts)
 
         assert results["score"] == 1
-        assert results["results"][0] == {"relevant_statements": ["c", "d"], "score": 1}
+        assert results["results"][0] == {"relevant_statements": ["c", "d"], "score": 1, "status": "evaluated"}
         assert results["results"][1]["relevant_statements"] == []
         assert math.isnan(results["results"][1]["score"])
+        assert results["results"][1]["status"] == "error"
 
         assert "1 query(s) failed and were excluded from the score." in caplog.text
 
@@ -337,7 +369,7 @@ class TestContextRelevanceEvaluatorAsync:
 
         required_fields = {"results"}
         assert all(field in result for field in required_fields)
-        nested_required_fields = {"score", "relevant_statements"}
+        nested_required_fields = {"score", "relevant_statements", "status"}
         assert all(field in result["results"][0] for field in nested_required_fields)
 
         assert "meta" in result

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -203,8 +203,8 @@ class TestFaithfulnessEvaluator:
         assert results == {
             "individual_scores": [0.5, 1],
             "results": [
-                {"score": 0.5, "statement_scores": [1, 0], "statements": ["a", "b"]},
-                {"score": 1, "statement_scores": [1, 1], "statements": ["c", "d"]},
+                {"score": 0.5, "statement_scores": [1, 0], "statements": ["a", "b"], "status": "evaluated"},
+                {"score": 1, "statement_scores": [1, 1], "statements": ["c", "d"], "status": "evaluated"},
             ],
             "score": 0.75,
             "meta": None,
@@ -241,8 +241,8 @@ class TestFaithfulnessEvaluator:
         assert results == {
             "individual_scores": [0.5, 0],
             "results": [
-                {"score": 0.5, "statement_scores": [1, 0], "statements": ["a", "b"]},
-                {"score": 0, "statement_scores": [], "statements": []},
+                {"score": 0.5, "statement_scores": [1, 0], "statements": ["a", "b"], "status": "evaluated"},
+                {"score": 0, "statement_scores": [], "statements": [], "status": "evaluated"},
             ],
             "score": 0.25,
             "meta": None,
@@ -254,13 +254,16 @@ class TestFaithfulnessEvaluator:
         with pytest.raises(ValueError, match="LLM evaluator expected input parameter"):
             component.run()
 
-    def test_run_returns_nan_raise_on_failure_false(self, monkeypatch, caplog):
+    @pytest.mark.parametrize("failure_mode", ["generation", "parsing"])
+    def test_run_returns_nan_raise_on_failure_false(self, monkeypatch, caplog, failure_mode):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = FaithfulnessEvaluator(raise_on_failure=False)
 
         def chat_generator_run(self, *args, **kwargs):
             if "Python" in kwargs["messages"][0].text:
-                raise Exception("OpenAI API request failed.")
+                if failure_mode == "generation":
+                    raise Exception("OpenAI API request failed.")
+                return {"replies": [ChatMessage.from_assistant("not valid JSON")]}
             return {"replies": [ChatMessage.from_assistant('{"statements": ["c", "d"], "statement_scores": [1, 1]}')]}
 
         monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
@@ -291,13 +294,34 @@ class TestFaithfulnessEvaluator:
         assert results["individual_scores"][0] == 1.0
         assert math.isnan(results["individual_scores"][1])
 
-        assert results["results"][0] == {"statements": ["c", "d"], "statement_scores": [1, 1], "score": 1.0}
+        assert results["results"][0] == {
+            "statements": ["c", "d"],
+            "statement_scores": [1, 1],
+            "score": 1.0,
+            "status": "evaluated",
+        }
 
         assert results["results"][1]["statements"] == []
         assert results["results"][1]["statement_scores"] == []
         assert math.isnan(results["results"][1]["score"])
+        assert results["results"][1]["status"] == "error"
 
         assert "1 query(s) failed and were excluded from the score." in caplog.text
+
+    def test_run_all_failures_returns_nan_and_error_statuses(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = FaithfulnessEvaluator(raise_on_failure=False)
+
+        def chat_generator_run(self, *args, **kwargs):
+            raise Exception("OpenAI API request failed.")
+
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
+
+        results = component.run(questions=["q1", "q2"], contexts=[["c1"], ["c2"]], predicted_answers=["a1", "a2"])
+
+        assert math.isnan(results["score"])
+        assert all(math.isnan(score) for score in results["individual_scores"])
+        assert [result["status"] for result in results["results"]] == ["error", "error"]
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),
@@ -313,7 +337,7 @@ class TestFaithfulnessEvaluator:
 
         required_fields = {"individual_scores", "results", "score"}
         assert all(field in result for field in required_fields)
-        nested_required_fields = {"score", "statement_scores", "statements"}
+        nested_required_fields = {"score", "statement_scores", "statements", "status"}
         assert all(field in result["results"][0] for field in nested_required_fields)
 
         # assert that metadata is present in the result
@@ -347,21 +371,24 @@ class TestFaithfulnessEvaluatorAsync:
         assert results == {
             "individual_scores": [0.5, 1.0],
             "results": [
-                {"score": 0.5, "statement_scores": [1, 0], "statements": ["a", "b"]},
-                {"score": 1.0, "statement_scores": [1, 1], "statements": ["c", "d"]},
+                {"score": 0.5, "statement_scores": [1, 0], "statements": ["a", "b"], "status": "evaluated"},
+                {"score": 1.0, "statement_scores": [1, 1], "statements": ["c", "d"], "status": "evaluated"},
             ],
             "score": 0.75,
             "meta": None,
         }
 
     @pytest.mark.asyncio
-    async def test_run_async_returns_nan_raise_on_failure_false(self, monkeypatch, caplog):
+    @pytest.mark.parametrize("failure_mode", ["generation", "parsing"])
+    async def test_run_async_returns_nan_raise_on_failure_false(self, monkeypatch, caplog, failure_mode):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = FaithfulnessEvaluator(raise_on_failure=False)
 
         async def chat_generator_run_async(self, *args, **kwargs):
             if "Python" in kwargs["messages"][0].text:
-                raise Exception("OpenAI API request failed.")
+                if failure_mode == "generation":
+                    raise Exception("OpenAI API request failed.")
+                return {"replies": [ChatMessage.from_assistant("not valid JSON")]}
             return {"replies": [ChatMessage.from_assistant('{"statements": ["c", "d"], "statement_scores": [1, 1]}')]}
 
         monkeypatch.setattr(
@@ -380,6 +407,8 @@ class TestFaithfulnessEvaluatorAsync:
         assert results["score"] == 1.0
         assert results["individual_scores"][0] == 1.0
         assert math.isnan(results["individual_scores"][1])
+        assert results["results"][0]["status"] == "evaluated"
+        assert results["results"][1]["status"] == "error"
         assert "1 query(s) failed and were excluded from the score." in caplog.text
 
     @pytest.mark.asyncio
@@ -397,7 +426,7 @@ class TestFaithfulnessEvaluatorAsync:
 
         required_fields = {"individual_scores", "results", "score"}
         assert all(field in result for field in required_fields)
-        nested_required_fields = {"score", "statement_scores", "statements"}
+        nested_required_fields = {"score", "statement_scores", "statements", "status"}
         assert all(field in result["results"][0] for field in nested_required_fields)
 
         # assert that metadata is present in the result


### PR DESCRIPTION
## Summary

This is Phase 1 for RFC #11332.

It adds a narrow top-level `evaluation_statuses` output to `LLMEvaluator` results so callers can distinguish rows that were successfully evaluated from rows that failed during generation or parsing when `raise_on_failure=False` is used.

## Scope

Included:

- `LLMEvaluator` now returns `evaluation_statuses` alongside existing `results` and `meta`.
- Successful parsed rows are marked as `evaluated`.
- generation/parsing failures that continue under `raise_on_failure=False` are marked as `error`.
- `ContextRelevanceEvaluator` and `FaithfulnessEvaluator` pass through the new status list while preserving their current `nan` behavior.
- focused tests for successful rows, invalid JSON, and generation failures.
- release note added under `releasenotes/notes`.

Intentionally excluded:

- no `EvaluationRunResult` reporting changes;
- no retriever, agent, router, HITL, or governance changes;
- no `indeterminate` status yet;
- no public neutrosophic naming in code.

Phase 2 and Phase 3 remain dependent on maintainer feedback from the RFC and this PR.

## Tests

```powershell
C:\Users\jeans\.local\bin\uv.exe run pytest test/components/evaluators/test_llm_evaluator.py test/components/evaluators/test_context_relevance_evaluator.py test/components/evaluators/test_faithfulness_evaluator.py -q
C:\Users\jeans\.local\bin\uv.exe run ruff check haystack/components/evaluators test/components/evaluators
C:\Users\jeans\.local\bin\uv.exe run ruff format --check haystack/components/evaluators test/components/evaluators
C:\Users\jeans\.local\bin\uv.exe run reno lint .
```

Results:

- `38 passed, 2 skipped`
- `ruff check`: passed
- `ruff format --check`: passed
- `reno lint`: passed
