### PR TITLE
fix(HuggingFaceLocalGenerator): remove stop_words cross-product in reply post-processing

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -259,7 +259,10 @@ class HuggingFaceLocalGenerator:
         replies = [o["generated_text"] for o in output if "generated_text" in o]
 
         if self.stop_words:
-            # the output of the pipeline includes the stop word
-            replies = [reply.replace(stop_word, "").rstrip() for reply in replies for stop_word in self.stop_words]
+            # The output of the pipeline includes the stop word. Strip each stop word from each
+            # reply in sequence — the previous double-loop comprehension was a cross-product that
+            # produced N*M replies (half still containing a stop word) instead of N. See #11409.
+            for stop_word in self.stop_words:
+                replies = [reply.replace(stop_word, "").rstrip() for reply in replies]
 
         return {"replies": replies}

--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -420,6 +420,34 @@ class TestHuggingFaceLocalGenerator:
         results = generator.run(prompt="irrelevant")
         assert results == {"replies": ["Hello"]}
 
+    def test_run_stop_words_removal_with_multiple_stop_words(self):
+        """Regression for #11409: with N replies and M stop words, the cross-product comprehension
+        produced N*M replies (half still containing a stop word). The result must stay at N replies,
+        each with every stop word removed."""
+        generator = HuggingFaceLocalGenerator(
+            model="Qwen/Qwen3-0.6B", task="text-generation", stop_words=["STOP", "END"]
+        )
+        generator.pipeline = Mock(
+            return_value=[
+                {"generated_text": "Paris is the capital. STOP"},
+                {"generated_text": "France is in Europe. END"},
+            ]
+        )
+        generator.stopping_criteria_list = Mock()
+        results = generator.run(prompt="irrelevant")
+        assert results == {"replies": ["Paris is the capital.", "France is in Europe."]}
+
+    def test_run_stop_words_removal_all_stop_words_removed_from_each_reply(self):
+        """Every stop word is removed from every reply, not just the first matching one."""
+        generator = HuggingFaceLocalGenerator(
+            model="Qwen/Qwen3-0.6B", task="text-generation", stop_words=["STOP", "END"]
+        )
+        # Reply contains BOTH stop words
+        generator.pipeline = Mock(return_value=[{"generated_text": "Hello STOP world END"}])
+        generator.stopping_criteria_list = Mock()
+        results = generator.run(prompt="irrelevant")
+        assert results == {"replies": ["Hello  world"]}
+
     @pytest.mark.integration
     def test_stop_words_criteria_using_hf_tokenizer(self):
         """


### PR DESCRIPTION
Refs #11409.

`HuggingFaceLocalGenerator.run` post-processes replies with a nested list comprehension:

```python
replies = [reply.replace(stop_word, '').rstrip()
           for reply in replies
           for stop_word in self.stop_words]
```

That's a cross-product. With N replies and M stop words it emits N*M replies, and only every M-th one has every stop word removed. Half the output silently still contains a stop word.

The chat sibling at `chat/hugging_face_local.py:660` already does this correctly with a sequential loop, so this PR aligns the non-chat path with the same pattern.

## RED

Two new regression tests on `main`:

```
FAILED test_run_stop_words_removal_with_multiple_stop_words
  assert {'replies': [...4 entries...]} == {'replies': ['Paris is the capital.', 'France is in Europe.']}

FAILED test_run_stop_words_removal_all_stop_words_removed_from_each_reply
  assert {'replies': ['Hello STOP world']} == {'replies': ['Hello  world']}
```

The original `test_run_stop_words_removal` (single stop word) keeps passing.

## GREEN

```
test_run_stop_words_removal                                              PASSED
test_run_stop_words_removal_with_multiple_stop_words                     PASSED
test_run_stop_words_removal_all_stop_words_removed_from_each_reply       PASSED
```

Full file: `28 passed, 1 deselected (integration, model download), 6 warnings in 140.60s`. No regression elsewhere.