### PR TITLE
test: assert on unused variables flagged by CodeQL (py/unused-local-variable)

### DIFF
--- a/e2e/pipelines/test_dense_doc_search.py
+++ b/e2e/pipelines/test_dense_doc_search.py
@@ -77,3 +77,7 @@ def test_dense_doc_search_pipeline(tmp_path, samples_path, del_hf_env_vars):
     # Load the querying pipeline back
     with open(tmp_path / "test_dense_doc_search_query_pipeline.json", "r") as f:
         query_pipeline = Pipeline.from_dict(json.load(f))
+
+    # Run the reloaded pipeline to verify the serialization round-trip preserves behavior
+    querying_result = query_pipeline.run({"text_embedder": {"text": "Who lives in Rome?"}})
+    assert querying_result["embedding_retriever"]["documents"][0].content == "My name is Giorgio and I live in Rome."

--- a/test/components/connectors/test_openapi_connector.py
+++ b/test/components/connectors/test_openapi_connector.py
@@ -104,6 +104,7 @@ class TestOpenAPIConnector:
         # Test without arguments
         response = connector.run(operation_id="search")
         mock_client.invoke.assert_called_with({"name": "search", "arguments": {}})
+        assert response == {"response": {"results": ["test result"]}}
 
     def test_in_pipeline(self, mock_client):
         mock_client.invoke.return_value = {"results": ["test result"]}


### PR DESCRIPTION
### Related Issues

Addresses CodeQL [`py/unused-local-variable`](https://github.com/deepset-ai/haystack/security/quality/rules) findings for two test files.

### Proposed Changes

In our tests, CodeQL flagged two local variables that were assigned but never used. In both cases the unused assignment pointed to a genuine gap in test coverage, so the fix is to actually assert on the value rather than to drop it.

- **`test/components/connectors/test_openapi_connector.py`** — In `test_run`, the "with arguments" call asserts on `response`, but the "without arguments" call assigned `response` and never checked it. Added the missing `assert response == {"response": {"results": ["test result"]}}`.
- **`e2e/pipelines/test_dense_doc_search.py`** — The querying pipeline was serialized to JSON and deserialized back via `Pipeline.from_dict`, but the reloaded `query_pipeline` was never used — so the serialization round-trip only verified that `from_dict` did not raise. Now the reloaded pipeline is run and its output asserted, mirroring the pre-serialization check.

### How did you test it?

### Notes for the reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
