### PR TITLE
docs: add governed OpenAI-compatible endpoint example

### DIFF
--- a/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
@@ -39,6 +39,21 @@ You can pass any chat completion parameters valid for the `openai.ChatCompletion
 
 `OpenAIChatGenerator` can support custom deployments of your OpenAI models through the `api_base_url` init parameter.
 
+You can also use `api_base_url` with a governed OpenAI-compatible endpoint when you want Haystack to keep owning pipeline orchestration, retrieval, and component composition while a centralized control plane handles model access, policy, audit trails, quotas, routing, and cost reporting. For example, [Tuning Engines](https://www.tuningengines.com/) exposes an OpenAI-compatible inference endpoint:
+
+```python
+import os
+
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.utils import Secret
+
+llm = OpenAIChatGenerator(
+    model=os.environ.get("TUNING_ENGINES_MODEL", "your-model-alias"),
+    api_base_url="https://api.tuningengines.com/v1",
+    api_key=Secret.from_env_var("TUNING_ENGINES_API_KEY"),
+)
+```
+
 ### Structured Output
 
 `OpenAIChatGenerator` supports structured output generation, allowing you to receive responses in a predictable format. You can use Pydantic models or JSON schemas to define the structure of the output through the `response_format` parameter in `generation_kwargs`.


### PR DESCRIPTION
This adds a small example showing how to use OpenAIChatGenerator with a governed OpenAI-compatible endpoint via the existing api_base_url parameter.\n\nWhy this may be useful:\n- Haystack already supports custom OpenAI-compatible deployments through api_base_url.\n- Production pipelines often need centralized model access, policy enforcement, audit trails, quotas, routing, and cost reporting across applications.\n- The example keeps Haystack responsible for pipeline orchestration, retrieval, and component composition while a gateway/control plane handles organization-wide controls.\n\nThe change is docs-only and uses placeholder environment variables.