### PR TITLE
fix: preserve zero scores in document joiner

### DIFF
--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -171,7 +171,7 @@ class DocumentJoiner:
         for doc in itertools.chain.from_iterable(document_lists):
             docs_per_id[doc.id].append(doc)
         for docs in docs_per_id.values():
-            doc_with_best_score = max(docs, key=lambda doc: doc.score if doc.score else -inf)
+            doc_with_best_score = max(docs, key=lambda doc: doc.score if doc.score is not None else -inf)
             output.append(doc_with_best_score)
         return output
 
@@ -189,7 +189,7 @@ class DocumentJoiner:
 
         for documents, weight in zip(document_lists, weights, strict=True):
             for doc in documents:
-                scores_map[doc.id] += (doc.score if doc.score else 0) * weight
+                scores_map[doc.id] += (doc.score if doc.score is not None else 0) * weight
                 documents_map[doc.id] = doc
 
         return [replace(doc, score=scores_map[doc.id]) for doc in documents_map.values()]

--- a/releasenotes/notes/fix-document-joiner-zero-score-2e854273419df4e8.yaml
+++ b/releasenotes/notes/fix-document-joiner-zero-score-2e854273419df4e8.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed `DocumentJoiner` duplicate handling in `concatenate` mode so documents with `score=0.0` are compared by
+    their actual score instead of being treated like documents with no score.

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -146,6 +146,16 @@ class TestDocumentJoiner:
             output["documents"], key=lambda d: d.id
         )
 
+    def test_run_with_concatenate_join_mode_keeps_duplicate_document_with_zero_score(self):
+        joiner = DocumentJoiner(sort_by_score=False)
+        documents_1 = [Document(content="a", score=0.0)]
+        documents_2 = [Document(content="a", score=-0.5)]
+
+        output = joiner.run([documents_1, documents_2])
+
+        assert len(output["documents"]) == 1
+        assert output["documents"][0].score == 0.0
+
     def test_run_with_merge_join_mode(self):
         joiner = DocumentJoiner(join_mode="merge", weights=[1.5, 0.5])
         documents_1 = [Document(content="a", score=1.0), Document(content="b", score=2.0)]


### PR DESCRIPTION
## Summary
- fix `DocumentJoiner` duplicate selection in `concatenate` mode so `score=0.0` is compared as a real score
- align merge-mode score handling with the same explicit `None` check
- add a regression test and release note

## Why
`DocumentJoiner._concatenate` used a truthiness check for scores. Since `0.0` is falsy in Python, a duplicate document with `score=0.0` was treated like an unscored document and could lose to a worse negative score.

## Testing
- `hatch -e test run pytest test/components/joiners/test_document_joiner.py::TestDocumentJoiner::test_run_with_concatenate_join_mode_keeps_duplicate_document_with_zero_score -q`
- `hatch -e test run pytest test/components/joiners/test_document_joiner.py -q`
- `env -u ALL_PROXY -u HTTPS_PROXY -u HTTP_PROXY -u all_proxy -u https_proxy -u http_proxy hatch -e test run pytest test/components/joiners -q`
- `hatch run fmt-check haystack/components/joiners/document_joiner.py test/components/joiners/test_document_joiner.py`
- `hatch run test:types haystack/components/joiners/document_joiner.py`
- `hatch -e test run python -m compileall -q haystack/components/joiners/document_joiner.py test/components/joiners/test_document_joiner.py`
- `git diff --check`

Closes #11352
