### PR TITLE
Document Tuning Engines OpenAI-compatible endpoint

### DIFF
--- a/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
@@ -39,6 +39,20 @@ You can pass any chat completion parameters valid for the `openai.ChatCompletion
 
 `OpenAIChatGenerator` can support custom deployments of your OpenAI models through the `api_base_url` init parameter.
 
+For example, you can route chat generation through a governed OpenAI-compatible endpoint such as [Tuning Engines](https://www.tuningengines.com/):
+
+```python
+from haystack.components.generators.chat import OpenAIChatGenerator
+
+generator = OpenAIChatGenerator(
+    model="gpt-4o-mini",
+    api_key="your-tuning-engines-key",
+    api_base_url="https://api.tuningengines.com/v1",
+)
+```
+
+Haystack continues to own the pipeline while the gateway centralizes model routing, policy controls, audit logs, traces, approvals, and cost visibility.
+
 ### Structured Output
 
 `OpenAIChatGenerator` supports structured output generation, allowing you to receive responses in a predictable format. You can use Pydantic models or JSON schemas to define the structure of the output through the `response_format` parameter in `generation_kwargs`.


### PR DESCRIPTION
## Summary

- Adds a small documentation example showing how to point this project’s existing OpenAI-compatible configuration at Tuning Engines.
- Keeps this project’s APIs and runtime behavior unchanged: no new dependency, adapter, or code path.
- Shows a path for teams to keep this framework in charge of app, agent, tool, workflow, or retrieval logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI applications.

This project already supports OpenAI-compatible endpoints. The docs change makes that existing capability discoverable for users who want governance and observability without rewriting their application around a separate SDK or changing this project’s runtime behavior.

## Testing

- `git diff --check`
