### PR TITLE
Fix duplicated replies when HuggingFaceLocalGenerator uses multiple stop words

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -259,7 +259,9 @@ class HuggingFaceLocalGenerator:
         replies = [o["generated_text"] for o in output if "generated_text" in o]
 
         if self.stop_words:
-            # the output of the pipeline includes the stop word
-            replies = [reply.replace(stop_word, "").rstrip() for reply in replies for stop_word in self.stop_words]
+            # The output of the pipeline includes the stop word, so strip each stop word
+            # from each reply without duplicating replies when multiple stop words are set.
+            for stop_word in self.stop_words:
+                replies = [reply.replace(stop_word, "").rstrip() for reply in replies]
 
         return {"replies": replies}

--- a/releasenotes/notes/fix-hf-local-generator-stop-words-cross-product-b9f320441e4714a5.yaml
+++ b/releasenotes/notes/fix-hf-local-generator-stop-words-cross-product-b9f320441e4714a5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes `HuggingFaceLocalGenerator` so using multiple `stop_words` no longer duplicates replies while stripping stop words from generated text.

--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -420,6 +420,23 @@ class TestHuggingFaceLocalGenerator:
         results = generator.run(prompt="irrelevant")
         assert results == {"replies": ["Hello"]}
 
+    def test_run_stop_words_removal_multiple_entries(self):
+        """Test that multiple stop words are removed sequentially without duplicating replies."""
+        generator = HuggingFaceLocalGenerator(
+            model="Qwen/Qwen3-0.6B", task="text-generation", stop_words=[" STOP", " END"]
+        )
+        generator.pipeline = Mock(
+            return_value=[
+                {"generated_text": "Paris is the capital. STOP"},
+                {"generated_text": "France is in Europe. END"},
+            ]
+        )
+        generator.stopping_criteria_list = Mock()
+
+        results = generator.run(prompt="irrelevant")
+
+        assert results == {"replies": ["Paris is the capital.", "France is in Europe."]}
+
     @pytest.mark.integration
     def test_stop_words_criteria_using_hf_tokenizer(self):
         """


### PR DESCRIPTION
## Summary

Fixes #11409.

`HuggingFaceLocalGenerator` currently duplicates replies when multiple `stop_words` are configured. This PR updates the stop word post-processing so each stop word is removed sequentially from the existing replies instead of producing a cross-product of replies and stop words.

## Problem

When `stop_words` contains more than one entry, the generator returns too many replies after generation.

## Root Cause

The current implementation uses a nested list comprehension that iterates over both `replies` and `self.stop_words` at the same time:

```python
[reply.replace(stop_word, "").rstrip() for reply in replies for stop_word in self.stop_words]
```

That creates one output entry per `(reply, stop_word)` pair, which duplicates replies.

## Fix

Apply stop words sequentially to the current reply list:

- iterate over `self.stop_words`
- rewrite `replies` in place for each stop word
- preserve the original number of replies while still stripping all configured stop words

## Tests

Ran:

```bash
hatch run test:unit test/components/generators/test_hugging_face_local_generator.py
```

Result:

- 25 passed
- 3 deselected

Added a regression test that verifies multiple stop words do not duplicate replies.
