### PR TITLE
fix: handle Document with content=None in DocumentLanguageClassifier

### DIFF
--- a/haystack/components/classifiers/document_language_classifier.py
+++ b/haystack/components/classifiers/document_language_classifier.py
@@ -116,7 +116,7 @@ class DocumentLanguageClassifier:
             )
             return None
         try:
-            language = langdetect.detect(document.content)
+            return langdetect.detect(document.content)
         except langdetect.LangDetectException:
             logger.warning(
                 "Langdetect cannot detect the language of Document with id: {document_id}", document_id=document.id

--- a/haystack/components/classifiers/document_language_classifier.py
+++ b/haystack/components/classifiers/document_language_classifier.py
@@ -110,16 +110,15 @@ class DocumentLanguageClassifier:
         return {"documents": new_documents}
 
     def _detect_language(self, document: Document) -> str | None:
-        language = None
         if document.content is None:
             logger.warning(
                 "Langdetect cannot detect the language of Document with id: {document_id}", document_id=document.id
             )
-            return language
+            return None
         try:
             language = langdetect.detect(document.content)
         except langdetect.LangDetectException:
             logger.warning(
                 "Langdetect cannot detect the language of Document with id: {document_id}", document_id=document.id
             )
-        return language
+        return None

--- a/haystack/components/classifiers/document_language_classifier.py
+++ b/haystack/components/classifiers/document_language_classifier.py
@@ -111,6 +111,11 @@ class DocumentLanguageClassifier:
 
     def _detect_language(self, document: Document) -> str | None:
         language = None
+        if document.content is None:
+            logger.warning(
+                "Langdetect cannot detect the language of Document with id: {document_id}", document_id=document.id
+            )
+            return language
         try:
             language = langdetect.detect(document.content)
         except langdetect.LangDetectException:

--- a/releasenotes/notes/document-language-classifier-none-content-a245d044b02a19b0.yaml
+++ b/releasenotes/notes/document-language-classifier-none-content-a245d044b02a19b0.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Prevent DocumentLanguageClassifier from crashing on Documents with no text by
+    Prevent DocumentLanguageClassifier from crashing when ``Document.content=None`` by
     marking them as unmatched and logging a warning.

--- a/releasenotes/notes/document-language-classifier-none-content-a245d044b02a19b0.yaml
+++ b/releasenotes/notes/document-language-classifier-none-content-a245d044b02a19b0.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Prevent DocumentLanguageClassifier from crashing on Documents with no text by
+    marking them as unmatched and logging a warning.

--- a/test/components/classifiers/test_document_language_classifier.py
+++ b/test/components/classifiers/test_document_language_classifier.py
@@ -50,3 +50,10 @@ class TestDocumentLanguageClassifier:
             classifier = DocumentLanguageClassifier()
             classifier.run(documents=[Document(content=".")])
             assert "Langdetect cannot detect the language of Document with id" in caplog.text
+
+    def test_none_content_is_unmatched(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            classifier = DocumentLanguageClassifier()
+            result = classifier.run(documents=[Document(content=None)])
+            assert result["documents"][0].meta["language"] == "unmatched"
+            assert "Langdetect cannot detect the language of Document with id" in caplog.text


### PR DESCRIPTION
### Related Issues
- fixes #11418

### Proposed Changes
- Guard `Document` entries with `content=None` in `DocumentLanguageClassifier._detect_language()` to log a warning and return `unmatched` instead of crashing.
- Added regression test for the `None` content case.
- Added release note.

### How did you test it?
- `hatch run test:unit test/components/classifiers/test_document_language_classifier.py -k none_content`

### Notes for the reviewer
- Keeps behavior consistent with existing `unmatched` handling when `LangDetectException` is raised.
- `Document.content` is explicitly allowed to be `None` (blob-only documents), so this is a valid edge case the classifier should handle gracefully.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.