### PR TITLE
ci: fix docstrings_checksum script location

### DIFF
--- a/.github/workflows/docstring_labeler.yml
+++ b/.github/workflows/docstring_labeler.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get base docstrings
         id: base-docstrings
         run: |
-          CHECKSUM=$(python "${{ runner.temp }}/docstrings_checksum.py" --root "${{ github.workspace }}")
+          CHECKSUM=$(python .github/utils/docstrings_checksum.py --root "${{ github.workspace }}")
           echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: Checkout HEAD commit
@@ -46,7 +46,7 @@ jobs:
       - name: Get HEAD docstrings
         id: head-docstrings
         run: |
-          CHECKSUM=$(python "${{ runner.temp }}/docstrings_checksum.py" --root "${{ github.workspace }}")
+          CHECKSUM=$(python .github/utils/docstrings_checksum.py --root "${{ github.workspace }}")
           echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: Write result

--- a/haystack/components/converters/csv.py
+++ b/haystack/components/converters/csv.py
@@ -40,6 +40,8 @@ class CSVToDocument:
     print(documents[0].content)
     # >>  'col1,col2\\nrow1,row1\\nrow2,row2\\n'
     ```
+
+    TRIGGER!
     """
 
     def __init__(

--- a/haystack/components/converters/csv.py
+++ b/haystack/components/converters/csv.py
@@ -40,8 +40,6 @@ class CSVToDocument:
     print(documents[0].content)
     # >>  'col1,col2\\nrow1,row1\\nrow2,row2\\n'
     ```
-
-    TRIGGER!
     """
 
     def __init__(


### PR DESCRIPTION
### Related Issues

- In https://github.com/deepset-ai/haystack/pull/11458, we removed a step that copies the `docstrings_checksum` python script
- now we have failures: https://github.com/deepset-ai/haystack/actions/runs/26761730355/job/78877051469?pr=11450

### Proposed Changes:
- simply fix the script location (now that it's no longer copied to a specific folder)

### How did you test it?
Tested on this PR temporarily -> detection executes cleanly and documentation label is applied.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
