### PR TITLE
docs: fix grammar in Azure generator docstring examples

### DIFF
--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -40,7 +40,7 @@ class AzureOpenAIGenerator(OpenAIGenerator):
     client = AzureOpenAIGenerator(
         azure_endpoint="<Your Azure endpoint e.g. `https://your-company.azure.openai.com/>",
         api_key=Secret.from_token("<your-api-key>"),
-        azure_deployment="<this a model name, e.g.  gpt-4.1-mini>")
+        azure_deployment="<this is a model name, e.g. gpt-4.1-mini>")
     response = client.run("What's Natural Language Processing? Be brief.")
     print(response)
     ```

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -53,7 +53,7 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
     client = AzureOpenAIChatGenerator(
         azure_endpoint="<Your Azure endpoint e.g. `https://your-company.azure.openai.com/>",
         api_key=Secret.from_token("<your-api-key>"),
-        azure_deployment="<this a model name, e.g. gpt-4.1-mini>")
+        azure_deployment="<this is a model name, e.g. gpt-4.1-mini>")
     response = client.run(messages)
     print(response)
     ```

--- a/releasenotes/notes/fix-azure-generator-docstring-typo-6ca4aa1ca8fc49f5.yaml
+++ b/releasenotes/notes/fix-azure-generator-docstring-typo-6ca4aa1ca8fc49f5.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Fix grammar in the ``AzureOpenAIGenerator`` and ``AzureOpenAIChatGenerator`` docstring code examples
+    (``"<this a model name..."`` → ``"<this is a model name..."``) so that copy-pasted snippets read correctly.


### PR DESCRIPTION
### Related Issues

 N/A — trivial docstring grammar fix.

### Proposed Changes:

Fixes a missing word and a stray double space in the docstring code examples for `AzureOpenAIGenerator` and `AzureOpenAIChatGenerator`:

  - `"<this a model name, e.g. gpt-4.1-mini>"` → `"<this is a model name, e.g. gpt-4.1-mini>"` in `haystack/components/generators/azure.py`
  
  - `"<this a model name, e.g. gpt-4.1-mini>"` → `"<this is a model name, e.g. gpt-4.1-mini>"` in `haystack/components/generators/chat/azure.py`

These docstrings are rendered in the public API reference and are commonly copy-pasted by users setting up Azure OpenAI deployments.

### How did you test it?

Visual review of the diff. No behavior change — string-literal content inside docstring code blocks. No unit tests apply.

### Notes for the reviewer

Release note added under `releasenotes/notes/` following the precedent set by `codespell-d4a32b9c589ca26e.yaml`. Happy to drop it if you'd prefer to label the PR `ignore-for-release-notes`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
