### PR TITLE
docs: Update AGENTS.md with inline code formatting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,4 @@ Every user-facing PR (not docs, not CI) must include a release note:
 
 hatch run release-note SHORT_DESCRIPTION
 
-Edit the generated file in `releasenotes/notes/`. 
-For inline code, use double backticks to wrap the code:
-
-```
-``OpenAIChatGenerator``
-```
+Edit the generated file in `releasenotes/notes/`. Release notes use reStructuredText formatting; see the [release notes section in CONTRIBUTING.md](CONTRIBUTING.md#release-notes) for details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,4 +56,9 @@ Every user-facing PR (not docs, not CI) must include a release note:
 
 hatch run release-note SHORT_DESCRIPTION
 
-Edit the generated file in `releasenotes/notes/`.
+Edit the generated file in `releasenotes/notes/`. 
+For inline code, use double backticks to wrap the code:
+
+```
+``OpenAIChatGenerator``
+```


### PR DESCRIPTION
### Related Issues

- Coding agents frequently fail at using double backticks in release notes

### Proposed Changes:

- Add instructions for inline code formatting in release notes to AGENTS.md

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

CONTRIBUTING.md already has such a note but apparently that's not enough

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
