### PR TITLE
ci: fix release branch-off permissions and gate releases on maintainer role

### DIFF
--- a/.github/workflows/branch_off.yml
+++ b/.github/workflows/branch_off.yml
@@ -24,6 +24,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
+          # Persist the bot token so the branch/tag pushes below authenticate as
+          # HaystackBot (a ruleset-bypass actor) instead of the default
+          # github-actions[bot], which only has contents:read and is blocked by
+          # the release rulesets.
+          token: ${{ secrets.HAYSTACK_BOT_TOKEN }}
 
       - name: Define all versions
         id: versions

--- a/.github/workflows/branch_off.yml
+++ b/.github/workflows/branch_off.yml
@@ -1,7 +1,6 @@
 name: Branch off
 
 on:
-  workflow_dispatch:
   workflow_call:
     outputs:
       bump_version_pr_url:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,30 @@ permissions:
   contents: read
 
 jobs:
+  authorize:
+    # Releasing acts as HaystackBot (a ruleset-bypass actor), so the ruleset
+    # cannot enforce *who* started the release. Gate on the triggering user's
+    # role instead: only maintainers/admins may run this workflow, even though
+    # workflow_dispatch itself is available to anyone with write access.
+    runs-on: ubuntu-slim
+    steps:
+      - name: Verify the triggering user may release
+        env:
+          GH_TOKEN: ${{ secrets.HAYSTACK_BOT_TOKEN }}
+          ACTOR: ${{ github.triggering_actor }}
+        run: |
+          ROLE=$(gh api "repos/${{ github.repository }}/collaborators/${ACTOR}/permission" --jq '.role_name')
+          echo "::notice::${ACTOR} has repository role '${ROLE}'"
+          case "$ROLE" in
+            admin|maintain)
+              echo "✅ ${ACTOR} is authorized to trigger a release." ;;
+            *)
+              echo "::error::${ACTOR} has role '${ROLE}'. A release can only be triggered by a user with the 'maintain' or 'admin' role."
+              exit 1 ;;
+          esac
+
   parse-validate-version:
+    needs: ["authorize"]
     runs-on: ubuntu-slim
     outputs:
       version: ${{ steps.parse-validate.outputs.version }}


### PR DESCRIPTION
### Related Issues

Release automation failed at the branch-off step ([run 26817138687](https://github.com/deepset-ai/haystack/actions/runs/26817138687/job/79061780150)):

> `remote: Permission to deepset-ai/haystack.git denied to github-actions[bot].`

### Proposed Changes:

Two root causes, both fixed here:

1. **Wrong git identity in `branch_off.yml`.** The checkout step ran without a `token:`, so `git push` authenticated as the default `github-actions[bot]` — which has `contents: read` only and is **not** a ruleset-bypass actor — instead of HaystackBot. Setting the env `GITHUB_TOKEN` did not help because git uses the credential `actions/checkout` persists, not that env var. Fixed by passing `token: ${{ secrets.HAYSTACK_BOT_TOKEN }}` to the checkout, mirroring the existing `create-release-tag` job in `release.yml`.

2. **No authorization on who can release.** Because the release always pushes as HaystackBot (a bypass actor), the branch/tag rulesets cannot enforce *who* started the release, and `workflow_dispatch` is available to anyone with **write** access. Added an `authorize` job that reads the triggering user's repository `role_name` and fails for anyone who is not `maintain`/`admin`. The whole pipeline gates on it via `parse-validate-version: needs: [authorize]`.

I also removed `workflow_dispatch:` from branch_off.yml. It meant that anyone with write access can trigger that workflow from the GitHub UI. Now, branch_off.yml can only be called, in our case from release.yml, which checks if the user has required maintainer or admin role before continuing with the release process. 


### How did you test it?

### Notes for the reviewer

- `github.triggering_actor` is used (not `github.actor`) so re-runs are attributed to whoever re-ran.
- The authorize step uses `HAYSTACK_BOT_TOKEN` because the "get user permission" endpoint requires push access, which the default token under `contents: read` lacks.

### Checklist

- [x] I've used a conventional commit type for my PR title (`ci:`).
- [x] I have documented my code (inline comments on both jobs).
- [ ] Release note: N/A — CI-only change, no user-facing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)