### PR TITLE
fix: remove unused import from NamedEntityExtractor test

### DIFF
--- a/e2e/pipelines/test_named_entity_extractor.py
+++ b/e2e/pipelines/test_named_entity_extractor.py
@@ -7,7 +7,6 @@
 # test environment. Spacy is not installed in the test environment to keep the CI fast.
 
 import os
-import sys
 
 import pytest
 from thinc.api import NumpyOps, get_current_ops, set_current_ops


### PR DESCRIPTION
### Related Issues

None. Came up in automated code quality checks with GitHub Code QL

### Proposed Changes:

Remove the unused `sys` import from `e2e/pipelines/test_named_entity_extractor.py`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.



_Suggested fixes powered by Copilot Autofix. Review carefully before merging._