### PR TITLE
test: mark flaky test_open_meteo_integration as slow

### DIFF
--- a/test/components/connectors/test_openapi_connector.py
+++ b/test/components/connectors/test_openapi_connector.py
@@ -195,6 +195,7 @@ class TestOpenAPIConnectorIntegration:
         assert "response" in response
 
     @pytest.mark.integration
+    @pytest.mark.slow
     @pytest.mark.flaky(reruns=3, reruns_delay=5)
     def test_open_meteo_integration(self):
         open_meteo_spec = {


### PR DESCRIPTION
### Related Issues
- Related to #10341 (closed flaky-tests tracker; the 2026-03-26 comment from @anakin87 logs this exact test).
- Blocked unrelated CI on #11379 earlier today.

### Proposed Changes
Add `@pytest.mark.slow` to `test_open_meteo_integration`. The test makes a live HTTPS call to `archive-api.open-meteo.com` and has been timing out intermittently across all three OS runners.

CONTRIBUTING.md classifies tests that "call unstable external services" as `@pytest.mark.slow`. This matches the criterion exactly.

After this change:
- Regular Integration job (`pytest -m "integration and not slow"`) excludes the test, so it no longer blocks PRs.
- Slow Integration workflow (`pytest -m "integration and slow"`) picks it up nightly and on manual/labeled runs.

The existing `@pytest.mark.flaky(reruns=3, reruns_delay=5)` is kept so the slow job still tolerates transient failures.

### How did you test it?
Verified marker filtering locally:

```
hatch run test:integration-only-fast test/components/connectors/test_openapi_connector.py --collect-only -q
# -> test_open_meteo_integration is deselected

hatch run test:integration-only-slow test/components/connectors/test_openapi_connector.py --collect-only -q
# -> test_open_meteo_integration is selected
```

### Notes for the reviewer
Tests-only change, so no release note. Per CONTRIBUTING.md, please add the `ignore-for-release-notes` label to bypass the reno check.

### Checklist
- [x] I have read the contributors guidelines and the code of conduct.
- [x] I've used a conventional commit type (`test:`).
- [x] I have run pre-commit hooks and quality checks.
- [ ] Release note: N/A (tests-only; needs `ignore-for-release-notes` label).
