### PR TITLE
feat(generators): add run_async to OpenAIGenerator

### DIFF
--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -5,7 +5,7 @@
 import os
 from typing import Any
 
-from openai import OpenAI, Stream
+from openai import AsyncOpenAI, AsyncStream, OpenAI, Stream
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
 from haystack import component, default_from_dict, default_to_dict, logging
@@ -141,6 +141,14 @@ class OpenAIGenerator:
             max_retries=max_retries,
             http_client=init_http_client(self.http_client_kwargs, async_client=False),
         )
+        self.async_client = AsyncOpenAI(
+            api_key=api_key.resolve_value(),
+            organization=organization,
+            base_url=api_base_url,
+            timeout=timeout,
+            max_retries=max_retries,
+            http_client=init_http_client(self.http_client_kwargs, async_client=True),
+        )
 
     def _get_telemetry_data(self) -> dict[str, Any]:
         """
@@ -261,6 +269,89 @@ class OpenAIGenerator:
             ]
 
         # before returning, do post-processing of the completions
+        for response in completions:
+            _check_finish_reason(response.meta)
+
+        return {
+            "replies": [message.text or "" for message in completions],
+            "meta": [message.meta for message in completions],
+        }
+
+    @component.output_types(replies=list[str], meta=list[dict[str, Any]])
+    async def run_async(
+        self,
+        prompt: str,
+        system_prompt: str | None = None,
+        streaming_callback: StreamingCallbackT | None = None,
+        generation_kwargs: dict[str, Any] | None = None,
+    ) -> dict[str, list[str] | list[dict[str, Any]]]:
+        """
+        Asynchronously invoke the text generation inference based on the provided prompt and generation parameters.
+
+        This is the asynchronous version of the ``run`` method. It has the same parameters and return values
+        but can be used with ``await`` in async code or within an ``AsyncPipeline``.
+
+        :param prompt:
+            The string prompt to use for text generation.
+        :param system_prompt:
+            The system prompt to use for text generation. If this run time system prompt is omitted, the system
+            prompt, if defined at initialisation time, is used.
+        :param streaming_callback:
+            A callback coroutine that is called when a new token is received from the stream.
+            Must be an async function (coroutine).
+        :param generation_kwargs:
+            Additional keyword arguments for text generation. These parameters will potentially override the parameters
+            passed in the ``__init__`` method. For more details on the parameters supported by the OpenAI API, refer to
+            the OpenAI `documentation <https://platform.openai.com/docs/api-reference/chat/create>`_.
+        :returns:
+            A list of strings containing the generated responses and a list of dictionaries containing the metadata
+            for each response.
+        """
+        message = ChatMessage.from_user(prompt)
+        if system_prompt is not None:
+            messages = [ChatMessage.from_system(system_prompt), message]
+        elif self.system_prompt:
+            messages = [ChatMessage.from_system(self.system_prompt), message]
+        else:
+            messages = [message]
+
+        generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
+
+        streaming_callback = select_streaming_callback(
+            init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=True
+        )
+
+        openai_formatted_messages = [message.to_openai_dict_format() for message in messages]
+
+        completion: AsyncStream[ChatCompletionChunk] | ChatCompletion = await self.async_client.chat.completions.create(
+            model=self.model,
+            messages=openai_formatted_messages,  # type: ignore
+            stream=streaming_callback is not None,
+            **generation_kwargs,
+        )
+
+        completions: list[ChatMessage] = []
+        if streaming_callback is not None:
+            num_responses = generation_kwargs.pop("n", 1)
+            if num_responses > 1:
+                raise ValueError("Cannot stream multiple responses, please set n=1.")
+
+            component_info = ComponentInfo.from_component(self)
+            chunks: list[StreamingChunk] = []
+            async for chunk in completion:  # type: ignore
+                chunk_delta: StreamingChunk = _convert_chat_completion_chunk_to_streaming_chunk(
+                    chunk=chunk, previous_chunks=chunks, component_info=component_info
+                )
+                chunks.append(chunk_delta)
+                await streaming_callback(chunk_delta)
+
+            completions = [_convert_streaming_chunks_to_chat_message(chunks=chunks)]
+        elif isinstance(completion, ChatCompletion):
+            completions = [
+                _convert_chat_completion_to_chat_message(completion=completion, choice=choice)
+                for choice in completion.choices
+            ]
+
         for response in completions:
             _check_finish_reason(response.meta)
 

--- a/releasenotes/notes/add-run-async-OpenAIGenerator-f2d7c9a915882839.yaml
+++ b/releasenotes/notes/add-run-async-OpenAIGenerator-f2d7c9a915882839.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add ``run_async`` method to ``OpenAIGenerator``. This method uses the async OpenAI client
+    (``AsyncOpenAI``) internally and can be used with ``await`` in async code or inside an
+    ``AsyncPipeline``. It has the same parameters and return values as ``run``, with
+    ``streaming_callback`` expected to be a coroutine when streaming is used.

--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -329,3 +329,77 @@ class TestOpenAIGenerator:
             assert "replies" in response
             assert "Hello" in response["replies"][0]
             assert response["meta"][0]["finish_reason"] == "stop"
+
+
+class TestOpenAIGeneratorAsync:
+    @pytest.mark.asyncio
+    async def test_run_async(self, openai_mock_async_chat_completion):
+        component = OpenAIGenerator(api_key=Secret.from_token("test-api-key"))
+        response = await component.run_async("What's Natural Language Processing?")
+
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert isinstance(response["replies"][0], str)
+        assert "meta" in response
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_streaming(self, openai_mock_async_chat_completion_chunk):
+        streaming_callback_called = False
+
+        async def streaming_callback(chunk: StreamingChunk) -> None:
+            nonlocal streaming_callback_called
+            streaming_callback_called = True
+
+        component = OpenAIGenerator(api_key=Secret.from_token("test-api-key"), streaming_callback=streaming_callback)
+        response = await component.run_async("Come on, stream!")
+
+        assert streaming_callback_called
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert "Hello" in response["replies"][0]
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_system_prompt(self, openai_mock_async_chat_completion):
+        component = OpenAIGenerator(
+            api_key=Secret.from_token("test-api-key"), system_prompt="You are a helpful assistant."
+        )
+        response = await component.run_async("What is Python?")
+
+        assert isinstance(response, dict)
+        assert "replies" in response
+
+        _, kwargs = openai_mock_async_chat_completion.call_args
+        messages = kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "You are a helpful assistant."
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_runtime_system_prompt(self, openai_mock_async_chat_completion):
+        component = OpenAIGenerator(api_key=Secret.from_token("test-api-key"))
+        response = await component.run_async("What is Python?", system_prompt="Be concise.")
+
+        assert isinstance(response, dict)
+        assert "replies" in response
+
+        _, kwargs = openai_mock_async_chat_completion.call_args
+        messages = kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "Be concise."
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_params(self, openai_mock_async_chat_completion):
+        component = OpenAIGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            generation_kwargs={"max_completion_tokens": 10, "temperature": 0.5},
+        )
+        response = await component.run_async("What's Natural Language Processing?")
+
+        _, kwargs = openai_mock_async_chat_completion.call_args
+        assert kwargs["max_completion_tokens"] == 10
+        assert kwargs["temperature"] == 0.5
+        assert isinstance(response, dict)
+        assert "replies" in response


### PR DESCRIPTION
## Summary

`OpenAIGenerator` — the string-in / string-out counterpart to `OpenAIChatGenerator` — previously had no `run_async()` method, making it the only widely-used OpenAI generator without async support. This PR adds `run_async()` following the exact same pattern already established for `OpenAIChatGenerator`, `HuggingFaceAPIChatGenerator`, `AzureOpenAIChatGenerator`, and others.

## Root Cause

`OpenAIGenerator.__init__` only created a synchronous `OpenAI` client (`self.client`). Without an `AsyncOpenAI` client, providing a `run_async()` implementation was not possible.

## Changes

| File | What changed |
|------|-------------|
| `haystack/components/generators/openai.py` | Import `AsyncOpenAI`, `AsyncStream`; create `self.async_client` in `__init__`; add `run_async()` |
| `test/components/generators/test_openai.py` | 5 new async unit tests covering: non-streaming, streaming, system prompt, runtime system prompt, and generation kwargs |
| `releasenotes/notes/add-run-async-OpenAIGenerator-*.yaml` | Release note |

## Testing

- [x] Existing `TestOpenAIGenerator` tests still pass
- [x] New `TestOpenAIGeneratorAsync.test_run_async` — non-streaming response returns correct structure
- [x] New `TestOpenAIGeneratorAsync.test_run_async_with_streaming` — streaming callback is invoked, response is correct
- [x] New `TestOpenAIGeneratorAsync.test_run_async_with_system_prompt` — system prompt is forwarded as the first message
- [x] New `TestOpenAIGeneratorAsync.test_run_async_with_runtime_system_prompt` — runtime system prompt overrides init-time prompt
- [x] New `TestOpenAIGeneratorAsync.test_run_async_with_params` — `generation_kwargs` are forwarded to the API call
- [x] `ruff check` and `ruff format --check` pass

## Impact

Users who have migrated to `AsyncPipeline` or are building async inference services can now use `OpenAIGenerator` without falling back to the chat generator or wrapping the sync method in a thread pool.