### PR TITLE
fix: Fix max runs per component

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1240,7 +1240,9 @@ class PipelineBase:  # noqa: PLW1641
 
         component_name = item[1]
         comp = self._get_component_with_graph_metadata_and_visits(component_name, component_visits[component_name])
-        if comp["visits"] > self._max_runs_per_component:
+        # Only raise the max run count error if the component is not blocked, since if it's blocked it means it
+        # can't run anyway.
+        if item[0] < ComponentPriority.BLOCKED and comp["visits"] >= self._max_runs_per_component:
             msg = f"Maximum run count {self._max_runs_per_component} reached for component '{component_name}'"
             raise PipelineMaxComponentRuns(msg)
         return ComponentPriority(item[0]), component_name, comp

--- a/releasenotes/notes/fix-max-runs-per-component-2e7b416535ad1854.yaml
+++ b/releasenotes/notes/fix-max-runs-per-component-2e7b416535ad1854.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fix the ``max_runs_per_component`` limit on ``Pipeline`` and ``AsyncPipeline``
+    so that a component is now stopped when its number of runs reaches
+    ``max_runs_per_component`` rather than when it strictly exceeds it. Previously,
+    a component could run one more time than the configured limit before
+    ``PipelineMaxComponentRuns`` was raised. This only affected pipelines with
+    loops. The check is also skipped for ``BLOCKED`` components, since they cannot
+    run anyway and should not trigger the error.

--- a/test/core/pipeline/features/test_run.py
+++ b/test/core/pipeline/features/test_run.py
@@ -107,7 +107,7 @@ def pipeline_that_has_an_infinite_loop(pipeline_class):
 
 @given("a pipeline that is really complex with lots of components, forks, and loops", target_fixture="pipeline_data")
 def pipeline_complex(pipeline_class):
-    pipeline = pipeline_class(max_runs_per_component=2)
+    pipeline = pipeline_class(max_runs_per_component=3)
     pipeline.add_component("greet_first", Greet(message="Hello, the value is {value}."))
     pipeline.add_component("accumulate_1", Accumulate())
     pipeline.add_component("add_two", AddFixedValue(add=2))

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -1381,16 +1381,30 @@ class TestPipelineBase:
 
     @patch("haystack.core.pipeline.base.PipelineBase._get_component_with_graph_metadata_and_visits")
     def test__get_next_runnable_component_max_visits(self, mock_get_component_with_graph_metadata_and_visits):
-        """Test component exceeding max visits raises exception"""
+        """Test component reaching max visits raises exception"""
         pipeline = PipelineBase(max_runs_per_component=2)
         queue = FIFOPriorityQueue()
         queue.push("ready_component", ComponentPriority.READY)
-        mock_get_component_with_graph_metadata_and_visits.return_value = {"instance": "test", "visits": 3}
+        mock_get_component_with_graph_metadata_and_visits.return_value = {"instance": "test", "visits": 2}
 
         with pytest.raises(PipelineMaxComponentRuns) as exc_info:
-            pipeline._get_next_runnable_component(queue, component_visits={"ready_component": 3})
+            pipeline._get_next_runnable_component(queue, component_visits={"ready_component": 2})
 
         assert "Maximum run count 2 reached for component 'ready_component'" in str(exc_info.value)
+
+    @patch("haystack.core.pipeline.base.PipelineBase._get_component_with_graph_metadata_and_visits")
+    def test__get_next_runnable_component_max_visits_blocked(self, mock_get_component_with_graph_metadata_and_visits):
+        """Test a BLOCKED component that has reached max visits does NOT raise, since it cannot run anyway."""
+        pipeline = PipelineBase(max_runs_per_component=2)
+        queue = FIFOPriorityQueue()
+        queue.push("blocked_component", ComponentPriority.BLOCKED)
+        mock_get_component_with_graph_metadata_and_visits.return_value = {"instance": "test", "visits": 2}
+
+        result = pipeline._get_next_runnable_component(queue, component_visits={"blocked_component": 2})
+        assert result is not None
+        priority, component_name, comp = result
+        assert priority == ComponentPriority.BLOCKED
+        assert component_name == "blocked_component"
 
     @patch("haystack.core.pipeline.base.PipelineBase._get_component_with_graph_metadata_and_visits")
     def test__get_next_runnable_component_ready(self, mock_get_component_with_graph_metadata_and_visits):


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/243

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fixes https://github.com/deepset-ai/haystack-private/issues/243 such that a component can run at most the number of times specified by `max_runs_per_component`. Previously a component could run one more time than the configured max. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

I decided to only push this fix to the v3 branch b/c I would like for us to test it for awhile before releasing. Also this should only affect pipelines that have loops. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
