### PR TITLE
fix: preserve caller-supplied timeout across all retry attempts in request_with_retry

### DIFF
--- a/haystack/utils/requests_utils.py
+++ b/haystack/utils/requests_utils.py
@@ -58,6 +58,11 @@ def request_with_retry(
     if status_codes_to_retry is None:
         status_codes_to_retry = [408, 418, 429, 503]
 
+    # Pop timeout once, before the retry loop.  Popping inside @retry-decorated
+    # run() would remove the key on the first attempt so all subsequent retries
+    # silently fall back to the default 10-second timeout.
+    timeout = kwargs.pop("timeout", 10)
+
     @retry(
         reraise=True,
         wait=wait_exponential(),
@@ -67,7 +72,6 @@ def request_with_retry(
         after=after_log(logger, logging.DEBUG),
     )
     def run() -> httpx.Response:
-        timeout = kwargs.pop("timeout", 10)
         with httpx.Client() as client:
             res = client.request(**kwargs, timeout=timeout)
 
@@ -168,6 +172,11 @@ async def async_request_with_retry(
     if status_codes_to_retry is None:
         status_codes_to_retry = [408, 418, 429, 503]
 
+    # Pop timeout once, before the retry loop.  Popping inside @retry-decorated
+    # run() would remove the key on the first attempt so all subsequent retries
+    # silently fall back to the default 10-second timeout.
+    timeout = kwargs.pop("timeout", 10)
+
     @retry(
         reraise=True,
         wait=wait_exponential(),
@@ -177,7 +186,6 @@ async def async_request_with_retry(
         after=after_log(logger, logging.DEBUG),
     )
     async def run() -> httpx.Response:
-        timeout = kwargs.pop("timeout", 10)
         async with httpx.AsyncClient() as client:
             res = await client.request(**kwargs, timeout=timeout)
 

--- a/test/utils/test_requests_utils.py
+++ b/test/utils/test_requests_utils.py
@@ -121,6 +121,33 @@ class TestRequestWithRetry:
                 assert mock_request.call_count == 2
                 mock_sleep.assert_called()
 
+    def test_request_with_retry_preserves_timeout_on_retry(self):
+        """Regression test: custom timeout must be forwarded on every retry attempt.
+
+        Previously, ``timeout`` was popped from ``kwargs`` *inside* the
+        ``@retry``-decorated ``run()`` closure.  On the first attempt the pop
+        succeeded and the caller-supplied value was used; on all subsequent
+        retries the key was already gone so ``kwargs.pop("timeout", 10)``
+        silently fell back to the 10-second default, ignoring the user's value.
+        """
+        with patch("time.sleep"):
+            success_response = httpx.Response(status_code=200, request=httpx.Request("GET", "https://example.com"))
+            success_response.raise_for_status = lambda: None
+
+            with patch("httpx.Client.request") as mock_request:
+                mock_request.side_effect = [
+                    httpx.RequestError("transient error", request=httpx.Request("GET", "https://example.com")),
+                    success_response,
+                ]
+
+                request_with_retry(method="GET", url="https://example.com", attempts=2, timeout=42)
+
+                assert mock_request.call_count == 2
+                for call in mock_request.call_args_list:
+                    assert call.kwargs["timeout"] == 42, (
+                        f"Expected timeout=42 on every attempt, got {call.kwargs['timeout']!r}"
+                    )
+
 
 class TestAsyncRequestWithRetry:
     @pytest.mark.asyncio
@@ -234,3 +261,31 @@ class TestAsyncRequestWithRetry:
                 assert response == success_response
                 assert mock_request.call_count == 2
                 mock_sleep.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_async_request_with_retry_preserves_timeout_on_retry(self):
+        """Regression test: custom timeout must be forwarded on every retry attempt.
+
+        Previously, ``timeout`` was popped from ``kwargs`` *inside* the
+        ``@retry``-decorated ``run()`` closure.  On the first attempt the pop
+        succeeded and the caller-supplied value was used; on all subsequent
+        retries the key was already gone so ``kwargs.pop("timeout", 10)``
+        silently fell back to the 10-second default, ignoring the user's value.
+        """
+        with patch("asyncio.sleep"):
+            success_response = httpx.Response(status_code=200, request=httpx.Request("GET", "https://example.com"))
+            success_response.raise_for_status = lambda: None
+
+            with patch("httpx.AsyncClient.request") as mock_request:
+                mock_request.side_effect = [
+                    httpx.RequestError("transient error", request=httpx.Request("GET", "https://example.com")),
+                    success_response,
+                ]
+
+                await async_request_with_retry(method="GET", url="https://example.com", attempts=2, timeout=42)
+
+                assert mock_request.call_count == 2
+                for call in mock_request.call_args_list:
+                    assert call.kwargs["timeout"] == 42, (
+                        f"Expected timeout=42 on every attempt, got {call.kwargs['timeout']!r}"
+                    )


### PR DESCRIPTION
## What

`request_with_retry` and `async_request_with_retry` accept a `timeout` kwarg, but that timeout was silently ignored on every retry after the first.

## Root cause

`timeout` was popped from `kwargs` *inside* the `@retry`-decorated `run()` closure:

```python
# Before (inside run())
def run() -> httpx.Response:
    timeout = kwargs.pop("timeout", 10)   # <-- pops on attempt 1…
    with httpx.Client() as client:
        res = client.request(**kwargs, timeout=timeout)
```

`kwargs.pop` mutates the dict in-place.  On the first attempt the caller's value is consumed.  On every subsequent retry the key is gone, so `kwargs.pop("timeout", 10)` returns the hardcoded default (`10`) regardless of what the caller passed.

## Fix

Move the pop to *before* the `@retry` decoration — once, not once-per-attempt — so the closed-over `timeout` variable holds the right value for every attempt:

```python
# After (outside run(), before @retry)
timeout = kwargs.pop("timeout", 10)

@retry(...)
def run() -> httpx.Response:
    with httpx.Client() as client:
        res = client.request(**kwargs, timeout=timeout)
```

The same fix is applied to `async_request_with_retry`.

## Tests

Added `test_request_with_retry_preserves_timeout_on_retry` and `test_async_request_with_retry_preserves_timeout_on_retry`.  Each test makes the first attempt fail with a `RequestError` so a retry is triggered, then asserts that **both** calls to `httpx.Client.request` / `httpx.AsyncClient.request` received the caller-supplied `timeout=42`, not the default `10`.