### PR TITLE
fix: keep NoneType argument when serializing typing generics

### DIFF
--- a/haystack/utils/type_serialization.py
+++ b/haystack/utils/type_serialization.py
@@ -75,10 +75,14 @@ def serialize_type(target: Any) -> str:
         # This avoids issues with Python's internal cache, where List[Union[str, int]] and List[str | int] are treated
         # as the same key. GenericAlias (builtins like list[...]) can keep the PEP 604 syntax.
         is_typing_generic = not isinstance(target, GenericAlias)
+        # Optional[X] is normalized by Python to Union[X, None]; the trailing None is already implied by the
+        # "Optional" name, so we drop it. For any other generic (e.g. Dict[str, None], Tuple[int, None] or a
+        # Union with more than two members) NoneType is a regular argument and must be kept.
+        skip_nonetype = name == "Optional"
         args_str = ", ".join(
             serialize_type(Union[tuple(get_args(a))] if is_typing_generic and isinstance(a, UnionType) else a)  # noqa: UP007
             for a in args
-            if a is not NoneType
+            if not (skip_nonetype and a is NoneType)
         )
         return f"{module_name}.{name}[{args_str}]" if module_name else f"{name}[{args_str}]"
 

--- a/releasenotes/notes/fix-serialize-type-nonetype-arg-444581c0b19217a7.yaml
+++ b/releasenotes/notes/fix-serialize-type-nonetype-arg-444581c0b19217a7.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed `serialize_type` dropping `NoneType` when it appears as a regular argument of a `typing` generic.
+    Types such as `typing.Dict[str, None]`, `typing.Tuple[int, None]`, `typing.List[None]` and unions with more
+    than two members like `typing.Union[str, int, None]` were serialized incorrectly (for example to
+    `typing.Dict[str]`), which produced malformed type strings that could not be deserialized again.
+    `typing.Optional[X]` is still serialized as `typing.Optional[X]` without a redundant trailing `None`.

--- a/releasenotes/notes/fix-serialize-type-nonetype-arg-444581c0b19217a7.yaml
+++ b/releasenotes/notes/fix-serialize-type-nonetype-arg-444581c0b19217a7.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixed `serialize_type` dropping `NoneType` when it appears as a regular argument of a `typing` generic.
+    Fixed ``serialize_type`` dropping ``NoneType`` when it appears as a regular argument of a ``typing`` generic.
     Types such as `typing.Dict[str, None]`, `typing.Tuple[int, None]`, `typing.List[None]` and unions with more
     than two members like `typing.Union[str, int, None]` were serialized incorrectly (for example to
     `typing.Dict[str]`), which produced malformed type strings that could not be deserialized again.

--- a/releasenotes/notes/fix-serialize-type-nonetype-arg-444581c0b19217a7.yaml
+++ b/releasenotes/notes/fix-serialize-type-nonetype-arg-444581c0b19217a7.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Fixed ``serialize_type`` dropping ``NoneType`` when it appears as a regular argument of a ``typing`` generic.
-    Types such as `typing.Dict[str, None]`, `typing.Tuple[int, None]`, `typing.List[None]` and unions with more
-    than two members like `typing.Union[str, int, None]` were serialized incorrectly (for example to
-    `typing.Dict[str]`), which produced malformed type strings that could not be deserialized again.
-    `typing.Optional[X]` is still serialized as `typing.Optional[X]` without a redundant trailing `None`.
+    Types such as ``typing.Dict[str, None]``, ``typing.Tuple[int, None]``, ``typing.List[None]`` and unions with more
+    than two members like ``typing.Union[str, int, None]`` were serialized incorrectly (for example to
+    ``typing.Dict[str]``), which produced malformed type strings that could not be deserialized again.
+    ``typing.Optional[X]`` is still serialized as ``typing.Optional[X]`` without a redundant trailing ``None``.

--- a/test/utils/test_type_serialization.py
+++ b/test/utils/test_type_serialization.py
@@ -195,6 +195,31 @@ def test_output_type_deserialization_nested():
     assert deserialize_type("list[dict[str, int] | None]") == list[Union[dict[str, int], None]]
 
 
+def test_output_type_serialization_typing_generic_with_nonetype():
+    # NoneType used as a regular argument of a typing generic (not the implicit None of Optional)
+    # must be kept, otherwise the serialized type is malformed (e.g. "typing.Dict[str]") or loses information.
+    assert serialize_type(Dict[str, type(None)]) == "typing.Dict[str, None]"
+    assert serialize_type(Dict[type(None), str]) == "typing.Dict[None, str]"
+    assert serialize_type(Tuple[int, type(None)]) == "typing.Tuple[int, None]"
+    assert serialize_type(List[type(None)]) == "typing.List[None]"
+    # A Union with more than two members that includes None must keep None as well.
+    assert serialize_type(Union[str, int, None]) == "typing.Union[str, int, None]"
+    # Optional must still be serialized without a redundant trailing None.
+    assert serialize_type(Optional[str]) == "typing.Optional[str]"
+
+
+def test_output_type_round_trip_typing_generic_with_nonetype():
+    for type_ in [
+        Dict[str, type(None)],
+        Dict[type(None), str],
+        Tuple[int, type(None)],
+        List[type(None)],
+        Union[str, int, None],
+        Optional[str],
+    ]:
+        assert deserialize_type(serialize_type(type_)) == type_
+
+
 def test_output_type_serialization_haystack_dataclasses():
     # typing
     # Answer


### PR DESCRIPTION
### Related Issues

No existing issue; reporting and fixing a bug found in `haystack.utils.type_serialization.serialize_type`.

### Proposed Changes:

`serialize_type` unconditionally dropped `NoneType` from the arguments of `typing` generics:

```python
args_str = ", ".join(
    serialize_type(...)
    for a in args
    if a is not NoneType   # drops None from *every* typing generic
)
```

This filter was only meant to remove the implicit `None` of `Optional[X]` (which is already conveyed by the `Optional` name). However, it also stripped `None` when it is a *regular* argument of a generic, producing malformed or lossy output:

| Input | Before (buggy) | Problem |
| --- | --- | --- |
| `typing.Dict[str, None]` | `"typing.Dict[str]"` | malformed, fails to deserialize (`DeserializationError`) |
| `typing.Dict[None, str]` | `"typing.Dict[str]"` | drops the key type |
| `typing.Tuple[int, None]` | `"typing.Tuple[int]"` | silently loses `None` |
| `typing.List[None]` | `"typing.List[]"` | malformed, `IndexError` on deserialize |
| `typing.Union[str, int, None]` | `"typing.Union[str, int]"` | silently loses `None` |

(The builtin `dict[str, None]` form was unaffected because `get_args` returns the literal `None` singleton there, not the `NoneType` class.)

The fix only drops `NoneType` for `Optional[X]` (where `name == "Optional"`) and keeps it for every other generic, so the values round-trip correctly again. `typing.Optional[X]` still serializes to `typing.Optional[X]` without a redundant trailing `None`.

### How did you test it?

Unit tests in `test/utils/test_type_serialization.py`:

- `test_output_type_serialization_typing_generic_with_nonetype` checks the serialized strings for `Dict[str, None]`, `Dict[None, str]`, `Tuple[int, None]`, `List[None]`, `Union[str, int, None]`, and that `Optional[str]` is unchanged.
- `test_output_type_round_trip_typing_generic_with_nonetype` checks `deserialize_type(serialize_type(t)) == t` for the same types.

Both tests fail on `main` and pass with this change. The full `test/utils/test_type_serialization.py` suite (159 tests) passes, along with the related serialization suites and component type/socket tests. `ruff check`, `ruff format --check`, and `mypy` are clean on the changed file.

### Notes for the reviewer

Single-line, behavior-preserving change for `Optional`; only positional `NoneType` arguments of other generics are affected. A release note is included.

Developed with AI coding assistance; reviewed and submitted by the author.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the code of conduct.
- I have added unit tests and updated the docstrings.
- I've used a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) type for my PR title (`fix:`).
- I have documented my code.
- I have added a release note file under `releasenotes/notes`.