### PR TITLE
build: add lightweight npm supply chain guardrails

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,6 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/docs-website'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
     cooldown:
       default-days: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,10 @@ updates:
       interval: 'daily'
     cooldown:
       default-days: 1
+
+  - package-ecosystem: 'npm'
+    directory: '/docs-website'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 1

--- a/.github/workflows/check_api_ref.yml
+++ b/.github/workflows/check_api_ref.yml
@@ -88,7 +88,7 @@ jobs:
           # Node 22+ prefers ESM when available. We force CJS (CommonJS) resolution to use the working katex build.
           # This should be safe because docusaurus-mdx-checker and its dependencies provide CJS builds.
           export NODE_OPTIONS="--conditions=require"
-          npx docusaurus-mdx-checker -v || {
+          npx docusaurus-mdx-checker@3.0.0 -v || {
               echo ""
               echo "For common MDX problems, see https://docusaurus.io/blog/preparing-your-site-for-docusaurus-v3#common-mdx-problems"
               exit 1

--- a/.github/workflows/docs_search_sync.yml
+++ b/.github/workflows/docs_search_sync.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Docusaurus and build docs-website
         working-directory: docs-website
         run: |
-          npm install
+          npm install --ignore-scripts
           npm run build
 
       - name: Install script dependencies

--- a/.github/workflows/docs_search_sync.yml
+++ b/.github/workflows/docs_search_sync.yml
@@ -32,6 +32,7 @@ jobs:
         working-directory: docs-website
         run: |
           npm install --ignore-scripts
+          npm rebuild sharp
           npm run build
 
       - name: Install script dependencies


### PR DESCRIPTION
### Related Issues

- Follows on from https://github.com/deepset-ai/haystack/pull/11170 which added supply chain guardrails for pip/uv.

### Changes

**`check_api_ref.yml`** — pin `npx docusaurus-mdx-checker` to `@3.0.0`:
- Previously `npx` fetched the latest version on every run with no version pin, so a compromised release could land in CI immediately. Now pinned to the current latest (3.0.0). Updates can be applied deliberately when needed.
- There aren't frequent releases: https://www.npmjs.com/package/docusaurus-mdx-checker?activeTab=versions

**`docs_search_sync.yml`** — add `--ignore-scripts` to `npm install`, then explicitly rebuild `sharp`:
- `npm install --ignore-scripts` blocks `preinstall`/`install`/`postinstall` lifecycle hooks across all packages which is a common supply chain attack vectors. Risk here is that there are any hooks that are required and this change will make them fail. We'll see.
- We add one exception: `npm rebuild sharp` then re-runs only sharp's install script. Sharp is a native module (libvips bindings) that downloads a platform-specific prebuilt binary in its install script — without it, `@docusaurus/plugin-ideal-image` and other Docusaurus image code would fail at build time.

**`.github/dependabot.yml`** — add npm ecosystem entry:
- Adds an `npm` entry for `/docs-website` on a daily cadence with `cooldown.default-days: 1`, matching what we use for GitHub actions and pip. Dependabot will open bump PRs for direct dependencies in `package.json`.

### Notes for the reviewer

I chose to **not** commit `docs-website/package-lock.json` or switch to `npm ci`. The lockfile is ~900KB and would generate frequent Dependabot bumps touching it because that would include all transitive dependencies. Not just direct dependencies. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)