### PR TITLE
fix(answer_builder): prevent run() from mutating input Document.meta

### DIFF
--- a/haystack/components/builders/answer_builder.py
+++ b/haystack/components/builders/answer_builder.py
@@ -204,7 +204,7 @@ class AnswerBuilder:
                         )
                         continue
 
-                    doc_meta: dict[str, Any] = doc.meta or {}
+                    doc_meta: dict[str, Any] = dict(doc.meta)  # copy to avoid mutating the caller's Document.meta
                     doc_meta["source_index"] = idx + 1
                     if reference_pattern:
                         doc_meta["referenced"] = idx in referenced_idxs

--- a/test/components/builders/test_answer_builder.py
+++ b/test/components/builders/test_answer_builder.py
@@ -418,3 +418,66 @@ class TestAnswerBuilder:
         assert "all_messages" in answers[0].meta
         assert answers[0].meta["all_messages"] == replies
         assert len(answers[0].meta["all_messages"]) == 1
+
+
+class TestAnswerBuilderDocMetaImmutability:
+    """Regression tests for issue #11371 — AnswerBuilder.run() must not mutate input Document.meta."""
+
+    def test_run_does_not_mutate_input_document_meta(self):
+        """source_index must not appear on the original Document.meta after run()."""
+        from haystack import Document
+        from haystack.components.builders import AnswerBuilder
+
+        doc = Document(content="Paris is the capital of France.", meta={"source": "wiki"})
+        original_meta = dict(doc.meta)  # snapshot before run
+
+        builder = AnswerBuilder()
+        builder.run(query="Capital of France?", replies=["Paris."], documents=[doc])
+
+        assert doc.meta == original_meta, (
+            f"AnswerBuilder mutated input Document.meta: got {doc.meta}, expected {original_meta}"
+        )
+        assert "source_index" not in doc.meta
+
+    def test_run_with_reference_pattern_does_not_mutate_input_document_meta(self):
+        """Neither source_index nor 'referenced' should appear on the original doc.meta."""
+        from haystack import Document
+        from haystack.components.builders import AnswerBuilder
+
+        doc = Document(content="Berlin is the capital of Germany.", meta={"topic": "geography"})
+        original_meta = dict(doc.meta)
+
+        builder = AnswerBuilder(reference_pattern="\\[([0-9]+)\\]")
+        builder.run(
+            query="Capital of Germany?",
+            replies=["[1] Berlin."],
+            documents=[doc],
+        )
+
+        assert doc.meta == original_meta
+        assert "source_index" not in doc.meta
+        assert "referenced" not in doc.meta
+
+    def test_answer_documents_have_source_index(self):
+        """The copy inside GeneratedAnswer.documents must still have source_index."""
+        from haystack import Document
+        from haystack.components.builders import AnswerBuilder
+
+        doc = Document(content="Rome is the capital of Italy.", meta={"lang": "en"})
+        builder = AnswerBuilder()
+        result = builder.run(query="Capital of Italy?", replies=["Rome."], documents=[doc])
+
+        answer_doc = result["answers"][0].documents[0]
+        assert answer_doc.meta["source_index"] == 1
+        assert answer_doc.meta["lang"] == "en"
+
+    def test_run_does_not_mutate_document_with_empty_meta(self):
+        """Document with no metadata should also be unaffected."""
+        from haystack import Document
+        from haystack.components.builders import AnswerBuilder
+
+        doc = Document(content="No meta here.")
+        builder = AnswerBuilder()
+        builder.run(query="test", replies=["answer"], documents=[doc])
+
+        assert "source_index" not in doc.meta


### PR DESCRIPTION
## Problem

`AnswerBuilder.run()` silently mutates the `meta` dict of every input `Document`
object. After the call, the original document gains `source_index` (and
`referenced` when `reference_pattern` is set) — keys the caller never put there.

```python
doc = Document(content="Paris is the capital of France.", meta={"source": "wiki"})
builder = AnswerBuilder()
builder.run(query="Capital of France?", replies=["Paris."], documents=[doc])

print(doc.meta)
# {"source": "wiki", "source_index": 1}  ← caller's dict was mutated
```

### Root cause

`answer_builder.py` line ~207:

```python
doc_meta: dict[str, Any] = doc.meta or {}
```

`doc.meta or {}` returns **the same dict object** when `meta` is non-empty (any
truthy dict evaluates to itself, not a copy). The subsequent writes
`doc_meta["source_index"] = idx + 1` then modify the caller's original dict.

`dataclasses.replace(doc, meta=doc_meta)` was intended to create a copy, but the
alias means both `doc.meta` and `doc_meta` point to the same dict, so the replace
does not help.

Reported in #11371. `chat_prompt_builder.py` already has a comment "use
`dataclasses.replace` to avoid in-place mutation" — `answer_builder.py` was
missed. A similar issue was fixed in `Document.from_dict` via #11330.

## Fix

Replace the aliasing `or {}` with an explicit shallow copy:

```python
doc_meta: dict[str, Any] = dict(doc.meta)  # copy to avoid mutating the caller's Document.meta
```

One character change, no behavior change for the answer output — `source_index`
still appears inside `GeneratedAnswer.documents[*].meta` as expected.

## Tests

Four new test methods in `TestAnswerBuilderDocMetaImmutability`:

| Test | What it checks |
|---|---|
| `test_run_does_not_mutate_input_document_meta` | `source_index` absent from original doc |
| `test_run_with_reference_pattern_does_not_mutate_input_document_meta` | same for `referenced` key |
| `test_answer_documents_have_source_index` | `source_index` still present in answer copy |
| `test_run_does_not_mutate_document_with_empty_meta` | edge case: empty meta |

Fixes #11371