### PR TITLE
fix: prevent AnswerBuilder from mutating input documents' meta

### DIFF
--- a/haystack/components/builders/answer_builder.py
+++ b/haystack/components/builders/answer_builder.py
@@ -204,7 +204,7 @@ class AnswerBuilder:
                         )
                         continue
 
-                    doc_meta: dict[str, Any] = dict(doc.meta)
+                    doc_meta: dict[str, Any] = dict(doc.meta or {})
                     doc_meta["source_index"] = idx + 1
                     if reference_pattern:
                         doc_meta["referenced"] = idx in referenced_idxs

--- a/haystack/components/builders/answer_builder.py
+++ b/haystack/components/builders/answer_builder.py
@@ -135,9 +135,12 @@ class AnswerBuilder:
         :param documents:
             The documents used as the Generator inputs. If specified, they are added to
             the `GeneratedAnswer` objects.
-            Each Document.meta includes a "source_index" key, representing its 1-based position in the input list.
+            The Document copies inside the returned `GeneratedAnswer.documents` each include a "source_index" key,
+            representing the document's 1-based position in the input list. The original input documents are
+            not modified.
             When `reference_pattern` is provided:
-            - "referenced" key is added to the Document.meta, indicating if the document was referenced in the output.
+            - "referenced" key is added to the Document copies inside `GeneratedAnswer.documents`, indicating if
+            the document was referenced in the output.
             - `return_only_referenced_documents` init parameter controls if all or only referenced documents are
             returned.
         :param pattern:
@@ -204,7 +207,7 @@ class AnswerBuilder:
                         )
                         continue
 
-                    doc_meta: dict[str, Any] = dict(doc.meta)
+                    doc_meta: dict[str, Any] = dict(doc.meta or {})
                     doc_meta["source_index"] = idx + 1
                     if reference_pattern:
                         doc_meta["referenced"] = idx in referenced_idxs

--- a/haystack/components/builders/answer_builder.py
+++ b/haystack/components/builders/answer_builder.py
@@ -204,7 +204,7 @@ class AnswerBuilder:
                         )
                         continue
 
-                    doc_meta: dict[str, Any] = doc.meta or {}
+                    doc_meta: dict[str, Any] = dict(doc.meta)
                     doc_meta["source_index"] = idx + 1
                     if reference_pattern:
                         doc_meta["referenced"] = idx in referenced_idxs

--- a/releasenotes/notes/fix-answer-builder-meta-mutation-8769660a55175afd.yaml
+++ b/releasenotes/notes/fix-answer-builder-meta-mutation-8769660a55175afd.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix `AnswerBuilder.run()` mutating the `meta` dict of input `Document` objects.
+    `source_index` (and `referenced` when `reference_pattern` is set) are now only added
+    to the document copies inside `GeneratedAnswer.documents`, not to the originals.

--- a/releasenotes/notes/fix-answer-builder-meta-mutation-8769660a55175afd.yaml
+++ b/releasenotes/notes/fix-answer-builder-meta-mutation-8769660a55175afd.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Fix `AnswerBuilder.run()` mutating the `meta` dict of input `Document` objects.
-    `source_index` (and `referenced` when `reference_pattern` is set) are now only added
-    to the document copies inside `GeneratedAnswer.documents`, not to the originals.
+    Fix ``AnswerBuilder.run()`` mutating the ``meta`` dict of input ``Document`` objects.
+    ``source_index`` (and ``referenced`` when ``reference_pattern`` is set) are now only added
+    to the document copies inside ``GeneratedAnswer.documents``, not to the originals.

--- a/test/components/builders/test_answer_builder.py
+++ b/test/components/builders/test_answer_builder.py
@@ -418,3 +418,15 @@ class TestAnswerBuilder:
         assert "all_messages" in answers[0].meta
         assert answers[0].meta["all_messages"] == replies
         assert len(answers[0].meta["all_messages"]) == 1
+
+    def test_run_does_not_mutate_input_documents_meta(self):
+        doc = Document(content="Paris is the capital of France.", meta={"source": "wiki"})
+        component = AnswerBuilder()
+        component.run(query="Capital of France?", replies=["Paris."], documents=[doc])
+        assert doc.meta == {"source": "wiki"}
+
+    def test_run_does_not_mutate_input_documents_meta_with_reference_pattern(self):
+        doc = Document(content="Paris is the capital of France.", meta={"source": "wiki"})
+        component = AnswerBuilder(reference_pattern=r"\[(\d+)\]", return_only_referenced_documents=False)
+        component.run(query="Capital?", replies=["Paris [1]."], documents=[doc])
+        assert doc.meta == {"source": "wiki"}

--- a/test/components/builders/test_answer_builder.py
+++ b/test/components/builders/test_answer_builder.py
@@ -430,3 +430,9 @@ class TestAnswerBuilder:
         component = AnswerBuilder(reference_pattern=r"\[(\d+)\]", return_only_referenced_documents=False)
         component.run(query="Capital?", replies=["Paris [1]."], documents=[doc])
         assert doc.meta == {"source": "wiki"}
+
+    def test_run_does_not_mutate_document_with_empty_meta(self):
+        doc = Document(content="Paris is the capital of France.")
+        component = AnswerBuilder()
+        component.run(query="Capital of France?", replies=["Paris."], documents=[doc])
+        assert doc.meta == {}


### PR DESCRIPTION
### Related Issues

- closes #11371

### Proposed Changes

`AnswerBuilder.run()` was using `doc.meta or {}` to get the document's metadata before adding
`source_index` (and `referenced` when `reference_pattern` is set). When `doc.meta` is non-empty
(which is always the case in production), `or` returns the **same dict object** — so the subsequent
writes mutate the original input document's meta permanently.

Replace with `dict(doc.meta)` to always work on a shallow copy.

Note: `chat_prompt_builder.py` already has an explicit comment "use dataclasses.replace to avoid
in-place mutation" showing awareness of this pattern — `answer_builder.py` was missed.
Similar bug was fixed in `Document.from_dict` via PR #11330.

### How did you test it?

- Added two new unit tests in `test/components/builders/test_answer_builder.py`:
  - `test_run_does_not_mutate_input_documents_meta` — verifies `doc.meta` is unchanged after `run()`
  - `test_run_does_not_mutate_input_documents_meta_with_reference_pattern` — same check with `reference_pattern` set
- All 24 existing tests continue to pass

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
