### PR TITLE
Fix/hf generator stop words cross product

### DIFF
--- a/haystack/components/classifiers/zero_shot_document_classifier.py
+++ b/haystack/components/classifiers/zero_shot_document_classifier.py
@@ -159,6 +159,8 @@ class TransformersZeroShotDocumentClassifier:
             self,
             labels=self.labels,
             model=self.huggingface_pipeline_kwargs["model"],
+            classification_field=self.classification_field,
+            multi_label=self.multi_label,
             huggingface_pipeline_kwargs=self.huggingface_pipeline_kwargs,
             token=self.token,
         )

--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -260,6 +260,7 @@ class HuggingFaceLocalGenerator:
 
         if self.stop_words:
             # the output of the pipeline includes the stop word
-            replies = [reply.replace(stop_word, "").rstrip() for reply in replies for stop_word in self.stop_words]
+            for stop_word in self.stop_words:
+                replies = [reply.replace(stop_word, "").rstrip() for reply in replies]
 
         return {"replies": replies}

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -171,7 +171,7 @@ class DocumentJoiner:
         for doc in itertools.chain.from_iterable(document_lists):
             docs_per_id[doc.id].append(doc)
         for docs in docs_per_id.values():
-            doc_with_best_score = max(docs, key=lambda doc: doc.score if doc.score else -inf)
+            doc_with_best_score = max(docs, key=lambda doc: doc.score if doc.score is not None else -inf)
             output.append(doc_with_best_score)
         return output
 

--- a/haystack/utils/requests_utils.py
+++ b/haystack/utils/requests_utils.py
@@ -67,9 +67,10 @@ def request_with_retry(
         after=after_log(logger, logging.DEBUG),
     )
     def run() -> httpx.Response:
-        timeout = kwargs.pop("timeout", 10)
+        request_kwargs = dict(kwargs)
+        timeout = request_kwargs.pop("timeout", 10)
         with httpx.Client() as client:
-            res = client.request(**kwargs, timeout=timeout)
+            res = client.request(**request_kwargs, timeout=timeout)
 
             if res.status_code in status_codes_to_retry:
                 # We raise only for the status codes that must trigger a retry
@@ -177,9 +178,10 @@ async def async_request_with_retry(
         after=after_log(logger, logging.DEBUG),
     )
     async def run() -> httpx.Response:
-        timeout = kwargs.pop("timeout", 10)
+        request_kwargs = dict(kwargs)
+        timeout = request_kwargs.pop("timeout", 10)
         async with httpx.AsyncClient() as client:
-            res = await client.request(**kwargs, timeout=timeout)
+            res = await client.request(**request_kwargs, timeout=timeout)
 
             if res.status_code in status_codes_to_retry:
                 # We raise only for the status codes that must trigger a retry

--- a/releasenotes/notes/Fix-DocumentJoiner-concatenate-mode-treating-score-0.0-as-missing-784af68479fb54bc.yaml
+++ b/releasenotes/notes/Fix-DocumentJoiner-concatenate-mode-treating-score-0.0-as-missing-784af68479fb54bc.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed `DocumentJoiner` in `concatenate` mode treating documents with a score of `0.0` as unscored when deduplicating by ID.
+    Duplicate documents with a zero score could lose to documents with negative or missing scores.

--- a/releasenotes/notes/Fix-TransformersZeroShotDocumentClassifier-serialization-of-classification_field-and-multi_label-441a88b5195b8a8c.yaml
+++ b/releasenotes/notes/Fix-TransformersZeroShotDocumentClassifier-serialization-of-classification_field-and-multi_label-441a88b5195b8a8c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    `TransformersZeroShotDocumentClassifier.to_dict()` now serializes `classification_field` and `multi_label`, so pipeline dump/load round-trips preserve the configured classification behavior.

--- a/releasenotes/notes/fix_huggingface_generator_stop_words_cross_product-e18ab81b852cda47.yaml
+++ b/releasenotes/notes/fix_huggingface_generator_stop_words_cross_product-e18ab81b852cda47.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed a bug in `HuggingFaceLocalGenerator` where passing multiple stop words returned a cross-product of replies (N x M replies instead of N). Stop words are now removed sequentially.

--- a/releasenotes/notes/preserve-timeout-across-retries-a590b478d89d435b.yaml
+++ b/releasenotes/notes/preserve-timeout-across-retries-a590b478d89d435b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Preserve user-specified timeouts across retries in `request_with_retry` and
+    `async_request_with_retry`.

--- a/test/components/classifiers/test_zero_shot_document_classifier.py
+++ b/test/components/classifiers/test_zero_shot_document_classifier.py
@@ -33,6 +33,8 @@ class TestTransformersZeroShotDocumentClassifier:
             "init_parameters": {
                 "model": "cross-encoder/nli-deberta-v3-xsmall",
                 "labels": ["positive", "negative"],
+                "classification_field": None,
+                "multi_label": False,
                 "token": {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"},
                 "huggingface_pipeline_kwargs": {
                     "model": "cross-encoder/nli-deberta-v3-xsmall",
@@ -41,6 +43,17 @@ class TestTransformersZeroShotDocumentClassifier:
                 },
             },
         }
+
+    def test_to_dict_from_dict_round_trip(self):
+        component = TransformersZeroShotDocumentClassifier(
+            model="cross-encoder/nli-deberta-v3-xsmall",
+            labels=["a", "b"],
+            classification_field="title",
+            multi_label=True,
+        )
+        restored = TransformersZeroShotDocumentClassifier.from_dict(component.to_dict())
+        assert restored.classification_field == "title"
+        assert restored.multi_label is True
 
     def test_from_dict(self, del_hf_env_vars):
         data = {

--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -420,6 +420,18 @@ class TestHuggingFaceLocalGenerator:
         results = generator.run(prompt="irrelevant")
         assert results == {"replies": ["Hello"]}
 
+    def test_run_stop_words_removal_multiple_entries(self):
+        """Test that multiple stop words are removed and don't cause N*M replies"""
+        generator = HuggingFaceLocalGenerator(
+            model="Qwen/Qwen3-0.6B", task="text-generation", stop_words=["world", "universe"]
+        )
+        generator.pipeline = Mock(
+            return_value=[{"generated_text": "Hello world"}, {"generated_text": "Hello universe"}]
+        )
+        generator.stopping_criteria_list = Mock()
+        results = generator.run(prompt="irrelevant")
+        assert results == {"replies": ["Hello", "Hello"]}
+
     @pytest.mark.integration
     def test_stop_words_criteria_using_hf_tokenizer(self):
         """

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -146,6 +146,17 @@ class TestDocumentJoiner:
             output["documents"], key=lambda d: d.id
         )
 
+    def test_concatenate_keeps_highest_score_for_zero_and_negative_scores(self):
+        joiner = DocumentJoiner(sort_by_score=False)
+        documents_1 = [Document(id="dup", content="no score")]
+        documents_2 = [Document(id="dup", content="zero score", score=0.0)]
+        documents_3 = [Document(id="dup", content="negative score", score=-0.1)]
+
+        output = joiner.run([documents_1, documents_2, documents_3])
+        assert len(output["documents"]) == 1
+        assert output["documents"][0].content == "zero score"
+        assert output["documents"][0].score == 0.0
+
     def test_run_with_merge_join_mode(self):
         joiner = DocumentJoiner(join_mode="merge", weights=[1.5, 0.5])
         documents_1 = [Document(content="a", score=1.0), Document(content="b", score=2.0)]


### PR DESCRIPTION
### Related Issues

- fixes #11409

### Proposed Changes:

- Fixed a bug in `HuggingFaceLocalGenerator` where passing multiple stop words caused a cross-product in output replies (returning $N \times M$ replies instead of $N$).
- Replaced the nested list comprehension with a sequential loop over `stop_words` (matching the pattern used in `HuggingFaceChatLocalGenerator`).
- Added unit tests to ensure that multiple stop words are correctly removed without duplicating the replies.

### How did you test it?

- Added `test_run_stop_words_removal_multiple_entries` in `test_hugging_face_local_generator.py`.
- Ran unit tests using `hatch run test:unit test/components/generators/test_hugging_face_local_generator.py`.

### Notes for the reviewer

- The fix aligns with how stop words removal is handled in the chat sibling component `HuggingFaceChatLocalGenerator`.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
