### PR TITLE
fix(types): guard unsubscripted Variadic type in InputSocket

### DIFF
--- a/haystack/core/component/types.py
+++ b/haystack/core/component/types.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from types import UnionType
 from typing import Annotated, Any, TypeAlias, TypedDict, TypeVar, get_args
 
+from haystack.core.errors import ComponentError
+
 HAYSTACK_VARIADIC_ANNOTATION = "__haystack__variadic_t"
 HAYSTACK_GREEDY_VARIADIC_ANNOTATION = "__haystack__greedy_variadic_t"
 
@@ -97,7 +99,13 @@ class InputSocket:
         # alias for Iterable[int]. Since we're interested in getting the inner type `int`, we call `get_args`
         # twice: the first time to get `list[int]` out of `Variadic`, the second time to get `int` out of `list[int]`.
         if self.is_lazy_variadic or self.is_greedy:
-            self.type = get_args(get_args(self.type)[0])[0]
+            outer_args = get_args(self.type)
+            inner_args = get_args(outer_args[0]) if outer_args else ()
+            if not inner_args:
+                raise ComponentError(
+                    f"Variadic input '{self.name}' must have a type argument, e.g. Variadic[int]."
+                )
+            self.type = inner_args[0]
 
 
 class InputSocketTypeDescriptor(TypedDict):

--- a/test/core/component/test_component.py
+++ b/test/core/component/test_component.py
@@ -574,3 +574,18 @@ def test_pre_init_hooking_variadic_kwargs():
         assert c.pos_arg1 == 2
         assert c.pos_arg2 == 0
         assert c.kwargs == {"kwarg1": 999, "some_kwarg": "modified string"}
+
+
+def test_input_socket_variadic_without_type_arg_raises_component_error():
+    from typing import Annotated
+    from collections.abc import Iterable
+    from haystack.core.component.types import HAYSTACK_VARIADIC_ANNOTATION
+
+    @component
+    class BadJoiner:
+        @component.output_types(result=str)
+        def run(self, inputs: Annotated[Iterable, HAYSTACK_VARIADIC_ANNOTATION]):
+            return {"result": ""}
+
+    with pytest.raises(ComponentError, match="must have a type argument"):
+        BadJoiner()


### PR DESCRIPTION
## What's broken

Instantiating a component with a bare `Annotated[Iterable, HAYSTACK_VARIADIC_ANNOTATION]` annotation (no type argument) crashes with `IndexError: tuple index out of range` in `InputSocket.__post_init__`. The crash happens at component instantiation time, bypassing static type checking. For example:
```python
def run(self, inputs: Annotated[Iterable, HAYSTACK_VARIADIC_ANNOTATION]):
```
raises `IndexError` inside `get_args(get_args(self.type)[0])[0]` at line 100.

## Why it happens

`get_args(Iterable)` returns an empty tuple when the iterable has no type argument, so the unconditional `[0]` index fails.

## Fix

Replaced the bare double-index with a guarded version that checks whether `get_args()` results are non-empty. When the inner type is unsubscripted, raises `ComponentError` with a clear message: "Variadic input 'inputs' must have a type argument, e.g. Variadic[int]."

## Test

Added `test_input_socket_variadic_without_type_arg_raises_component_error` which creates a component with a bare `Annotated[Iterable, HAYSTACK_VARIADIC_ANNOTATION]` input and asserts that `ComponentError` is raised with the expected message.

Fixes #11453