### PR TITLE
test: use 'is None' instead of '== None' (CodeQL py/test-equals-none)

### DIFF
--- a/test/components/embedders/test_openai_text_embedder.py
+++ b/test/components/embedders/test_openai_text_embedder.py
@@ -19,7 +19,7 @@ class TestOpenAITextEmbedder:
 
         assert embedder.client.api_key == "fake-api-key"
         assert embedder.model == "text-embedding-ada-002"
-        assert embedder.api_base_url == None
+        assert embedder.api_base_url is None
         assert embedder.organization is None
         assert embedder.prefix == ""
         assert embedder.suffix == ""

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -46,8 +46,8 @@ class TestDocumentJoiner:
         data = {"type": "haystack.components.joiners.document_joiner.DocumentJoiner", "init_parameters": {}}
         document_joiner = DocumentJoiner.from_dict(data)
         assert document_joiner.join_mode == JoinMode.CONCATENATE
-        assert document_joiner.weights == None
-        assert document_joiner.top_k == None
+        assert document_joiner.weights is None
+        assert document_joiner.top_k is None
         assert document_joiner.sort_by_score
 
     def test_from_dict_customs_parameters(self):

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -17,7 +17,7 @@ def test_from_file_path(tmp_path, request):
 
     b = ByteStream.from_file_path(test_path)
     assert b.data == test_bytes
-    assert b.mime_type == None
+    assert b.mime_type is None
 
     b = ByteStream.from_file_path(test_path, mime_type="text/plain")
     assert b.data == test_bytes
@@ -78,7 +78,7 @@ def test_from_string():
     test_string = "Hello, world!"
     b = ByteStream.from_string(test_string)
     assert b.data.decode() == test_string
-    assert b.mime_type == None
+    assert b.mime_type is None
 
     b = ByteStream.from_string(test_string, mime_type="text/plain")
     assert b.data.decode() == test_string

--- a/test/dataclasses/test_document.py
+++ b/test/dataclasses/test_document.py
@@ -28,12 +28,12 @@ def test_document_str(doc, doc_str):
 def test_init():
     doc = Document()
     assert doc.id == "d4675c57fcfe114db0b95f1da46eea3c5d6f5729c17d01fb5251ae19830a3455"
-    assert doc.content == None
-    assert doc.blob == None
+    assert doc.content is None
+    assert doc.blob is None
     assert doc.meta == {}
-    assert doc.score == None
-    assert doc.embedding == None
-    assert doc.sparse_embedding == None
+    assert doc.score is None
+    assert doc.embedding is None
+    assert doc.sparse_embedding is None
 
 
 def test_init_with_wrong_parameters():
@@ -74,11 +74,11 @@ def test_init_with_legacy_fields():
     )
     assert doc.id == "18fc2c114825872321cf5009827ca162f54d3be50ab9e9ffa027824b6ec223af"
     assert doc.content == "test text"
-    assert doc.blob == None
+    assert doc.blob is None
     assert doc.meta == {}
     assert doc.score == 0.812
     assert doc.embedding == [0.1, 0.2, 0.3]
-    assert doc.sparse_embedding == None
+    assert doc.sparse_embedding is None
 
     assert doc.content_type == "text"  # this is a property now
 
@@ -100,7 +100,7 @@ def test_init_with_legacy_field():
     assert doc.meta == {"date": "10-10-2023", "type": "article"}
     assert doc.score == 0.812
     assert doc.embedding == [0.1, 0.2, 0.3]
-    assert doc.sparse_embedding == None
+    assert doc.sparse_embedding is None
 
     assert doc.content_type == "text"  # this is a property now
     assert not hasattr(doc, "id_hash_keys")

--- a/test/utils/test_auth.py
+++ b/test/utils/test_auth.py
@@ -53,7 +53,7 @@ def test_env_var_secret():
 
     secret = Secret.from_env_var("TEST_ENV_VAR2", strict=False)
     assert secret._strict is False
-    assert secret.resolve_value() == None
+    assert secret.resolve_value() is None
 
     secret = Secret.from_env_var(["TEST_ENV_VAR2", "TEST_ENV_VAR1"], strict=True)
     assert secret._env_vars == ("TEST_ENV_VAR2", "TEST_ENV_VAR1")


### PR DESCRIPTION
### Related Issues

Addresses the CodeQL code quality finding [`py/test-equals-none`](https://github.com/deepset-ai/haystack/security/quality/rules/py%2Ftest-equals-none) ("Testing for None should use the 'is' operator").

### Proposed Changes

CodeQL flagged 15 occurrences across the test suite where values were compared against `None` using `==` instead of the identity operator `is`. Using `==` is discouraged because it can invoke a custom `__eq__`, whereas `None` is a singleton that should be tested with `is`.

Replaced `== None` with `is None` in:

- `test/utils/test_auth.py`
- `test/components/joiners/test_document_joiner.py`
- `test/components/embedders/test_openai_text_embedder.py`
- `test/dataclasses/test_byte_stream.py`
- `test/dataclasses/test_document.py`

### How did you test it?

- `hatch run test:unit` on all affected files: all tests pass (97 + 10 passed)

### Notes for the reviewer


🤖 Generated with [Claude Code](https://claude.com/claude-code)
