### PR TITLE
fix: preserve classification_field and multi_label in TransformersZeroShotDocumentClassifier serialization

### DIFF
--- a/haystack/components/classifiers/zero_shot_document_classifier.py
+++ b/haystack/components/classifiers/zero_shot_document_classifier.py
@@ -161,6 +161,8 @@ class TransformersZeroShotDocumentClassifier:
             model=self.huggingface_pipeline_kwargs["model"],
             huggingface_pipeline_kwargs=self.huggingface_pipeline_kwargs,
             token=self.token,
+            multi_label=self.multi_label,
+            classification_field=self.classification_field,
         )
 
         huggingface_pipeline_kwargs = serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"]

--- a/releasenotes/notes/serialize-zero-shot-document-classifier-init-params-77eab88a122266cb.yaml
+++ b/releasenotes/notes/serialize-zero-shot-document-classifier-init-params-77eab88a122266cb.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix `TransformersZeroShotDocumentClassifier.to_dict` to include the `classification_field` and `multi_label`
+    init parameters, which were previously dropped on serialization and reset to defaults after `from_dict`.

--- a/releasenotes/notes/serialize-zero-shot-document-classifier-init-params-77eab88a122266cb.yaml
+++ b/releasenotes/notes/serialize-zero-shot-document-classifier-init-params-77eab88a122266cb.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fix `TransformersZeroShotDocumentClassifier.to_dict` to include the `classification_field` and `multi_label`
-    init parameters, which were previously dropped on serialization and reset to defaults after `from_dict`.
+    Fix ``TransformersZeroShotDocumentClassifier.to_dict`` to include the ``classification_field`` and ``multi_label``
+    init parameters, which were previously dropped on serialization and reset to defaults after ``from_dict``.

--- a/test/components/classifiers/test_zero_shot_document_classifier.py
+++ b/test/components/classifiers/test_zero_shot_document_classifier.py
@@ -25,7 +25,10 @@ class TestTransformersZeroShotDocumentClassifier:
 
     def test_to_dict(self):
         component = TransformersZeroShotDocumentClassifier(
-            model="cross-encoder/nli-deberta-v3-xsmall", labels=["positive", "negative"]
+            model="cross-encoder/nli-deberta-v3-xsmall",
+            labels=["positive", "negative"],
+            multi_label=True,
+            classification_field="title",
         )
         component_dict = component.to_dict()
         assert component_dict == {
@@ -34,6 +37,8 @@ class TestTransformersZeroShotDocumentClassifier:
                 "model": "cross-encoder/nli-deberta-v3-xsmall",
                 "labels": ["positive", "negative"],
                 "token": {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"},
+                "multi_label": True,
+                "classification_field": "title",
                 "huggingface_pipeline_kwargs": {
                     "model": "cross-encoder/nli-deberta-v3-xsmall",
                     "device": ComponentDevice.resolve_device(None).to_hf(),
@@ -49,6 +54,8 @@ class TestTransformersZeroShotDocumentClassifier:
                 "model": "cross-encoder/nli-deberta-v3-xsmall",
                 "labels": ["positive", "negative"],
                 "token": {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"},
+                "multi_label": True,
+                "classification_field": "title",
                 "huggingface_pipeline_kwargs": {
                     "model": "cross-encoder/nli-deberta-v3-xsmall",
                     "device": ComponentDevice.resolve_device(None).to_hf(),
@@ -59,6 +66,8 @@ class TestTransformersZeroShotDocumentClassifier:
         component = TransformersZeroShotDocumentClassifier.from_dict(data)
         assert component.labels == ["positive", "negative"]
         assert component.pipeline is None
+        assert component.multi_label is True
+        assert component.classification_field == "title"
         assert component.token == Secret.from_dict(
             {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"}
         )


### PR DESCRIPTION
### Related Issues

- fixes #11389

### Proposed Changes:

 `TransformersZeroShotDocumentClassifier.to_dict` was not emitting the `classification_field` and `multi_label` init parameters. After a `to_dict` / `from_dict` round-trip (which is what `Pipeline.dumps` / `Pipeline.loads` does), both fields silently reverted to their defaults: `classification_field` back to `None` (so the model would classify `doc.content` instead of the meta field it was configured for) and `multi_label` back to `False`.

This PR adds both fields to the `default_to_dict` call in `to_dict`. `from_dict` already forwards `init_parameters` through `__init__`, so once the values appear in the dict the round-trip closes on its own.

### How did you test it?

- Extended the existing `test_to_dict` and `test_from_dict` in `test/components/classifiers/test_zero_shot_document_classifier.py` to construct the component with non-default values (`multi_label=True`, `classification_field="title"`) and assert they survive serialization. These tests would have caught the bug.
- Ran `hatch run test:unit test/components/classifiers/test_zero_shot_document_classifier.py`. All 9 unit tests pass (1 integration test deselected).
- Ran `hatch run fmt` and `hatch run test:types` on the touched files. Both clean.
- Manually verified end-to-end: constructed a classifier with non-default values, called `from_dict(clf.to_dict())`, confirmed the restored attributes match.

### Notes for the reviewer

The change is purely additive, `to_dict` now emits more keys, never fewer. Pipelines serialized with the old code still load correctly; they just continue using the default values they were already (incorrectly) getting. The behaviour only changes for users who had explicitly configured `classification_field` or `multi_label` to non-default values, for them, broken behaviour becomes correct behaviour.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
