### PR TITLE
fix: DocumentJoiner concatenate keeps score=0.0 over worse duplicates

### DIFF
--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -171,7 +171,7 @@ class DocumentJoiner:
         for doc in itertools.chain.from_iterable(document_lists):
             docs_per_id[doc.id].append(doc)
         for docs in docs_per_id.values():
-            doc_with_best_score = max(docs, key=lambda doc: doc.score if doc.score else -inf)
+            doc_with_best_score = max(docs, key=lambda doc: doc.score if doc.score is not None else -inf)
             output.append(doc_with_best_score)
         return output
 
@@ -189,7 +189,7 @@ class DocumentJoiner:
 
         for documents, weight in zip(document_lists, weights, strict=True):
             for doc in documents:
-                scores_map[doc.id] += (doc.score if doc.score else 0) * weight
+                scores_map[doc.id] += (doc.score if doc.score is not None else 0) * weight
                 documents_map[doc.id] = doc
 
         return [replace(doc, score=scores_map[doc.id]) for doc in documents_map.values()]

--- a/releasenotes/notes/fix-document-joiner-zero-score-dedup-e79458b9865b0867.yaml
+++ b/releasenotes/notes/fix-document-joiner-zero-score-dedup-e79458b9865b0867.yaml
@@ -1,9 +1,9 @@
 ---
 fixes:
   - |
-    Fixed `DocumentJoiner` in `concatenate` mode so that documents with a score of
-    exactly `0.0` are no longer treated as unscored during deduplication. Previously
-    a truthiness check coerced `score=0.0` to `-inf`, which could cause a worse,
-    negatively-scored duplicate to be kept instead of the `0.0`-scored document.
-    The `merge` mode was updated to the same explicit `is not None` check for
+    Fixed ``DocumentJoiner`` in ``concatenate`` mode so that documents with a score of
+    exactly ``0.0`` are no longer treated as unscored during deduplication. Previously
+    a truthiness check coerced ``score=0.0`` to ``-inf``, which could cause a worse,
+    negatively-scored duplicate to be kept instead of the ``0.0``-scored document.
+    The ``merge`` mode was updated to the same explicit ``is not None`` check for
     consistency; its observable behavior is unchanged.

--- a/releasenotes/notes/fix-document-joiner-zero-score-dedup-e79458b9865b0867.yaml
+++ b/releasenotes/notes/fix-document-joiner-zero-score-dedup-e79458b9865b0867.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed `DocumentJoiner` in `concatenate` mode so that documents with a score of
+    exactly `0.0` are no longer treated as unscored during deduplication. Previously
+    a truthiness check coerced `score=0.0` to `-inf`, which could cause a worse,
+    negatively-scored duplicate to be kept instead of the `0.0`-scored document.
+    The `merge` mode was updated to the same explicit `is not None` check for
+    consistency; its observable behavior is unchanged.

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -146,6 +146,29 @@ class TestDocumentJoiner:
             output["documents"], key=lambda d: d.id
         )
 
+    def test_run_with_concatenate_join_mode_keeps_zero_score_over_negative_duplicate(self):
+        joiner = DocumentJoiner(sort_by_score=False)
+        documents_1 = [Document(content="a", score=0.0)]
+        documents_2 = [Document(content="a", score=-0.5)]
+        output = joiner.run([documents_1, documents_2])
+        assert len(output["documents"]) == 1
+        assert output["documents"][0].score == 0.0
+
+    def test_run_with_concatenate_join_mode_keeps_zero_score_over_none_duplicate(self):
+        joiner = DocumentJoiner(sort_by_score=False)
+        documents_1 = [Document(content="a", score=0.0)]
+        documents_2 = [Document(content="a")]
+        output = joiner.run([documents_1, documents_2])
+        assert len(output["documents"]) == 1
+        assert output["documents"][0].score == 0.0
+
+    def test_run_with_merge_join_mode_handles_zero_score(self):
+        joiner = DocumentJoiner(join_mode="merge", weights=[0.5, 0.5])
+        documents_1 = [Document(content="a", score=0.0)]
+        documents_2 = [Document(content="a", score=0.0)]
+        output = joiner.run([documents_1, documents_2])
+        assert output["documents"][0].score == 0.0
+
     def test_run_with_merge_join_mode(self):
         joiner = DocumentJoiner(join_mode="merge", weights=[1.5, 0.5])
         documents_1 = [Document(content="a", score=1.0), Document(content="b", score=2.0)]


### PR DESCRIPTION
### Related Issues

- fixes #11352

### Proposed Changes:

- In `DocumentJoiner._concatenate`, replace `doc.score if doc.score else -inf` with `doc.score if doc.score is not None else -inf`. The truthiness check treated `score=0.0` as unscored, causing a worse-scored duplicate (e.g. `score=-0.5`) to win during deduplication.
- Apply the same `is not None` check in `_merge` for stylistic consistency with `_distribution_based_rank_fusion` and the `sort_by_score` branch in `run`. Behavior is unchanged in merge  mode (`None` and `0.0` both contribute `0`).
- Add unit tests covering `score=0.0` vs negatively-scored and `None`-scored duplicates in concatenate mode.

### How did you test it?

- Added three unit tests in `test/components/joiners/test_document_joiner.py`.
- Ran `hatch run test:unit -- test/components/joiners/test_document_joiner.py` locally.
- Ran `hatch run test:types` and `hatch run fmt`.

### Notes for the reviewer

 Minimal, surgical fix. One operator on two lines plus tests. No public API or serialization change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
