### PR TITLE
feat: validate Mermaid server response in Pipeline.draw before writing to disk

### DIFF
--- a/haystack/core/pipeline/draw.py
+++ b/haystack/core/pipeline/draw.py
@@ -169,6 +169,81 @@ def _validate_mermaid_params(params: dict[str, Any]) -> None:
             logger.warning("`fit` overrides `paper` and `landscape` for PDFs. Ignoring `paper` and `landscape`.")
 
 
+# Magic-byte signatures used to verify a Mermaid server response matches the requested output format.
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+_JPEG_SIGNATURE = b"\xff\xd8\xff"
+_PDF_SIGNATURE = b"%PDF-"
+_RIFF_SIGNATURE = b"RIFF"
+_WEBP_SIGNATURE = b"WEBP"
+_SVG_PREFIXES = (b"<?xml", b"<svg")
+
+
+def _validate_image_response(resp: httpx.Response, params: dict[str, Any]) -> None:
+    """
+    Validate that the Mermaid server response actually contains the expected image/SVG/PDF data.
+
+    `Pipeline.draw()` writes the raw response body to disk, so a misconfigured or malicious
+    `server_url` could otherwise cause arbitrary content (e.g. an HTML error page or a crafted
+    payload) to be written verbatim to the output path. As defense-in-depth we check both the
+    `Content-Type` header (which the server controls and could spoof) and the response body's
+    magic-byte signature (which is harder to forge while still producing a usable payload).
+
+    :param resp:
+        The HTTP response returned by the Mermaid server.
+    :param params:
+        Validated Mermaid parameters; used to determine the expected output format.
+    :raises PipelineDrawingError:
+        If the response is empty or does not match the expected format.
+    """
+    content = resp.content
+    if not content:
+        raise PipelineDrawingError("The Mermaid server returned an empty response; no image will be saved.")
+
+    output_format = params.get("format", "img")
+    img_type = params.get("type", "png")
+
+    # (human-readable label, expected Content-Type prefix, body signature check)
+    content_type_prefixes: tuple[str, ...]
+    if output_format == "svg":
+        expected_label = "SVG"
+        content_type_prefixes = ("image/svg+xml", "text/xml", "application/xml")
+        stripped = content.lstrip()[:512].lower()
+        body_ok = stripped.startswith(_SVG_PREFIXES) or _SVG_PREFIXES[1] in stripped
+    elif output_format == "pdf":
+        expected_label = "PDF"
+        content_type_prefixes = ("application/pdf",)
+        body_ok = content.startswith(_PDF_SIGNATURE)
+    elif img_type == "jpeg":
+        expected_label = "JPEG image"
+        content_type_prefixes = ("image/jpeg",)
+        body_ok = content.startswith(_JPEG_SIGNATURE)
+    elif img_type == "webp":
+        expected_label = "WebP image"
+        content_type_prefixes = ("image/webp",)
+        body_ok = content[0:4] == _RIFF_SIGNATURE and content[8:12] == _WEBP_SIGNATURE
+    else:  # png (default)
+        expected_label = "PNG image"
+        content_type_prefixes = ("image/png",)
+        body_ok = content.startswith(_PNG_SIGNATURE)
+
+    # The Content-Type header is server-controlled, so a mismatch is only a warning: the
+    # authoritative check is the body signature below.
+    content_type = resp.headers.get("content-type", "").split(";")[0].strip().lower()
+    if content_type and not content_type.startswith(content_type_prefixes):
+        logger.warning(
+            "The Mermaid server returned an unexpected Content-Type '{content_type}' (expected {expected}).",
+            content_type=content_type,
+            expected=expected_label,
+        )
+
+    if not body_ok:
+        raise PipelineDrawingError(
+            f"The Mermaid server response does not look like a valid {expected_label}. "
+            f"This can happen if 'server_url' points to a server that is not a Mermaid renderer. "
+            f"To avoid writing untrusted content to disk, no file will be saved."
+        )
+
+
 def _to_mermaid_image(
     graph: networkx.MultiDiGraph,
     server_url: str = "https://mermaid.ink",
@@ -252,6 +327,10 @@ def _to_mermaid_image(
         logger.info("Exact URL requested: {url}", url=url)
         logger.warning("No pipeline diagram will be saved.")
         raise PipelineDrawingError(f"There was an issue with {server_url}, see the stacktrace for details.") from exc
+
+    # Validate the response before it gets written to disk by the caller, so that a misconfigured
+    # or malicious server cannot cause arbitrary content to be saved to the output path.
+    _validate_image_response(resp, params)
 
     return resp.content
 

--- a/releasenotes/notes/validate-mermaid-response-b1d5c1059544cefd.yaml
+++ b/releasenotes/notes/validate-mermaid-response-b1d5c1059544cefd.yaml
@@ -1,10 +1,10 @@
 ---
 enhancements:
   - |
-    `Pipeline.draw()` and `Pipeline.show()` now validate the Mermaid server response before
+    ``Pipeline.draw()`` and ``Pipeline.show()`` now validate the Mermaid server response before
     writing it to disk. The response body is checked against the expected output format
-    (PNG, JPEG, WebP, SVG, or PDF) via its magic-byte signature, and the `Content-Type`
+    (PNG, JPEG, WebP, SVG, or PDF) via its magic-byte signature, and the ``Content-Type``
     header is checked as well. If the response is empty or does not match the requested
-    format, a `PipelineDrawingError` is raised and no file is written. This prevents a
-    misconfigured or untrusted `server_url` from causing arbitrary content (for example an
+    format, a ``PipelineDrawingError`` is raised and no file is written. This prevents a
+    misconfigured or untrusted ``server_url`` from causing arbitrary content (for example an
     HTML error page) to be saved verbatim to the output path.

--- a/releasenotes/notes/validate-mermaid-response-b1d5c1059544cefd.yaml
+++ b/releasenotes/notes/validate-mermaid-response-b1d5c1059544cefd.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    `Pipeline.draw()` and `Pipeline.show()` now validate the Mermaid server response before
+    writing it to disk. The response body is checked against the expected output format
+    (PNG, JPEG, WebP, SVG, or PDF) via its magic-byte signature, and the `Content-Type`
+    header is checked as well. If the response is empty or does not match the requested
+    format, a `PipelineDrawingError` is raised and no file is written. This prevents a
+    misconfigured or untrusted `server_url` from causing arbitrary content (for example an
+    HTML error page) to be saved verbatim to the output path.

--- a/test/core/pipeline/test_draw.py
+++ b/test/core/pipeline/test_draw.py
@@ -9,7 +9,7 @@ import pytest
 
 from haystack.core.errors import PipelineDrawingError
 from haystack.core.pipeline import Pipeline
-from haystack.core.pipeline.draw import _to_mermaid_image, _to_mermaid_text
+from haystack.core.pipeline.draw import _to_mermaid_image, _to_mermaid_text, _validate_image_response
 from haystack.testing.sample_components import AddFixedValue, Double
 
 
@@ -34,7 +34,9 @@ def test_to_mermaid_image_does_not_edit_graph(mock_httpx):
     pipe.connect("comp1.result", "comp2.value")
     pipe.connect("comp2.value", "comp1.value")
 
-    mock_httpx.get.return_value = MagicMock(status_code=200)
+    mock_httpx.get.return_value = MagicMock(
+        status_code=200, content=b"\x89PNG\r\n\x1a\n", headers={"content-type": "image/png"}
+    )
     expected_pipe = pipe.to_dict()
     _to_mermaid_image(pipe.graph)
     assert expected_pipe == pipe.to_dict()
@@ -47,7 +49,9 @@ def test_to_mermaid_image_applies_timeout(mock_httpx):
     pipe.add_component("comp2", Double())
     pipe.connect("comp1", "comp2")
 
-    mock_httpx.get.return_value = MagicMock(status_code=200)
+    mock_httpx.get.return_value = MagicMock(
+        status_code=200, content=b"\x89PNG\r\n\x1a\n", headers={"content-type": "image/png"}
+    )
     _to_mermaid_image(pipe.graph, timeout=1)
 
     assert mock_httpx.get.call_args[1]["timeout"] == 1
@@ -200,3 +204,57 @@ def test_to_mermaid_image_invalid_server_url():
 
     with pytest.raises(PipelineDrawingError, match=f"There was an issue with {server_url}"):
         _to_mermaid_image(pipe.graph, server_url=server_url)
+
+
+@pytest.mark.parametrize(
+    "params, content, content_type",
+    [
+        ({"format": "img", "type": "png"}, b"\x89PNG\r\n\x1a\n" + b"rest", "image/png"),
+        ({"format": "img", "type": "jpeg"}, b"\xff\xd8\xff" + b"rest", "image/jpeg"),
+        ({"format": "img", "type": "webp"}, b"RIFF\x00\x00\x00\x00WEBPrest", "image/webp"),
+        ({"format": "svg"}, b'<?xml version="1.0"?><svg></svg>', "image/svg+xml"),
+        ({"format": "svg"}, b"<svg xmlns='...'></svg>", "image/svg+xml"),
+        ({"format": "pdf"}, b"%PDF-1.7\nrest", "application/pdf"),
+    ],
+)
+def test_validate_image_response_accepts_expected_formats(params, content, content_type):
+    resp = MagicMock(content=content, headers={"content-type": content_type})
+    # Should not raise
+    _validate_image_response(resp, params)
+
+
+def test_validate_image_response_rejects_empty_body():
+    resp = MagicMock(content=b"", headers={"content-type": "image/png"})
+    with pytest.raises(PipelineDrawingError, match="empty response"):
+        _validate_image_response(resp, {"format": "img", "type": "png"})
+
+
+def test_validate_image_response_rejects_mismatched_body():
+    # A server returning an HTML error page (or attacker-controlled payload) while the caller
+    # expects a PNG must be rejected so it never gets written to disk.
+    resp = MagicMock(content=b"<html><body>error</body></html>", headers={"content-type": "image/png"})
+    with pytest.raises(PipelineDrawingError, match="does not look like a valid PNG image"):
+        _validate_image_response(resp, {"format": "img", "type": "png"})
+
+
+def test_validate_image_response_warns_on_spoofed_content_type_but_relies_on_body(caplog):
+    # Content-Type is server-controlled, so a wrong header only warns as long as the body is valid.
+    resp = MagicMock(content=b"\x89PNG\r\n\x1a\n" + b"rest", headers={"content-type": "text/html"})
+    _validate_image_response(resp, {"format": "img", "type": "png"})
+    assert "unexpected Content-Type" in caplog.text
+
+
+@patch("haystack.core.pipeline.draw.httpx.get")
+def test_to_mermaid_image_rejects_non_image_response(mock_get):
+    # End-to-end: a 200 response with non-image content must not be returned for writing to disk.
+    pipe = Pipeline()
+    pipe.add_component("comp1", Double())
+    pipe.add_component("comp2", Double())
+    pipe.connect("comp1", "comp2")
+
+    mock_get.return_value = MagicMock(
+        status_code=200, content=b"#!/bin/sh\nrm -rf /\n", headers={"content-type": "image/png"}
+    )
+
+    with pytest.raises(PipelineDrawingError, match="does not look like a valid PNG image"):
+        _to_mermaid_image(pipe.graph)


### PR DESCRIPTION
### Related Issues

- Fixes https://github.com/deepset-ai/haystack-private/issues/356

`Pipeline.draw()` (and `Pipeline.show()`) wrote the raw HTTP response body returned by the Mermaid server directly to the output path via `Path(path).write_bytes(...)`, with no validation of the response. A misconfigured or untrusted `server_url` could therefore cause arbitrary content (for example an HTML error page, or attacker-controlled bytes) to be saved verbatim to disk.

### Proposed Changes:

Add `_validate_image_response()` in `haystack/core/pipeline/draw.py`, called inside `_to_mermaid_image()` before the bytes are returned for writing. It:
- rejects empty responses;
- verifies the response **body's magic-byte signature** against the requested output format (PNG / JPEG / WebP / SVG / PDF), raising `PipelineDrawingError` on mismatch so nothing is written;
- warns on a mismatched `Content-Type` header

### How did you test it?

Unit tests in `test/core/pipeline/test_draw.py`:
- parametrized acceptance test for valid PNG/JPEG/WebP/SVG/PDF responses;
- rejection of empty bodies;
- rejection of a body that does not match the requested format (e.g. an HTML error page);
- warning when only the `Content-Type` header is wrong but the body is valid;
- end-to-end test that a 200 response with non-image content raises `PipelineDrawingError` instead of being returned for writing.


### Notes for the reviewer

`Content-Type` header is server-controlled and can be spoofed. This is defense-in-depth rather than a complete control: a server that fully controls its response could still prepend valid magic bytes. It does, however, fix the common real-world case of silently saving an HTML error page as a `.png`, and forces any written file to begin with binary image headers (breaking text-based payload targets such as cron files, `.bashrc`, or `authorized_keys`).

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)