### PR TITLE
feat!: secure-by-default symlink handling for ByteStream and converters

### DIFF
--- a/haystack/components/converters/utils.py
+++ b/haystack/components/converters/utils.py
@@ -8,7 +8,9 @@ from typing import Any
 from haystack.dataclasses import ByteStream
 
 
-def get_bytestream_from_source(source: str | Path | ByteStream, guess_mime_type: bool = False) -> ByteStream:
+def get_bytestream_from_source(
+    source: str | Path | ByteStream, guess_mime_type: bool = False, follow_symlinks: bool = False
+) -> ByteStream:
     """
     Creates a ByteStream object from a source.
 
@@ -16,6 +18,8 @@ def get_bytestream_from_source(source: str | Path | ByteStream, guess_mime_type:
         A source to convert to a ByteStream. Can be a string (path to a file), a Path object, or a ByteStream.
     :param guess_mime_type:
         Whether to guess the mime type from the file.
+    :param follow_symlinks:
+        Whether to follow symbolic links. If False, an error is raised if the source path is a symlink.
     :return:
         A ByteStream object.
     """
@@ -23,7 +27,7 @@ def get_bytestream_from_source(source: str | Path | ByteStream, guess_mime_type:
     if isinstance(source, ByteStream):
         return source
     if isinstance(source, (str, Path)):
-        bs = ByteStream.from_file_path(Path(source), guess_mime_type=guess_mime_type)
+        bs = ByteStream.from_file_path(Path(source), guess_mime_type=guess_mime_type, follow_symlinks=follow_symlinks)
         bs.meta["file_path"] = str(source)
         return bs
     raise ValueError(f"Unsupported source type {type(source)}")

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -41,6 +41,7 @@ class ByteStream:
         mime_type: str | None = None,
         meta: dict[str, Any] | None = None,
         guess_mime_type: bool = False,
+        follow_symlinks: bool = False,
     ) -> "ByteStream":
         """
         Create a ByteStream from the contents read from a file.
@@ -49,7 +50,14 @@ class ByteStream:
         :param mime_type: The mime type of the file.
         :param meta: Additional metadata to be stored with the ByteStream.
         :param guess_mime_type: Whether to guess the mime type from the file.
+        :param follow_symlinks: Whether to follow symbolic links. If False, an error is raised if the path is a symlink.
         """
+        if not follow_symlinks and filepath.is_symlink():
+            raise ValueError(
+                f"The file path {filepath} is a symbolic link. Following symbolic links is disabled by default for security reasons. "
+                "Set follow_symlinks=True to follow it."
+            )
+
         if not mime_type and guess_mime_type:
             mime_type = _guess_mime_type(filepath)
         with open(filepath, "rb") as fd:

--- a/test/components/converters/test_utils.py
+++ b/test/components/converters/test_utils.py
@@ -61,6 +61,34 @@ def test_get_bytestream_from_string_path(tmp_path):
     assert bs.meta["file_path"].endswith("test.txt")
 
 
+def test_get_bytestream_from_source_symlink_disabled(tmp_path):
+    import os
+    bytes_ = b"hello world"
+    target = tmp_path / "target.txt"
+    target.write_bytes(bytes_)
+
+    symlink_path = tmp_path / "symlink.txt"
+    os.symlink(target, symlink_path)
+
+    with pytest.raises(ValueError, match="is a symbolic link"):
+        get_bytestream_from_source(symlink_path)
+
+
+def test_get_bytestream_from_source_symlink_enabled(tmp_path):
+    import os
+    bytes_ = b"hello world"
+    target = tmp_path / "target.txt"
+    target.write_bytes(bytes_)
+
+    symlink_path = tmp_path / "symlink.txt"
+    os.symlink(target, symlink_path)
+
+    bs = get_bytestream_from_source(symlink_path, follow_symlinks=True)
+    assert isinstance(bs, ByteStream)
+    assert bs.data == bytes_
+
+
+
 def test_get_bytestream_from_source_invalid_type():
     with pytest.raises(ValueError, match="Unsupported source type"):
         get_bytestream_from_source(123)

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -28,6 +28,35 @@ def test_from_file_path(tmp_path, request):
     assert b.meta == {"foo": "bar"}
 
 
+def test_from_file_path_symlink_disabled(tmp_path):
+    import os
+    test_bytes = b"Sensitive content"
+    target_path = tmp_path / "target.txt"
+    with open(target_path, "wb") as fd:
+        fd.write(test_bytes)
+
+    symlink_path = tmp_path / "symlink.txt"
+    os.symlink(target_path, symlink_path)
+
+    with pytest.raises(ValueError, match="is a symbolic link"):
+        ByteStream.from_file_path(symlink_path)
+
+
+def test_from_file_path_symlink_enabled(tmp_path):
+    import os
+    test_bytes = b"Sensitive content"
+    target_path = tmp_path / "target.txt"
+    with open(target_path, "wb") as fd:
+        fd.write(test_bytes)
+
+    symlink_path = tmp_path / "symlink.txt"
+    os.symlink(target_path, symlink_path)
+
+    b = ByteStream.from_file_path(symlink_path, follow_symlinks=True)
+    assert b.data == test_bytes
+
+
+
 @pytest.mark.parametrize(
     "file_path, expected_mime_types",
     [


### PR DESCRIPTION
### Related Issues

- fixes #11252 

### Proposed Changes:

<!--- In case of a bug: Describe what caused the issue and how you solved it -->
<!--- In case of a feature: Describe what did you add and how it works -->
Currently, `ByteStream.from_file_path` and the `get_bytestream_from_source` utility follow symbolic links by default when reading files from disk. This "blind follow" behavior could lead to accidental Local File Inclusion (LFI) or Information Disclosure if a developer passes a user-supplied path that happens to be a symlink to a sensitive system file.

This PR implements a "Secure by Default" approach:
- Added a `follow_symlinks: bool = False` parameter to `ByteStream.from_file_path`.
- If `follow_symlinks` is False (the new default), the method checks `filepath.is_symlink()` and raises a `ValueError` if a link is detected.
- Propagated this setting to the `get_bytestream_from_source` utility so that components reading file paths (like routers or converters) inherit this secure behavior.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Added unit tests in `test/dataclasses/test_byte_stream.py` to verify that `ValueError` is raised when trying to read a symlink with default parameters, and that it successfully reads it when `follow_symlinks=True` is explicitly passed.
- Added corresponding unit tests in `test/components/converters/test_utils.py` for `get_bytestream_from_source`.
- Verified changes locally using `hatch run test:unit` and `hatch run test:types`.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
- The change uses `.is_symlink()` rather than aggressively resolving all parent paths to avoid breaking legitimate environments (like macOS `/tmp` directories which are often symlinked to `/private/tmp`).
- This change is isolated to the core dataclasses and utilities to keep the scope focused and avoid breaking the API of all individual converter components at once.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.