### PR TITLE
fix: guard unsubscripted Variadic type in InputSocket

### DIFF
--- a/haystack/core/component/types.py
+++ b/haystack/core/component/types.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from types import UnionType
 from typing import Annotated, Any, TypeAlias, TypedDict, TypeVar, get_args
 
+from haystack.core.errors import ComponentError
+
 HAYSTACK_VARIADIC_ANNOTATION = "__haystack__variadic_t"
 HAYSTACK_GREEDY_VARIADIC_ANNOTATION = "__haystack__greedy_variadic_t"
 
@@ -101,8 +103,6 @@ class InputSocket:
             inner_type = outer_args[0]
             inner_args = get_args(inner_type)
             if not inner_args:
-                from haystack.core.errors import ComponentError
-
                 raise ComponentError(
                     f"Variadic input '{self.name}' must have a type argument, e.g. Variadic[int]. "
                     f"Got bare {inner_type!r} without a type argument."

--- a/haystack/core/component/types.py
+++ b/haystack/core/component/types.py
@@ -97,7 +97,17 @@ class InputSocket:
         # alias for Iterable[int]. Since we're interested in getting the inner type `int`, we call `get_args`
         # twice: the first time to get `list[int]` out of `Variadic`, the second time to get `int` out of `list[int]`.
         if self.is_lazy_variadic or self.is_greedy:
-            self.type = get_args(get_args(self.type)[0])[0]
+            outer_args = get_args(self.type)
+            inner_type = outer_args[0]
+            inner_args = get_args(inner_type)
+            if not inner_args:
+                from haystack.core.errors import ComponentError
+
+                raise ComponentError(
+                    f"Variadic input '{self.name}' must have a type argument, e.g. Variadic[int]. "
+                    f"Got bare {inner_type!r} without a type argument."
+                )
+            self.type = inner_args[0]
 
 
 class InputSocketTypeDescriptor(TypedDict):

--- a/releasenotes/notes/fix-variadic-unsubscripted-indexerror-32788f5484bd3b5c.yaml
+++ b/releasenotes/notes/fix-variadic-unsubscripted-indexerror-32788f5484bd3b5c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix ``InputSocket.__post_init__`` crashing with ``IndexError`` when a Variadic input
+    uses a bare ``Iterable`` without a type argument (e.g. ``Annotated[Iterable, HAYSTACK_VARIADIC_ANNOTATION]``).
+    Now raises ``ComponentError`` with a clear message instead of an unhelpful ``IndexError``.

--- a/test/core/component/test_sockets.py
+++ b/test/core/component/test_sockets.py
@@ -85,3 +85,17 @@ class TestSockets:
         assert "input_1" in io
         assert "input_2" in io
         assert "invalid" not in io
+
+
+def test_input_socket_variadic_without_type_arg_raises_component_error():
+    """Bare Variadic (no type argument) should raise ComponentError, not IndexError."""
+    from collections.abc import Iterable
+    from typing import Annotated
+
+    from haystack.core.component.types import HAYSTACK_VARIADIC_ANNOTATION
+    from haystack.core.errors import ComponentError
+
+    bare_variadic = Annotated[Iterable, HAYSTACK_VARIADIC_ANNOTATION]
+
+    with pytest.raises(ComponentError, match="must have a type argument"):
+        InputSocket("inputs", bare_variadic)


### PR DESCRIPTION
## What's broken

Instantiating a component with a bare `Annotated[Iterable, HAYSTACK_VARIADIC_ANNOTATION]` annotation (no type argument) crashes with `IndexError: tuple index out of range` in `InputSocket.__post_init__`. The crash happens at component instantiation time, bypassing static type checking. For example:

```python
def run(self, inputs: Annotated[Iterable, HAYSTACK_VARIADIC_ANNOTATION]):
```

raises `IndexError` inside `get_args(get_args(self.type)[0])[0]` at line 100.

## Why it happens

`get_args(Iterable)` returns an empty tuple when the iterable has no type argument, so the unconditional `[0]` index fails.

## Fix

Replaced the bare double-index with a guarded version that checks whether `get_args()` results are non-empty. When the inner type is unsubscripted, raises `ComponentError` with a clear message: "Variadic input 'inputs' must have a type argument, e.g. Variadic[int]."

## Test

Added `test_input_socket_variadic_without_type_arg_raises_component_error` which creates a component with a bare `Annotated[Iterable, HAYSTACK_VARIADIC_ANNOTATION]` input and asserts that `ComponentError` is raised with the expected message.

Fixes #11453

---

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.
