### PR TITLE
test: let HF API embedders integrations tests fail to unblock CI

### DIFF
--- a/test/components/embedders/test_hugging_face_api_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_document_embedder.py
@@ -382,6 +382,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
     )
     @pytest.mark.flaky(reruns=3, reruns_delay=10)
     @pytest.mark.skipif(sys.platform != "linux", reason="We only test on Linux to avoid overloading the HF server")
+    @pytest.mark.xfail(reason="hf-inference is temporarily returning 500s")
     def test_live_run_serverless(self):
         docs = [
             Document(content="I love cheese", meta={"topic": "Cuisine"}),
@@ -415,6 +416,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
     )
     @pytest.mark.flaky(reruns=3, reruns_delay=10)
     @pytest.mark.skipif(sys.platform != "linux", reason="We only test on Linux to avoid overloading the HF server")
+    @pytest.mark.xfail(reason="hf-inference is temporarily returning 500s")
     async def test_live_run_serverless_async(self) -> None:
         docs = [
             Document(content="I love cheese", meta={"topic": "Cuisine"}),

--- a/test/components/embedders/test_hugging_face_api_text_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_text_embedder.py
@@ -223,6 +223,7 @@ class TestHuggingFaceAPITextEmbedder:
         reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
     )
     @pytest.mark.skipif(sys.platform != "linux", reason="We only test on Linux to avoid overloading the HF server")
+    @pytest.mark.xfail(reason="hf-inference is temporarily returning 500s")
     def test_live_run_serverless(self):
         embedder = HuggingFaceAPITextEmbedder(
             api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
@@ -240,6 +241,7 @@ class TestHuggingFaceAPITextEmbedder:
     @pytest.mark.flaky(reruns=3, reruns_delay=10)
     @pytest.mark.skipif(os.environ.get("HF_API_TOKEN", "") == "", reason="HF_API_TOKEN is not set")
     @pytest.mark.skipif(sys.platform != "linux", reason="We only test on Linux to avoid overloading the HF server")
+    @pytest.mark.xfail(reason="hf-inference is temporarily returning 500s")
     async def test_live_run_async_serverless(self):
         model_name = "sentence-transformers/all-MiniLM-L6-v2"
 


### PR DESCRIPTION
### Related Issues

- https://discuss.huggingface.co/t/help-please-hypererrorlegacy/176481/3?u=anakin87
- CI is blocked on several PRs: https://github.com/deepset-ai/haystack/actions/runs/26878379037/job/79273113621

### Proposed Changes:
- temporarily let these specific tests fail but make the test suite pass to unblock CI

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
