### PR TITLE
docs: replace Generators with ChatGenerators where possible

### DIFF
--- a/docs-website/docs/concepts/secret-management.mdx
+++ b/docs-website/docs/concepts/secret-management.mdx
@@ -23,10 +23,10 @@ You can find additional details for the `Secret` class in our [API reference](/r
 
 Let’s consider an example RAG pipeline that embeds a query, uses a Retriever component to locate documents relevant to the query, and then leverages an LLM to generate an answer based on the retrieved documents.
 
-The `OpenAIGenerator` component used in the pipeline below expects an API key to authenticate with OpenAI’s servers and perform the generation. Let’s assume that the component accepts a `str`  value for it:
+The `OpenAIChatGenerator` component used in the pipeline below expects an API key to authenticate with OpenAI’s servers and perform the generation. Let’s assume that the component accepts a `str`  value for it:
 
 ```python
-generator = OpenAIGenerator(model="gpt-4", api_key="sk-xxxxxxxxxxxxxxxxxx")
+generator = OpenAIChatGenerator(model="gpt-4", api_key="sk-xxxxxxxxxxxxxxxxxx")
 pipeline.add_component("generator", generator)
 ```
 
@@ -36,7 +36,7 @@ This works in a pinch, but this is bad practice - we shouldn’t hard-code such 
 import os
 
 api_key = os.environ.get("OPENAI_API_KEY")
-generator = OpenAIGenerator(model="gpt-4", api_key=api_key)
+generator = OpenAIChatGenerator(model="gpt-4", api_key=api_key)
 pipeline.add_component("generator", generator)
 ```
 
@@ -67,7 +67,7 @@ from haystack.utils import Secret
 You can paste tokens directly as a string using the `from_token` method:
 
 ```python
-llm = OpenAIGenerator(api_key=Secret.from_token("sk-randomAPIkeyasdsa32ekasd32e"))
+llm = OpenAIChatGenerator(api_key=Secret.from_token("sk-randomAPIkeyasdsa32ekasd32e"))
 ```
 
 Note that this type of code cannot be serialized, meaning you can't convert the above component to a dictionary or save a pipeline containing it to a YAML file. This is a security feature to prevent accidental exposure of sensitive data.
@@ -76,7 +76,7 @@ Note that this type of code cannot be serialized, meaning you can't convert the 
 
 Environment variable-based secrets are more flexible. They allow you to specify one or more environment variables that may contain your secret.
 
-Existing Haystack components that require an API Key (like OpenAIGenerator) have a default value for `Secret.from_env_var` (in this case, `OPENAI_API_KEY`). This means that the `OpenAIGenerator` will look for the value of the environment variable `OPENAI_API_KEY` (if it exists) and use it for authentication. And when pipelines are serialized to YAML, only the name of the environment variable is save to the YAML file. In doing so, this method ensures that there are no security leaks and is therefore strongly recommended.
+Existing Haystack components that require an API Key (like OpenAIChatGenerator) have a default value for `Secret.from_env_var` (in this case, `OPENAI_API_KEY`). This means that the `OpenAIChatGenerator` will look for the value of the environment variable `OPENAI_API_KEY` (if it exists) and use it for authentication. And when pipelines are serialized to YAML, only the name of the environment variable is save to the YAML file. In doing so, this method ensures that there are no security leaks and is therefore strongly recommended.
 
 ```bash
 ## First, export an environment variable name `OPENAI_API_KEY` with its value
@@ -89,7 +89,7 @@ export OPENAI_API_KEY=sk-randomAPIkeyasdsa32ekasd32e
 
 ```python
 llm_generator = (
-    OpenAIGenerator()
+    OpenAIChatGenerator()
 )  # Uses the default value from the env var for the component
 ```
 
@@ -97,10 +97,10 @@ Alternatively, in components where a Secret is expected, you can customize the n
 
 ```python
 # Export an environment variable with custom name and its value
-llm_generator = OpenAIGenerator(api_key=Secret.from_env_var("YOUR_ENV_VAR"))
+llm_generator = OpenAIChatGenerator(api_key=Secret.from_env_var("YOUR_ENV_VAR"))
 ```
 
-When `OpenAIGenerator` is serialized within a pipeline, this is what the YAML code will look like, using the custom variable name:
+When `OpenAIChatGenerator` is serialized within a pipeline, this is what the YAML code will look like, using the custom variable name:
 
 ```yaml
 components:
@@ -113,11 +113,15 @@ components:
         strict: true
         type: env_var
       generation_kwargs: {}
+      http_client_kwargs: null
+      max_retries: null
       model: gpt-4o-mini
       organization: null
       streaming_callback: null
-      system_prompt: null
-    type: haystack.components.generators.openai.OpenAIGenerator
+      timeout: null
+      tools: null
+      tools_strict: false
+    type: haystack.components.generators.chat.openai.OpenAIChatGenerator
     ...
 ```
 
@@ -152,6 +156,7 @@ Here is a complete example that shows how to create a component that uses the `S
 ```python
 from haystack.utils import Secret, deserialize_secrets_inplace
 
+
 @component
 class MyComponent:
     def __init__(self, api_key: Optional[Secret] = None, **kwargs):
@@ -162,14 +167,15 @@ class MyComponent:
         # Call resolve_value to yield a single result. The semantics of the result is policy-dependent.
         # Currently, all supported policies will return a single string token.
         self.backend = SomeBackend(
-            api_key=self.api_key.resolve_value() if self.api_key else None, ...
+            api_key=self.api_key.resolve_value() if self.api_key else None,  # ...
         )
 
     def to_dict(self):
         # Serialize the policy like any other (custom) data. If the policy is token-based, it will
         # raise an error.
         return default_to_dict(
-            self, api_key=self.api_key.to_dict() if self.api_key else None, ...
+            self,
+            api_key=self.api_key.to_dict() if self.api_key else None,  # ...
         )
 
     @classmethod
@@ -182,14 +188,15 @@ class MyComponent:
         # deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
+
 # No authentication.
 component = MyComponent(api_key=None)
 
 # Token based authentication
 component = MyComponent(api_key=Secret.from_token("sk-randomAPIkeyasdsa32ekasd32e"))
-component.to_dict() # Error! Can't serialize authentication tokens
+component.to_dict()  # Error! Can't serialize authentication tokens
 
 # Environment variable based authentication
 component = MyComponent(api_key=Secret.from_env_var("OPENAI_API_KEY"))
-component.to_dict() # This is fine
+component.to_dict()  # This is fine
 ```

--- a/docs-website/docs/concepts/secret-management.mdx
+++ b/docs-website/docs/concepts/secret-management.mdx
@@ -26,7 +26,7 @@ Let’s consider an example RAG pipeline that embeds a query, uses a Retriever c
 The `OpenAIChatGenerator` component used in the pipeline below expects an API key to authenticate with OpenAI’s servers and perform the generation. Let’s assume that the component accepts a `str`  value for it:
 
 ```python
-generator = OpenAIChatGenerator(model="gpt-4", api_key="sk-xxxxxxxxxxxxxxxxxx")
+generator = OpenAIChatGenerator(api_key="sk-xxxxxxxxxxxxxxxxxx")
 pipeline.add_component("generator", generator)
 ```
 
@@ -36,7 +36,7 @@ This works in a pinch, but this is bad practice - we shouldn’t hard-code such 
 import os
 
 api_key = os.environ.get("OPENAI_API_KEY")
-generator = OpenAIChatGenerator(model="gpt-4", api_key=api_key)
+generator = OpenAIChatGenerator(api_key=api_key)
 pipeline.add_component("generator", generator)
 ```
 
@@ -115,7 +115,7 @@ components:
       generation_kwargs: {}
       http_client_kwargs: null
       max_retries: null
-      model: gpt-4o-mini
+      model: gpt-5-mini
       organization: null
       streaming_callback: null
       timeout: null

--- a/docs-website/docs/optimization/advanced-rag-techniques/hypothetical-document-embeddings-hyde.mdx
+++ b/docs-website/docs/optimization/advanced-rag-techniques/hypothetical-document-embeddings-hyde.mdx
@@ -33,28 +33,37 @@ import os
 from numpy import array, mean
 from typing import List
 
-from haystack.components.generators.openai import OpenAIGenerator
-from haystack.components.builders import PromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.builders import ChatPromptBuilder
 from haystack import component, Document
 from haystack.components.converters import OutputAdapter
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder
+from haystack.dataclasses import ChatMessage
 
 # We need to ensure we have the OpenAI API key in our environment variables
 os.environ["OPENAI_API_KEY"] = "YOUR_OPENAI_KEY"
 
 # Initializing standard Haystack components
-generator = OpenAIGenerator(
+generator = OpenAIChatGenerator(
     model="gpt-3.5-turbo",
     generation_kwargs={"n": 5, "temperature": 0.75, "max_tokens": 400},
 )
-prompt_builder = PromptBuilder(
-    template="""Given a question, generate a paragraph of text that answers the question.    Question: {{question}}    Paragraph:""",
+prompt_builder = ChatPromptBuilder(
+    template=[
+        ChatMessage.from_user(
+            """Given a question, generate a paragraph of text that answers the question.    Question: {{question}}    Paragraph:""",
+        ),
+    ],
+    required_variables="*",
 )
 
+# The ChatGenerator returns ChatMessage replies, so we read each reply's text.
+# unsafe=True lets the adapter return actual Document objects instead of a string.
 adapter = OutputAdapter(
     template="{{answers | build_doc}}",
     output_type=List[Document],
-    custom_filters={"build_doc": lambda data: [Document(content=d) for d in data]},
+    custom_filters={"build_doc": lambda data: [Document(content=d.text) for d in data]},
+    unsafe=True,
 )
 
 embedder = SentenceTransformersDocumentEmbedder(
@@ -86,7 +95,7 @@ pipeline.add_component(name="adapter", instance=adapter)
 pipeline.add_component(name="embedder", instance=embedder)
 pipeline.add_component(name="hyde", instance=HypotheticalDocumentEmbedder())
 
-pipeline.connect("prompt_builder", "generator")
+pipeline.connect("prompt_builder.prompt", "generator.messages")
 pipeline.connect("generator.replies", "adapter.answers")
 pipeline.connect("adapter.output", "embedder.documents")
 pipeline.connect("embedder.documents", "hyde.documents")

--- a/docs-website/docs/pipeline-components/joiners/branchjoiner.mdx
+++ b/docs-website/docs/pipeline-components/joiners/branchjoiner.mdx
@@ -39,8 +39,7 @@ from haystack.components.joiners import BranchJoiner
 bj = BranchJoiner(int)
 bj.run(value=[3, 4, 5])
 
->>> ValueError: BranchJoiner expects only one input, but 3 were received.
-
+# ValueError: BranchJoiner expects only one input, but 3 were received.
 ```
 
 ## Usage
@@ -55,12 +54,12 @@ from haystack.components.joiners import BranchJoiner
 # an example where input and output are strings
 bj = BranchJoiner(str)
 bj.run(value=["hello"])
->>> {"value" : "hello"}
+# {"value" : "hello"}
 
 # an example where input and output are integers
 bj = BranchJoiner(int)
 bj.run(value=[3])
->>> {"value": 3}
+# {"value": 3}
 ```
 
 ### In a pipeline
@@ -136,11 +135,14 @@ from haystack import Document, Pipeline
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.components.joiners import BranchJoiner
-from haystack.components.builders import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.routers import TextLanguageRouter
+from haystack.dataclasses import ChatMessage
 
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
 Answer the question based on the given reviews.
 Reviews:
   {% for doc in documents %}
@@ -148,7 +150,9 @@ Reviews:
   {% endfor %}
 Question: {{ query}}
 Answer:
-"""
+""",
+    ),
+]
 
 documents = [
     Document(
@@ -191,10 +195,10 @@ rag_pipeline.add_component(
 )
 rag_pipeline.add_component(instance=BranchJoiner(type_=list[Document]), name="joiner")
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 
 rag_pipeline.connect("router.en", "en_retriever.query")
 rag_pipeline.connect("router.fr", "fr_retriever.query")
@@ -203,7 +207,7 @@ rag_pipeline.connect("en_retriever", "joiner")
 rag_pipeline.connect("fr_retriever", "joiner")
 rag_pipeline.connect("es_retriever", "joiner")
 rag_pipeline.connect("joiner", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 
 en_question = "Does this apartment has a noise problem?"
 
@@ -211,7 +215,7 @@ result = rag_pipeline.run(
     {"router": {"text": en_question}, "prompt_builder": {"query": en_question}},
 )
 
-print(result["llm"]["replies"][0])
+print(result["llm"]["replies"][0].text)
 ```
 
 <details>

--- a/docs-website/docs/pipeline-components/retrievers/azureaisearchbm25retriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/azureaisearchbm25retriever.mdx
@@ -92,8 +92,9 @@ from haystack_integrations.document_stores.azure_ai_search import (
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
 import os
@@ -101,7 +102,9 @@ import os
 api_key = os.environ["OPENAI_API_KEY"]
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -109,7 +112,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 document_store = AzureAISearchDocumentStore(index_name="haystack-docs")
 
@@ -131,15 +136,14 @@ retriever = AzureAISearchBM25Retriever(document_store=document_store)
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(name="retriever", instance=retriever)
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.meta", "answer_builder.meta")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "Tell me something about languages?"

--- a/docs-website/docs/pipeline-components/retrievers/elasticsearchbm25retriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/elasticsearchbm25retriever.mdx
@@ -105,16 +105,17 @@ from elasticsearch import Elasticsearch
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
-import os
-
-api_key = os.environ["OPENAI_API_KEY"]
+# OpenAIChatGenerator reads the OPENAI_API_KEY environment variable by default.
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -122,7 +123,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 document_store = ElasticsearchDocumentStore(hosts="http://localhost:9200/")
 
@@ -145,15 +148,14 @@ retriever = ElasticsearchBM25Retriever(document_store=document_store)
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(name="retriever", instance=retriever)
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(api_key=api_key), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.meta", "answer_builder.meta")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "How many languages are spoken around the world today?"

--- a/docs-website/docs/pipeline-components/retrievers/filterretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/filterretriever.mdx
@@ -77,25 +77,26 @@ from haystack.components.retrievers.filter_retriever import FilterRetriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 from haystack import Document, Pipeline
-from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
-import os
-api_key = os.environ['OPENAI_API_KEY']
+# OpenAIChatGenerator reads the OPENAI_API_KEY environment variable by default.
 
 document_store = InMemoryDocumentStore()
 documents = [
-		Document(content="Mark lives in Berlin.", meta={"year": 2018}),
-		Document(content="Mark lives in Paris.", meta={"year": 2021}),
-		Document(content="Mark is Danish.", meta={"year": 2021}),
-		Document(content="Mark lives in New York.", meta={"year": 2023}),
+    Document(content="Mark lives in Berlin.", meta={"year": 2018}),
+    Document(content="Mark lives in Paris.", meta={"year": 2021}),
+    Document(content="Mark is Danish.", meta={"year": 2021}),
+    Document(content="Mark lives in New York.", meta={"year": 2023}),
 ]
 document_store.write_documents(documents=documents)
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -103,22 +104,30 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 rag_pipeline = Pipeline()
-rag_pipeline.add_component(name="retriever", instance=FilterRetriever(document_store=document_store))
-rag_pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
-rag_pipeline.add_component(instance=OpenAIGenerator(api_key=api_key), name="llm")
+rag_pipeline.add_component(
+    name="retriever",
+    instance=FilterRetriever(document_store=document_store),
+)
+rag_pipeline.add_component(
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
+    name="prompt_builder",
+)
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 
 result = rag_pipeline.run(
-  {
-    "retriever": {"filters": {"field": "year", "operator": "==", "value": 2021}},
-    "prompt_builder": {"question": "Where does Mark live?"},
-  }
+    {
+        "retriever": {"filters": {"field": "year", "operator": "==", "value": 2021}},
+        "prompt_builder": {"question": "Where does Mark live?"},
+    },
 )
-print(result['answer_builder']['answers'][0])`
+print(result["llm"]["replies"][0].text)
 ```
 
 Here’s an example output you might get:

--- a/docs-website/docs/pipeline-components/retrievers/inmemorybm25retriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/inmemorybm25retriever.mdx
@@ -68,13 +68,16 @@ import os
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -82,7 +85,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 os.environ["OPENAI_API_KEY"] = "sk-XXXXXX"
 
@@ -92,15 +97,14 @@ rag_pipeline.add_component(
     name="retriever",
 )
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 # Draw the pipeline

--- a/docs-website/docs/pipeline-components/retrievers/mongodbatlasembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/mongodbatlasembeddingretriever.mdx
@@ -67,8 +67,9 @@ retriever.run(query_embedding=[0.1] * 384)
 from haystack import Pipeline, Document
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.components.writers import DocumentWriter
-from haystack.components.generators import OpenAIGenerator
-from haystack.components.builders.prompt_builder import PromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.dataclasses import ChatMessage
 from haystack.components.embedders import (
     SentenceTransformersDocumentEmbedder,
     SentenceTransformersTextEmbedder,
@@ -104,8 +105,10 @@ ingestion_pipe.connect("doc_embedder.documents", "doc_writer.documents")
 ingestion_pipe.run({"doc_embedder": {"documents": documents}})
 
 # Build a RAG pipeline with a Retriever to get relevant documents to
-# the query and a OpenAIGenerator interacting with LLMs using a custom prompt.
-prompt_template = """
+# the query and an OpenAIChatGenerator interacting with LLMs using a custom prompt.
+prompt_template = [
+    ChatMessage.from_user(
+        """
 Given these documents, answer the question.\nDocuments:
 {% for doc in documents %}
     {{ doc.content }}
@@ -113,7 +116,9 @@ Given these documents, answer the question.\nDocuments:
 
 \nQuestion: {{question}}
 \nAnswer:
-"""
+""",
+    ),
+]
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(instance=query_embedder, name="query_embedder")
 rag_pipeline.add_component(
@@ -121,13 +126,13 @@ rag_pipeline.add_component(
     name="retriever",
 )
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.connect("query_embedder", "retriever.query_embedding")
-rag_pipeline.connect("embedding_retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("retriever", "prompt_builder.documents")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 
 # Ask a question on the data you just added.
 question = "Where does Mark live?"
@@ -138,6 +143,6 @@ result = rag_pipeline.run(
     },
 )
 
-# For details, like which documents were used to generate the answer, look into the GeneratedAnswer object
-print(result["answer_builder"]["answers"])
+# The generated reply is a ChatMessage; its text holds the answer.
+print(result["llm"]["replies"][0].text)
 ```

--- a/docs-website/docs/pipeline-components/retrievers/opensearchbm25retriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/opensearchbm25retriever.mdx
@@ -77,16 +77,17 @@ from haystack_integrations.document_stores.opensearch import OpenSearchDocumentS
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
-import os
-
-api_key = os.environ["OPENAI_API_KEY"]
+# OpenAIChatGenerator reads the OPENAI_API_KEY environment variable by default.
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -94,7 +95,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 document_store = OpenSearchDocumentStore(
     hosts="http://localhost:9200",
@@ -121,15 +124,14 @@ retriever = OpenSearchBM25Retriever(document_store=document_store)
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(name="retriever", instance=retriever)
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(api_key=api_key), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "How many languages are spoken around the world today?"
@@ -146,13 +148,13 @@ print(result["answer_builder"]["answers"][0])
 Here’s an example output:
 
 ```python
-GeneratedAnswer(
-  data='Over 7,000 languages are spoken around the world today.',
-  query='How many languages are spoken around the world today?',
-  documents=[
-    Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, content: 'There are over 7,000 languages spoken around the world today.', score: 7.179112),
-    Document(id=7f225626ad1019b273326fbaf11308edfca6d663308a4a3533ec7787367d59a2, content: 'In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the ph...', score: 1.1426818)],
-  meta={'model': 'gpt-5-mini', 'index': 0, 'finish_reason': 'stop', 'usage': {'prompt_tokens': 86, 'completion_tokens': 13, 'total_tokens': 99}})
+# GeneratedAnswer(
+#   data='Over 7,000 languages are spoken around the world today.',
+#   query='How many languages are spoken around the world today?',
+#   documents=[
+#     Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, content: 'There are over 7,000 languages spoken around the world today.', score: 7.179112),
+#     Document(id=7f225626ad1019b273326fbaf11308edfca6d663308a4a3533ec7787367d59a2, content: 'In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the ph...', score: 1.1426818)],
+#   meta={'model': 'gpt-5-mini', 'index': 0, 'finish_reason': 'stop', 'usage': {'prompt_tokens': 86, 'completion_tokens': 13, 'total_tokens': 99}})
 ```
 
 ## Additional References

--- a/docs-website/docs/pipeline-components/retrievers/pgvectorkeywordretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/pgvectorkeywordretriever.mdx
@@ -82,8 +82,9 @@ The prerequisites necessary for running this code are:
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
 from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
@@ -92,7 +93,9 @@ from haystack_integrations.components.retrievers.pgvector import (
 )
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -100,7 +103,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 document_store = PgvectorDocumentStore(
     language="english",  # this parameter influences text parsing for keyword retrieval
@@ -124,15 +129,14 @@ retriever = PgvectorKeywordRetriever(document_store=document_store)
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(name="retriever", instance=retriever)
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.meta", "answer_builder.meta")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "languages spoken around the world today"

--- a/docs-website/docs/pipeline-components/retrievers/snowflaketableretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/snowflaketableretriever.mdx
@@ -38,27 +38,31 @@ pip install snowflake-haystack
 ### On its own
 
 ```python
-from haystack_integrations.components.retrievers.snowflake import SnowflakeTableRetriever
+from haystack.utils import Secret
+from haystack_integrations.components.retrievers.snowflake import (
+    SnowflakeTableRetriever,
+)
 
-snowflake = SnowflakeRetriever(
+snowflake = SnowflakeTableRetriever(
     user="<ACCOUNT-USER>",
     account="<ACCOUNT-IDENTIFIER>",
     api_key=Secret.from_env_var("SNOWFLAKE_API_KEY"),
     warehouse="<WAREHOUSE-NAME>",
 )
 
-snowflake.run(query="""select * from table limit 10;"""")
+snowflake.run(query="select * from table limit 10;")
 ```
 
 ### In a pipeline
 
-In the following pipeline example, the `PromptBuilder` is using the table received from the `SnowflakeTableRetriever` to create a prompt template and pass it on to an LLM:
+In the following pipeline example, the `ChatPromptBuilder` is using the table received from the `SnowflakeTableRetriever` to create a prompt and pass it on to an LLM:
 
 ```python
 from haystack import Pipeline
 from haystack.utils import Secret
-from haystack.components.builders import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack_integrations.components.retrievers.snowflake import (
     SnowflakeTableRetriever,
 )
@@ -73,13 +77,16 @@ executor = SnowflakeTableRetriever(
 pipeline = Pipeline()
 pipeline.add_component(
     "builder",
-    PromptBuilder(template="Describe this table: {{ table }}"),
+    ChatPromptBuilder(
+        template=[ChatMessage.from_user("Describe this table: {{ table }}")],
+        required_variables="*",
+    ),
 )
 pipeline.add_component("snowflake", executor)
-pipeline.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+pipeline.add_component("llm", OpenAIChatGenerator(model="gpt-4o"))
 
 pipeline.connect("snowflake.table", "builder.table")
-pipeline.connect("builder", "llm")
+pipeline.connect("builder.prompt", "llm.messages")
 
 pipeline.run(data={"query": "select employee, salary from table limit 10;"})
 ```

--- a/docs-website/docs/pipeline-components/retrievers/weaviatebm25retriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/weaviatebm25retriever.mdx
@@ -76,12 +76,15 @@ from haystack_integrations.components.retrievers.weaviate import (
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -89,7 +92,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 document_store = WeaviateDocumentStore(url="http://localhost:8080")
 
@@ -113,15 +118,14 @@ rag_pipeline.add_component(
     instance=WeaviateBM25Retriever(document_store=document_store),
 )
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "How many languages are spoken around the world today?"

--- a/docs-website/docs/pipeline-components/routers/transformerstextrouter.mdx
+++ b/docs-website/docs/pipeline-components/routers/transformerstextrouter.mdx
@@ -47,7 +47,7 @@ Below is an example of a simple pipeline that routes English queries to a Text G
 from haystack import Pipeline
 from haystack.components.routers import TransformersTextRouter
 from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
-from haystack.components.generators.huggingface import HuggingFaceLocalGenerator
+from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
 from haystack.dataclasses import ChatMessage
 
 p = Pipeline()
@@ -73,20 +73,20 @@ p.add_component(
     name="german_prompt_builder",
 )
 p.add_component(
-    instance=HuggingFaceLocalGenerator(
+    instance=HuggingFaceLocalChatGenerator(
         model="DiscoResearch/Llama3-DiscoLeo-Instruct-8B-v0.1",
     ),
     name="german_llm",
 )
 p.add_component(
-    instance=HuggingFaceLocalGenerator(model="microsoft/Phi-3-mini-4k-instruct"),
+    instance=HuggingFaceLocalChatGenerator(model="microsoft/Phi-3-mini-4k-instruct"),
     name="english_llm",
 )
 
 p.connect("text_router.en", "english_prompt_builder.query")
 p.connect("text_router.de", "german_prompt_builder.query")
-p.connect("english_prompt_builder.messages", "english_llm.messages")
-p.connect("german_prompt_builder.messages", "german_llm.messages")
+p.connect("english_prompt_builder.prompt", "english_llm.messages")
+p.connect("german_prompt_builder.prompt", "german_llm.messages")
 
 # English Example
 print(p.run({"text_router": {"text": "What is the capital of Germany?"}}))

--- a/docs-website/docs/pipeline-components/websearch/searchapiwebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/searchapiwebsearch.mdx
@@ -53,7 +53,7 @@ response = web_search.run(query)
 
 ### In a pipeline
 
-Here’s an example of a RAG pipeline where we use a `SearchApiWebSearch` to look up the answer to the query. The resulting documents are then passed to `LinkContentFetcher` to get the full text from the URLs. Finally, `PromptBuilder` and `OpenAIGenerator` work together to form the final answer.
+Here’s an example of a RAG pipeline where we use a `SearchApiWebSearch` to look up the answer to the query. The resulting documents are then passed to `LinkContentFetcher` to get the full text from the URLs. Finally, `ChatPromptBuilder` and `OpenAIChatGenerator` work together to form the final answer.
 
 ```python
 from haystack import Pipeline
@@ -96,7 +96,7 @@ pipe.add_component("llm", llm)
 pipe.connect("search.links", "fetcher.urls")
 pipe.connect("fetcher.streams", "converter.sources")
 pipe.connect("converter.documents", "prompt_builder.documents")
-pipe.connect("prompt_builder.messages", "llm.messages")
+pipe.connect("prompt_builder.prompt", "llm.messages")
 
 query = "What is the most famous landmark in Berlin?"
 

--- a/docs-website/docs/pipeline-components/websearch/serperdevwebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/serperdevwebsearch.mdx
@@ -54,7 +54,7 @@ response = web_search.run(query)
 
 ### In a pipeline
 
-Here’s an example of a RAG pipeline where we use a `SerperDevWebSearch` to look up the answer to the query. The resulting documents are then passed to `LinkContentFetcher` to get the full text from the URLs. Finally, `PromptBuilder` and `OpenAIGenerator` work together to form the final answer.
+Here’s an example of a RAG pipeline where we use a `SerperDevWebSearch` to look up the answer to the query. The resulting documents are then passed to `LinkContentFetcher` to get the full text from the URLs. Finally, `ChatPromptBuilder` and `OpenAIChatGenerator` work together to form the final answer.
 
 ```python
 from haystack import Pipeline
@@ -98,7 +98,7 @@ pipe.add_component("llm", llm)
 pipe.connect("search.links", "fetcher.urls")
 pipe.connect("fetcher.streams", "converter.sources")
 pipe.connect("converter.documents", "prompt_builder.documents")
-pipe.connect("prompt_builder.messages", "llm.messages")
+pipe.connect("prompt_builder.prompt", "llm.messages")
 
 query = "What is the most famous landmark in Berlin?"
 

--- a/docs-website/versioned_docs/version-2.29/concepts/secret-management.mdx
+++ b/docs-website/versioned_docs/version-2.29/concepts/secret-management.mdx
@@ -23,10 +23,10 @@ You can find additional details for the `Secret` class in our [API reference](/r
 
 Let’s consider an example RAG pipeline that embeds a query, uses a Retriever component to locate documents relevant to the query, and then leverages an LLM to generate an answer based on the retrieved documents.
 
-The `OpenAIGenerator` component used in the pipeline below expects an API key to authenticate with OpenAI’s servers and perform the generation. Let’s assume that the component accepts a `str`  value for it:
+The `OpenAIChatGenerator` component used in the pipeline below expects an API key to authenticate with OpenAI’s servers and perform the generation. Let’s assume that the component accepts a `str`  value for it:
 
 ```python
-generator = OpenAIGenerator(model="gpt-4", api_key="sk-xxxxxxxxxxxxxxxxxx")
+generator = OpenAIChatGenerator(model="gpt-4", api_key="sk-xxxxxxxxxxxxxxxxxx")
 pipeline.add_component("generator", generator)
 ```
 
@@ -36,7 +36,7 @@ This works in a pinch, but this is bad practice - we shouldn’t hard-code such 
 import os
 
 api_key = os.environ.get("OPENAI_API_KEY")
-generator = OpenAIGenerator(model="gpt-4", api_key=api_key)
+generator = OpenAIChatGenerator(model="gpt-4", api_key=api_key)
 pipeline.add_component("generator", generator)
 ```
 
@@ -67,7 +67,7 @@ from haystack.utils import Secret
 You can paste tokens directly as a string using the `from_token` method:
 
 ```python
-llm = OpenAIGenerator(api_key=Secret.from_token("sk-randomAPIkeyasdsa32ekasd32e"))
+llm = OpenAIChatGenerator(api_key=Secret.from_token("sk-randomAPIkeyasdsa32ekasd32e"))
 ```
 
 Note that this type of code cannot be serialized, meaning you can't convert the above component to a dictionary or save a pipeline containing it to a YAML file. This is a security feature to prevent accidental exposure of sensitive data.
@@ -76,7 +76,7 @@ Note that this type of code cannot be serialized, meaning you can't convert the 
 
 Environment variable-based secrets are more flexible. They allow you to specify one or more environment variables that may contain your secret.
 
-Existing Haystack components that require an API Key (like OpenAIGenerator) have a default value for `Secret.from_env_var` (in this case, `OPENAI_API_KEY`). This means that the `OpenAIGenerator` will look for the value of the environment variable `OPENAI_API_KEY` (if it exists) and use it for authentication. And when pipelines are serialized to YAML, only the name of the environment variable is save to the YAML file. In doing so, this method ensures that there are no security leaks and is therefore strongly recommended.
+Existing Haystack components that require an API Key (like OpenAIChatGenerator) have a default value for `Secret.from_env_var` (in this case, `OPENAI_API_KEY`). This means that the `OpenAIChatGenerator` will look for the value of the environment variable `OPENAI_API_KEY` (if it exists) and use it for authentication. And when pipelines are serialized to YAML, only the name of the environment variable is save to the YAML file. In doing so, this method ensures that there are no security leaks and is therefore strongly recommended.
 
 ```bash
 ## First, export an environment variable name `OPENAI_API_KEY` with its value
@@ -89,7 +89,7 @@ export OPENAI_API_KEY=sk-randomAPIkeyasdsa32ekasd32e
 
 ```python
 llm_generator = (
-    OpenAIGenerator()
+    OpenAIChatGenerator()
 )  # Uses the default value from the env var for the component
 ```
 
@@ -97,10 +97,10 @@ Alternatively, in components where a Secret is expected, you can customize the n
 
 ```python
 # Export an environment variable with custom name and its value
-llm_generator = OpenAIGenerator(api_key=Secret.from_env_var("YOUR_ENV_VAR"))
+llm_generator = OpenAIChatGenerator(api_key=Secret.from_env_var("YOUR_ENV_VAR"))
 ```
 
-When `OpenAIGenerator` is serialized within a pipeline, this is what the YAML code will look like, using the custom variable name:
+When `OpenAIChatGenerator` is serialized within a pipeline, this is what the YAML code will look like, using the custom variable name:
 
 ```yaml
 components:
@@ -113,11 +113,15 @@ components:
         strict: true
         type: env_var
       generation_kwargs: {}
+      http_client_kwargs: null
+      max_retries: null
       model: gpt-4o-mini
       organization: null
       streaming_callback: null
-      system_prompt: null
-    type: haystack.components.generators.openai.OpenAIGenerator
+      timeout: null
+      tools: null
+      tools_strict: false
+    type: haystack.components.generators.chat.openai.OpenAIChatGenerator
     ...
 ```
 
@@ -152,6 +156,7 @@ Here is a complete example that shows how to create a component that uses the `S
 ```python
 from haystack.utils import Secret, deserialize_secrets_inplace
 
+
 @component
 class MyComponent:
     def __init__(self, api_key: Optional[Secret] = None, **kwargs):
@@ -162,14 +167,15 @@ class MyComponent:
         # Call resolve_value to yield a single result. The semantics of the result is policy-dependent.
         # Currently, all supported policies will return a single string token.
         self.backend = SomeBackend(
-            api_key=self.api_key.resolve_value() if self.api_key else None, ...
+            api_key=self.api_key.resolve_value() if self.api_key else None,  # ...
         )
 
     def to_dict(self):
         # Serialize the policy like any other (custom) data. If the policy is token-based, it will
         # raise an error.
         return default_to_dict(
-            self, api_key=self.api_key.to_dict() if self.api_key else None, ...
+            self,
+            api_key=self.api_key.to_dict() if self.api_key else None,  # ...
         )
 
     @classmethod
@@ -182,14 +188,15 @@ class MyComponent:
         # deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
+
 # No authentication.
 component = MyComponent(api_key=None)
 
 # Token based authentication
 component = MyComponent(api_key=Secret.from_token("sk-randomAPIkeyasdsa32ekasd32e"))
-component.to_dict() # Error! Can't serialize authentication tokens
+component.to_dict()  # Error! Can't serialize authentication tokens
 
 # Environment variable based authentication
 component = MyComponent(api_key=Secret.from_env_var("OPENAI_API_KEY"))
-component.to_dict() # This is fine
+component.to_dict()  # This is fine
 ```

--- a/docs-website/versioned_docs/version-2.29/concepts/secret-management.mdx
+++ b/docs-website/versioned_docs/version-2.29/concepts/secret-management.mdx
@@ -26,7 +26,7 @@ Let’s consider an example RAG pipeline that embeds a query, uses a Retriever c
 The `OpenAIChatGenerator` component used in the pipeline below expects an API key to authenticate with OpenAI’s servers and perform the generation. Let’s assume that the component accepts a `str`  value for it:
 
 ```python
-generator = OpenAIChatGenerator(model="gpt-4", api_key="sk-xxxxxxxxxxxxxxxxxx")
+generator = OpenAIChatGenerator(api_key="sk-xxxxxxxxxxxxxxxxxx")
 pipeline.add_component("generator", generator)
 ```
 
@@ -36,7 +36,7 @@ This works in a pinch, but this is bad practice - we shouldn’t hard-code such 
 import os
 
 api_key = os.environ.get("OPENAI_API_KEY")
-generator = OpenAIChatGenerator(model="gpt-4", api_key=api_key)
+generator = OpenAIChatGenerator(api_key=api_key)
 pipeline.add_component("generator", generator)
 ```
 
@@ -115,7 +115,7 @@ components:
       generation_kwargs: {}
       http_client_kwargs: null
       max_retries: null
-      model: gpt-4o-mini
+      model: gpt-5-mini
       organization: null
       streaming_callback: null
       timeout: null

--- a/docs-website/versioned_docs/version-2.29/optimization/advanced-rag-techniques/hypothetical-document-embeddings-hyde.mdx
+++ b/docs-website/versioned_docs/version-2.29/optimization/advanced-rag-techniques/hypothetical-document-embeddings-hyde.mdx
@@ -33,28 +33,37 @@ import os
 from numpy import array, mean
 from typing import List
 
-from haystack.components.generators.openai import OpenAIGenerator
-from haystack.components.builders import PromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.builders import ChatPromptBuilder
 from haystack import component, Document
 from haystack.components.converters import OutputAdapter
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder
+from haystack.dataclasses import ChatMessage
 
 # We need to ensure we have the OpenAI API key in our environment variables
 os.environ["OPENAI_API_KEY"] = "YOUR_OPENAI_KEY"
 
 # Initializing standard Haystack components
-generator = OpenAIGenerator(
+generator = OpenAIChatGenerator(
     model="gpt-3.5-turbo",
     generation_kwargs={"n": 5, "temperature": 0.75, "max_tokens": 400},
 )
-prompt_builder = PromptBuilder(
-    template="""Given a question, generate a paragraph of text that answers the question.    Question: {{question}}    Paragraph:""",
+prompt_builder = ChatPromptBuilder(
+    template=[
+        ChatMessage.from_user(
+            """Given a question, generate a paragraph of text that answers the question.    Question: {{question}}    Paragraph:""",
+        ),
+    ],
+    required_variables="*",
 )
 
+# The ChatGenerator returns ChatMessage replies, so we read each reply's text.
+# unsafe=True lets the adapter return actual Document objects instead of a string.
 adapter = OutputAdapter(
     template="{{answers | build_doc}}",
     output_type=List[Document],
-    custom_filters={"build_doc": lambda data: [Document(content=d) for d in data]},
+    custom_filters={"build_doc": lambda data: [Document(content=d.text) for d in data]},
+    unsafe=True,
 )
 
 embedder = SentenceTransformersDocumentEmbedder(
@@ -86,7 +95,7 @@ pipeline.add_component(name="adapter", instance=adapter)
 pipeline.add_component(name="embedder", instance=embedder)
 pipeline.add_component(name="hyde", instance=HypotheticalDocumentEmbedder())
 
-pipeline.connect("prompt_builder", "generator")
+pipeline.connect("prompt_builder.prompt", "generator.messages")
 pipeline.connect("generator.replies", "adapter.answers")
 pipeline.connect("adapter.output", "embedder.documents")
 pipeline.connect("embedder.documents", "hyde.documents")

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/joiners/branchjoiner.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/joiners/branchjoiner.mdx
@@ -39,8 +39,7 @@ from haystack.components.joiners import BranchJoiner
 bj = BranchJoiner(int)
 bj.run(value=[3, 4, 5])
 
->>> ValueError: BranchJoiner expects only one input, but 3 were received.
-
+# ValueError: BranchJoiner expects only one input, but 3 were received.
 ```
 
 ## Usage
@@ -55,12 +54,12 @@ from haystack.components.joiners import BranchJoiner
 # an example where input and output are strings
 bj = BranchJoiner(str)
 bj.run(value=["hello"])
->>> {"value" : "hello"}
+# {"value" : "hello"}
 
 # an example where input and output are integers
 bj = BranchJoiner(int)
 bj.run(value=[3])
->>> {"value": 3}
+# {"value": 3}
 ```
 
 ### In a pipeline
@@ -136,11 +135,14 @@ from haystack import Document, Pipeline
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.components.joiners import BranchJoiner
-from haystack.components.builders import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.routers import TextLanguageRouter
+from haystack.dataclasses import ChatMessage
 
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
 Answer the question based on the given reviews.
 Reviews:
   {% for doc in documents %}
@@ -148,7 +150,9 @@ Reviews:
   {% endfor %}
 Question: {{ query}}
 Answer:
-"""
+""",
+    ),
+]
 
 documents = [
     Document(
@@ -191,10 +195,10 @@ rag_pipeline.add_component(
 )
 rag_pipeline.add_component(instance=BranchJoiner(type_=list[Document]), name="joiner")
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 
 rag_pipeline.connect("router.en", "en_retriever.query")
 rag_pipeline.connect("router.fr", "fr_retriever.query")
@@ -203,7 +207,7 @@ rag_pipeline.connect("en_retriever", "joiner")
 rag_pipeline.connect("fr_retriever", "joiner")
 rag_pipeline.connect("es_retriever", "joiner")
 rag_pipeline.connect("joiner", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 
 en_question = "Does this apartment has a noise problem?"
 
@@ -211,7 +215,7 @@ result = rag_pipeline.run(
     {"router": {"text": en_question}, "prompt_builder": {"query": en_question}},
 )
 
-print(result["llm"]["replies"][0])
+print(result["llm"]["replies"][0].text)
 ```
 
 <details>

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/azureaisearchbm25retriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/azureaisearchbm25retriever.mdx
@@ -92,8 +92,9 @@ from haystack_integrations.document_stores.azure_ai_search import (
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
 import os
@@ -101,7 +102,9 @@ import os
 api_key = os.environ["OPENAI_API_KEY"]
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -109,7 +112,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 document_store = AzureAISearchDocumentStore(index_name="haystack-docs")
 
@@ -131,15 +136,14 @@ retriever = AzureAISearchBM25Retriever(document_store=document_store)
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(name="retriever", instance=retriever)
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.meta", "answer_builder.meta")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "Tell me something about languages?"

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/elasticsearchbm25retriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/elasticsearchbm25retriever.mdx
@@ -105,16 +105,17 @@ from elasticsearch import Elasticsearch
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
-import os
-
-api_key = os.environ["OPENAI_API_KEY"]
+# OpenAIChatGenerator reads the OPENAI_API_KEY environment variable by default.
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -122,7 +123,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 document_store = ElasticsearchDocumentStore(hosts="http://localhost:9200/")
 
@@ -145,15 +148,14 @@ retriever = ElasticsearchBM25Retriever(document_store=document_store)
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(name="retriever", instance=retriever)
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(api_key=api_key), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.meta", "answer_builder.meta")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "How many languages are spoken around the world today?"

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/filterretriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/filterretriever.mdx
@@ -77,25 +77,26 @@ from haystack.components.retrievers.filter_retriever import FilterRetriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 from haystack import Document, Pipeline
-from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
-import os
-api_key = os.environ['OPENAI_API_KEY']
+# OpenAIChatGenerator reads the OPENAI_API_KEY environment variable by default.
 
 document_store = InMemoryDocumentStore()
 documents = [
-		Document(content="Mark lives in Berlin.", meta={"year": 2018}),
-		Document(content="Mark lives in Paris.", meta={"year": 2021}),
-		Document(content="Mark is Danish.", meta={"year": 2021}),
-		Document(content="Mark lives in New York.", meta={"year": 2023}),
+    Document(content="Mark lives in Berlin.", meta={"year": 2018}),
+    Document(content="Mark lives in Paris.", meta={"year": 2021}),
+    Document(content="Mark is Danish.", meta={"year": 2021}),
+    Document(content="Mark lives in New York.", meta={"year": 2023}),
 ]
 document_store.write_documents(documents=documents)
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -103,22 +104,30 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 rag_pipeline = Pipeline()
-rag_pipeline.add_component(name="retriever", instance=FilterRetriever(document_store=document_store))
-rag_pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
-rag_pipeline.add_component(instance=OpenAIGenerator(api_key=api_key), name="llm")
+rag_pipeline.add_component(
+    name="retriever",
+    instance=FilterRetriever(document_store=document_store),
+)
+rag_pipeline.add_component(
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
+    name="prompt_builder",
+)
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 
 result = rag_pipeline.run(
-  {
-    "retriever": {"filters": {"field": "year", "operator": "==", "value": 2021}},
-    "prompt_builder": {"question": "Where does Mark live?"},
-  }
+    {
+        "retriever": {"filters": {"field": "year", "operator": "==", "value": 2021}},
+        "prompt_builder": {"question": "Where does Mark live?"},
+    },
 )
-print(result['answer_builder']['answers'][0])`
+print(result["llm"]["replies"][0].text)
 ```
 
 Here’s an example output you might get:

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/inmemorybm25retriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/inmemorybm25retriever.mdx
@@ -68,13 +68,16 @@ import os
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -82,7 +85,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 os.environ["OPENAI_API_KEY"] = "sk-XXXXXX"
 
@@ -92,15 +97,14 @@ rag_pipeline.add_component(
     name="retriever",
 )
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 # Draw the pipeline

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/mongodbatlasembeddingretriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/mongodbatlasembeddingretriever.mdx
@@ -67,8 +67,9 @@ retriever.run(query_embedding=[0.1] * 384)
 from haystack import Pipeline, Document
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.components.writers import DocumentWriter
-from haystack.components.generators import OpenAIGenerator
-from haystack.components.builders.prompt_builder import PromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.dataclasses import ChatMessage
 from haystack.components.embedders import (
     SentenceTransformersDocumentEmbedder,
     SentenceTransformersTextEmbedder,
@@ -104,8 +105,10 @@ ingestion_pipe.connect("doc_embedder.documents", "doc_writer.documents")
 ingestion_pipe.run({"doc_embedder": {"documents": documents}})
 
 # Build a RAG pipeline with a Retriever to get relevant documents to
-# the query and a OpenAIGenerator interacting with LLMs using a custom prompt.
-prompt_template = """
+# the query and an OpenAIChatGenerator interacting with LLMs using a custom prompt.
+prompt_template = [
+    ChatMessage.from_user(
+        """
 Given these documents, answer the question.\nDocuments:
 {% for doc in documents %}
     {{ doc.content }}
@@ -113,7 +116,9 @@ Given these documents, answer the question.\nDocuments:
 
 \nQuestion: {{question}}
 \nAnswer:
-"""
+""",
+    ),
+]
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(instance=query_embedder, name="query_embedder")
 rag_pipeline.add_component(
@@ -121,13 +126,13 @@ rag_pipeline.add_component(
     name="retriever",
 )
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.connect("query_embedder", "retriever.query_embedding")
-rag_pipeline.connect("embedding_retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("retriever", "prompt_builder.documents")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 
 # Ask a question on the data you just added.
 question = "Where does Mark live?"
@@ -138,6 +143,6 @@ result = rag_pipeline.run(
     },
 )
 
-# For details, like which documents were used to generate the answer, look into the GeneratedAnswer object
-print(result["answer_builder"]["answers"])
+# The generated reply is a ChatMessage; its text holds the answer.
+print(result["llm"]["replies"][0].text)
 ```

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/opensearchbm25retriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/opensearchbm25retriever.mdx
@@ -77,16 +77,17 @@ from haystack_integrations.document_stores.opensearch import OpenSearchDocumentS
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
-import os
-
-api_key = os.environ["OPENAI_API_KEY"]
+# OpenAIChatGenerator reads the OPENAI_API_KEY environment variable by default.
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -94,7 +95,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 document_store = OpenSearchDocumentStore(
     hosts="http://localhost:9200",
@@ -121,15 +124,14 @@ retriever = OpenSearchBM25Retriever(document_store=document_store)
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(name="retriever", instance=retriever)
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(api_key=api_key), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "How many languages are spoken around the world today?"
@@ -146,13 +148,13 @@ print(result["answer_builder"]["answers"][0])
 Here’s an example output:
 
 ```python
-GeneratedAnswer(
-  data='Over 7,000 languages are spoken around the world today.',
-  query='How many languages are spoken around the world today?',
-  documents=[
-    Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, content: 'There are over 7,000 languages spoken around the world today.', score: 7.179112),
-    Document(id=7f225626ad1019b273326fbaf11308edfca6d663308a4a3533ec7787367d59a2, content: 'In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the ph...', score: 1.1426818)],
-  meta={'model': 'gpt-5-mini', 'index': 0, 'finish_reason': 'stop', 'usage': {'prompt_tokens': 86, 'completion_tokens': 13, 'total_tokens': 99}})
+# GeneratedAnswer(
+#   data='Over 7,000 languages are spoken around the world today.',
+#   query='How many languages are spoken around the world today?',
+#   documents=[
+#     Document(id=cfe93bc1c274908801e6670440bf2bbba54fad792770d57421f85ffa2a4fcc94, content: 'There are over 7,000 languages spoken around the world today.', score: 7.179112),
+#     Document(id=7f225626ad1019b273326fbaf11308edfca6d663308a4a3533ec7787367d59a2, content: 'In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the ph...', score: 1.1426818)],
+#   meta={'model': 'gpt-5-mini', 'index': 0, 'finish_reason': 'stop', 'usage': {'prompt_tokens': 86, 'completion_tokens': 13, 'total_tokens': 99}})
 ```
 
 ## Additional References

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/pgvectorkeywordretriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/pgvectorkeywordretriever.mdx
@@ -82,8 +82,9 @@ The prerequisites necessary for running this code are:
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
 from haystack_integrations.document_stores.pgvector import PgvectorDocumentStore
@@ -92,7 +93,9 @@ from haystack_integrations.components.retrievers.pgvector import (
 )
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -100,7 +103,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 document_store = PgvectorDocumentStore(
     language="english",  # this parameter influences text parsing for keyword retrieval
@@ -124,15 +129,14 @@ retriever = PgvectorKeywordRetriever(document_store=document_store)
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(name="retriever", instance=retriever)
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.meta", "answer_builder.meta")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "languages spoken around the world today"

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/snowflaketableretriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/snowflaketableretriever.mdx
@@ -38,27 +38,31 @@ pip install snowflake-haystack
 ### On its own
 
 ```python
-from haystack_integrations.components.retrievers.snowflake import SnowflakeTableRetriever
+from haystack.utils import Secret
+from haystack_integrations.components.retrievers.snowflake import (
+    SnowflakeTableRetriever,
+)
 
-snowflake = SnowflakeRetriever(
+snowflake = SnowflakeTableRetriever(
     user="<ACCOUNT-USER>",
     account="<ACCOUNT-IDENTIFIER>",
     api_key=Secret.from_env_var("SNOWFLAKE_API_KEY"),
     warehouse="<WAREHOUSE-NAME>",
 )
 
-snowflake.run(query="""select * from table limit 10;"""")
+snowflake.run(query="select * from table limit 10;")
 ```
 
 ### In a pipeline
 
-In the following pipeline example, the `PromptBuilder` is using the table received from the `SnowflakeTableRetriever` to create a prompt template and pass it on to an LLM:
+In the following pipeline example, the `ChatPromptBuilder` is using the table received from the `SnowflakeTableRetriever` to create a prompt and pass it on to an LLM:
 
 ```python
 from haystack import Pipeline
 from haystack.utils import Secret
-from haystack.components.builders import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack_integrations.components.retrievers.snowflake import (
     SnowflakeTableRetriever,
 )
@@ -73,13 +77,16 @@ executor = SnowflakeTableRetriever(
 pipeline = Pipeline()
 pipeline.add_component(
     "builder",
-    PromptBuilder(template="Describe this table: {{ table }}"),
+    ChatPromptBuilder(
+        template=[ChatMessage.from_user("Describe this table: {{ table }}")],
+        required_variables="*",
+    ),
 )
 pipeline.add_component("snowflake", executor)
-pipeline.add_component("llm", OpenAIGenerator(model="gpt-4o"))
+pipeline.add_component("llm", OpenAIChatGenerator(model="gpt-4o"))
 
 pipeline.connect("snowflake.table", "builder.table")
-pipeline.connect("builder", "llm")
+pipeline.connect("builder.prompt", "llm.messages")
 
 pipeline.run(data={"query": "select employee, salary from table limit 10;"})
 ```

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/weaviatebm25retriever.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/retrievers/weaviatebm25retriever.mdx
@@ -76,12 +76,15 @@ from haystack_integrations.components.retrievers.weaviate import (
 from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.document_stores.types import DuplicatePolicy
 
 # Create a RAG query pipeline
-prompt_template = """
+prompt_template = [
+    ChatMessage.from_user(
+        """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
         {{ doc.content }}
@@ -89,7 +92,9 @@ prompt_template = """
 
     \nQuestion: {{question}}
     \nAnswer:
-    """
+    """,
+    ),
+]
 
 document_store = WeaviateDocumentStore(url="http://localhost:8080")
 
@@ -113,15 +118,14 @@ rag_pipeline.add_component(
     instance=WeaviateBM25Retriever(document_store=document_store),
 )
 rag_pipeline.add_component(
-    instance=PromptBuilder(template=prompt_template),
+    instance=ChatPromptBuilder(template=prompt_template, required_variables="*"),
     name="prompt_builder",
 )
-rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
+rag_pipeline.add_component(instance=OpenAIChatGenerator(), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
-rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("prompt_builder.prompt", "llm.messages")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 question = "How many languages are spoken around the world today?"

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/routers/transformerstextrouter.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/routers/transformerstextrouter.mdx
@@ -47,7 +47,7 @@ Below is an example of a simple pipeline that routes English queries to a Text G
 from haystack import Pipeline
 from haystack.components.routers import TransformersTextRouter
 from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
-from haystack.components.generators.huggingface import HuggingFaceLocalGenerator
+from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
 from haystack.dataclasses import ChatMessage
 
 p = Pipeline()
@@ -73,20 +73,20 @@ p.add_component(
     name="german_prompt_builder",
 )
 p.add_component(
-    instance=HuggingFaceLocalGenerator(
+    instance=HuggingFaceLocalChatGenerator(
         model="DiscoResearch/Llama3-DiscoLeo-Instruct-8B-v0.1",
     ),
     name="german_llm",
 )
 p.add_component(
-    instance=HuggingFaceLocalGenerator(model="microsoft/Phi-3-mini-4k-instruct"),
+    instance=HuggingFaceLocalChatGenerator(model="microsoft/Phi-3-mini-4k-instruct"),
     name="english_llm",
 )
 
 p.connect("text_router.en", "english_prompt_builder.query")
 p.connect("text_router.de", "german_prompt_builder.query")
-p.connect("english_prompt_builder.messages", "english_llm.messages")
-p.connect("german_prompt_builder.messages", "german_llm.messages")
+p.connect("english_prompt_builder.prompt", "english_llm.messages")
+p.connect("german_prompt_builder.prompt", "german_llm.messages")
 
 # English Example
 print(p.run({"text_router": {"text": "What is the capital of Germany?"}}))

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/websearch/searchapiwebsearch.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/websearch/searchapiwebsearch.mdx
@@ -53,7 +53,7 @@ response = web_search.run(query)
 
 ### In a pipeline
 
-Here’s an example of a RAG pipeline where we use a `SearchApiWebSearch` to look up the answer to the query. The resulting documents are then passed to `LinkContentFetcher` to get the full text from the URLs. Finally, `PromptBuilder` and `OpenAIGenerator` work together to form the final answer.
+Here’s an example of a RAG pipeline where we use a `SearchApiWebSearch` to look up the answer to the query. The resulting documents are then passed to `LinkContentFetcher` to get the full text from the URLs. Finally, `ChatPromptBuilder` and `OpenAIChatGenerator` work together to form the final answer.
 
 ```python
 from haystack import Pipeline
@@ -96,7 +96,7 @@ pipe.add_component("llm", llm)
 pipe.connect("search.links", "fetcher.urls")
 pipe.connect("fetcher.streams", "converter.sources")
 pipe.connect("converter.documents", "prompt_builder.documents")
-pipe.connect("prompt_builder.messages", "llm.messages")
+pipe.connect("prompt_builder.prompt", "llm.messages")
 
 query = "What is the most famous landmark in Berlin?"
 

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/websearch/serperdevwebsearch.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/websearch/serperdevwebsearch.mdx
@@ -54,7 +54,7 @@ response = web_search.run(query)
 
 ### In a pipeline
 
-Here’s an example of a RAG pipeline where we use a `SerperDevWebSearch` to look up the answer to the query. The resulting documents are then passed to `LinkContentFetcher` to get the full text from the URLs. Finally, `PromptBuilder` and `OpenAIGenerator` work together to form the final answer.
+Here’s an example of a RAG pipeline where we use a `SerperDevWebSearch` to look up the answer to the query. The resulting documents are then passed to `LinkContentFetcher` to get the full text from the URLs. Finally, `ChatPromptBuilder` and `OpenAIChatGenerator` work together to form the final answer.
 
 ```python
 from haystack import Pipeline
@@ -98,7 +98,7 @@ pipe.add_component("llm", llm)
 pipe.connect("search.links", "fetcher.urls")
 pipe.connect("fetcher.streams", "converter.sources")
 pipe.connect("converter.documents", "prompt_builder.documents")
-pipe.connect("prompt_builder.messages", "llm.messages")
+pipe.connect("prompt_builder.prompt", "llm.messages")
 
 query = "What is the most famous landmark in Berlin?"
 


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack-private/issues/378

### Proposed Changes:
- where possible, use ChatGenerators in docs instead of Generators
- fix some existing bugs in code examples

### How did you test it?
Executed code examples or a simplified version of them.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
