### PR TITLE
fix(classifiers): guard against content=None in DocumentLanguageClassifier (fixes #11418)

### DIFF
--- a/haystack/components/classifiers/document_language_classifier.py
+++ b/haystack/components/classifiers/document_language_classifier.py
@@ -111,6 +111,12 @@ class DocumentLanguageClassifier:
 
     def _detect_language(self, document: Document) -> str | None:
         language = None
+        if document.content is None:
+            logger.warning(
+                "Langdetect cannot detect the language of Document with id: {document_id} because its content is None",
+                document_id=document.id,
+            )
+            return language
         try:
             language = langdetect.detect(document.content)
         except langdetect.LangDetectException:

--- a/test/components/classifiers/test_document_language_classifier.py
+++ b/test/components/classifiers/test_document_language_classifier.py
@@ -50,3 +50,33 @@ class TestDocumentLanguageClassifier:
             classifier = DocumentLanguageClassifier()
             classifier.run(documents=[Document(content=".")])
             assert "Langdetect cannot detect the language of Document with id" in caplog.text
+
+    def test_content_none_does_not_raise(self):
+        """Regression test for https://github.com/deepset-ai/haystack/issues/11418.
+
+        Documents with content=None (blob-only documents) must not raise TypeError.
+        They should be classified as 'unmatched' and a warning must be emitted.
+        """
+        classifier = DocumentLanguageClassifier()
+        # Should NOT raise TypeError
+        result = classifier.run(documents=[Document(content=None)])
+        assert len(result["documents"]) == 1
+        assert result["documents"][0].meta["language"] == "unmatched"
+
+    def test_content_none_emits_warning(self, caplog):
+        """Regression test: a warning is logged for documents with content=None."""
+        with caplog.at_level(logging.WARNING):
+            classifier = DocumentLanguageClassifier()
+            classifier.run(documents=[Document(content=None)])
+            assert "Langdetect cannot detect the language of Document with id" in caplog.text
+
+    def test_mixed_none_and_text_content(self):
+        """Documents with content=None and normal documents can coexist in the same batch."""
+        classifier = DocumentLanguageClassifier()
+        docs = [
+            Document(content="This is an english sentence."),
+            Document(content=None),
+        ]
+        result = classifier.run(documents=docs)
+        assert result["documents"][0].meta["language"] == "en"
+        assert result["documents"][1].meta["language"] == "unmatched"


### PR DESCRIPTION
## Summary

Fixes #11418 — `DocumentLanguageClassifier` crashes with `TypeError` when a `Document` has `content=None`.

**Before:**
```python
def _detect_language(self, document: Document) -> str | None:
    language = None
    try:
        language = langdetect.detect(document.content)  # TypeError if content is None
    except langdetect.LangDetectException:
        ...
```
`langdetect.detect(None)` raises `TypeError`, which is not caught by the `LangDetectException` handler. The exception propagates to the caller, crashing the pipeline. This affects any blob-only `Document` (e.g. images, PDFs loaded without text extraction) since `Document.content` is explicitly allowed to be `None`.

**After:** an explicit `None` guard is added before calling `langdetect.detect()`. Documents with `content=None` log a warning and return `None` (which causes `run()` to route them to `"unmatched"`), consistent with existing behaviour for text that `langdetect` fails to detect.

## Changes

**`haystack/components/classifiers/document_language_classifier.py`**
- Added `if document.content is None:` guard at the top of `_detect_language`
- Logs a warning including the document ID (same pattern as the `LangDetectException` branch)
- Returns `None` so the caller routes the document to `"unmatched"`

**`test/components/classifiers/test_document_language_classifier.py`**
Three new tests:
| Test | Assertion |
|---|---|
| `test_content_none_does_not_raise` | `run([Document(content=None)])` must not raise; document gets `language="unmatched"` |
| `test_content_none_emits_warning` | A warning containing the document ID is logged |
| `test_mixed_none_and_text_content` | Batch with a `None`-content doc and a text doc both classified correctly |

## Test plan
- [x] All 10 tests in `test_document_language_classifier.py` pass: `uv run --with langdetect --with pytest python -m pytest test/components/classifiers/test_document_language_classifier.py -v` → `10 passed`