### PR TITLE
fix(utils/device): prevent ValueError: too many values to unpack in _split_device_string

### DIFF
--- a/haystack/utils/device.py
+++ b/haystack/utils/device.py
@@ -533,7 +533,9 @@ def _split_device_string(string: str) -> tuple[str, int | None]:
         The device type and device id, if any.
     """
     if ":" in string:
-        device_type, device_id_str = string.split(":")
+        parts = string.split(":")
+        device_type = parts[0]
+        device_id_str = parts[1]
         try:
             device_id = int(device_id_str)
         except ValueError as e:

--- a/test/utils/test_device.py
+++ b/test/utils/test_device.py
@@ -35,6 +35,13 @@ def test_device_creation():
         Device.gpu(-1)
 
 
+def test_device_from_str_extra_colons():
+    # Device strings with extra colons (e.g. "cuda:0:1") must not raise
+    # "too many values to unpack"; only the first two colon-separated parts are used.
+    assert Device.from_str("cuda:0:1") == Device.gpu(0)
+    assert Device.from_str("cuda:1:extra") == Device.gpu(1)
+
+
 def test_device_map():
     device_map = DeviceMap({"layer1": Device.cpu(), "layer2": Device.gpu(1), "layer3": Device.disk()})
 


### PR DESCRIPTION
## What's broken

Calling `Device.from_str()`, `ComponentDevice.from_str()`, or `DeviceMap.from_dict()` with a device string containing more than one colon (e.g. `"cuda:0:1"`) crashes with `ValueError: too many values to unpack (expected 2)`. All three public device-parsing entry points are affected because they all call `_split_device_string()`.

## Why it happens

`_split_device_string()` calls `string.split(":")` with no `maxsplit`, producing a list of three or more elements, which then fails the two-variable unpack on the next line.

## Fix

Replace the two-variable unpack with explicit index access (`parts[0]` and `parts[1]`) so that any extra colon-separated segments beyond the first two are silently ignored. This is a three-line change in `haystack/utils/device.py`.

## Test

Added `test_device_from_str_extra_colons` in `test/utils/test_device.py` which asserts that `Device.from_str("cuda:0:1")` and `Device.from_str("cuda:1:extra")` both return the correct device without raising.

Fixes #11451