### PR TITLE
fix: meta_fields_to_embed dropping falsy metadata

### DIFF
--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -245,7 +245,7 @@ class SentenceTransformersDocumentEmbedder:
         texts_to_embed = []
         for doc in documents:
             meta_values_to_embed = [
-                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key]
+                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key] is not None
             ]
             text_to_embed = (
                 self.prefix + self.embedding_separator.join(meta_values_to_embed + [doc.content or ""]) + self.suffix

--- a/haystack/components/embedders/sentence_transformers_sparse_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_sparse_document_embedder.py
@@ -217,7 +217,7 @@ class SentenceTransformersSparseDocumentEmbedder:
         texts_to_embed = []
         for doc in documents:
             meta_values_to_embed = [
-                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key]
+                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key] is not None
             ]
             text_to_embed = (
                 self.prefix + self.embedding_separator.join(meta_values_to_embed + [doc.content or ""]) + self.suffix

--- a/haystack/components/rankers/sentence_transformers_diversity.py
+++ b/haystack/components/rankers/sentence_transformers_diversity.py
@@ -265,7 +265,7 @@ class SentenceTransformersDiversityRanker:
         texts_to_embed = []
         for doc in documents:
             meta_values_to_embed = [
-                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key]
+                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key] is not None
             ]
             text_to_embed = (
                 self.document_prefix

--- a/haystack/components/rankers/sentence_transformers_similarity.py
+++ b/haystack/components/rankers/sentence_transformers_similarity.py
@@ -264,7 +264,7 @@ class SentenceTransformersSimilarityRanker:
         prepared_documents = []
         for doc in deduplicated_documents:
             meta_values_to_embed = [
-                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key]
+                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key] is not None
             ]
             prepared_documents.append(
                 self.document_prefix

--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -280,7 +280,7 @@ class TransformersSimilarityRanker:
         deduplicated_documents = _deduplicate_documents(documents)
         for doc in deduplicated_documents:
             meta_values_to_embed = [
-                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key]
+                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key] is not None
             ]
             text_to_embed = self.embedding_separator.join(meta_values_to_embed + [doc.content or ""])
             query_doc_pairs.append([self.query_prefix + query, self.document_prefix + text_to_embed])

--- a/releasenotes/notes/preserve-falsy-meta-fields-8f2c91a4b6d7e3a1.yaml
+++ b/releasenotes/notes/preserve-falsy-meta-fields-8f2c91a4b6d7e3a1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Preserve falsy metadata values such as ``0``, ``False``, and empty strings when ``meta_fields_to_embed`` is used by sentence-transformer embedders and rankers.

--- a/test/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_document_embedder.py
@@ -346,6 +346,26 @@ class TestSentenceTransformersDocumentEmbedder:
             precision="float32",
         )
 
+    def test_embed_metadata_preserves_falsy_values(self):
+        embedder = SentenceTransformersDocumentEmbedder(
+            model="model",
+            meta_fields_to_embed=["rating", "is_available", "missing", "none_value"],
+            embedding_separator="\n",
+        )
+        embedder.embedding_backend = MagicMock()
+        embedder.embedding_backend.embed.return_value = [[random.random() for _ in range(16)]]
+        documents = [Document(content="document", meta={"rating": 0, "is_available": False, "none_value": None})]
+
+        embedder.run(documents=documents)
+
+        embedder.embedding_backend.embed.assert_called_once_with(
+            ["0\nFalse\ndocument"],
+            batch_size=32,
+            show_progress_bar=True,
+            normalize_embeddings=False,
+            precision="float32",
+        )
+
     def test_embed_encode_kwargs(self):
         embedder = SentenceTransformersDocumentEmbedder(model="model", encode_kwargs={"task": "retrieval.passage"})
         embedder.embedding_backend = MagicMock()

--- a/test/components/embedders/test_sentence_transformers_sparse_document_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_sparse_document_embedder.py
@@ -308,6 +308,22 @@ class TestSentenceTransformersDocumentEmbedder:
             show_progress_bar=True,
         )
 
+    def test_embed_metadata_preserves_falsy_values(self):
+        embedder = SentenceTransformersSparseDocumentEmbedder(
+            model="model",
+            meta_fields_to_embed=["rating", "is_available", "missing", "none_value"],
+            embedding_separator="\n",
+        )
+        embedder.embedding_backend = MagicMock()
+        embedder.embedding_backend.embed.return_value = [SparseEmbedding(indices=[0], values=[0.1])]
+        documents = [Document(content="document", meta={"rating": 0, "is_available": False, "none_value": None})]
+
+        embedder.run(documents=documents)
+
+        embedder.embedding_backend.embed.assert_called_once_with(
+            data=["0\nFalse\ndocument"], batch_size=32, show_progress_bar=True
+        )
+
     def test_prefix_suffix(self):
         embedder = SentenceTransformersSparseDocumentEmbedder(
             model="model",

--- a/test/components/rankers/test_sentence_transformers_diversity.py
+++ b/test/components/rankers/test_sentence_transformers_diversity.py
@@ -474,6 +474,22 @@ class TestSentenceTransformersDiversityRanker:
         ]
 
     @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
+    def test_prepare_texts_to_embed_preserves_falsy_meta_values(self, similarity):
+        ranker = SentenceTransformersDiversityRanker(
+            model="sentence-transformers/all-MiniLM-L6-v2",
+            similarity=similarity,
+            document_prefix="test doc: ",
+            document_suffix=" end doc.",
+            meta_fields_to_embed=["rating", "is_available", "missing", "none_value"],
+            embedding_separator="\n",
+        )
+        documents = [Document(content="document", meta={"rating": 0, "is_available": False, "none_value": None})]
+
+        texts = ranker._prepare_texts_to_embed(documents=documents)
+
+        assert texts == ["test doc: 0\nFalse\ndocument end doc."]
+
+    @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
     def test_encode_text(self, similarity):
         """
         Test addition of suffix and prefix to the query and documents when creating embeddings.

--- a/test/components/rankers/test_sentence_transformers_similarity.py
+++ b/test/components/rankers/test_sentence_transformers_similarity.py
@@ -303,6 +303,22 @@ class TestSentenceTransformersSimilarityRanker:
         assert kwargs["convert_to_numpy"] is True
         assert kwargs["return_documents"] is False
 
+    def test_embed_meta_preserves_falsy_values(self):
+        ranker = SentenceTransformersSimilarityRanker(
+            model="model",
+            meta_fields_to_embed=["rating", "is_available", "missing", "none_value"],
+            embedding_separator="\n",
+        )
+        mock_cross_encoder = MagicMock()
+        mock_cross_encoder.rank.return_value = [{"corpus_id": 0, "score": 1.0}]
+        ranker._cross_encoder = mock_cross_encoder
+        documents = [Document(content="document", meta={"rating": 0, "is_available": False, "none_value": None})]
+
+        ranker.run(query="test", documents=documents)
+
+        _, kwargs = mock_cross_encoder.rank.call_args
+        assert kwargs["documents"] == ["0\nFalse\ndocument"]
+
     def test_prefix(self):
         ranker = SentenceTransformersSimilarityRanker(
             model="model", query_prefix="query_instruction: ", document_prefix="document_instruction: "

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -244,6 +244,29 @@ class TestSimilarityRanker:
     @patch("torch.sigmoid")
     @patch("torch.sort")
     @patch("torch.stack")
+    def test_embed_meta_preserves_falsy_values(self, mocked_stack, mocked_sort, mocked_sigmoid):
+        mocked_stack.return_value = torch.tensor([0])
+        mocked_sort.return_value = (None, torch.tensor([0]))
+        mocked_sigmoid.return_value = torch.tensor([0])
+        embedder = TransformersSimilarityRanker(
+            model="model",
+            meta_fields_to_embed=["rating", "is_available", "missing", "none_value"],
+            embedding_separator="\n",
+        )
+        embedder.model = MagicMock()
+        embedder.tokenizer = MagicMock()
+        embedder.device = MagicMock()
+        documents = [Document(content="document", meta={"rating": 0, "is_available": False, "none_value": None})]
+
+        embedder.run(query="test", documents=documents)
+
+        embedder.tokenizer.assert_called_once_with(
+            [["test", "0\nFalse\ndocument"]], padding=True, truncation=True, return_tensors="pt"
+        )
+
+    @patch("torch.sigmoid")
+    @patch("torch.sort")
+    @patch("torch.stack")
     def test_prefix(self, mocked_stack, mocked_sort, mocked_sigmoid):
         mocked_stack.return_value = torch.tensor([0])
         mocked_sort.return_value = (None, torch.tensor([0]))


### PR DESCRIPTION
## Summary

Fixes #11405.

Several components used a truthiness check while preparing `meta_fields_to_embed` values:

```python
if key in doc.meta and doc.meta[key]
```

That silently dropped valid metadata values such as `0` and `False`, changing the text passed into embedding/ranking without warning. The affected paths now match the existing OpenAI/Azure embedder behavior and only skip metadata that is absent or explicitly `None`.

Updated components:

- `SentenceTransformersDocumentEmbedder`
- `SentenceTransformersSparseDocumentEmbedder`
- `SentenceTransformersSimilarityRanker`
- `SentenceTransformersDiversityRanker`
- `TransformersSimilarityRanker`

## Tests

- `.venv/bin/python -m pytest test/components/embedders/test_sentence_transformers_document_embedder.py::TestSentenceTransformersDocumentEmbedder::test_embed_metadata_preserves_falsy_values test/components/embedders/test_sentence_transformers_sparse_document_embedder.py::TestSentenceTransformersDocumentEmbedder::test_embed_metadata_preserves_falsy_values test/components/rankers/test_sentence_transformers_similarity.py::TestSentenceTransformersSimilarityRanker::test_embed_meta_preserves_falsy_values test/components/rankers/test_sentence_transformers_diversity.py::TestSentenceTransformersDiversityRanker::test_prepare_texts_to_embed_preserves_falsy_meta_values test/components/rankers/test_transformers_similarity.py::TestSimilarityRanker::test_embed_meta_preserves_falsy_values`
- `python -m ruff check <changed files>`
- `python -m ruff format --check <changed files>`
- `git diff --check`
