### PR TITLE
feat: Extend `ChatPromptBuilder` with `insert` tag

### DIFF
--- a/haystack/utils/jinja2_chat_extension.py
+++ b/haystack/utils/jinja2_chat_extension.py
@@ -136,7 +136,7 @@ class ChatMessageExtension(Extension):
         :return: A CallBlock node that expands the (optionally subscripted) `messages` variable.
         :raises TemplateSyntaxError: If the tag is given anything other than a subscript.
         """
-        node: nodes.Node = nodes.Name("messages", "load", lineno=lineno)
+        node: nodes.Expr = nodes.Name("messages", "load", lineno=lineno)
         # Apply any trailing subscripts (`[...]`) directly onto the implicit `messages` name, so users can index or
         # slice the runtime messages, e.g. `{% messages[-1:] %}`.
         while parser.stream.current.type == "lbracket":

--- a/haystack/utils/jinja2_chat_extension.py
+++ b/haystack/utils/jinja2_chat_extension.py
@@ -72,6 +72,16 @@ class ChatMessageExtension(Extension):
     {% endmessage %}
     ```
 
+    This extension also provides a `{% messages %}` placeholder tag that expands a list of `ChatMessage`
+    objects (bound to the `messages` template variable) into the prompt, so a runtime conversation can be
+    interleaved with literal `{% message %}` blocks:
+
+    ```
+    {% message role="system" %}You are a helpful assistant.{% endmessage %}
+    {% messages %}
+    {% message role="user" %}{{ query }}{% endmessage %}
+    ```
+
     ### How it works
     1. The `{% message %}` tag is used to define a chat message.
     2. The message can contain text and other structured content parts.
@@ -85,7 +95,7 @@ class ChatMessageExtension(Extension):
 
     SUPPORTED_ROLES = [role.value for role in ChatRole]
 
-    tags = {"message"}
+    tags = {"message", "messages"}
 
     def __init__(self, environment: Any) -> None:
         super().__init__(environment)
@@ -94,15 +104,52 @@ class ChatMessageExtension(Extension):
 
     def parse(self, parser: Any) -> nodes.Node | list[nodes.Node]:
         """
+        Dispatch parsing based on the tag that triggered the extension.
+
+        Handles both the single `{% message %}` tag and the `{% messages %}` placeholder tag.
+
+        :param parser: The Jinja2 parser instance
+        :return: A CallBlock node containing the parsed configuration
+        """
+        tag = next(parser.stream)
+        if tag.value == "messages":
+            return self._parse_messages_tag(parser, tag.lineno)
+        return self._parse_message_tag(parser, tag.lineno)
+
+    def _parse_messages_tag(self, parser: Any, lineno: int) -> nodes.Node:
+        """
+        Parse the `{% messages %}` placeholder tag.
+
+        This bodyless tag expands the list of `ChatMessage` objects bound to the `messages` template variable into
+        the same JSON-line format produced by `{% message %}` blocks, so runtime messages can be interleaved with
+        literal message blocks (for example a system message above and a user message below).
+
+        :param parser: The Jinja2 parser instance
+        :param lineno: The line number of the tag, used for error reporting.
+        :return: A CallBlock node that expands the `messages` variable.
+        :raises TemplateSyntaxError: If the tag is given any arguments.
+        """
+        if not parser.stream.current.test("block_end"):
+            raise TemplateSyntaxError(
+                "The 'messages' tag does not take any arguments. It expands the 'messages' template variable.", lineno
+            )
+        messages_expr = nodes.Name("messages", "load", lineno=lineno)
+        # Bodyless tag: empty body, no matching end tag required.
+        return nodes.CallBlock(
+            self.call_method(name="_build_messages_json", args=[messages_expr]), [], [], []
+        ).set_lineno(lineno)
+
+    def _parse_message_tag(self, parser: Any, lineno: int) -> nodes.Node | list[nodes.Node]:
+        """
         Parse the message tag and its attributes in the Jinja2 template.
 
         This method handles the parsing of role (mandatory), name (optional), meta (optional) and message body content.
 
         :param parser: The Jinja2 parser instance
+        :param lineno: The line number of the tag, used for error reporting.
         :return: A CallBlock node containing the parsed message configuration
         :raises TemplateSyntaxError: If an invalid role is provided
         """
-        lineno = next(parser.stream).lineno
 
         # Parse role attribute (mandatory)
         parser.stream.expect("name:role")
@@ -172,6 +219,31 @@ class ChatMessageExtension(Extension):
         chat_message = self._validate_build_chat_message(parts=parts, role=role, meta=meta, name=name)
 
         return json.dumps(chat_message.to_dict()) + "\n"
+
+    def _build_messages_json(self, messages: Any, caller: Callable[[], str]) -> str:  # noqa: ARG002
+        """
+        Expand a list of ChatMessage objects into newline-separated JSON, one message per line.
+
+        This method is called by Jinja2 when processing a `{% messages %}` tag. It produces the same JSON-line format
+        as `_build_chat_message_json`, so the messages are parsed back into ChatMessage objects by the
+        ChatPromptBuilder alongside any literal `{% message %}` blocks. The full `ChatMessage.to_dict()` payload is
+        serialized so that all content types (tool calls, tool call results, images, reasoning, name and meta) round
+        trip without loss.
+
+        :param messages: The list of ChatMessage objects bound to the `messages` template variable. A missing or
+            empty value expands to nothing.
+        :param caller: Callable that returns the (empty) rendered body. Unused.
+        :return: Newline-terminated JSON lines, one per message, or an empty string if there are no messages.
+        :raises ValueError: If `messages` is not a list of ChatMessage objects.
+        """
+        if not messages:
+            return ""
+        if not isinstance(messages, (list, tuple)) or not all(isinstance(m, ChatMessage) for m in messages):
+            raise ValueError(
+                "The 'messages' template variable must be a list of ChatMessage objects. "
+                f"Got: {type(messages).__name__}."
+            )
+        return "".join(json.dumps(message.to_dict()) + "\n" for message in messages)
 
     @staticmethod
     def _parse_content_parts(content: str) -> list[ChatMessageContentT]:

--- a/haystack/utils/jinja2_chat_extension.py
+++ b/haystack/utils/jinja2_chat_extension.py
@@ -72,19 +72,19 @@ class ChatMessageExtension(Extension):
     {% endmessage %}
     ```
 
-    This extension also provides a `{% messages %}` placeholder tag that expands a list of `ChatMessage`
-    objects (bound to the `messages` template variable) into the prompt, so a runtime conversation can be
-    interleaved with literal `{% message %}` blocks:
+    This extension also provides an `{% insert %}` placeholder tag that evaluates an expression to a `ChatMessage`
+    or a list of `ChatMessage` objects and expands it into the prompt, so a runtime conversation can be interleaved
+    with literal `{% message %}` blocks:
 
     ```
     {% message role="system" %}You are a helpful assistant.{% endmessage %}
-    {% messages %}
+    {% insert messages %}
     {% message role="user" %}{{ query }}{% endmessage %}
     ```
 
-    The `{% messages %}` tag also accepts an optional subscript to select a slice or a single message, for example
-    `{% messages[-1] %}` (last message), `{% messages[-1:] %}` (last message as a list) or `{% messages[:-1] %}`
-    (everything but the last message).
+    The expression can be a plain variable (`{% insert messages %}`), a slice or index
+    (`{% insert messages[-1:] %}`, `{% insert messages[-1] %}`), or a combination of variables
+    (`{% insert previous + current %}`).
 
     ### How it works
     1. The `{% message %}` tag is used to define a chat message.
@@ -99,7 +99,7 @@ class ChatMessageExtension(Extension):
 
     SUPPORTED_ROLES = [role.value for role in ChatRole]
 
-    tags = {"message", "messages"}
+    tags = {"message", "insert"}
 
     def __init__(self, environment: Any) -> None:
         super().__init__(environment)
@@ -110,47 +110,44 @@ class ChatMessageExtension(Extension):
         """
         Dispatch parsing based on the tag that triggered the extension.
 
-        Handles both the single `{% message %}` tag and the `{% messages %}` placeholder tag.
+        Handles both the single `{% message %}` block tag and the `{% insert %}` placeholder tag.
 
         :param parser: The Jinja2 parser instance
         :return: A CallBlock node containing the parsed configuration
         """
         tag = next(parser.stream)
-        if tag.value == "messages":
-            return self._parse_messages_tag(parser, tag.lineno)
+        if tag.value == "insert":
+            return self._parse_insert_tag(parser, tag.lineno)
         return self._parse_message_tag(parser, tag.lineno)
 
-    def _parse_messages_tag(self, parser: Any, lineno: int) -> nodes.Node:
+    def _parse_insert_tag(self, parser: Any, lineno: int) -> nodes.Node:
         """
-        Parse the `{% messages %}` placeholder tag.
+        Parse the `{% insert %}` placeholder tag.
 
-        This bodyless tag expands the list of `ChatMessage` objects bound to the `messages` template variable into
-        the same JSON-line format produced by `{% message %}` blocks, so runtime messages can be interleaved with
-        literal message blocks (for example a system message above and a user message below).
+        This bodyless tag evaluates an expression to a `ChatMessage` or a list of `ChatMessage` objects and expands
+        it into the same JSON-line format produced by `{% message %}` blocks, so messages provided at runtime can be
+        interleaved with literal message blocks (for example a system message above and a user message below).
 
-        An optional subscript can select a slice or a single message, for example `{% messages[-1] %}` (last message),
-        `{% messages[-1:] %}` (last message as a list) or `{% messages[:-1] %}` (everything but the last message).
+        The expression can be a plain variable (`{% insert messages %}`), a slice or index
+        (`{% insert messages[-1:] %}`, `{% insert messages[-1] %}`), or a combination of variables
+        (`{% insert previous + current %}`).
 
         :param parser: The Jinja2 parser instance
         :param lineno: The line number of the tag, used for error reporting.
-        :return: A CallBlock node that expands the (optionally subscripted) `messages` variable.
-        :raises TemplateSyntaxError: If the tag is given anything other than a subscript.
+        :return: A CallBlock node that expands the evaluated expression.
+        :raises TemplateSyntaxError: If the tag is not given an expression.
         """
-        node: nodes.Expr = nodes.Name("messages", "load", lineno=lineno)
-        # Apply any trailing subscripts (`[...]`) directly onto the implicit `messages` name, so users can index or
-        # slice the runtime messages, e.g. `{% messages[-1:] %}`.
-        while parser.stream.current.type == "lbracket":
-            node = parser.parse_subscript(node)
-        if not parser.stream.current.test("block_end"):
+        if parser.stream.current.test("block_end"):
             raise TemplateSyntaxError(
-                "The 'messages' tag only accepts an optional subscript on the messages list "
-                "(for example '{% messages[-1:] %}').",
+                "The 'insert' tag requires an expression that evaluates to a ChatMessage or a list of ChatMessage "
+                "objects, for example '{% insert messages %}' or '{% insert messages[-1:] %}'.",
                 lineno,
             )
+        expr = parser.parse_expression()
         # Bodyless tag: empty body, no matching end tag required.
-        return nodes.CallBlock(self.call_method(name="_build_messages_json", args=[node]), [], [], []).set_lineno(
-            lineno
-        )
+        return nodes.CallBlock(
+            self.call_method(name="_build_inserted_messages_json", args=[expr]), [], [], []
+        ).set_lineno(lineno)
 
     def _parse_message_tag(self, parser: Any, lineno: int) -> nodes.Node | list[nodes.Node]:
         """
@@ -233,7 +230,7 @@ class ChatMessageExtension(Extension):
 
         return json.dumps(chat_message.to_dict()) + "\n"
 
-    def _build_messages_json(
+    def _build_inserted_messages_json(
         self,
         messages: list[ChatMessage] | ChatMessage,
         caller: Callable[[], str],  # noqa: ARG002
@@ -241,19 +238,19 @@ class ChatMessageExtension(Extension):
         """
         Expand a list of ChatMessage objects into newline-separated JSON, one message per line.
 
-        This method is called by Jinja2 when processing a `{% messages %}` tag. It produces the same JSON-line format
+        This method is called by Jinja2 when processing an `{% insert %}` tag. It produces the same JSON-line format
         as `_build_chat_message_json`, so the messages are parsed back into ChatMessage objects by the
         ChatPromptBuilder alongside any literal `{% message %}` blocks. The full `ChatMessage.to_dict()` payload is
         serialized so that all content types (tool calls, tool call results, images, reasoning, name and meta) round
         trip without loss.
 
-        :param messages: The list of ChatMessage objects bound to the `messages` template variable. A missing or
-            empty value expands to nothing. A single ChatMessage is also accepted, since indexing the tag with an
-            integer (for example `{% messages[-1] %}`) yields one message rather than a list. The value is validated
-            at render time because it comes from untrusted template input.
+        :param messages: The value the `{% insert %}` expression evaluated to. A missing or empty value expands to
+            nothing. A single ChatMessage is also accepted, since indexing with an integer (for example
+            `{% insert messages[-1] %}`) yields one message rather than a list. The value is validated at render time
+            because it comes from untrusted template input.
         :param caller: Callable that returns the (empty) rendered body. Unused.
         :return: Newline-terminated JSON lines, one per message, or an empty string if there are no messages.
-        :raises ValueError: If `messages` is not a ChatMessage or a list of ChatMessage objects.
+        :raises ValueError: If the value is not a ChatMessage or a list of ChatMessage objects.
         """
         if isinstance(messages, ChatMessage):
             messages = [messages]
@@ -261,7 +258,7 @@ class ChatMessageExtension(Extension):
             return ""
         if not isinstance(messages, (list, tuple)) or not all(isinstance(m, ChatMessage) for m in messages):
             raise ValueError(
-                "The 'messages' template variable must be a ChatMessage or a list of ChatMessage objects. "
+                "The '{% insert %}' expression must evaluate to a ChatMessage or a list of ChatMessage objects. "
                 f"Got: {type(messages).__name__}."
             )
         return "".join(json.dumps(message.to_dict()) + "\n" for message in messages)

--- a/haystack/utils/jinja2_chat_extension.py
+++ b/haystack/utils/jinja2_chat_extension.py
@@ -220,7 +220,7 @@ class ChatMessageExtension(Extension):
 
         return json.dumps(chat_message.to_dict()) + "\n"
 
-    def _build_messages_json(self, messages: Any, caller: Callable[[], str]) -> str:  # noqa: ARG002
+    def _build_messages_json(self, messages: list[ChatMessage], caller: Callable[[], str]) -> str:  # noqa: ARG002
         """
         Expand a list of ChatMessage objects into newline-separated JSON, one message per line.
 
@@ -231,7 +231,8 @@ class ChatMessageExtension(Extension):
         trip without loss.
 
         :param messages: The list of ChatMessage objects bound to the `messages` template variable. A missing or
-            empty value expands to nothing.
+            empty value expands to nothing. The value is validated at render time because it comes from untrusted
+            template input.
         :param caller: Callable that returns the (empty) rendered body. Unused.
         :return: Newline-terminated JSON lines, one per message, or an empty string if there are no messages.
         :raises ValueError: If `messages` is not a list of ChatMessage objects.

--- a/haystack/utils/jinja2_chat_extension.py
+++ b/haystack/utils/jinja2_chat_extension.py
@@ -82,6 +82,10 @@ class ChatMessageExtension(Extension):
     {% message role="user" %}{{ query }}{% endmessage %}
     ```
 
+    The `{% messages %}` tag also accepts an optional subscript to select a slice or a single message, for example
+    `{% messages[-1] %}` (last message), `{% messages[-1:] %}` (last message as a list) or `{% messages[:-1] %}`
+    (everything but the last message).
+
     ### How it works
     1. The `{% message %}` tag is used to define a chat message.
     2. The message can contain text and other structured content parts.
@@ -124,20 +128,29 @@ class ChatMessageExtension(Extension):
         the same JSON-line format produced by `{% message %}` blocks, so runtime messages can be interleaved with
         literal message blocks (for example a system message above and a user message below).
 
+        An optional subscript can select a slice or a single message, for example `{% messages[-1] %}` (last message),
+        `{% messages[-1:] %}` (last message as a list) or `{% messages[:-1] %}` (everything but the last message).
+
         :param parser: The Jinja2 parser instance
         :param lineno: The line number of the tag, used for error reporting.
-        :return: A CallBlock node that expands the `messages` variable.
-        :raises TemplateSyntaxError: If the tag is given any arguments.
+        :return: A CallBlock node that expands the (optionally subscripted) `messages` variable.
+        :raises TemplateSyntaxError: If the tag is given anything other than a subscript.
         """
+        node: nodes.Node = nodes.Name("messages", "load", lineno=lineno)
+        # Apply any trailing subscripts (`[...]`) directly onto the implicit `messages` name, so users can index or
+        # slice the runtime messages, e.g. `{% messages[-1:] %}`.
+        while parser.stream.current.type == "lbracket":
+            node = parser.parse_subscript(node)
         if not parser.stream.current.test("block_end"):
             raise TemplateSyntaxError(
-                "The 'messages' tag does not take any arguments. It expands the 'messages' template variable.", lineno
+                "The 'messages' tag only accepts an optional subscript on the messages list "
+                "(for example '{% messages[-1:] %}').",
+                lineno,
             )
-        messages_expr = nodes.Name("messages", "load", lineno=lineno)
         # Bodyless tag: empty body, no matching end tag required.
-        return nodes.CallBlock(
-            self.call_method(name="_build_messages_json", args=[messages_expr]), [], [], []
-        ).set_lineno(lineno)
+        return nodes.CallBlock(self.call_method(name="_build_messages_json", args=[node]), [], [], []).set_lineno(
+            lineno
+        )
 
     def _parse_message_tag(self, parser: Any, lineno: int) -> nodes.Node | list[nodes.Node]:
         """
@@ -220,7 +233,11 @@ class ChatMessageExtension(Extension):
 
         return json.dumps(chat_message.to_dict()) + "\n"
 
-    def _build_messages_json(self, messages: list[ChatMessage], caller: Callable[[], str]) -> str:  # noqa: ARG002
+    def _build_messages_json(
+        self,
+        messages: list[ChatMessage] | ChatMessage,
+        caller: Callable[[], str],  # noqa: ARG002
+    ) -> str:
         """
         Expand a list of ChatMessage objects into newline-separated JSON, one message per line.
 
@@ -231,17 +248,20 @@ class ChatMessageExtension(Extension):
         trip without loss.
 
         :param messages: The list of ChatMessage objects bound to the `messages` template variable. A missing or
-            empty value expands to nothing. The value is validated at render time because it comes from untrusted
-            template input.
+            empty value expands to nothing. A single ChatMessage is also accepted, since indexing the tag with an
+            integer (for example `{% messages[-1] %}`) yields one message rather than a list. The value is validated
+            at render time because it comes from untrusted template input.
         :param caller: Callable that returns the (empty) rendered body. Unused.
         :return: Newline-terminated JSON lines, one per message, or an empty string if there are no messages.
-        :raises ValueError: If `messages` is not a list of ChatMessage objects.
+        :raises ValueError: If `messages` is not a ChatMessage or a list of ChatMessage objects.
         """
+        if isinstance(messages, ChatMessage):
+            messages = [messages]
         if not messages:
             return ""
         if not isinstance(messages, (list, tuple)) or not all(isinstance(m, ChatMessage) for m in messages):
             raise ValueError(
-                "The 'messages' template variable must be a list of ChatMessage objects. "
+                "The 'messages' template variable must be a ChatMessage or a list of ChatMessage objects. "
                 f"Got: {type(messages).__name__}."
             )
         return "".join(json.dumps(message.to_dict()) + "\n" for message in messages)

--- a/releasenotes/notes/add-messages-jinja-tag-483cca5bda6884f2.yaml
+++ b/releasenotes/notes/add-messages-jinja-tag-483cca5bda6884f2.yaml
@@ -1,0 +1,18 @@
+---
+features:
+  - |
+    Added a new ``{% messages %}`` tag to the Jinja2 string templates used by ``ChatPromptBuilder``.
+    The tag is a placeholder that expands the list of ``ChatMessage`` objects bound to the ``messages``
+    template variable into the prompt, so a runtime conversation can be interleaved with literal
+    ``{% message %}`` blocks. For example, you can wrap the runtime messages with a system message above
+    and a templated user message below:
+
+    .. code-block:: jinja
+
+        {% message role="system" %}You are a helpful assistant.{% endmessage %}
+        {% messages %}
+        {% message role="user" %}{{ query }}{% endmessage %}
+
+    All content types (tool calls, tool call results, images, reasoning, ``name`` and ``meta``) round trip
+    without loss. The tag takes no arguments and expects ``messages`` to be a list of ``ChatMessage`` objects;
+    a missing or empty value expands to nothing.

--- a/releasenotes/notes/add-messages-jinja-tag-483cca5bda6884f2.yaml
+++ b/releasenotes/notes/add-messages-jinja-tag-483cca5bda6884f2.yaml
@@ -14,5 +14,9 @@ features:
         {% message role="user" %}{{ query }}{% endmessage %}
 
     All content types (tool calls, tool call results, images, reasoning, ``name`` and ``meta``) round trip
-    without loss. The tag takes no arguments and expects ``messages`` to be a list of ``ChatMessage`` objects;
-    a missing or empty value expands to nothing.
+    without loss. The tag expects ``messages`` to be a list of ``ChatMessage`` objects; a missing or empty value
+    expands to nothing.
+
+    The tag also accepts an optional subscript to select a slice or a single message, for example
+    ``{% messages[-1] %}`` (last message), ``{% messages[-1:] %}`` (last message as a list) or
+    ``{% messages[:-1] %}`` (everything but the last message).

--- a/releasenotes/notes/add-messages-jinja-tag-483cca5bda6884f2.yaml
+++ b/releasenotes/notes/add-messages-jinja-tag-483cca5bda6884f2.yaml
@@ -5,13 +5,25 @@ features:
     The tag is a placeholder that evaluates an expression to a ``ChatMessage`` or a list of ``ChatMessage``
     objects and expands it into the prompt, so messages provided at runtime can be interleaved with literal
     ``{% message %}`` blocks. For example, you can wrap the runtime messages with a system message above
-    and a templated user message below:
+    and a templated user message below, then pass the messages (and any template variables) at run time:
 
-    .. code-block:: jinja
+    .. code-block:: python
 
+        from haystack.components.builders import ChatPromptBuilder
+        from haystack.dataclasses import ChatMessage
+
+        template = """
         {% message role="system" %}You are a helpful assistant.{% endmessage %}
         {% insert messages %}
         {% message role="user" %}{{ query }}{% endmessage %}
+        """
+
+        builder = ChatPromptBuilder(template=template)
+        result = builder.run(
+            messages=[ChatMessage.from_user("Hi"), ChatMessage.from_assistant("Hello!")],
+            query="What's the weather?",
+        )
+        # result["prompt"] -> [system, user "Hi", assistant "Hello!", user "What's the weather?"]
 
     All content types (tool calls, tool call results, images, reasoning, ``name`` and ``meta``) round trip
     without loss. A missing or empty value expands to nothing.

--- a/releasenotes/notes/add-messages-jinja-tag-483cca5bda6884f2.yaml
+++ b/releasenotes/notes/add-messages-jinja-tag-483cca5bda6884f2.yaml
@@ -1,25 +1,22 @@
 ---
 features:
   - |
-    Added a new ``{% messages %}`` tag to the Jinja2 string templates used by ``ChatPromptBuilder``.
-    The tag is a placeholder that expands the list of ``ChatMessage`` objects bound to the ``messages``
-    template variable into the prompt, so a runtime conversation can be interleaved with literal
+    Added a new ``{% insert %}`` tag to the Jinja2 string templates used by ``ChatPromptBuilder``.
+    The tag is a placeholder that evaluates an expression to a ``ChatMessage`` or a list of ``ChatMessage``
+    objects and expands it into the prompt, so messages provided at runtime can be interleaved with literal
     ``{% message %}`` blocks. For example, you can wrap the runtime messages with a system message above
     and a templated user message below:
 
     .. code-block:: jinja
 
         {% message role="system" %}You are a helpful assistant.{% endmessage %}
-        {% messages %}
+        {% insert messages %}
         {% message role="user" %}{{ query }}{% endmessage %}
 
     All content types (tool calls, tool call results, images, reasoning, ``name`` and ``meta``) round trip
-    without loss. The tag expects ``messages`` to be a list of ``ChatMessage`` objects; a missing or empty value
-    expands to nothing.
+    without loss. A missing or empty value expands to nothing.
 
-    The tag also accepts an optional subscript to select a slice or a single message, for example
-    ``{% messages[-1] %}`` (last message), ``{% messages[-1:] %}`` (last message as a list) or
-    ``{% messages[:-1] %}`` (everything but the last message).
-
-    Multiple ``{% messages %}`` tags can be used in a single template, so the runtime messages can be split,
-    reordered, or repeated across different positions.
+    The expression can be a plain variable (``{% insert messages %}``), a slice or index
+    (``{% insert messages[-1:] %}``, ``{% insert messages[-1] %}``), or a combination of variables
+    (``{% insert previous + current %}``). Multiple ``{% insert %}`` tags can be used in a single template,
+    so the runtime messages can be split, reordered, or repeated across different positions.

--- a/releasenotes/notes/add-messages-jinja-tag-483cca5bda6884f2.yaml
+++ b/releasenotes/notes/add-messages-jinja-tag-483cca5bda6884f2.yaml
@@ -20,3 +20,6 @@ features:
     The tag also accepts an optional subscript to select a slice or a single message, for example
     ``{% messages[-1] %}`` (last message), ``{% messages[-1:] %}`` (last message as a list) or
     ``{% messages[:-1] %}`` (everything but the last message).
+
+    Multiple ``{% messages %}`` tags can be used in a single template, so the runtime messages can be split,
+    reordered, or repeated across different positions.

--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -1084,6 +1084,13 @@ Hello, my name is {{name}}!
         result = builder.run(messages=runtime)
         assert result["prompt"] == runtime
 
+    def test_messages_placeholder_with_subscript(self):
+        builder = ChatPromptBuilder(template="{% messages[-1:] %}")
+        assert builder.variables == ["messages"]
+        runtime = [ChatMessage.from_user("first"), ChatMessage.from_assistant("last")]
+        result = builder.run(messages=runtime)
+        assert result["prompt"] == [ChatMessage.from_assistant("last")]
+
     def test_messages_placeholder_interleaved_with_blocks(self):
         template = (
             '{% message role="system" %}You are helpful.{% endmessage %}'

--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -1077,24 +1077,24 @@ Hello, my name is {{name}}!
         images = [p for p in msg._content if isinstance(p, ImageContent)]
         assert len(images) == 0
 
-    def test_messages_placeholder(self):
-        builder = ChatPromptBuilder(template="{% messages %}")
+    def test_insert_placeholder(self):
+        builder = ChatPromptBuilder(template="{% insert messages %}")
         assert builder.variables == ["messages"]
         runtime = [ChatMessage.from_user("Hello"), ChatMessage.from_assistant("Hi")]
         result = builder.run(messages=runtime)
         assert result["prompt"] == runtime
 
-    def test_messages_placeholder_with_subscript(self):
-        builder = ChatPromptBuilder(template="{% messages[-1:] %}")
+    def test_insert_placeholder_with_subscript(self):
+        builder = ChatPromptBuilder(template="{% insert messages[-1:] %}")
         assert builder.variables == ["messages"]
         runtime = [ChatMessage.from_user("first"), ChatMessage.from_assistant("last")]
         result = builder.run(messages=runtime)
         assert result["prompt"] == [ChatMessage.from_assistant("last")]
 
-    def test_messages_placeholder_interleaved_with_blocks(self):
+    def test_insert_placeholder_interleaved_with_blocks(self):
         template = (
             '{% message role="system" %}You are helpful.{% endmessage %}'
-            "{% messages %}"
+            "{% insert messages %}"
             '{% message role="user" %}{{ query }}{% endmessage %}'
         )
         builder = ChatPromptBuilder(template=template)

--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -1076,3 +1076,25 @@ Hello, my name is {{name}}!
 
         images = [p for p in msg._content if isinstance(p, ImageContent)]
         assert len(images) == 0
+
+    def test_messages_placeholder(self):
+        builder = ChatPromptBuilder(template="{% messages %}")
+        assert builder.variables == ["messages"]
+        runtime = [ChatMessage.from_user("Hello"), ChatMessage.from_assistant("Hi")]
+        result = builder.run(messages=runtime)
+        assert result["prompt"] == runtime
+
+    def test_messages_placeholder_interleaved_with_blocks(self):
+        template = (
+            '{% message role="system" %}You are helpful.{% endmessage %}'
+            "{% messages %}"
+            '{% message role="user" %}{{ query }}{% endmessage %}'
+        )
+        builder = ChatPromptBuilder(template=template)
+        assert set(builder.variables) == {"messages", "query"}
+        result = builder.run(messages=[ChatMessage.from_user("earlier")], query="now")
+        assert result["prompt"] == [
+            ChatMessage.from_system("You are helpful."),
+            ChatMessage.from_user("earlier"),
+            ChatMessage.from_user("now"),
+        ]

--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -1091,6 +1091,21 @@ Hello, my name is {{name}}!
         result = builder.run(messages=runtime)
         assert result["prompt"] == [ChatMessage.from_assistant("last")]
 
+    def test_insert_placeholder_custom_variable_name(self):
+        builder = ChatPromptBuilder(template="{% insert chat_history %}")
+        assert builder.variables == ["chat_history"]
+        runtime = [ChatMessage.from_user("Hello"), ChatMessage.from_assistant("Hi")]
+        result = builder.run(chat_history=runtime)
+        assert result["prompt"] == runtime
+
+    def test_insert_placeholder_combines_variables(self):
+        builder = ChatPromptBuilder(template="{% insert previous + current %}")
+        assert set(builder.variables) == {"previous", "current"}
+        previous = [ChatMessage.from_user("p1"), ChatMessage.from_assistant("p2")]
+        current = [ChatMessage.from_user("c1")]
+        result = builder.run(previous=previous, current=current)
+        assert result["prompt"] == previous + current
+
     def test_insert_placeholder_interleaved_with_blocks(self):
         template = (
             '{% message role="system" %}You are helpful.{% endmessage %}'

--- a/test/utils/test_jinja2_chat_extension.py
+++ b/test/utils/test_jinja2_chat_extension.py
@@ -7,10 +7,11 @@ import json
 from unittest.mock import patch
 
 import pytest
-from jinja2 import TemplateSyntaxError
+from jinja2 import TemplateSyntaxError, meta
 from jinja2.sandbox import SandboxedEnvironment
 
 from haystack.dataclasses.chat_message import (
+    ChatMessage,
     FileContent,
     ImageContent,
     ReasoningContent,
@@ -602,6 +603,76 @@ But my favorite subject is Small Language Models.
         output = json.loads(rendered.strip())
 
         assert output["content"][0]["text"] == text_with_symbols
+
+
+class TestMessagesPlaceholderTag:
+    def _parse_lines(self, rendered: str) -> list[ChatMessage]:
+        return [ChatMessage.from_dict(json.loads(line)) for line in rendered.strip().split("\n") if line.strip()]
+
+    def test_expands_messages(self, jinja_env):
+        template = "{% messages %}"
+        messages = [ChatMessage.from_user("Hello"), ChatMessage.from_assistant("Hi there")]
+        rendered = jinja_env.from_string(template).render(messages=messages)
+        assert self._parse_lines(rendered) == messages
+
+    def test_empty_messages_expands_to_nothing(self, jinja_env):
+        template = "{% messages %}"
+        assert jinja_env.from_string(template).render(messages=[]).strip() == ""
+
+    def test_missing_messages_variable_expands_to_nothing(self, jinja_env):
+        # `messages` is falsy/Undefined when not provided -> emits nothing rather than raising
+        template = "{% messages %}"
+        assert jinja_env.from_string(template).render().strip() == ""
+
+    def test_interleaved_with_literal_message_blocks(self, jinja_env):
+        template = """
+        {% message role="system" %}You are helpful.{% endmessage %}
+        {% messages %}
+        {% message role="user" %}{{ query }}{% endmessage %}
+        """
+        runtime = [ChatMessage.from_user("first"), ChatMessage.from_assistant("second")]
+        rendered = jinja_env.from_string(template).render(messages=runtime, query="final question")
+        parsed = self._parse_lines(rendered)
+        assert [m.role.value for m in parsed] == ["system", "user", "assistant", "user"]
+        assert parsed[0].text == "You are helpful."
+        assert parsed[1].text == "first"
+        assert parsed[2].text == "second"
+        assert parsed[3].text == "final question"
+
+    def test_is_detected_as_template_variable(self):
+        # The `{% messages %}` tag must surface `messages` as an undeclared variable so that the
+        # ChatPromptBuilder (and Agent) can register and pass it.
+        env = SandboxedEnvironment(extensions=[ChatMessageExtension])
+        ast = env.parse("{% messages %}")
+        assert "messages" in meta.find_undeclared_variables(ast)
+
+    def test_round_trips_all_content_types(self, jinja_env, base64_image_string):
+        tool_call = ToolCall(tool_name="search", arguments={"query": "q"}, id="search_1")
+        messages = [
+            ChatMessage.from_system("system text", meta={"k": "v"}),
+            ChatMessage.from_user("user text", name="Bob"),
+            ChatMessage.from_user(
+                content_parts=["look", ImageContent(base64_image=base64_image_string, mime_type="image/png")]
+            ),
+            ChatMessage.from_assistant(
+                text="thinking then calling",
+                tool_calls=[tool_call],
+                reasoning=ReasoningContent(reasoning_text="let me think", extra={"a": 1}),
+            ),
+            ChatMessage.from_tool(tool_result="result", origin=tool_call, error=False),
+        ]
+        rendered = jinja_env.from_string("{% messages %}").render(messages=messages)
+        assert self._parse_lines(rendered) == messages
+
+    def test_no_arguments_allowed(self, jinja_env):
+        template = '{% messages role="user" %}'
+        with pytest.raises(TemplateSyntaxError, match="does not take any arguments"):
+            jinja_env.from_string(template).render(messages=[])
+
+    def test_non_message_list_raises_error(self, jinja_env):
+        template = "{% messages %}"
+        with pytest.raises(ValueError, match="must be a list of ChatMessage objects"):
+            jinja_env.from_string(template).render(messages=["not a message"])
 
 
 class TestSentinelTagInjectionPrevention:

--- a/test/utils/test_jinja2_chat_extension.py
+++ b/test/utils/test_jinja2_chat_extension.py
@@ -605,29 +605,29 @@ But my favorite subject is Small Language Models.
         assert output["content"][0]["text"] == text_with_symbols
 
 
-class TestMessagesPlaceholderTag:
+class TestInsertTag:
     def _parse_lines(self, rendered: str) -> list[ChatMessage]:
         return [ChatMessage.from_dict(json.loads(line)) for line in rendered.strip().split("\n") if line.strip()]
 
     def test_expands_messages(self, jinja_env):
-        template = "{% messages %}"
+        template = "{% insert messages %}"
         messages = [ChatMessage.from_user("Hello"), ChatMessage.from_assistant("Hi there")]
         rendered = jinja_env.from_string(template).render(messages=messages)
         assert self._parse_lines(rendered) == messages
 
     def test_empty_messages_expands_to_nothing(self, jinja_env):
-        template = "{% messages %}"
+        template = "{% insert messages %}"
         assert jinja_env.from_string(template).render(messages=[]).strip() == ""
 
-    def test_missing_messages_variable_expands_to_nothing(self, jinja_env):
-        # `messages` is falsy/Undefined when not provided -> emits nothing rather than raising
-        template = "{% messages %}"
+    def test_missing_variable_expands_to_nothing(self, jinja_env):
+        # The expression resolves to Undefined (falsy) when not provided -> emits nothing rather than raising
+        template = "{% insert messages %}"
         assert jinja_env.from_string(template).render().strip() == ""
 
     def test_interleaved_with_literal_message_blocks(self, jinja_env):
         template = """
         {% message role="system" %}You are helpful.{% endmessage %}
-        {% messages %}
+        {% insert messages %}
         {% message role="user" %}{{ query }}{% endmessage %}
         """
         runtime = [ChatMessage.from_user("first"), ChatMessage.from_assistant("second")]
@@ -640,11 +640,12 @@ class TestMessagesPlaceholderTag:
         assert parsed[3].text == "final question"
 
     def test_is_detected_as_template_variable(self):
-        # The `{% messages %}` tag must surface `messages` as an undeclared variable so that the
-        # ChatPromptBuilder (and Agent) can register and pass it.
+        # The `{% insert %}` expression must surface its variables as undeclared so that the
+        # ChatPromptBuilder (and Agent) can register and pass them.
         env = SandboxedEnvironment(extensions=[ChatMessageExtension])
-        ast = env.parse("{% messages %}")
-        assert "messages" in meta.find_undeclared_variables(ast)
+        assert "messages" in meta.find_undeclared_variables(env.parse("{% insert messages %}"))
+        assert "messages" in meta.find_undeclared_variables(env.parse("{% insert messages[-1] %}"))
+        assert {"previous", "current"} <= meta.find_undeclared_variables(env.parse("{% insert previous + current %}"))
 
     def test_round_trips_all_content_types(self, jinja_env, base64_image_string):
         tool_call = ToolCall(tool_name="search", arguments={"query": "q"}, id="search_1")
@@ -661,45 +662,51 @@ class TestMessagesPlaceholderTag:
             ),
             ChatMessage.from_tool(tool_result="result", origin=tool_call, error=False),
         ]
-        rendered = jinja_env.from_string("{% messages %}").render(messages=messages)
+        rendered = jinja_env.from_string("{% insert messages %}").render(messages=messages)
         assert self._parse_lines(rendered) == messages
 
     @pytest.fixture
     def three_messages(self) -> list[ChatMessage]:
         return [ChatMessage.from_user("a"), ChatMessage.from_assistant("b"), ChatMessage.from_user("c")]
 
-    def test_subscript_single_index(self, jinja_env, three_messages):
+    def test_single_index(self, jinja_env, three_messages):
         # An integer index yields a single ChatMessage, which is expanded as a one-message list.
-        rendered = jinja_env.from_string("{% messages[-1] %}").render(messages=three_messages)
+        rendered = jinja_env.from_string("{% insert messages[-1] %}").render(messages=three_messages)
         assert self._parse_lines(rendered) == [three_messages[-1]]
 
-    def test_subscript_slice(self, jinja_env, three_messages):
-        rendered = jinja_env.from_string("{% messages[-1:] %}").render(messages=three_messages)
+    def test_slice(self, jinja_env, three_messages):
+        rendered = jinja_env.from_string("{% insert messages[-1:] %}").render(messages=three_messages)
         assert self._parse_lines(rendered) == three_messages[-1:]
 
-        rendered = jinja_env.from_string("{% messages[:-1] %}").render(messages=three_messages)
+        rendered = jinja_env.from_string("{% insert messages[:-1] %}").render(messages=three_messages)
         assert self._parse_lines(rendered) == three_messages[:-1]
 
-        rendered = jinja_env.from_string("{% messages[1:] %}").render(messages=three_messages)
+        rendered = jinja_env.from_string("{% insert messages[1:] %}").render(messages=three_messages)
         assert self._parse_lines(rendered) == three_messages[1:]
 
-    def test_subscript_still_detected_as_template_variable(self):
-        env = SandboxedEnvironment(extensions=[ChatMessageExtension])
-        for template in ["{% messages[-1] %}", "{% messages[1:] %}"]:
-            assert "messages" in meta.find_undeclared_variables(env.parse(template))
+    def test_combine_multiple_variables(self, jinja_env):
+        # The expression can combine several variables, e.g. concatenating two message lists.
+        previous = [ChatMessage.from_user("p1"), ChatMessage.from_assistant("p2")]
+        current = [ChatMessage.from_user("c1")]
+        rendered = jinja_env.from_string("{% insert previous + current %}").render(previous=previous, current=current)
+        assert self._parse_lines(rendered) == previous + current
 
-    def test_subscript_interleaved_with_blocks(self, jinja_env, three_messages):
+    def test_custom_variable_name(self, jinja_env, three_messages):
+        rendered = jinja_env.from_string("{% insert chat_history %}").render(chat_history=three_messages)
+        assert self._parse_lines(rendered) == three_messages
+
+    def test_slice_interleaved_with_blocks(self, jinja_env, three_messages):
         template = (
             '{% message role="system" %}sys{% endmessage %}'
-            "{% messages[-1:] %}"
+            "{% insert messages[-1:] %}"
             '{% message role="user" %}{{ query }}{% endmessage %}'
         )
         rendered = jinja_env.from_string(template).render(messages=three_messages, query="q")
         parsed = self._parse_lines(rendered)
         assert [m.text for m in parsed] == ["sys", "c", "q"]
 
-    def test_multiple_placeholders_split_and_reorder(self, jinja_env):
-        # Each `{% messages %}` tag expands independently, so a template can split the runtime messages across
+    def test_multiple_inserts_split_and_reorder(self, jinja_env):
+        # Each `{% insert %}` tag expands independently, so a template can split the runtime messages across
         # several positions, interleave literal blocks, and even repeat a slice.
         messages = [
             ChatMessage.from_system("S"),
@@ -708,7 +715,10 @@ class TestMessagesPlaceholderTag:
             ChatMessage.from_user("u2"),
         ]
         template = (
-            '{% messages[0] %}{% message role="user" %}INJECTED{% endmessage %}{% messages[1:] %}{% messages[-1] %}'
+            "{% insert messages[0] %}"
+            '{% message role="user" %}INJECTED{% endmessage %}'
+            "{% insert messages[1:] %}"
+            "{% insert messages[-1] %}"
         )
         rendered = jinja_env.from_string(template).render(messages=messages)
         parsed = self._parse_lines(rendered)
@@ -725,17 +735,16 @@ class TestMessagesPlaceholderTag:
         # The tag uses a CallBlock so output bypasses `finalize` sentinel-escaping; message text containing
         # the literal sentinel tag must round trip intact.
         message = ChatMessage.from_user("see <haystack_content_part> here")
-        rendered = jinja_env.from_string("{% messages %}").render(messages=[message])
+        rendered = jinja_env.from_string("{% insert messages %}").render(messages=[message])
         assert self._parse_lines(rendered) == [message]
 
-    def test_only_subscript_allowed(self, jinja_env):
-        template = '{% messages role="user" %}'
-        with pytest.raises(TemplateSyntaxError, match="only accepts an optional subscript"):
-            jinja_env.from_string(template).render(messages=[])
+    def test_requires_an_expression(self, jinja_env):
+        with pytest.raises(TemplateSyntaxError, match="requires an expression"):
+            jinja_env.from_string("{% insert %}").render(messages=[])
 
-    def test_non_message_list_raises_error(self, jinja_env):
-        template = "{% messages %}"
-        with pytest.raises(ValueError, match="must be a ChatMessage or a list of ChatMessage objects"):
+    def test_non_message_value_raises_error(self, jinja_env):
+        template = "{% insert messages %}"
+        with pytest.raises(ValueError, match="must evaluate to a ChatMessage or a list of ChatMessage objects"):
             jinja_env.from_string(template).render(messages=["not a message"])
 
 

--- a/test/utils/test_jinja2_chat_extension.py
+++ b/test/utils/test_jinja2_chat_extension.py
@@ -732,8 +732,11 @@ class TestInsertTag:
         ]
 
     def test_message_text_with_sentinel_tag_is_not_escaped(self, jinja_env):
-        # The tag uses a CallBlock so output bypasses `finalize` sentinel-escaping; message text containing
-        # the literal sentinel tag must round trip intact.
+        # The tag uses a CallBlock so its output bypasses `finalize` sentinel-escaping. This is safe here because
+        # `{% insert %}` serializes with ChatMessage.to_dict and the builder reparses with json.loads +
+        # ChatMessage.from_dict -- it never runs the content-part parser. So a user-injected `<haystack_content_part>`
+        # string in the message text stays plain text and can't be promoted to a structured part (image, tool call,
+        # ...); it just has to round trip intact.
         message = ChatMessage.from_user("see <haystack_content_part> here")
         rendered = jinja_env.from_string("{% insert messages %}").render(messages=[message])
         assert self._parse_lines(rendered) == [message]

--- a/test/utils/test_jinja2_chat_extension.py
+++ b/test/utils/test_jinja2_chat_extension.py
@@ -664,6 +664,13 @@ class TestMessagesPlaceholderTag:
         rendered = jinja_env.from_string("{% messages %}").render(messages=messages)
         assert self._parse_lines(rendered) == messages
 
+    def test_message_text_with_sentinel_tag_is_not_escaped(self, jinja_env):
+        # The tag uses a CallBlock so output bypasses `finalize` sentinel-escaping; message text containing
+        # the literal sentinel tag must round trip intact.
+        message = ChatMessage.from_user("see <haystack_content_part> here")
+        rendered = jinja_env.from_string("{% messages %}").render(messages=[message])
+        assert self._parse_lines(rendered) == [message]
+
     def test_no_arguments_allowed(self, jinja_env):
         template = '{% messages role="user" %}'
         with pytest.raises(TemplateSyntaxError, match="does not take any arguments"):

--- a/test/utils/test_jinja2_chat_extension.py
+++ b/test/utils/test_jinja2_chat_extension.py
@@ -698,6 +698,29 @@ class TestMessagesPlaceholderTag:
         parsed = self._parse_lines(rendered)
         assert [m.text for m in parsed] == ["sys", "c", "q"]
 
+    def test_multiple_placeholders_split_and_reorder(self, jinja_env):
+        # Each `{% messages %}` tag expands independently, so a template can split the runtime messages across
+        # several positions, interleave literal blocks, and even repeat a slice.
+        messages = [
+            ChatMessage.from_system("S"),
+            ChatMessage.from_user("u1"),
+            ChatMessage.from_assistant("a1"),
+            ChatMessage.from_user("u2"),
+        ]
+        template = (
+            '{% messages[0] %}{% message role="user" %}INJECTED{% endmessage %}{% messages[1:] %}{% messages[-1] %}'
+        )
+        rendered = jinja_env.from_string(template).render(messages=messages)
+        parsed = self._parse_lines(rendered)
+        assert [(m.role.value, m.text) for m in parsed] == [
+            ("system", "S"),
+            ("user", "INJECTED"),
+            ("user", "u1"),
+            ("assistant", "a1"),
+            ("user", "u2"),
+            ("user", "u2"),
+        ]
+
     def test_message_text_with_sentinel_tag_is_not_escaped(self, jinja_env):
         # The tag uses a CallBlock so output bypasses `finalize` sentinel-escaping; message text containing
         # the literal sentinel tag must round trip intact.

--- a/test/utils/test_jinja2_chat_extension.py
+++ b/test/utils/test_jinja2_chat_extension.py
@@ -664,6 +664,40 @@ class TestMessagesPlaceholderTag:
         rendered = jinja_env.from_string("{% messages %}").render(messages=messages)
         assert self._parse_lines(rendered) == messages
 
+    @pytest.fixture
+    def three_messages(self) -> list[ChatMessage]:
+        return [ChatMessage.from_user("a"), ChatMessage.from_assistant("b"), ChatMessage.from_user("c")]
+
+    def test_subscript_single_index(self, jinja_env, three_messages):
+        # An integer index yields a single ChatMessage, which is expanded as a one-message list.
+        rendered = jinja_env.from_string("{% messages[-1] %}").render(messages=three_messages)
+        assert self._parse_lines(rendered) == [three_messages[-1]]
+
+    def test_subscript_slice(self, jinja_env, three_messages):
+        rendered = jinja_env.from_string("{% messages[-1:] %}").render(messages=three_messages)
+        assert self._parse_lines(rendered) == three_messages[-1:]
+
+        rendered = jinja_env.from_string("{% messages[:-1] %}").render(messages=three_messages)
+        assert self._parse_lines(rendered) == three_messages[:-1]
+
+        rendered = jinja_env.from_string("{% messages[1:] %}").render(messages=three_messages)
+        assert self._parse_lines(rendered) == three_messages[1:]
+
+    def test_subscript_still_detected_as_template_variable(self):
+        env = SandboxedEnvironment(extensions=[ChatMessageExtension])
+        for template in ["{% messages[-1] %}", "{% messages[1:] %}"]:
+            assert "messages" in meta.find_undeclared_variables(env.parse(template))
+
+    def test_subscript_interleaved_with_blocks(self, jinja_env, three_messages):
+        template = (
+            '{% message role="system" %}sys{% endmessage %}'
+            "{% messages[-1:] %}"
+            '{% message role="user" %}{{ query }}{% endmessage %}'
+        )
+        rendered = jinja_env.from_string(template).render(messages=three_messages, query="q")
+        parsed = self._parse_lines(rendered)
+        assert [m.text for m in parsed] == ["sys", "c", "q"]
+
     def test_message_text_with_sentinel_tag_is_not_escaped(self, jinja_env):
         # The tag uses a CallBlock so output bypasses `finalize` sentinel-escaping; message text containing
         # the literal sentinel tag must round trip intact.
@@ -671,14 +705,14 @@ class TestMessagesPlaceholderTag:
         rendered = jinja_env.from_string("{% messages %}").render(messages=[message])
         assert self._parse_lines(rendered) == [message]
 
-    def test_no_arguments_allowed(self, jinja_env):
+    def test_only_subscript_allowed(self, jinja_env):
         template = '{% messages role="user" %}'
-        with pytest.raises(TemplateSyntaxError, match="does not take any arguments"):
+        with pytest.raises(TemplateSyntaxError, match="only accepts an optional subscript"):
             jinja_env.from_string(template).render(messages=[])
 
     def test_non_message_list_raises_error(self, jinja_env):
         template = "{% messages %}"
-        with pytest.raises(ValueError, match="must be a list of ChatMessage objects"):
+        with pytest.raises(ValueError, match="must be a ChatMessage or a list of ChatMessage objects"):
             jinja_env.from_string(template).render(messages=["not a message"])
 
 


### PR DESCRIPTION
### Related Issues

- Part of resolving this idea https://github.com/deepset-ai/haystack/pull/11209#issuecomment-4343754420
- Part of https://github.com/deepset-ai/haystack-private/issues/331

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add a new `messages` tag in our `ChatPromptBuilder` (`{% messages %}`) to support building prompts like
```
{% message role="system" %}You are a helpful assistant.{% endmessage %}
{% messages %}
{% message role="user" %}{{ query }}{% endmessage %}
```
so users can interleave a list of chat messages into their prompt. 

I also added support for subscripting (e.g. `{% messages[0] %}`, `{% messages[-1:] %}`) to allow users to select which of the incoming messages they would like to include or not. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added new unit tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

The immediate use case for this would be to use this new format for `Agent`. So get rid of `system_prompt` and `user_prompt` from `Agent`'s init method and replace it with a singular `messages_template` (or `prompt_template`) variable. The default `prompt_template` would be `{% messages %}` which translates to the Agent expecting the `messages` variable to be provided at runtime. Then if users want to customize and add new additional messages like a system message they can easily update the `prompt_template` to 
```
{% message role="system" %}You are a helpful assistant.{% endmessage %}
{% messages %}
```
and any new jinja2 params added would then be expected runtime params. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
