### PR TITLE
fix: enforce max_runs_per_component limit correctly

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1242,7 +1242,7 @@ class PipelineBase:  # noqa: PLW1641
 
         component_name = item[1]
         comp = self._get_component_with_graph_metadata_and_visits(component_name, component_visits[component_name])
-        if comp["visits"] > self._max_runs_per_component:
+        if comp["visits"] >= self._max_runs_per_component:
             msg = f"Maximum run count {self._max_runs_per_component} reached for component '{component_name}'"
             raise PipelineMaxComponentRuns(msg)
         return ComponentPriority(item[0]), component_name, comp

--- a/releasenotes/notes/fix-pipeline-max-runs-off-by-one-4a8e2f1c9b3d7051.yaml
+++ b/releasenotes/notes/fix-pipeline-max-runs-off-by-one-4a8e2f1c9b3d7051.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix an off-by-one error in ``max_runs_per_component`` so a component cannot run more
+    times than the configured limit within a single ``Pipeline.run()`` call.

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -1385,10 +1385,10 @@ class TestPipelineBase:
         pipeline = PipelineBase(max_runs_per_component=2)
         queue = FIFOPriorityQueue()
         queue.push("ready_component", ComponentPriority.READY)
-        mock_get_component_with_graph_metadata_and_visits.return_value = {"instance": "test", "visits": 3}
+        mock_get_component_with_graph_metadata_and_visits.return_value = {"instance": "test", "visits": 2}
 
         with pytest.raises(PipelineMaxComponentRuns) as exc_info:
-            pipeline._get_next_runnable_component(queue, component_visits={"ready_component": 3})
+            pipeline._get_next_runnable_component(queue, component_visits={"ready_component": 2})
 
         assert "Maximum run count 2 reached for component 'ready_component'" in str(exc_info.value)
 


### PR DESCRIPTION
### Proposed Changes

`max_runs_per_component` checked `visits > max` before each run while `visits` increments after the run, allowing one extra execution (e.g. 101 runs when the limit is 100). Use `visits >= max` so behavior matches the [documented](https://github.com/deepset-ai/haystack/blob/main/docs-website/docs/concepts/pipelines/pipeline-loops.mdx) limit.

### How did you test it?

- Updated `test__get_next_runnable_component_max_visits` in `test/core/pipeline/test_pipeline_base.py`
- `hatch run test:unit test/core/pipeline/test_pipeline_base.py::TestPipelineBase::test__get_next_runnable_component_max_visits`

### Checklist

- [x] Release note added
- [x] Unit test updated