### PR TITLE
fix(device): Device.from_str crashes on a multi-colon device string

### DIFF
--- a/haystack/utils/device.py
+++ b/haystack/utils/device.py
@@ -533,7 +533,7 @@ def _split_device_string(string: str) -> tuple[str, int | None]:
         The device type and device id, if any.
     """
     if ":" in string:
-        device_type, device_id_str = string.split(":")
+        device_type, device_id_str = string.split(":", maxsplit=1)
         try:
             device_id = int(device_id_str)
         except ValueError as e:

--- a/test/utils/test_device.py
+++ b/test/utils/test_device.py
@@ -34,6 +34,9 @@ def test_device_creation():
     with pytest.raises(ValueError, match="Device id must be >= 0"):
         Device.gpu(-1)
 
+    with pytest.raises(ValueError, match="Device id must be an integer, got 0:1"):
+        Device.from_str("cuda:0:1")
+
 
 def test_device_map():
     device_map = DeviceMap({"layer1": Device.cpu(), "layer2": Device.gpu(1), "layer3": Device.disk()})


### PR DESCRIPTION
## What's broken

`_split_device_string` unpacks `string.split(":")` into exactly two variables with no `maxsplit`. A device string with a second colon raises an uncaught error through the public `Device.from_str`:

```python
>>> from haystack.utils.device import Device
>>> Device.from_str("cuda:0:1")
ValueError: too many values to unpack (expected 2)
```

## Why it happens

`str.split(":")` without `maxsplit=1` returns more than two parts when the string has more than one colon.

## Fix

Use `split(":", maxsplit=1)`. `"cuda:0:1"` then splits to `("cuda", "0:1")`; `int("0:1")` fails and raises the function's existing, descriptive `ValueError("Device id must be an integer, got 0:1")` instead of the opaque unpack error.

## Test

Added a case asserting `Device.from_str("cuda:0:1")` raises `ValueError` about the device id; `"cuda:0"` and `"cpu"` still parse correctly.

Fixes #11518