### PR TITLE
docs: Add documentation for Amazon Textract integration

### DIFF
--- a/docs-website/docs/pipeline-components/converters.mdx
+++ b/docs-website/docs/pipeline-components/converters.mdx
@@ -11,6 +11,7 @@ Use various Converters to extract data from files in different formats and cast 
 
 | Converter                                                    | Description                                                                                                   |
 | --- | --- |
+| [AmazonTextractConverter](converters/amazontextractconverter.mdx) | Converts images and single-page PDFs to documents using AWS Textract, with optional structured analysis of tables, forms, signatures, and layout, plus natural-language queries. |
 | [AzureDocumentIntelligenceConverter](converters/azuredocumentintelligenceconverter.mdx) | Converts PDF, JPEG, PNG, BMP, TIFF, DOCX, XLSX, PPTX, and HTML to documents using Azure's Document Intelligence service with GitHub Flavored Markdown output. |
 | [AzureOCRDocumentConverter](converters/azureocrdocumentconverter.mdx) | Converts PDF (both searchable and image-only), JPEG, PNG, BMP, TIFF, DOCX, XLSX, PPTX, and HTML to documents. |
 | [CSVToDocument](converters/csvtodocument.mdx)                           | Converts CSV files to documents.                                                                              |

--- a/docs-website/docs/pipeline-components/converters/amazontextractconverter.mdx
+++ b/docs-website/docs/pipeline-components/converters/amazontextractconverter.mdx
@@ -1,0 +1,143 @@
+---
+title: "AmazonTextractConverter"
+id: amazontextractconverter
+slug: "/amazontextractconverter"
+description: "`AmazonTextractConverter` converts images and single-page PDFs to documents using AWS Textract. It supports plain text OCR, structured analysis of tables, forms, signatures, and layout, as well as natural-language queries over the document."
+---
+
+# AmazonTextractConverter
+
+`AmazonTextractConverter` converts images and single-page PDFs to documents using AWS Textract. It supports plain text OCR, structured analysis of tables, forms, signatures, and layout, as well as natural-language queries over the document.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | Before [PreProcessors](../preprocessors.mdx), or right at the beginning of an indexing pipeline |
+| **Mandatory init variables** | AWS credentials are resolved via `Secret` parameters or the default boto3 credential chain (environment variables, AWS config files, IAM roles). |
+| **Mandatory run variables** | `sources`: A list of file paths or `ByteStream` objects |
+| **Output variables** | `documents`: A list of documents <br /> <br />`raw_textract_response`: A list of raw responses from the Textract API |
+| **API reference** | [Amazon Textract](/reference/integrations-amazon_textract) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/amazon_textract |
+| **Package name** | `amazon-textract-haystack` |
+
+</div>
+
+## Overview
+
+`AmazonTextractConverter` takes a list of file paths or [`ByteStream`](../../concepts/data-classes.mdx#bytestream) objects as input and uses AWS Textract to extract text from images and single-page PDFs. Optionally, metadata can be attached to the documents through the `meta` input parameter. You need an active AWS account with access to the Textract service to use this integration. Refer to the [AWS Textract documentation](https://docs.aws.amazon.com/textract/latest/dg/getting-started.html) to set up your AWS credentials and ensure Textract is available in your selected region.
+
+Supported input formats: JPEG, PNG, TIFF, BMP, and single-page PDF (up to 10 MB).
+
+By default, the component uses the standard AWS environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION`, `AWS_PROFILE`) for authentication. You can also pass these as `Secret` objects at initialization. The component falls back to the default boto3 credential chain if no explicit credentials are provided, which makes it work with IAM roles when running on AWS infrastructure.
+
+### Operation modes
+
+The component switches between two Textract APIs depending on how you configure it:
+
+- **Plain text OCR (`DetectDocumentText`)** – Used when `feature_types` is not set. This is the fastest and cheapest option, extracting raw text from the document.
+- **Structured analysis (`AnalyzeDocument`)** – Used when `feature_types` is set. You can pass any combination of `"TABLES"`, `"FORMS"`, `"SIGNATURES"`, and `"LAYOUT"` to extract richer structural information from the document.
+
+### Natural-language queries
+
+You can pass a list of natural-language questions through the `queries` parameter on `run()`. When queries are provided, the `QUERIES` feature type is added automatically and Textract returns the extracted answers in the raw response. This is useful for pulling specific fields out of forms, invoices, or receipts without writing custom parsing logic.
+
+## Usage
+
+You need to install the `amazon-textract-haystack` integration to use `AmazonTextractConverter`:
+
+```shell
+pip install amazon-textract-haystack
+```
+
+### On its own
+
+Basic usage with plain text OCR:
+
+```python
+from haystack_integrations.components.converters.amazon_textract import (
+    AmazonTextractConverter,
+)
+
+converter = AmazonTextractConverter()
+result = converter.run(sources=["document.png"])
+documents = result["documents"]
+```
+
+Extracting tables and forms with `AnalyzeDocument`:
+
+```python
+from haystack_integrations.components.converters.amazon_textract import (
+    AmazonTextractConverter,
+)
+
+converter = AmazonTextractConverter(feature_types=["TABLES", "FORMS"])
+converter.warm_up()
+result = converter.run(sources=["invoice.pdf"])
+documents = result["documents"]
+raw_responses = result["raw_textract_response"]
+```
+
+Using natural-language queries to extract specific fields:
+
+```python
+from haystack_integrations.components.converters.amazon_textract import (
+    AmazonTextractConverter,
+)
+
+converter = AmazonTextractConverter()
+result = converter.run(
+    sources=["receipt.png"],
+    queries=["What is the patient name?", "What is the total due?"],
+)
+documents = result["documents"]
+raw_responses = result["raw_textract_response"]
+```
+
+Passing AWS credentials explicitly:
+
+```python
+from haystack.utils import Secret
+from haystack_integrations.components.converters.amazon_textract import (
+    AmazonTextractConverter,
+)
+
+converter = AmazonTextractConverter(
+    aws_access_key_id=Secret.from_env_var("AWS_ACCESS_KEY_ID"),
+    aws_secret_access_key=Secret.from_env_var("AWS_SECRET_ACCESS_KEY"),
+    aws_region_name=Secret.from_token("us-east-1"),
+)
+result = converter.run(sources=["document.png"])
+```
+
+### In a pipeline
+
+Here's an example of an indexing pipeline that uses Textract to extract text from images and writes the resulting documents to a Document Store:
+
+```python
+from haystack import Pipeline
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack.components.preprocessors import DocumentCleaner, DocumentSplitter
+from haystack.components.writers import DocumentWriter
+from haystack_integrations.components.converters.amazon_textract import (
+    AmazonTextractConverter,
+)
+
+document_store = InMemoryDocumentStore()
+
+pipeline = Pipeline()
+pipeline.add_component("converter", AmazonTextractConverter())
+pipeline.add_component("cleaner", DocumentCleaner())
+pipeline.add_component(
+    "splitter",
+    DocumentSplitter(split_by="sentence", split_length=5),
+)
+pipeline.add_component("writer", DocumentWriter(document_store=document_store))
+
+pipeline.connect("converter", "cleaner")
+pipeline.connect("cleaner", "splitter")
+pipeline.connect("splitter", "writer")
+
+file_names = ["document.png", "invoice.pdf"]
+pipeline.run({"converter": {"sources": file_names}})
+```

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -230,6 +230,7 @@ export default {
             id: 'pipeline-components/converters'
           },
           items: [
+            'pipeline-components/converters/amazontextractconverter',
             'pipeline-components/converters/azuredocumentintelligenceconverter',
             'pipeline-components/converters/azureocrdocumentconverter',
             'pipeline-components/converters/csvtodocument',

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/converters.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/converters.mdx
@@ -11,6 +11,7 @@ Use various Converters to extract data from files in different formats and cast 
 
 | Converter                                                    | Description                                                                                                   |
 | --- | --- |
+| [AmazonTextractConverter](converters/amazontextractconverter.mdx) | Converts images and single-page PDFs to documents using AWS Textract, with optional structured analysis of tables, forms, signatures, and layout, plus natural-language queries. |
 | [AzureDocumentIntelligenceConverter](converters/azuredocumentintelligenceconverter.mdx) | Converts PDF, JPEG, PNG, BMP, TIFF, DOCX, XLSX, PPTX, and HTML to documents using Azure's Document Intelligence service with GitHub Flavored Markdown output. |
 | [AzureOCRDocumentConverter](converters/azureocrdocumentconverter.mdx) | Converts PDF (both searchable and image-only), JPEG, PNG, BMP, TIFF, DOCX, XLSX, PPTX, and HTML to documents. |
 | [CSVToDocument](converters/csvtodocument.mdx)                           | Converts CSV files to documents.                                                                              |

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/converters/amazontextractconverter.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/converters/amazontextractconverter.mdx
@@ -1,0 +1,143 @@
+---
+title: "AmazonTextractConverter"
+id: amazontextractconverter
+slug: "/amazontextractconverter"
+description: "`AmazonTextractConverter` converts images and single-page PDFs to documents using AWS Textract. It supports plain text OCR, structured analysis of tables, forms, signatures, and layout, as well as natural-language queries over the document."
+---
+
+# AmazonTextractConverter
+
+`AmazonTextractConverter` converts images and single-page PDFs to documents using AWS Textract. It supports plain text OCR, structured analysis of tables, forms, signatures, and layout, as well as natural-language queries over the document.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | Before [PreProcessors](../preprocessors.mdx), or right at the beginning of an indexing pipeline |
+| **Mandatory init variables** | AWS credentials are resolved via `Secret` parameters or the default boto3 credential chain (environment variables, AWS config files, IAM roles). |
+| **Mandatory run variables** | `sources`: A list of file paths or `ByteStream` objects |
+| **Output variables** | `documents`: A list of documents <br /> <br />`raw_textract_response`: A list of raw responses from the Textract API |
+| **API reference** | [Amazon Textract](/reference/integrations-amazon_textract) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/amazon_textract |
+| **Package name** | `amazon-textract-haystack` |
+
+</div>
+
+## Overview
+
+`AmazonTextractConverter` takes a list of file paths or [`ByteStream`](../../concepts/data-classes.mdx#bytestream) objects as input and uses AWS Textract to extract text from images and single-page PDFs. Optionally, metadata can be attached to the documents through the `meta` input parameter. You need an active AWS account with access to the Textract service to use this integration. Refer to the [AWS Textract documentation](https://docs.aws.amazon.com/textract/latest/dg/getting-started.html) to set up your AWS credentials and ensure Textract is available in your selected region.
+
+Supported input formats: JPEG, PNG, TIFF, BMP, and single-page PDF (up to 10 MB).
+
+By default, the component uses the standard AWS environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION`, `AWS_PROFILE`) for authentication. You can also pass these as `Secret` objects at initialization. The component falls back to the default boto3 credential chain if no explicit credentials are provided, which makes it work with IAM roles when running on AWS infrastructure.
+
+### Operation modes
+
+The component switches between two Textract APIs depending on how you configure it:
+
+- **Plain text OCR (`DetectDocumentText`)** – Used when `feature_types` is not set. This is the fastest and cheapest option, extracting raw text from the document.
+- **Structured analysis (`AnalyzeDocument`)** – Used when `feature_types` is set. You can pass any combination of `"TABLES"`, `"FORMS"`, `"SIGNATURES"`, and `"LAYOUT"` to extract richer structural information from the document.
+
+### Natural-language queries
+
+You can pass a list of natural-language questions through the `queries` parameter on `run()`. When queries are provided, the `QUERIES` feature type is added automatically and Textract returns the extracted answers in the raw response. This is useful for pulling specific fields out of forms, invoices, or receipts without writing custom parsing logic.
+
+## Usage
+
+You need to install the `amazon-textract-haystack` integration to use `AmazonTextractConverter`:
+
+```shell
+pip install amazon-textract-haystack
+```
+
+### On its own
+
+Basic usage with plain text OCR:
+
+```python
+from haystack_integrations.components.converters.amazon_textract import (
+    AmazonTextractConverter,
+)
+
+converter = AmazonTextractConverter()
+result = converter.run(sources=["document.png"])
+documents = result["documents"]
+```
+
+Extracting tables and forms with `AnalyzeDocument`:
+
+```python
+from haystack_integrations.components.converters.amazon_textract import (
+    AmazonTextractConverter,
+)
+
+converter = AmazonTextractConverter(feature_types=["TABLES", "FORMS"])
+converter.warm_up()
+result = converter.run(sources=["invoice.pdf"])
+documents = result["documents"]
+raw_responses = result["raw_textract_response"]
+```
+
+Using natural-language queries to extract specific fields:
+
+```python
+from haystack_integrations.components.converters.amazon_textract import (
+    AmazonTextractConverter,
+)
+
+converter = AmazonTextractConverter()
+result = converter.run(
+    sources=["receipt.png"],
+    queries=["What is the patient name?", "What is the total due?"],
+)
+documents = result["documents"]
+raw_responses = result["raw_textract_response"]
+```
+
+Passing AWS credentials explicitly:
+
+```python
+from haystack.utils import Secret
+from haystack_integrations.components.converters.amazon_textract import (
+    AmazonTextractConverter,
+)
+
+converter = AmazonTextractConverter(
+    aws_access_key_id=Secret.from_env_var("AWS_ACCESS_KEY_ID"),
+    aws_secret_access_key=Secret.from_env_var("AWS_SECRET_ACCESS_KEY"),
+    aws_region_name=Secret.from_token("us-east-1"),
+)
+result = converter.run(sources=["document.png"])
+```
+
+### In a pipeline
+
+Here's an example of an indexing pipeline that uses Textract to extract text from images and writes the resulting documents to a Document Store:
+
+```python
+from haystack import Pipeline
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack.components.preprocessors import DocumentCleaner, DocumentSplitter
+from haystack.components.writers import DocumentWriter
+from haystack_integrations.components.converters.amazon_textract import (
+    AmazonTextractConverter,
+)
+
+document_store = InMemoryDocumentStore()
+
+pipeline = Pipeline()
+pipeline.add_component("converter", AmazonTextractConverter())
+pipeline.add_component("cleaner", DocumentCleaner())
+pipeline.add_component(
+    "splitter",
+    DocumentSplitter(split_by="sentence", split_length=5),
+)
+pipeline.add_component("writer", DocumentWriter(document_store=document_store))
+
+pipeline.connect("converter", "cleaner")
+pipeline.connect("cleaner", "splitter")
+pipeline.connect("splitter", "writer")
+
+file_names = ["document.png", "invoice.pdf"]
+pipeline.run({"converter": {"sources": file_names}})
+```

--- a/docs-website/versioned_sidebars/version-2.29-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.29-sidebars.json
@@ -226,6 +226,7 @@
             "id": "pipeline-components/converters"
           },
           "items": [
+            "pipeline-components/converters/amazontextractconverter",
             "pipeline-components/converters/azuredocumentintelligenceconverter",
             "pipeline-components/converters/azureocrdocumentconverter",
             "pipeline-components/converters/csvtodocument",


### PR DESCRIPTION
### Related Issues

- partially addresses https://github.com/deepset-ai/haystack-core-integrations/issues/2391

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds a documentation page for the Amazon textract integration.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
