### PR TITLE
chore!: Remove haystack exp dep

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -154,6 +154,20 @@ agent = Agent(
 The `convert_result_to_json_string` option (also previously set through `tool_invoker_kwargs`) has been removed.
 Non-string tool results are now always serialized with `json.dumps` rather than `str`, which changes their string form.
 
+### `haystack-experimental` is no longer a core dependency
+
+**What changed:** `haystack-experimental` has been removed from Haystack's core dependencies. Installing `haystack-ai` no longer pulls in `haystack-experimental` automatically.
+
+**Why:** Reduces the default installation footprint. Experimental features are opt-in and should not be installed for users who do not need them.
+
+**How to migrate:** If your code imports from `haystack_experimental` (directly or through an integration that depends on it), install the package explicitly:
+
+```bash
+pip install haystack-experimental
+```
+
+Installations that do not use `haystack_experimental` require no changes.
+
 ### Agent
 
 #### Breakpoint and snapshot API removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "MarkupSafe",             # already required by Jinja2 but used directly in templatize_part
   "posthog!=3.12.0",        # telemetry # 3.12.0 was problematic https://github.com/PostHog/posthog-python/issues/187
   "pyyaml",
-  "more-itertools",         # TextDocumentSplitter
+  "more-itertools",         # DocumentSplitter
   "networkx",               # Pipeline graphs
   "typing_extensions>=4.7", # Extended typing features (NotRequired, etc.)
   "httpx",
@@ -60,7 +60,6 @@ dependencies = [
   "jsonschema",             # JsonSchemaValidator, Tool
   "docstring-parser",       # ComponentTool
   "filetype",               # MIME type guessing for ImageContent
-  "haystack-experimental",
 ]
 
 [tool.hatch.envs.default]
@@ -369,7 +368,7 @@ ignore = [
 # install/lock time, so no manual date updates are needed.
 # First-party packages are exempted so freshly published releases are always resolvable.
 exclude-newer = "24 hours"
-exclude-newer-package = { haystack-experimental = "0 days", haystack-pydoc-tools = "0 days" }
+exclude-newer-package = { haystack-pydoc-tools = "0 days" }
 
 [tool.coverage.run]
 omit = ["haystack/testing/*"]

--- a/releasenotes/notes/remove-haystack-experimental-core-dep-2b2db288a39d2d40.yaml
+++ b/releasenotes/notes/remove-haystack-experimental-core-dep-2b2db288a39d2d40.yaml
@@ -1,8 +1,8 @@
 ---
 upgrade:
   - |
-    ``haystack-experimental`` is no longer a core dependency of Haystack and is no longer installed
-    automatically with ``haystack-ai``. If your code imports from ``haystack_experimental`` (directly or
+    ``haystack-experimental`` is no longer a core dependency of Haystack and is no longer installed automatically with ``haystack-ai``.
+    If your code imports from ``haystack_experimental`` (directly or
     through an integration that relies on it), you must now install it explicitly, for example with
     ``pip install haystack-experimental``. Installations that do not use ``haystack_experimental`` are
     unaffected.

--- a/releasenotes/notes/remove-haystack-experimental-core-dep-2b2db288a39d2d40.yaml
+++ b/releasenotes/notes/remove-haystack-experimental-core-dep-2b2db288a39d2d40.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    ``haystack-experimental`` is no longer a core dependency of Haystack and is no longer installed
+    automatically with ``haystack-ai``. If your code imports from ``haystack_experimental`` (directly or
+    through an integration that relies on it), you must now install it explicitly, for example with
+    ``pip install haystack-experimental``. Installations that do not use ``haystack_experimental`` are
+    unaffected.


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/377

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Remove haystack-experimental as a core dependency of Haystack. Should help reduce the install size of Haystack and users can still install haystack-experimental if they want to use any experimental features. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
