### PR TITLE
docs: Add MCP tool for Haystack documentation

### DIFF
--- a/docs-website/api/mcp.ts
+++ b/docs-website/api/mcp.ts
@@ -6,7 +6,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
   res.setHeader(
     "Access-Control-Allow-Headers",
-    "Content-Type, Accept, Mcp-Session-Id"
+    "Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version"
   );
   res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
 
@@ -43,6 +43,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           // Forward MCP session id so upstream can correlate requests.
           ...(req.headers["mcp-session-id"] && {
             "Mcp-Session-Id": req.headers["mcp-session-id"] as string,
+          }),
+          // Forward the protocol version the client negotiated.
+          ...(req.headers["mcp-protocol-version"] && {
+            "Mcp-Protocol-Version": req.headers[
+              "mcp-protocol-version"
+            ] as string,
           }),
         },
         body: JSON.stringify(req.body),

--- a/docs-website/api/mcp.ts
+++ b/docs-website/api/mcp.ts
@@ -2,8 +2,16 @@
 import { VercelRequest, VercelResponse } from "@vercel/node";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Accept");
+
+  if (req.method === "OPTIONS") {
+    return res.status(204).end();
+  }
+
   if (req.method !== "POST") {
-    res.setHeader("Allow", "POST");
+    res.setHeader("Allow", "POST, OPTIONS");
     return res.status(405).end("Method Not Allowed");
   }
 
@@ -23,6 +31,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          Accept:
+            (req.headers.accept as string) ||
+            "application/json, text/event-stream",
           "X-Client-Source": "haystack-docs",
           Authorization: `Bearer ${SEARCH_API_TOKEN}`,
         },

--- a/docs-website/api/mcp.ts
+++ b/docs-website/api/mcp.ts
@@ -1,0 +1,43 @@
+// Files under `api/` become HTTP endpoints automatically — this is `/api/mcp`.
+import { VercelRequest, VercelResponse } from "@vercel/node";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  // Get environment variables
+  const { MCP_WORKSPACE_ID, SEARCH_API_TOKEN } = process.env;
+
+  if (!MCP_WORKSPACE_ID || !SEARCH_API_TOKEN) {
+    return res.status(500).json({ error: "MCP service is not configured." });
+  }
+
+  try {
+    // Forward the JSON-RPC body unchanged with the API key injected, so we
+    // don't need to know any MCP methods — new upstream tools just work.
+    const apiResponse = await fetch(
+      `https://api.cloud.deepset.ai/api/v2/workspaces/${MCP_WORKSPACE_ID}/mcp`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Client-Source": "haystack-docs",
+          Authorization: `Bearer ${SEARCH_API_TOKEN}`,
+        },
+        body: JSON.stringify(req.body),
+      }
+    );
+
+    // Pass the response through as-is (status, content-type, raw body).
+    const text = await apiResponse.text();
+    res.status(apiResponse.status);
+    const contentType = apiResponse.headers.get("content-type");
+    if (contentType) res.setHeader("Content-Type", contentType);
+    return res.send(text);
+  } catch (error) {
+    console.error("MCP proxy error:", error);
+    return res.status(502).json({ error: "Failed to reach MCP upstream." });
+  }
+}

--- a/docs-website/api/mcp.ts
+++ b/docs-website/api/mcp.ts
@@ -4,7 +4,11 @@ import { VercelRequest, VercelResponse } from "@vercel/node";
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Accept");
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Accept, Mcp-Session-Id"
+  );
+  res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
 
   if (req.method === "OPTIONS") {
     return res.status(204).end();
@@ -36,6 +40,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             "application/json, text/event-stream",
           "X-Client-Source": "haystack-docs",
           Authorization: `Bearer ${SEARCH_API_TOKEN}`,
+          // Forward MCP session id so upstream can correlate requests.
+          ...(req.headers["mcp-session-id"] && {
+            "Mcp-Session-Id": req.headers["mcp-session-id"] as string,
+          }),
         },
         body: JSON.stringify(req.body),
       }
@@ -46,6 +54,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     res.status(apiResponse.status);
     const contentType = apiResponse.headers.get("content-type");
     if (contentType) res.setHeader("Content-Type", contentType);
+    // Surface the session id back to the client (browsers can read it because
+    // it's in Access-Control-Expose-Headers above).
+    const sessionId = apiResponse.headers.get("mcp-session-id");
+    if (sessionId) res.setHeader("Mcp-Session-Id", sessionId);
     return res.send(text);
   } catch (error) {
     console.error("MCP proxy error:", error);

--- a/docs-website/api/well-known.ts
+++ b/docs-website/api/well-known.ts
@@ -1,0 +1,13 @@
+// Returns a JSON 404 for OAuth discovery probes (e.g.
+// `/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`).
+// Per RFC 9728 / the MCP authorization spec a 404 here means "this resource
+// doesn't require OAuth — connect anonymously." Without this handler the
+// Docusaurus catch-all serves an HTML 404, which trips MCP clients that try to
+// JSON-parse the body to extract an OAuth error.
+import { VercelRequest, VercelResponse } from "@vercel/node";
+
+export default function handler(_req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Cache-Control", "public, max-age=3600");
+  return res.status(404).end("{}");
+}

--- a/docs-website/docs/overview/docs-mcp-server.mdx
+++ b/docs-website/docs/overview/docs-mcp-server.mdx
@@ -1,0 +1,88 @@
+---
+title: "Using Haystack Docs in Your Coding Agent"
+id: docs-mcp-server
+slug: "/docs-mcp-server"
+description: "Connect your coding agent to the Haystack documentation through the public MCP server. Includes setup instructions for Claude Code, Cursor, and GitHub Copilot."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Using Haystack Docs in Your Coding Agent
+
+Haystack publishes a public [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that lets coding agents search the official Haystack documentation. Pointing your agent at it means it answers questions from up-to-date docs instead of relying on training data, which can lag behind the framework.
+
+The server exposes a single tool, `search_haystack_docs`, that returns relevant documentation sections with source URLs. No API key or sign-up is needed.
+
+## Server URL
+
+```
+https://docs.haystack.deepset.ai/api/mcp
+```
+
+The server speaks **HTTP** transport. Most agents auto-detect this. If yours asks you to choose, pick `http`.
+
+## Setup
+
+<Tabs>
+<TabItem value="claude-code" label="Claude Code" default>
+
+Add the server with the `claude mcp` CLI:
+
+```shell
+claude mcp add --transport http haystack-docs https://docs.haystack.deepset.ai/api/mcp
+```
+
+Restart your Claude Code session. Verify it's connected by running `/mcp` — you should see `haystack-docs` listed with the `search_haystack_docs` tool.
+
+For more options (project vs. user scope, SSE transport, headers), see the [Claude Code MCP docs](https://code.claude.com/docs/en/mcp).
+
+</TabItem>
+<TabItem value="cursor" label="Cursor">
+
+Open Cursor settings → **Tools & MCPs** → **Add new MCP server**, or edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per-project) directly:
+
+```json
+{
+  "mcpServers": {
+    "haystack-docs": {
+      "url": "https://docs.haystack.deepset.ai/api/mcp"
+    }
+  }
+}
+```
+
+Save the file and reload Cursor. The tool appears in the **Available Tools** list inside the chat panel.
+
+See the [Cursor MCP docs](https://cursor.com/docs/context/mcp) for the full configuration reference.
+
+</TabItem>
+<TabItem value="copilot" label="GitHub Copilot">
+
+In VS Code, create or edit `.vscode/mcp.json` in your workspace:
+
+```json
+{
+  "servers": {
+    "haystack-docs": {
+      "type": "http",
+      "url": "https://docs.haystack.deepset.ai/api/mcp"
+    }
+  }
+}
+```
+
+Open the Copilot Chat panel, switch to **Agent** mode, then click the tools icon and enable `haystack-docs`. You can also register the server globally from the command palette via **MCP: Add Server**.
+
+See [Add and manage MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) for the full configuration reference.
+
+</TabItem>
+</Tabs>
+
+## Verifying it works
+
+Ask your agent a question that requires current Haystack knowledge, for example:
+
+> What are the required methods on a Haystack custom component?
+
+The agent should call `search_haystack_docs` and cite source URLs under `docs.haystack.deepset.ai` in its answer. If it answers without calling the tool, prompt it explicitly: *"Use the haystack-docs MCP server to answer."*

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -15,6 +15,7 @@ export default {
       items: [
         'overview/installation',
         'overview/get-started',
+        'overview/docs-mcp-server',
         'overview/faq',
         'overview/telemetry',
         'overview/breaking-change-policy',

--- a/docs-website/vercel.json
+++ b/docs-website/vercel.json
@@ -1,4 +1,22 @@
 {
+  "rewrites": [
+    {
+      "source": "/.well-known/oauth-protected-resource",
+      "destination": "/api/well-known"
+    },
+    {
+      "source": "/.well-known/oauth-protected-resource/:path*",
+      "destination": "/api/well-known"
+    },
+    {
+      "source": "/.well-known/oauth-authorization-server",
+      "destination": "/api/well-known"
+    },
+    {
+      "source": "/.well-known/oauth-authorization-server/:path*",
+      "destination": "/api/well-known"
+    }
+  ],
   "redirects": [
     {
       "source": "/docs/2.21/:slug*",

--- a/docs-website/vercel.json
+++ b/docs-website/vercel.json
@@ -1,19 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/.well-known/oauth-protected-resource",
-      "destination": "/api/well-known"
-    },
-    {
-      "source": "/.well-known/oauth-protected-resource/:path*",
-      "destination": "/api/well-known"
-    },
-    {
-      "source": "/.well-known/oauth-authorization-server",
-      "destination": "/api/well-known"
-    },
-    {
-      "source": "/.well-known/oauth-authorization-server/:path*",
+      "source": "/.well-known/:path*",
       "destination": "/api/well-known"
     }
   ],

--- a/docs-website/versioned_docs/version-2.29/overview/docs-mcp-server.mdx
+++ b/docs-website/versioned_docs/version-2.29/overview/docs-mcp-server.mdx
@@ -1,0 +1,88 @@
+---
+title: "Using Haystack Docs in Your Coding Agent"
+id: docs-mcp-server
+slug: "/docs-mcp-server"
+description: "Connect your coding agent to the Haystack documentation through the public MCP server. Includes setup instructions for Claude Code, Cursor, and GitHub Copilot."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Using Haystack Docs in Your Coding Agent
+
+Haystack publishes a public [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that lets coding agents search the official Haystack documentation. Pointing your agent at it means it answers questions from up-to-date docs instead of relying on training data, which can lag behind the framework.
+
+The server exposes a single tool, `search_haystack_docs`, that returns relevant documentation sections with source URLs. No API key or sign-up is needed.
+
+## Server URL
+
+```
+https://docs.haystack.deepset.ai/api/mcp
+```
+
+The server speaks **HTTP** transport. Most agents auto-detect this. If yours asks you to choose, pick `http`.
+
+## Setup
+
+<Tabs>
+<TabItem value="claude-code" label="Claude Code" default>
+
+Add the server with the `claude mcp` CLI:
+
+```shell
+claude mcp add --transport http haystack-docs https://docs.haystack.deepset.ai/api/mcp
+```
+
+Restart your Claude Code session. Verify it's connected by running `/mcp` — you should see `haystack-docs` listed with the `search_haystack_docs` tool.
+
+For more options (project vs. user scope, SSE transport, headers), see the [Claude Code MCP docs](https://code.claude.com/docs/en/mcp).
+
+</TabItem>
+<TabItem value="cursor" label="Cursor">
+
+Open Cursor settings → **Tools & MCPs** → **Add new MCP server**, or edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per-project) directly:
+
+```json
+{
+  "mcpServers": {
+    "haystack-docs": {
+      "url": "https://docs.haystack.deepset.ai/api/mcp"
+    }
+  }
+}
+```
+
+Save the file and reload Cursor. The tool appears in the **Available Tools** list inside the chat panel.
+
+See the [Cursor MCP docs](https://cursor.com/docs/context/mcp) for the full configuration reference.
+
+</TabItem>
+<TabItem value="copilot" label="GitHub Copilot">
+
+In VS Code, create or edit `.vscode/mcp.json` in your workspace:
+
+```json
+{
+  "servers": {
+    "haystack-docs": {
+      "type": "http",
+      "url": "https://docs.haystack.deepset.ai/api/mcp"
+    }
+  }
+}
+```
+
+Open the Copilot Chat panel, switch to **Agent** mode, then click the tools icon and enable `haystack-docs`. You can also register the server globally from the command palette via **MCP: Add Server**.
+
+See [Add and manage MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) for the full configuration reference.
+
+</TabItem>
+</Tabs>
+
+## Verifying it works
+
+Ask your agent a question that requires current Haystack knowledge, for example:
+
+> What are the required methods on a Haystack custom component?
+
+The agent should call `search_haystack_docs` and cite source URLs under `docs.haystack.deepset.ai` in its answer. If it answers without calling the tool, prompt it explicitly: *"Use the haystack-docs MCP server to answer."*

--- a/docs-website/versioned_sidebars/version-2.29-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.29-sidebars.json
@@ -11,6 +11,7 @@
       "items": [
         "overview/installation",
         "overview/get-started",
+        "overview/docs-mcp-server",
         "overview/faq",
         "overview/telemetry",
         "overview/breaking-change-policy",


### PR DESCRIPTION
### Related Issues

- fixes #9885

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Adds a public MCP server that lets coding agents search the official Haystack documentation, plus a documentation page describing how to connect to it.

  - **`docs-website/api/mcp.ts`**: 
  Vercel function at `/api/mcp` that proxies JSON-RPC requests to the Haystack Platform MCP backend, injecting the API key server-side so no auth is required from clients. 
  - **`docs-website/api/well-known.ts` + `vercel.json` rewrite**: 
 every `/.well-known/*` path returns a JSON 404 instead of Docusaurus's HTML 404 page. Without this, MCP clients that probe OAuth discovery paths (`oauth-protected-resource`, `oauth-authorization-server`, `openid-configuration`, …) try to JSON-parse the HTML 404 body, fail with a syntax error, and refuse to connect anonymously. The JSON 404 lets them correctly conclude "no OAuth required."
  - **`docs-website/docs/overview/docs-mcp-server.mdx`** (+ v2.29 copy and sidebar entries):
 New "Using Haystack Docs in Your Coding Agent" page with setup instructions for Claude Code, Cursor, and GitHub Copilot, each linking to the agent's own MCP documentation.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I tested it using the Vercel Preview: `https://haystack-docs-git-docs-mcp-endpoint-deepset-ai.vercel.app/api/mcp`

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
I placed the new documentation page under **Overview**, but I'm not sure if that's the best place for it. Let me know if there's a more appropriate section.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
