### PR TITLE
fix: honor exit_conditions when LLM emits parallel tool calls

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -1190,30 +1190,38 @@ class Agent:
 
     def _check_exit_conditions(self, llm_messages: list[ChatMessage], tool_messages: list[ChatMessage]) -> bool:
         """
-        Check if any of the LLM messages' tool calls match an exit condition and if there are no errors.
+        Decide whether the agent should stop looping.
+
+        Returns True when the model called at least one tool listed in ``exit_conditions`` and
+        that tool did not error. Every tool call in the message is checked, so the order of
+        parallel tool calls does not matter.
 
         :param llm_messages: List of messages from the LLM
         :param tool_messages: List of messages from the tool invoker
         :return: True if an exit condition is met and there are no errors, False otherwise
         """
-        matched_exit_conditions = set()
+        matched_exit_conditions: set[str] = set()
         has_errors = False
 
         for msg in llm_messages:
-            if msg.tool_call and msg.tool_call.tool_name in self.exit_conditions:
-                matched_exit_conditions.add(msg.tool_call.tool_name)
+            for tool_call in msg.tool_calls:
+                if tool_call.tool_name not in self.exit_conditions:
+                    continue
+                matched_exit_conditions.add(tool_call.tool_name)
 
                 # Check if any error is specifically from the tool matching the exit condition
                 tool_errors = [
                     tool_msg.tool_call_result.error
                     for tool_msg in tool_messages
                     if tool_msg.tool_call_result is not None
-                    and tool_msg.tool_call_result.origin.tool_name == msg.tool_call.tool_name
+                    and tool_msg.tool_call_result.origin.tool_name == tool_call.tool_name
                 ]
                 if any(tool_errors):
                     has_errors = True
                     # No need to check further if we found an error
                     break
+            if has_errors:
+                break
 
         # Only return True if at least one exit condition was matched AND none had errors
         return bool(matched_exit_conditions) and not has_errors

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -1192,7 +1192,7 @@ class Agent:
         """
         Decide whether the agent should stop looping.
 
-        Returns True when the model called at least one tool listed in ``exit_conditions`` and
+        Returns True when the model called at least one tool listed in `exit_conditions` and
         that tool did not error. Every tool call in the message is checked, so the order of
         parallel tool calls does not matter.
 

--- a/releasenotes/notes/fix-agent-exit-conditions-parallel-tool-calls-6939ba4845fe87d4.yaml
+++ b/releasenotes/notes/fix-agent-exit-conditions-parallel-tool-calls-6939ba4845fe87d4.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Fixed a bug where ``Agent`` would not exit when the model emitted multiple
+    tool calls in a single turn and the configured exit-condition tool was not
+    the first one in the list. Previously, only the first tool call in each
+    assistant message was checked against ``exit_conditions``, so a reply like
+    ``[search, finish]`` (with ``exit_conditions=["finish"]``) would silently
+    fail to stop the loop and keep iterating until ``max_agent_steps`` was
+    reached. Since parallel tool calls are now the norm for frontier models,
+    this could quietly turn a single successful turn into dozens of wasted LLM
+    calls. The ``Agent`` now inspects every tool call in the message, so the
+    exit condition is honored regardless of ordering.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -792,6 +792,53 @@ class TestAgent:
         assert isinstance(result["last_message"], ChatMessage)
         assert result["messages"][-1] == result["last_message"]
 
+    def test_check_exit_conditions_parallel_tool_calls(self, monkeypatch, weather_tool):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        agent = Agent(chat_generator=OpenAIChatGenerator(), tools=[weather_tool], exit_conditions=["weather_tool"])
+
+        finish_call = ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})
+        other_call = ToolCall(tool_name="search", arguments={"q": "weather Berlin"})
+
+        # Exit-condition call first — historically worked.
+        llm_first = [ChatMessage.from_assistant(tool_calls=[finish_call, other_call])]
+        # Exit-condition call second — the case that regressed.
+        llm_second = [ChatMessage.from_assistant(tool_calls=[other_call, finish_call])]
+        tool_messages_ok = [ChatMessage.from_tool(tool_result="ok", origin=finish_call, error=False)]
+
+        assert agent._check_exit_conditions(llm_first, tool_messages_ok) is True
+        assert agent._check_exit_conditions(llm_second, tool_messages_ok) is True
+
+    def test_check_exit_conditions_parallel_calls_with_errored_exit_tool(self, monkeypatch, weather_tool):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        agent = Agent(chat_generator=OpenAIChatGenerator(), tools=[weather_tool], exit_conditions=["weather_tool"])
+
+        finish_call = ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})
+        other_call = ToolCall(tool_name="search", arguments={"q": "weather Berlin"})
+
+        llm_messages = [ChatMessage.from_assistant(tool_calls=[other_call, finish_call])]
+        tool_messages_errored = [ChatMessage.from_tool(tool_result="boom", origin=finish_call, error=True)]
+
+        assert agent._check_exit_conditions(llm_messages, tool_messages_errored) is False
+
+    def test_check_exit_conditions_parallel_calls_error_only_on_non_exit_tool(
+        self, monkeypatch, weather_tool, component_tool
+    ):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        agent = Agent(
+            chat_generator=OpenAIChatGenerator(), tools=[weather_tool, component_tool], exit_conditions=["weather_tool"]
+        )
+
+        finish_call = ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})
+        other_call = ToolCall(tool_name="parrot", arguments={"parrot": "hi"})
+
+        llm_messages = [ChatMessage.from_assistant(tool_calls=[other_call, finish_call])]
+        tool_messages = [
+            ChatMessage.from_tool(tool_result="boom", origin=other_call, error=True),
+            ChatMessage.from_tool(tool_result="ok", origin=finish_call, error=False),
+        ]
+
+        assert agent._check_exit_conditions(llm_messages, tool_messages) is True
+
     def test_agent_with_no_tools(self, monkeypatch, caplog):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
         generator = OpenAIChatGenerator()

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -801,7 +801,7 @@ class TestAgent:
 
         # Exit-condition call first — historically worked.
         llm_first = [ChatMessage.from_assistant(tool_calls=[finish_call, other_call])]
-        # Exit-condition call second — the case that regressed.
+        # Exit-condition call second
         llm_second = [ChatMessage.from_assistant(tool_calls=[other_call, finish_call])]
         tool_messages_ok = [ChatMessage.from_tool(tool_result="ok", origin=finish_call, error=False)]
 

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -799,7 +799,7 @@ class TestAgent:
         finish_call = ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})
         other_call = ToolCall(tool_name="search", arguments={"q": "weather Berlin"})
 
-        # Exit-condition call first — historically worked.
+        # Exit-condition call first
         llm_first = [ChatMessage.from_assistant(tool_calls=[finish_call, other_call])]
         # Exit-condition call second
         llm_second = [ChatMessage.from_assistant(tool_calls=[other_call, finish_call])]


### PR DESCRIPTION
### Related Issues

- fixes #11392

### Proposed Changes:

`Agent._check_exit_conditions` was reading `msg.tool_call` (singular), which only returns the **first** `ToolCall` in the message. So when the LLM emitted a parallel batch like `[search, finish]` with `exit_conditions=["finish"]`, the `finish` call was invisible to the exit check and the agent kept looping  silently until `max_agent_steps` was reached.

Switched to iterating `msg.tool_calls` (plural) so every call in the batch is checked. The existing  error-suppression behaviour is preserved, if the exit-condition tool errored, the agent still does not exit.  The helper is shared by both `run` and `run_async`, so one fix covers both flows.

### How did you test it?

- Added 3 regression unit tests in `test/components/agents/test_agent.py` covering: exit-condition tool not first in the batch, error on the exit tool (must not exit), error only on a sibling non-exit tool (must still exit).
- `hatch run test:unit test/components/agents/` → **146 passed**, no regressions.
- `hatch run test:types` and `hatch run fmt` → clean.

### Notes for the reviewer

Behaviour-correcting bug fix, not a breaking change. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
