### PR TITLE
ci: pin container images by digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,14 @@ updates:
       interval: 'daily'
     cooldown:
       default-days: 1
+
+  # Tracks the digest-pinned `COPY --from` image (ghcr.io/astral-sh/uv) in
+  # docker/Dockerfile.base. Note: the python:3.12-slim base/builder images are
+  # passed via build args from docker/docker-bake.hcl and the `docker run` image
+  # strings in workflows are not parsed by Dependabot; bump those manually.
+  - package-ecosystem: 'docker'
+    directory: '/docker'
+    schedule:
+      interval: 'daily'
+    cooldown:
+      default-days: 1

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -54,7 +54,7 @@ jobs:
           reno report --no-show-source --ignore-cache --earliest-version "$EARLIEST_VERSION" -o relnotes.rst
 
       - name: Convert to Markdown
-        uses: docker://pandoc/core:3.8
+        uses: docker://pandoc/core:3.8@sha256:c7127705b9d84c1b4acbbe411a86e3a6d67ac57870654dc378b6fe636ab747df
         with:
           args: "--from rst --to gfm --syntax-highlighting=none --wrap=none relnotes.rst -o relnotes.md"
 

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Run Tika
         if: matrix.os == 'ubuntu-latest'
         run: |
-          docker run -d -p 9998:9998 apache/tika:2.9.0.0
+          docker run -d -p 9998:9998 apache/tika:2.9.0.0@sha256:92d055a84e9efbedb5541fb38d635a44a16a875d88d1014c183af9eb93a09aaf
 
       - name: Install Whisper dependencies
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         run: hatch run fmt-check
 
       - name: Check presence of license header
-        run: docker run --rm -v "$(pwd):/github/workspace" ghcr.io/korandoru/hawkeye check
+        run: docker run --rm -v "$(pwd):/github/workspace" ghcr.io/korandoru/hawkeye:v6.5.1@sha256:0ebd72353053aa6d3f0cb44a6897786386347bd4636ffc9592f8e47c81ea2b9d check
 
   check-imports:
     needs: format

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -9,7 +9,7 @@ ARG haystack_version
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.17@sha256:03bdc89bb9798628846e60c3a9ad19006c8c3c724ccd2985a33145c039a0577b /uv /uvx /bin/
 
 # Shallow clone Haystack repo, we'll install from the local sources
 RUN git clone --depth=1 --branch=${haystack_version} https://github.com/deepset-ai/haystack.git /opt/haystack

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -32,8 +32,8 @@ target "base" {
     equal("${IS_STABLE}", "true") ? "${IMAGE_NAME}:stable" : ""
   ])}"
   args = {
-    build_image = "python:3.12-slim"
-    base_image = "python:3.12-slim"
+    build_image = "python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203"
+    base_image = "python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203"
     haystack_version = "${HAYSTACK_VERSION}"
   }
   platforms = ["linux/amd64", "linux/arm64"]


### PR DESCRIPTION
### Related Issues

- Harden supply-chain security and as a result also improve the [OpenSSF Scorecard](https://github.com/ossf/scorecard) **Pinned-Dependencies** check (was 4/10). Follow-up to the workflow token-permissions hardening (#11458). 

### Proposed Changes:

GitHub Actions are already SHA-pinned, so the remaining Pinned-Dependencies gap was entirely **container images referenced by mutable tags**. This pins every one to an immutable digest:

| File | Before | After |
|------|--------|-------|
| [docker/Dockerfile.base](docker/Dockerfile.base) | `ghcr.io/astral-sh/uv:latest` | `uv:0.11.17@sha256:03bdc89…` |
| [docker/docker-bake.hcl](docker/docker-bake.hcl) | `python:3.12-slim` (build + base) | `python:3.12-slim@sha256:090ba77…` |
| [tests.yml](.github/workflows/tests.yml) | `ghcr.io/korandoru/hawkeye` (untagged → `latest`) | `hawkeye:v6.5.1@sha256:0ebd72…` |
| [github_release.yml](.github/workflows/github_release.yml) | `docker://pandoc/core:3.8` | `…/core:3.8@sha256:c712770…` |
| [slow.yml](.github/workflows/slow.yml) | `apache/tika:2.9.0.0` | `…/tika:2.9.0.0@sha256:92d055a…` |

The two highest-impact ones are `uv` and `python:3.12-slim`, since those are baked into the image published to Docker Hub. The`latest`/tag there was a supply-chain security risk.

All digests are the **multi-arch index digests** (resolved via `docker buildx imagetools inspect`), so `linux/amd64` + `linux/arm64` builds keep working. The pinned version tags (`uv:0.11.17`, `hawkeye:v6.5.1`) are exactly what `latest` resolved to at the time of this change.

I also added a **`docker` Dependabot ecosystem** so the digest-pinned `COPY --from` image (uv) in `Dockerfile.base` is bumped automatically.

### How did you test it?

### Notes for the reviewer

- **Maintenance trade-off:** digests are immutable, so they must be bumped deliberately or images go stale. Dependabot now tracks the `uv` image, but it **cannot** see the `python:3.12-slim` images (passed via build args from `docker-bake.hcl`) or the `docker run` image strings in workflows. Those need a manual bump. I believe there we should anyway upgrade to python:3.13-slim

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I've used a [conventional commit type](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title (`ci:`).
- [x] I have documented my code (comment in `dependabot.yml` explaining tracking limits).
- [ ] Release note: not applicable — CI/build-tooling change, no user-facing library behavior.
- [x] I have run pre-commit hooks and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)