### PR TITLE
feat: add SiftqWebSearch component for SiftQ API web search

### DIFF
--- a/docs-website/docs/pipeline-components/websearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch.mdx
@@ -16,4 +16,5 @@ Use these components to look up answers on the internet.
 | [PerplexityWebSearch](websearch/perplexitywebsearch.mdx) | Search engine using the Perplexity Search API. |
 | [SearchApiWebSearch](websearch/searchapiwebsearch.mdx) | Search engine using Search API.    |
 | [SerperDevWebSearch](websearch/serperdevwebsearch.mdx) | Search engine using SerperDev API. |
+| [SiftqWebSearch](websearch/siftqwebsearch.mdx) | Search engine using the SiftQ AI-powered search API. |
 | [TavilyWebSearch](websearch/tavilywebsearch.mdx) | Search engine using the Tavily AI-powered search API. |

--- a/docs-website/docs/pipeline-components/websearch/siftqwebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/siftqwebsearch.mdx
@@ -1,0 +1,131 @@
+---
+title: "SiftqWebSearch"
+id: siftqwebsearch
+slug: "/siftqwebsearch"
+description: "Search engine using the SiftQ AI-powered search API."
+---
+
+# SiftqWebSearch
+
+Search the web using [SiftQ](https://siftq.com), an AI-powered search engine with multi-scope support for webpages, documents, scholarly papers, images, videos, and podcasts.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | Before a [`ChatPromptBuilder`](../builders/chatpromptbuilder.mdx) or right at the beginning of an indexing pipeline |
+| **Mandatory init variables** | None. Defaults to the built-in free tier key (100 searches/day). Set `SIFTQ_API_KEY` env var or `api_key` parameter for more. |
+| **Mandatory run variables** | `query`: A string with your search query. |
+| **Output variables** | `documents`: A list of Haystack Documents containing search result content and metadata. <br /> <br />`links`: A list of strings of resulting URLs. |
+| **API reference** | [SiftqWebSearch API](/reference/native-api/websearch#siftqwebsearch) |
+| **GitHub link** | https://github.com/siftq/siftq |
+
+</div>
+
+## Overview
+
+When you give `SiftqWebSearch` a query, it uses the [SiftQ](https://siftq.com) Search API to search the web and return relevant content as Haystack `Document` objects. It also returns a list of the source URLs.
+
+SiftQ is an AI-powered search engine built for LLM applications. It supports six search scopes: webpages, documents, scholarly papers, images, videos, and podcasts — each returning structured results with titles, snippets, URLs, and metadata. Use the `scope` parameter to select which scope to query (defaults to `"webpage"`).
+
+### API Key
+
+By default, `SiftqWebSearch` uses a **built-in free tier API key** (100 searches/day, no configuration needed). For higher usage limits, you can provide your own key via:
+
+- **Environment variable**: Set `SIFTQ_API_KEY`
+- **Explicit parameter**: Pass `api_key=Secret.from_token("your-key")` during initialization
+
+The resolution order is: explicit parameter → env var → built-in free tier key.
+
+## Usage
+
+### On its own
+
+Here is a quick example of how `SiftqWebSearch` searches the web based on a query and returns a list of Documents.
+
+```python
+from haystack.components.websearch import SiftqWebSearch
+
+web_search = SiftqWebSearch(top_k=5)
+query = "What is Haystack by deepset?"
+
+response = web_search.run(query=query)
+
+for doc in response["documents"]:
+    print(doc.content)
+```
+
+### With custom scope
+
+Search for scholarly papers instead of webpages:
+
+```python
+from haystack.components.websearch import SiftqWebSearch
+
+web_search = SiftqWebSearch(top_k=5, scope="scholar")
+response = web_search.run(query="transformer attention mechanism")
+
+for doc in response["documents"]:
+    print(doc.meta["title"], "-", doc.meta.get("venue", ""))
+```
+
+### With summary-enhanced recall and raw content
+
+Use `includeSummary: True` to fetch full-page summaries for better retrieval recall. Use `includeRawContent: True` to get the raw text content from all source pages.
+
+```python
+from haystack.components.websearch import SiftqWebSearch
+
+web_search = SiftqWebSearch(
+    top_k=3,
+    search_params={"includeSummary": True, "includeRawContent": True},
+)
+response = web_search.run(query="retrieval augmented generation")
+```
+
+### In a pipeline
+
+Here is an example of a Retrieval-Augmented Generation (RAG) pipeline that uses `SiftqWebSearch` to look up an answer on the web.
+
+```python
+from haystack import Pipeline
+from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.websearch import SiftqWebSearch
+from haystack.dataclasses import ChatMessage
+from haystack.utils import Secret
+
+web_search = SiftqWebSearch(top_k=3)
+
+prompt_template = [
+    ChatMessage.from_system("You are a helpful assistant."),
+    ChatMessage.from_user(
+        "Given the information below:\n"
+        "{% for document in documents %}{{ document.content }}\n{% endfor %}\n"
+        "Answer the following question: {{ query }}.\nAnswer:",
+    ),
+]
+
+prompt_builder = ChatPromptBuilder(
+    template=prompt_template,
+    required_variables={"query", "documents"},
+)
+
+llm = OpenAIChatGenerator(
+    api_key=Secret.from_env_var("OPENAI_API_KEY"),
+)
+
+pipe = Pipeline()
+pipe.add_component("search", web_search)
+pipe.add_component("prompt_builder", prompt_builder)
+pipe.add_component("llm", llm)
+
+pipe.connect("search.documents", "prompt_builder.documents")
+pipe.connect("prompt_builder.prompt", "llm.messages")
+
+query = "What is Haystack by deepset?"
+
+result = pipe.run(data={"search": {"query": query}, "prompt_builder": {"query": query}})
+
+print(result["llm"]["replies"][0].text)
+```

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -639,6 +639,7 @@ export default {
             'pipeline-components/websearch/perplexitywebsearch',
             'pipeline-components/websearch/searchapiwebsearch',
             'pipeline-components/websearch/serperdevwebsearch',
+            'pipeline-components/websearch/siftqwebsearch',
             'pipeline-components/websearch/tavilywebsearch',
             'pipeline-components/websearch/external-integrations-websearch',
           ],

--- a/haystack/components/websearch/__init__.py
+++ b/haystack/components/websearch/__init__.py
@@ -7,11 +7,16 @@ from typing import TYPE_CHECKING
 
 from lazy_imports import LazyImporter
 
-_import_structure = {"searchapi": ["SearchApiWebSearch"], "serper_dev": ["SerperDevWebSearch"]}
+_import_structure = {
+    "searchapi": ["SearchApiWebSearch"],
+    "serper_dev": ["SerperDevWebSearch"],
+    "siftq": ["SiftqWebSearch"],
+}
 
 if TYPE_CHECKING:
     from .searchapi import SearchApiWebSearch as SearchApiWebSearch
     from .serper_dev import SerperDevWebSearch as SerperDevWebSearch
+    from .siftq import SiftqWebSearch as SiftqWebSearch
 
 else:
     sys.modules[__name__] = LazyImporter(name=__name__, module_file=__file__, import_structure=_import_structure)

--- a/haystack/components/websearch/siftq.py
+++ b/haystack/components/websearch/siftq.py
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import httpx
+
+from haystack import ComponentError, Document, component, default_from_dict, default_to_dict, logging
+from haystack.utils import Secret
+
+logger = logging.getLogger(__name__)
+
+SIFTQ_BASE_URL = "https://api.siftq.com/v1/search"
+SIFTQ_DEFAULT_API_KEY = "mk-1D3D81EFC32A25683B0C2C3B315F8579"  # intentionally public — free tier key
+
+SIFTQ_SCOPE_MAP: dict[str, tuple[str, str]] = {
+    "webpage": ("webpages", "link"),
+    "document": ("documents", "link"),
+    "scholar": ("scholars", "link"),
+    "image": ("images", "imageUrl"),
+    "video": ("videos", "link"),
+    "podcast": ("podcasts", "link"),
+}
+
+
+class SiftqError(ComponentError): ...
+
+
+_SIFTQ_ERROR_CODES: dict[int, str] = {
+    2005: "API key rejected. Check your SiftQ API key.",
+    3003: "daily search limit reached. See: https://siftq.com/playground",
+}
+
+
+@component
+class SiftqWebSearch:
+    """
+    Uses [SiftQ](https://siftq.com) to search the web for relevant documents.
+
+    Supports multi-scope search: webpages, documents, scholarly papers, images, videos, and podcasts.
+    Use the `scope` parameter to select which scope to query.
+
+    Use `search_params={"includeSummary": True}` to enhance recall with page summaries,
+    and `search_params={"includeRawContent": True}` to fetch raw text content from source pages.
+
+    Usage example:
+    <!-- test-ignore -->
+    ```python
+    from haystack.components.websearch import SiftqWebSearch
+    from haystack.utils import Secret
+
+    websearch = SiftqWebSearch(top_k=10, api_key=Secret.from_env_var("SIFTQ_API_KEY"))
+    results = websearch.run(query="What is the capital of France?")
+
+    assert results["documents"]
+    assert results["links"]
+    ```
+    """
+
+    def __init__(
+        self,
+        api_key: Secret = Secret.from_env_var("SIFTQ_API_KEY", strict=False),
+        top_k: int | None = 10,
+        scope: str = "webpage",
+        allowed_domains: list[str] | None = None,
+        search_params: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Initialize the SiftqWebSearch component.
+
+        :param api_key: API key for the SiftQ API. Falls back to the built-in free tier key
+            if not provided.
+        :param top_k: Number of documents to return.
+        :param scope: Search scope. One of "webpage", "document", "scholar", "image", "video", "podcast".
+            Defaults to "webpage".
+        :param allowed_domains: List of domains to limit the search to. Only applies to "webpage" scope.
+        :param search_params: Additional parameters passed to the SiftQ API.
+            For example: `{"includeSummary": true, "includeRawContent": true, "conciseSnippet": true}.
+        """
+        if scope not in SIFTQ_SCOPE_MAP:
+            raise ValueError(
+                f"Unknown scope '{scope}'. Must be one of: {', '.join(SIFTQ_SCOPE_MAP)}"
+            )
+        self.api_key = api_key
+        self.top_k = top_k
+        self.scope = scope
+        self.allowed_domains = allowed_domains
+        self.search_params = search_params or {}
+
+    def _resolve_api_key(self) -> str:
+        key = self.api_key.resolve_value()
+        return key or SIFTQ_DEFAULT_API_KEY
+
+    def to_dict(self) -> dict[str, Any]:
+        return default_to_dict(
+            self,
+            top_k=self.top_k,
+            scope=self.scope,
+            allowed_domains=self.allowed_domains,
+            search_params=self.search_params,
+            api_key=self.api_key,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SiftqWebSearch":
+        return default_from_dict(cls, data)
+
+    @component.output_types(documents=list[Document], links=list[str])
+    def run(self, query: str) -> dict[str, list[Document] | list[str]]:
+        """
+        Uses [SiftQ](https://siftq.com) to search the web.
+
+        :param query: Search query.
+        :returns: A dictionary with the following keys:
+            - "documents": List of documents returned by the search engine.
+            - "links": List of links returned by the search engine.
+        :raises TimeoutError: If the request to the SiftQ API times out.
+        :raises SiftqError: If an error occurs while querying the SiftQ API.
+        """
+        result_key, link_field = SIFTQ_SCOPE_MAP[self.scope]
+        payload, headers = self._build_payload(query), self._build_headers()
+        try:
+            response = httpx.post(SIFTQ_BASE_URL, headers=headers, json=payload, timeout=90)
+            response.raise_for_status()
+        except httpx.ConnectTimeout as error:
+            raise TimeoutError(f"Request to {self.__class__.__name__} timed out.") from error
+        except httpx.HTTPStatusError as e:
+            raise SiftqError(
+                f"An error occurred while querying {self.__class__.__name__}. "
+                f"Error: {e}, Response: {e.response.text}"
+            ) from e
+        except httpx.HTTPError as e:
+            raise SiftqError(f"An error occurred while querying {self.__class__.__name__}. Error: {e}") from e
+        self._check_api_error(response)
+
+        documents, links = self._parse_response(response, result_key, link_field)
+
+        logger.debug(
+            "SiftQ returned {number_documents} documents for the query '{query}'",
+            number_documents=len(documents),
+            query=query,
+        )
+        return {"documents": documents[: self.top_k], "links": links[: self.top_k]}
+
+    @component.output_types(documents=list[Document], links=list[str])
+    async def run_async(self, query: str) -> dict[str, list[Document] | list[str]]:
+        """
+        Asynchronously uses [SiftQ](https://siftq.com) to search the web.
+
+        This is the asynchronous version of the `run` method with the same parameters and return values.
+
+        :param query: Search query.
+        :returns: A dictionary with the following keys:
+            - "documents": List of documents returned by the search engine.
+            - "links": List of links returned by the search engine.
+        :raises TimeoutError: If the request to the SiftQ API times out.
+        :raises SiftqError: If an error occurs while querying the SiftQ API.
+        """
+        result_key, link_field = SIFTQ_SCOPE_MAP[self.scope]
+        payload, headers = self._build_payload(query), self._build_headers()
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(SIFTQ_BASE_URL, headers=headers, json=payload, timeout=90)
+                response.raise_for_status()
+        except httpx.ConnectTimeout as error:
+            raise TimeoutError(f"Request to {self.__class__.__name__} timed out.") from error
+        except httpx.HTTPStatusError as e:
+            raise SiftqError(
+                f"An error occurred while querying {self.__class__.__name__}. "
+                f"Error: {e}, Response: {e.response.text}"
+            ) from e
+        except httpx.HTTPError as e:
+            raise SiftqError(f"An error occurred while querying {self.__class__.__name__}. Error: {e}") from e
+        self._check_api_error(response)
+
+        documents, links = self._parse_response(response, result_key, link_field)
+
+        logger.debug(
+            "SiftQ returned {number_documents} documents for the query '{query}'",
+            number_documents=len(documents),
+            query=query,
+        )
+        return {"documents": documents[: self.top_k], "links": links[: self.top_k]}
+
+    @staticmethod
+    def _check_api_error(response: httpx.Response) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            return
+        code = body.get("code")
+        if not code:
+            return
+        msg = _SIFTQ_ERROR_CODES.get(code) or body.get("message", f"unknown error code {code}")
+        raise SiftqError(f"SiftQ API error: {msg}")
+
+    def _build_headers(self) -> dict[str, str]:
+        api_key = self._resolve_api_key()
+        return {"Authorization": f"Bearer {api_key}"}
+
+    def _build_payload(self, query: str) -> dict[str, Any]:
+        query_prepend = "OR ".join(f"site:{domain} " for domain in self.allowed_domains) if self.allowed_domains else ""
+        payload: dict[str, Any] = {
+            "q": query_prepend + query,
+            "scope": self.scope,
+            "size": self.top_k or 10,
+            **self.search_params,
+        }
+        return payload
+
+    def _parse_response(
+        self, response: httpx.Response, result_key: str, link_field: str
+    ) -> tuple[list[Document], list[str]]:
+        json_result = response.json()
+        documents: list[Document] = []
+        links: list[str] = []
+
+        for item in json_result.get(result_key, []):
+            link = item.get(link_field, "")
+            snippet_fields = ["snippet", "summary", "description", "title"]
+            content = ""
+            for f in snippet_fields:
+                if item.get(f):
+                    content = item[f]
+                    break
+            doc = Document(
+                content=content,
+                meta={
+                    "title": item.get("title", ""),
+                    "link": link,
+                    "score": item.get("score", ""),
+                    "position": item.get("position", 0),
+                    "authors": item.get("authors", []),
+                    "date": item.get("date", ""),
+                },
+            )
+            if result_key == "scholars":
+                doc.meta["citationCount"] = item.get("citationCount", 0)
+                doc.meta["venue"] = item.get("venue", "")
+                doc.meta["doi"] = item.get("doi", "")
+            elif result_key == "videos":
+                doc.meta["duration"] = item.get("duration", "")
+                doc.meta["viewCount"] = item.get("viewCount", "")
+            elif result_key == "podcasts":
+                doc.meta["podcastName"] = item.get("podcastName", "")
+                doc.meta["audioUrl"] = item.get("audioUrl", "")
+                doc.meta["duration"] = item.get("duration", "")
+            documents.append(doc)
+            links.append(link)
+
+        return documents, links

--- a/test/components/websearch/test_siftq.py
+++ b/test/components/websearch/test_siftq.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from httpx import ConnectTimeout, HTTPStatusError, Request, RequestError, Response
+
+from haystack import Document
+from haystack.components.websearch.siftq import SIFTQ_DEFAULT_API_KEY, SiftqError, SiftqWebSearch
+from haystack.utils.auth import Secret
+
+EXAMPLE_SIFTQ_RESPONSE = {
+    "credits": 1,
+    "total": 3,
+    "webpages": [
+        {
+            "title": "Paris - Wikipedia",
+            "link": "https://en.wikipedia.org/wiki/Paris",
+            "snippet": "Paris is the capital and largest city of France.",
+            "score": "0.95",
+            "position": 0,
+        },
+        {
+            "title": "Paris travel guide",
+            "link": "https://example.com/paris-guide",
+            "snippet": "The best things to do in Paris, France.",
+            "score": "0.85",
+            "position": 1,
+        },
+        {
+            "title": "France info",
+            "link": "https://example.com/france",
+            "snippet": "General information about France and its capital Paris.",
+            "score": "0.75",
+            "position": 2,
+        },
+    ],
+}
+
+
+@pytest.fixture
+def mock_siftq_search_result() -> Generator[MagicMock, None, None]:
+    with patch("haystack.components.websearch.siftq.httpx") as mock_run:
+        mock_run.post.return_value = Mock(status_code=200, json=lambda: EXAMPLE_SIFTQ_RESPONSE)
+        yield mock_run
+
+
+@pytest.fixture
+def mock_siftq_search_result_async() -> Generator[MagicMock, None, None]:
+    with patch("haystack.components.websearch.siftq.httpx.AsyncClient") as mock_run:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = Mock(status_code=200, json=lambda: EXAMPLE_SIFTQ_RESPONSE)
+        mock_client.__aenter__.return_value = mock_client
+        mock_run.return_value = mock_client
+        yield mock_run
+
+
+class TestSiftqWebSearch:
+    def test_init_default_params(self):
+        ws = SiftqWebSearch()
+        assert ws.top_k == 10
+        assert ws.scope == "webpage"
+        assert ws.allowed_domains is None
+        assert ws.search_params == {}
+
+    def test_init_custom_params(self):
+        ws = SiftqWebSearch(
+            api_key=Secret.from_token("test-key"),
+            top_k=5,
+            scope="scholar",
+            allowed_domains=["example.com"],
+            search_params={"includeSummary": True},
+        )
+        assert ws.top_k == 5
+        assert ws.scope == "scholar"
+        assert ws.allowed_domains == ["example.com"]
+        assert ws.search_params == {"includeSummary": True}
+
+    def test_to_dict(self, monkeypatch):
+        monkeypatch.setenv("SIFTQ_API_KEY", "test-api-key")
+        ws = SiftqWebSearch(top_k=10, scope="webpage")
+        data = ws.to_dict()
+        assert data == {
+            "type": "haystack.components.websearch.siftq.SiftqWebSearch",
+            "init_parameters": {
+                "api_key": {"env_vars": ["SIFTQ_API_KEY"], "strict": False, "type": "env_var"},
+                "top_k": 10,
+                "scope": "webpage",
+                "allowed_domains": None,
+                "search_params": {},
+            },
+        }
+
+    @pytest.mark.parametrize("top_k", [1, 2, 3])
+    def test_web_search_top_k(self, mock_siftq_search_result: MagicMock, top_k: int) -> None:
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-api-key"), top_k=top_k)
+        results = ws.run(query="capital of France")
+        documents = results["documents"]
+        links = results["links"]
+        assert len(documents) == len(links) == top_k
+        assert all(isinstance(doc, Document) for doc in documents)
+        assert all(isinstance(link, str) for link in links)
+        assert all(link.startswith("http") for link in links)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("top_k", [1, 2, 3])
+    async def test_web_search_top_k_async(self, mock_siftq_search_result_async: MagicMock, top_k: int) -> None:
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-api-key"), top_k=top_k)
+        results = await ws.run_async(query="capital of France")
+        documents = results["documents"]
+        links = results["links"]
+        assert len(documents) == len(links) == top_k
+        assert all(isinstance(doc, Document) for doc in documents)
+        assert all(isinstance(link, str) for link in links)
+        assert all(link.startswith("http") for link in links)
+
+    @patch("haystack.components.websearch.siftq.httpx.post")
+    def test_prepare_request_with_allowed_domains(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = Mock(status_code=200, json=lambda: {"webpages": []})
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-key"), allowed_domains=["example.com", "test.org"])
+        ws.run(query="test query")
+        call_kwargs = mock_post.call_args[1]
+        assert "site:example.com" in call_kwargs["json"]["q"]
+        assert "site:test.org" in call_kwargs["json"]["q"]
+        assert call_kwargs["json"]["scope"] == "webpage"
+        assert call_kwargs["headers"]["Authorization"] == "Bearer test-key"
+
+    def test_invalid_scope_raises(self):
+        with pytest.raises(ValueError, match="Unknown scope"):
+            SiftqWebSearch(scope="invalid")
+
+    def test_document_metadata(self, mock_siftq_search_result: MagicMock) -> None:
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-api-key"), top_k=1)
+        results = ws.run(query="capital of France")
+        doc = results["documents"][0]
+        assert doc.meta["title"] == "Paris - Wikipedia"
+        assert doc.meta["link"] == "https://en.wikipedia.org/wiki/Paris"
+        assert doc.meta["score"] == "0.95"
+        assert doc.meta["position"] == 0
+
+    @patch("httpx.post")
+    def test_timeout_error(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = ConnectTimeout("Request has timed out.")
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(TimeoutError):
+            ws.run(query="capital of France")
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient.post")
+    async def test_timeout_error_async(self, mock_post: AsyncMock) -> None:
+        mock_post.side_effect = ConnectTimeout("Request has timed out.")
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(TimeoutError):
+            await ws.run_async(query="capital of France")
+
+    @patch("httpx.post")
+    def test_request_exception(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = RequestError("An error has occurred in the request.")
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(SiftqError):
+            ws.run(query="capital of France")
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient.post")
+    async def test_request_exception_async(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = RequestError("An error has occurred in the request.")
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(SiftqError):
+            await ws.run_async(query="capital of France")
+
+    @patch("httpx.post")
+    def test_bad_response_code(self, mock_post: MagicMock) -> None:
+        mock_response = mock_post.return_value
+        mock_response.status_code = 404
+        mock_error_request = Request("POST", "https://example.com")
+        mock_error_response = Response(404)
+        mock_response.raise_for_status.side_effect = HTTPStatusError(
+            "404 Not Found.", request=mock_error_request, response=mock_error_response
+        )
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(SiftqError):
+            ws.run(query="capital of France")
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient")
+    async def test_bad_response_code_async(self, mock_run: MagicMock) -> None:
+        mock_client = AsyncMock()
+        mock_response = Mock(status_code=404)
+        mock_error_request = Request("POST", "https://example.com")
+        mock_error_response = Response(404)
+        mock_response.raise_for_status.side_effect = HTTPStatusError(
+            "404 Not Found.", request=mock_error_request, response=mock_error_response
+        )
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_run.return_value = mock_client
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-api-key"))
+
+        with pytest.raises(SiftqError):
+            await ws.run_async(query="capital of France")
+
+    def test_resolve_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("SIFTQ_API_KEY", "env-key-value")
+        ws = SiftqWebSearch()
+        assert ws._resolve_api_key() == "env-key-value"
+
+    def test_resolve_api_key_default_when_not_configured(self, monkeypatch):
+        monkeypatch.delenv("SIFTQ_API_KEY", raising=False)
+        ws = SiftqWebSearch()
+        key = ws._resolve_api_key()
+        assert key == SIFTQ_DEFAULT_API_KEY
+
+    def test_resolve_api_key_token_takes_precedence(self):
+        ws = SiftqWebSearch(api_key=Secret.from_token("explicit-key"))
+        assert ws._resolve_api_key() == "explicit-key"
+
+    def test_api_error_2005_key_rejected(self):
+        error_body = {"code": 2005, "message": "API key rejected"}
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-key"))
+
+        with patch("haystack.components.websearch.siftq.httpx.post") as mock_post:
+            response = Mock(status_code=200)
+            response.json.return_value = error_body
+            mock_post.return_value = response
+
+            with pytest.raises(SiftqError, match="API key rejected"):
+                ws.run(query="test")
+
+    def test_api_error_3003_limit_reached(self):
+        error_body = {"code": 3003, "message": "daily limit reached"}
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-key"))
+
+        with patch("haystack.components.websearch.siftq.httpx.post") as mock_post:
+            response = Mock(status_code=200)
+            response.json.return_value = error_body
+            mock_post.return_value = response
+
+            with pytest.raises(SiftqError, match="daily search limit reached"):
+                ws.run(query="test")
+
+    def test_api_error_unknown_code(self):
+        error_body = {"code": 9999, "message": "something went wrong"}
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-key"))
+
+        with patch("haystack.components.websearch.siftq.httpx.post") as mock_post:
+            response = Mock(status_code=200)
+            response.json.return_value = error_body
+            mock_post.return_value = response
+
+            with pytest.raises(SiftqError, match="something went wrong"):
+                ws.run(query="test")
+
+    def test_api_error_no_code_passes_through(self):
+        normal_body = {"webpages": [{"title": "ok", "link": "https://example.com", "snippet": "test"}]}
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-key"))
+
+        with patch("haystack.components.websearch.siftq.httpx.post") as mock_post:
+            response = Mock(status_code=200)
+            response.json.return_value = normal_body
+            mock_post.return_value = response
+
+            result = ws.run(query="test")
+            assert len(result["documents"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_api_error_2005_async(self):
+        error_body = {"code": 2005, "message": "API key rejected"}
+        ws = SiftqWebSearch(api_key=Secret.from_token("test-key"))
+
+        with patch("haystack.components.websearch.siftq.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            response = Mock(status_code=200)
+            response.json.return_value = error_body
+            mock_client.post.return_value = response
+            mock_client.__aenter__.return_value = mock_client
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(SiftqError, match="API key rejected"):
+                await ws.run_async(query="test")
+
+    @pytest.mark.skipif(
+        not os.environ.get("SIFTQ_API_KEY", None),
+        reason="Export an env var called SIFTQ_API_KEY containing the SiftQ API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_web_search(self) -> None:
+        ws = SiftqWebSearch(top_k=10)
+        results = ws.run(query="capital of France")
+        documents = results["documents"]
+        links = results["links"]
+        assert len(documents) == len(links) == 10
+        assert all(isinstance(doc, Document) for doc in documents)
+        assert all(isinstance(link, str) for link in links)
+        assert all(link.startswith("http") for link in links)
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("SIFTQ_API_KEY", None),
+        reason="Export an env var called SIFTQ_API_KEY containing the SiftQ API key to run this test.",
+    )
+    @pytest.mark.integration
+    async def test_web_search_async(self) -> None:
+        ws = SiftqWebSearch(top_k=10)
+        results = await ws.run_async(query="capital of France")
+        documents = results["documents"]
+        links = results["links"]
+        assert len(documents) == len(links) == 10
+        assert all(isinstance(doc, Document) for doc in documents)
+        assert all(isinstance(link, str) for link in links)
+        assert all(link.startswith("http") for link in links)


### PR DESCRIPTION
## feat: add SiftqWebSearch component for SiftQ API web search

Adds a new built-in Haystack component `SiftqWebSearch` that searches the web using the [SiftQ](https://siftq.com) AI-powered search API.

### What it does

`SiftqWebSearch` takes a query and a scope (webpages, documents, scholarly papers, images, videos, or podcasts) and returns results as Haystack `Document` objects with source URLs.

### Key features

- **Six search scopes** — webpages, documents, scholarly papers, images, videos, podcasts, selected via `scope` parameter (defaults to `"webpage"`)
- **No API key required** — built-in free tier key (100 searches/day) works out of the box; override via `SIFTQ_API_KEY` env var or explicit `api_key` parameter
- **Scope-specific metadata** — citation counts for scholars, duration for videos/podcasts, authors/dates across all types
- **Domain filtering** — `allowed_domains` parameter to restrict web results to specific sites
- **Async support** — `run_async()` for async pipelines
- **Full pipeline integration** — standard Haystack `@component` with serialization (`to_dict`/`from_dict`)
- **Error handling** — catches HTTP errors, timeouts, and SiftQ API error codes (2005 key rejected, 3003 daily limit reached)

### Files changed

| File | Change |
|---|---|
| `haystack/components/websearch/siftq.py` | New — SiftqWebSearch component |
| `test/components/websearch/test_siftq.py` | New — 28 tests (26 pass, 2 integration skipped) |
| `haystack/components/websearch/__init__.py` | Added lazy import for SiftqWebSearch |
| `docs-website/docs/pipeline-components/websearch/siftqwebsearch.mdx` | New — documentation page with usage examples |
| `docs-website/docs/pipeline-components/websearch.mdx` | Added to the component table |
| `docs-website/sidebars.js` | Added sidebar entry |