### PR TITLE
feat: Add more `run_async` methods to components that internally use `ChatGenerator` or an async compatible client

### DIFF
--- a/haystack/components/audio/whisper_remote.py
+++ b/haystack/components/audio/whisper_remote.py
@@ -6,7 +6,7 @@ import io
 from pathlib import Path
 from typing import Any
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import ByteStream
@@ -104,6 +104,12 @@ class RemoteWhisperTranscriber:
             base_url=api_base_url,
             http_client=init_http_client(self.http_client_kwargs, async_client=False),
         )
+        self.async_client = AsyncOpenAI(
+            api_key=api_key.resolve_value(),
+            organization=organization,
+            base_url=api_base_url,
+            http_client=init_http_client(self.http_client_kwargs, async_client=True),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -158,6 +164,40 @@ class RemoteWhisperTranscriber:
             file.name = str(source.meta["file_path"]) if "file_path" in source.meta else "__fallback__.wav"
 
             content = self.client.audio.transcriptions.create(file=file, model=self.model, **self.whisper_params)
+            doc = Document(content=content.text, meta=source.meta)
+            documents.append(doc)
+
+        return {"documents": documents}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(self, sources: list[str | Path | ByteStream]) -> dict[str, Any]:
+        """
+        Asynchronously transcribes the list of audio files into a list of documents.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code.
+
+        :param sources:
+            A list of file paths or `ByteStream` objects containing the audio files to transcribe.
+
+        :returns: A dictionary with the following keys:
+            - `documents`: A list of documents, one document for each file.
+                The content of each document is the transcribed text.
+        """
+        documents = []
+
+        for source in sources:
+            if not isinstance(source, ByteStream):
+                path = source
+                source = ByteStream.from_file_path(Path(source))
+                source.meta["file_path"] = path
+
+            file = io.BytesIO(source.data)
+            file.name = str(source.meta["file_path"]) if "file_path" in source.meta else "__fallback__.wav"
+
+            content = await self.async_client.audio.transcriptions.create(
+                file=file, model=self.model, **self.whisper_params
+            )
             doc = Document(content=content.text, meta=source.meta)
             documents.append(doc)
 

--- a/haystack/components/extractors/image/llm_document_content_extractor.py
+++ b/haystack/components/extractors/image/llm_document_content_extractor.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
@@ -17,6 +18,7 @@ from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ImageContent, TextContent
 from haystack.dataclasses.chat_message import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -271,6 +273,34 @@ class LLMDocumentContentExtractor:
 
         return result
 
+    async def _run_async(self, image_content: ImageContent | None) -> dict[str, Any]:
+        """
+        Execute the LLM inference asynchronously for each document.
+
+        :param image_content: The image content for one document, or None if conversion failed.
+        :returns:
+            The LLM response if successful, or a dictionary with an "error" key on failure.
+        """
+        if image_content is None:
+            return {"error": "Document has no content, skipping LLM call."}
+
+        # the prompt is the same for all documents, so we can set it up once here for each document
+        message = ChatMessage.from_user(content_parts=[TextContent(text=self.prompt), image_content])
+
+        try:
+            result = await _run_component_async(self._chat_generator, messages=[message])
+        except Exception as e:
+            if self.raise_on_failure:
+                raise e
+            logger.exception(
+                "LLM {class_name} execution failed. Skipping metadata extraction. Failed with exception '{error}'.",
+                class_name=self._chat_generator.__class__.__name__,
+                error=e,
+            )
+            result = {"error": "LLM failed with exception: " + str(e)}
+
+        return result
+
     @staticmethod
     def _process_llm_results(document: Document, result: dict[str, Any]) -> tuple[Document, bool]:
         """
@@ -317,6 +347,46 @@ class LLMDocumentContentExtractor:
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             results = executor.map(self._run_on_thread, image_contents)
+
+        successful_documents = []
+        failed_documents = []
+        for document, result in zip(documents, results, strict=True):
+            doc, success = self._process_llm_results(document, result)
+            if success:
+                successful_documents.append(doc)
+            else:
+                failed_documents.append(doc)
+
+        return {"documents": successful_documents, "failed_documents": failed_documents}
+
+    @component.output_types(documents=list[Document], failed_documents=list[Document])
+    async def run_async(self, documents: list[Document]) -> dict[str, list[Document]]:
+        """
+        Asynchronously run extraction on image-based documents. One LLM call per document.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code.
+
+        :param documents: A list of image-based documents to process. Each must have a valid file path in its metadata.
+        :returns:
+            A dictionary with "documents" (successfully processed) and "failed_documents" (with failure metadata).
+        """
+        if not documents:
+            return {"documents": [], "failed_documents": []}
+
+        if not self._is_warmed_up:
+            self.warm_up()
+
+        image_contents = self._document_to_image_content.run(documents=documents)["image_contents"]
+
+        # Run the LLM on each image content, bounding concurrency per task so max_workers is enforced.
+        sem = asyncio.Semaphore(max(1, self.max_workers))
+
+        async def _bounded_run(image_content: ImageContent | None) -> dict[str, Any]:
+            async with sem:
+                return await self._run_async(image_content)
+
+        results = await asyncio.gather(*[_bounded_run(image_content) for image_content in image_contents])
 
         successful_documents = []
         failed_documents = []

--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -20,6 +20,7 @@ from haystack.components.preprocessors import DocumentSplitter
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace, expand_page_range
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -306,7 +307,7 @@ class LLMMetadataExtractor:
             return {"error": "Document has no content, skipping LLM call."}
 
         try:
-            result = await self._chat_generator.run_async(messages=[prompt])  # type: ignore[attr-defined]
+            result = await _run_component_async(self._chat_generator, messages=[prompt])
         except Exception as e:
             if self.raise_on_failure:
                 raise e
@@ -421,13 +422,6 @@ class LLMMetadataExtractor:
             "metadata_extraction_error" and "metadata_extraction_response" in their metadata. These documents can be
             re-run with the extractor to extract metadata.
         """
-        if not hasattr(self._chat_generator, "run_async"):
-            logger.warning(
-                "{chat_generator_type} does not implement method 'run_async'. Falling back to 'run'.",
-                chat_generator_type=type(self._chat_generator).__name__,
-            )
-            return self.run(documents, page_range)
-
         if len(documents) == 0:
             logger.warning("No documents provided. Skipping metadata extraction.")
             return {"documents": [], "failed_documents": []}

--- a/haystack/components/generators/chat/fallback.py
+++ b/haystack/components/generators/chat/fallback.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict, logging
@@ -12,6 +11,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.components.generators.utils import _normalize_messages
 from haystack.dataclasses import ChatMessage, StreamingCallbackT
 from haystack.tools import ToolsType
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.deserialization import deserialize_component_inplace
 
 logger = logging.getLogger(__name__)
@@ -118,15 +118,8 @@ class FallbackChatGenerator:
         tools: ToolsType | None,
         streaming_callback: StreamingCallbackT | None,
     ) -> dict[str, Any]:
-        if hasattr(gen, "run_async") and callable(gen.run_async):
-            return await gen.run_async(
-                messages=messages,
-                generation_kwargs=generation_kwargs,
-                tools=tools,
-                streaming_callback=streaming_callback,
-            )
-        return await asyncio.to_thread(
-            gen.run,
+        return await _run_component_async(
+            gen,
             messages=messages,
             generation_kwargs=generation_kwargs,
             tools=tools,

--- a/haystack/components/generators/openai_image_generator.py
+++ b/haystack/components/generators/openai_image_generator.py
@@ -5,7 +5,7 @@
 import os
 from typing import Any, Literal
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 from openai.types.image import Image
 
 from haystack import component, default_from_dict, default_to_dict, logging
@@ -85,6 +85,7 @@ class OpenAIImageGenerator:
         self.http_client_kwargs = http_client_kwargs
 
         self.client: OpenAI | None = None
+        self.async_client: AsyncOpenAI | None = None
 
     def warm_up(self) -> None:
         """
@@ -98,6 +99,15 @@ class OpenAIImageGenerator:
                 timeout=self.timeout,
                 max_retries=self.max_retries,
                 http_client=init_http_client(self.http_client_kwargs, async_client=False),
+            )
+        if self.async_client is None:
+            self.async_client = AsyncOpenAI(
+                api_key=self.api_key.resolve_value(),
+                organization=self.organization,
+                base_url=self.api_base_url,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                http_client=init_http_client(self.http_client_kwargs, async_client=True),
             )
 
     @component.output_types(images=list[str], revised_prompt=str)
@@ -130,6 +140,50 @@ class OpenAIImageGenerator:
         size = size or self.size
         quality = quality or self.quality
         response = self.client.images.generate(model=self.model, prompt=prompt, size=size, quality=quality, n=1)
+        image_str = ""
+        revised_prompt = ""
+        if response.data is not None:
+            image: Image = response.data[0]
+            image_str = image.b64_json or ""
+            revised_prompt = image.revised_prompt or ""
+
+        return {"images": [image_str], "revised_prompt": revised_prompt}
+
+    @component.output_types(images=list[str], revised_prompt=str)
+    async def run_async(
+        self,
+        prompt: str,
+        size: Literal["1024x1024", "1024x1536", "1536x1024", "auto"] | None = None,
+        quality: Literal["auto", "high", "medium", "low"] | None = None,
+        response_format: Literal["b64_json"] | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        """
+        Asynchronously invokes the image generation inference based on the provided prompt and generation parameters.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code.
+
+        :param prompt: The prompt to generate the image.
+        :param size: If provided, overrides the size provided during initialization.
+        :param quality: If provided, overrides the quality provided during initialization.
+        :param response_format: This parameter is ignored and only kept for backward compatibility.
+
+        :returns:
+            A dictionary containing the generated list of images as base64 encoded JSON strings and the revised prompt.
+            The revised prompt is the prompt that was used to generate the image, if there was any revision
+            to the prompt made by OpenAI.
+        """
+        if self.async_client is None:
+            self.warm_up()
+
+        # at this point the client is initialized, but mypy doesn't know that
+        assert self.async_client is not None
+
+        size = size or self.size
+        quality = quality or self.quality
+        response = await self.async_client.images.generate(
+            model=self.model, prompt=prompt, size=size, quality=quality, n=1
+        )
         image_str = ""
         revised_prompt = ""
         if response.data is not None:

--- a/haystack/components/preprocessors/embedding_based_document_splitter.py
+++ b/haystack/components/preprocessors/embedding_based_document_splitter.py
@@ -14,6 +14,7 @@ from haystack import Document, component, logging
 from haystack.components.embedders.types import DocumentEmbedder
 from haystack.components.preprocessors.sentence_tokenizer import Language, SentenceSplitter
 from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.deserialization import deserialize_component_inplace
 
 logger = logging.getLogger(__name__)
@@ -194,13 +195,6 @@ class EmbeddingBasedDocumentSplitter:
         if not self._is_warmed_up:
             self.warm_up()
 
-        if not hasattr(self.document_embedder, "run_async"):
-            logger.warning(
-                "{embedder_type} does not implement method 'run_async'. Falling back to 'run'.",
-                embedder_type=type(self.document_embedder).__name__,
-            )
-            return self.run(documents)
-
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             raise TypeError("EmbeddingBasedDocumentSplitter expects a List of Documents as input.")
 
@@ -320,7 +314,7 @@ class EmbeddingBasedDocumentSplitter:
         """
         # Create Document objects for each group
         group_docs = [Document(content=group) for group in sentence_groups]
-        result = await self.document_embedder.run_async(group_docs)  # type: ignore[attr-defined]
+        result = await _run_component_async(self.document_embedder, documents=group_docs)
         embedded_docs = result["documents"]
         return [doc.embedding for doc in embedded_docs]
 

--- a/haystack/components/query/query_expander.py
+++ b/haystack/components/query/query_expander.py
@@ -12,6 +12,7 @@ from haystack.core.component import component
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses.chat_message import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -211,6 +212,74 @@ class QueryExpander:
         try:
             prompt_result = self._prompt_builder.run(query=query.strip(), n_expansions=expansion_count)
             generator_result = self.chat_generator.run(messages=[ChatMessage.from_user(prompt_result["prompt"])])
+
+            if not generator_result.get("replies") or len(generator_result["replies"]) == 0:
+                logger.warning("ChatGenerator returned no replies for query: {query}", query=query)
+                return response
+
+            expanded_text = generator_result["replies"][0].text.strip()
+            expanded_queries = self._parse_expanded_queries(expanded_text)
+
+            # Limit the number of expanded queries to the requested amount
+            if len(expanded_queries) > expansion_count:
+                logger.warning(
+                    "Generated {generated_count} queries but only {requested_count} were requested. "
+                    "Truncating to the first {requested_count} queries. ",
+                    generated_count=len(expanded_queries),
+                    requested_count=expansion_count,
+                )
+                expanded_queries = expanded_queries[:expansion_count]
+
+            # Add original query if requested and remove duplicates
+            if self.include_original_query:
+                expanded_queries_lower = [q.lower() for q in expanded_queries]
+                if query.lower() not in expanded_queries_lower:
+                    expanded_queries.append(query)
+
+            response["queries"] = expanded_queries
+            return response
+
+        except Exception as e:
+            # Fallback: return original query to maintain pipeline functionality
+            logger.exception("Failed to expand query {query}: {error}", query=query, error=str(e))
+            return response
+
+    @component.output_types(queries=list[str])
+    async def run_async(self, query: str, n_expansions: int | None = None) -> dict[str, list[str]]:
+        """
+        Asynchronously expand the input query into multiple semantically similar queries.
+
+        The language of the original query is preserved in the expanded queries.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code.
+
+        :param query: The original query to expand.
+        :param n_expansions: Number of additional queries to generate (not including the original).
+            If None, uses the value from initialization. Can be 0 to generate no additional queries.
+        :return: Dictionary with "queries" key containing the list of expanded queries.
+            If include_original_query=True, the original query will be included in addition
+            to the n_expansions alternative queries.
+        :raises ValueError: If n_expansions is not positive (less than or equal to 0).
+        """
+
+        if not self._is_warmed_up:
+            self.warm_up()
+
+        response = {"queries": [query] if self.include_original_query else []}
+
+        if not query.strip():
+            logger.warning("Empty query provided to QueryExpander")
+            return response
+
+        expansion_count = n_expansions if n_expansions is not None else self.n_expansions
+        if expansion_count <= 0:
+            raise ValueError("n_expansions must be positive")
+
+        try:
+            prompt_result = self._prompt_builder.run(query=query.strip(), n_expansions=expansion_count)
+            messages = [ChatMessage.from_user(prompt_result["prompt"])]
+            generator_result = await _run_component_async(self.chat_generator, messages=messages)
 
             if not generator_result.get("replies") or len(generator_result["replies"]) == 0:
                 logger.warning("ChatGenerator returned no replies for query: {query}", query=query)

--- a/haystack/components/rankers/llm_ranker.py
+++ b/haystack/components/rankers/llm_ranker.py
@@ -11,6 +11,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _deduplicate_documents, _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -248,6 +249,71 @@ class LLMRanker:
 
         try:
             result = self._chat_generator.run(messages=[ChatMessage.from_user(prompt["prompt"])])
+        except Exception as exc:
+            if self.raise_on_failure:
+                raise
+            logger.warning(
+                "LLMRanker failed during chat generation. Returning fallback order. Error: {error}", error=exc
+            )
+            return {"documents": fallback_documents}
+
+        try:
+            reply_text = self._get_reply_text(result)
+            ranked_documents = self._rank_documents_from_reply(reply_text=reply_text, documents=deduplicated_documents)
+        except (TypeError, ValueError) as exc:
+            if self.raise_on_failure:
+                raise
+            logger.warning(
+                "LLMRanker failed while processing the chat response. Returning fallback order. Error: {error}",
+                error=exc,
+            )
+            return {"documents": fallback_documents}
+
+        return {"documents": ranked_documents[:top_k]}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self, query: str, documents: list[Document], top_k: int | None = None
+    ) -> dict[str, list[Document]]:
+        """
+        Asynchronously rank documents for a query using an LLM.
+
+        Before ranking, duplicate documents are removed.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code.
+
+        :param query:
+            The query used for reranking.
+        :param documents:
+            Candidate documents to rerank.
+        :param top_k:
+            The maximum number of documents to return. Overrides the instance's `top_k` if provided.
+        :returns:
+            A dictionary with the ranked documents under the `documents` key.
+        """
+        if top_k is not None and top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {top_k}")
+
+        if not documents:
+            return {"documents": []}
+
+        top_k = self.top_k if top_k is None else top_k
+        deduplicated_documents = _deduplicate_documents(documents)
+        fallback_documents = deduplicated_documents
+
+        if not query.strip():
+            logger.warning("Empty query provided to LLMRanker. Returning documents without reranking.")
+            return {"documents": fallback_documents}
+
+        if not self._is_warmed_up:
+            self.warm_up()
+
+        prompt = self._prompt_builder.run(query=query.strip(), documents=deduplicated_documents)
+
+        messages = [ChatMessage.from_user(prompt["prompt"])]
+        try:
+            result = await _run_component_async(self._chat_generator, messages=messages)
         except Exception as exc:
             if self.raise_on_failure:
                 raise

--- a/haystack/components/retrievers/multi_query_embedding_retriever.py
+++ b/haystack/components/retrievers/multi_query_embedding_retriever.py
@@ -10,6 +10,7 @@ from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.components.embedders.types.protocol import TextEmbedder
 from haystack.components.retrievers.types import EmbeddingRetriever
 from haystack.core.serialization import component_to_dict
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _deduplicate_documents
 
 
@@ -178,21 +179,11 @@ class MultiQueryEmbeddingRetriever:
         :returns:
             List of retrieved documents or None if no results.
         """
-        loop = asyncio.get_running_loop()
-
-        if hasattr(self.query_embedder, "run_async") and callable(self.query_embedder.run_async):
-            embedding_result = await self.query_embedder.run_async(text=query)
-        else:
-            embedding_result = await loop.run_in_executor(None, lambda: self.query_embedder.run(text=query))
+        embedding_result = await _run_component_async(self.query_embedder, text=query)
 
         query_embedding = embedding_result["embedding"]
 
-        if hasattr(self.retriever, "run_async") and callable(self.retriever.run_async):
-            result = await self.retriever.run_async(query_embedding=query_embedding, **retriever_kwargs)
-        else:
-            result = await loop.run_in_executor(
-                None, lambda: self.retriever.run(query_embedding=query_embedding, **retriever_kwargs)
-            )
+        result = await _run_component_async(self.retriever, query_embedding=query_embedding, **retriever_kwargs)
 
         if result and "documents" in result:
             return result["documents"]

--- a/haystack/components/retrievers/multi_query_text_retriever.py
+++ b/haystack/components/retrievers/multi_query_text_retriever.py
@@ -9,6 +9,7 @@ from typing import Any
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.components.retrievers.types import TextRetriever
 from haystack.core.serialization import component_to_dict
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _deduplicate_documents
 
 
@@ -156,12 +157,7 @@ class MultiQueryTextRetriever:
         :returns:
             List of retrieved documents or None if no results.
         """
-        loop = asyncio.get_running_loop()
-
-        if hasattr(self.retriever, "run_async") and callable(self.retriever.run_async):
-            result = await self.retriever.run_async(query=query, **retriever_kwargs)
-        else:
-            result = await loop.run_in_executor(None, lambda: self.retriever.run(query=query, **retriever_kwargs))
+        result = await _run_component_async(self.retriever, query=query, **retriever_kwargs)
 
         if result and "documents" in result:
             return result["documents"]

--- a/haystack/components/retrievers/multi_retriever.py
+++ b/haystack/components/retrievers/multi_retriever.py
@@ -11,6 +11,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.components.retrievers.types.protocol import TextRetriever
 from haystack.core.serialization import component_from_dict, component_to_dict, import_class_by_name
 from haystack.dataclasses import Document
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.experimental import _experimental
 from haystack.utils.misc import _deduplicate_documents, _reciprocal_rank_fusion
 
@@ -244,16 +245,11 @@ class MultiRetriever:
 
         retrievers_to_run = self._resolve_retrievers(active_retrievers)
 
-        loop = asyncio.get_running_loop()
-
         async def _run_one(name: str, retriever: TextRetriever) -> list[Document]:
             try:
-                if hasattr(retriever, "run_async") and callable(retriever.run_async):
-                    result = await retriever.run_async(query=query, filters=resolved_filters, top_k=resolved_top_k)
-                else:
-                    result = await loop.run_in_executor(
-                        None, lambda: retriever.run(query=query, filters=resolved_filters, top_k=resolved_top_k)
-                    )
+                result = await _run_component_async(
+                    retriever, query=query, filters=resolved_filters, top_k=resolved_top_k
+                )
                 return result.get("documents", [])
             except Exception as e:
                 raise RuntimeError(f"Retriever '{name}' failed: {e}") from e

--- a/haystack/components/retrievers/text_embedding_retriever.py
+++ b/haystack/components/retrievers/text_embedding_retriever.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.components.embedders.types.protocol import TextEmbedder
 from haystack.components.retrievers.types import EmbeddingRetriever
 from haystack.core.serialization import component_to_dict
+from haystack.utils.async_utils import _run_component_async
 
 
 @component
@@ -125,22 +125,10 @@ class TextEmbeddingRetriever:
         if not self._is_warmed_up:
             self.warm_up()
 
-        loop = asyncio.get_running_loop()
-
-        if hasattr(self.text_embedder, "run_async") and callable(self.text_embedder.run_async):
-            embedding_result = await self.text_embedder.run_async(text=query)
-        else:
-            embedding_result = await loop.run_in_executor(None, lambda: self.text_embedder.run(text=query))
-
-        if hasattr(self.retriever, "run_async") and callable(self.retriever.run_async):
-            result = await self.retriever.run_async(
-                query_embedding=embedding_result["embedding"], filters=filters, top_k=top_k
-            )
-        else:
-            result = await loop.run_in_executor(
-                None,
-                lambda: self.retriever.run(query_embedding=embedding_result["embedding"], filters=filters, top_k=top_k),
-            )
+        embedding_result = await _run_component_async(self.text_embedder, text=query)
+        result = await _run_component_async(
+            self.retriever, query_embedding=embedding_result["embedding"], filters=filters, top_k=top_k
+        )
 
         docs: list[Document] = result["documents"]
         docs.sort(key=lambda x: x.score or 0.0, reverse=True)

--- a/haystack/components/routers/llm_messages_router.py
+++ b/haystack/components/routers/llm_messages_router.py
@@ -10,6 +10,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage, ChatRole
 from haystack.utils import deserialize_chatgenerator_inplace
+from haystack.utils.async_utils import _run_component_async
 
 
 @component
@@ -129,6 +130,53 @@ class LLMMessagesRouter:
         messages_for_inference.extend(messages)
 
         chat_generator_text = self._chat_generator.run(messages=messages_for_inference)["replies"][0].text
+
+        output = {"chat_generator_text": chat_generator_text}
+
+        for output_name, pattern in zip(self._output_names, self._compiled_patterns, strict=True):
+            if pattern.search(chat_generator_text):
+                output[output_name] = messages
+                break
+        else:
+            output["unmatched"] = messages
+
+        return output
+
+    async def run_async(self, messages: list[ChatMessage]) -> dict[str, str | list[ChatMessage]]:
+        """
+        Asynchronously classify the messages based on LLM output and route them to the appropriate output connection.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code.
+
+        :param messages: A list of ChatMessages to be routed. Only user and assistant messages are supported.
+
+        :returns: A dictionary with the following keys:
+            - "chat_generator_text": The text output of the LLM, useful for debugging.
+            - "output_names": Each contains the list of messages that matched the corresponding pattern.
+            - "unmatched": The messages that did not match any of the output patterns.
+
+        :raises ValueError: If messages is an empty list or contains messages with unsupported roles.
+        """
+        if not messages:
+            raise ValueError("`messages` must be a non-empty list.")
+        if not all(message.is_from(ChatRole.USER) or message.is_from(ChatRole.ASSISTANT) for message in messages):
+            msg = (
+                "`messages` must contain only user and assistant messages. To customize the behavior of the "
+                "`chat_generator`, you can use the `system_prompt` parameter."
+            )
+            raise ValueError(msg)
+
+        if not self._is_warmed_up:
+            self.warm_up()
+
+        messages_for_inference = []
+        if self._system_prompt:
+            messages_for_inference.append(ChatMessage.from_system(self._system_prompt))
+        messages_for_inference.extend(messages)
+
+        generator_result = await _run_component_async(self._chat_generator, messages=messages_for_inference)
+        chat_generator_text = generator_result["replies"][0].text
 
         output = {"chat_generator_text": chat_generator_text}
 

--- a/releasenotes/notes/add-run-async-to-llm-and-openai-components-794d50afba102113.yaml
+++ b/releasenotes/notes/add-run-async-to-llm-and-openai-components-794d50afba102113.yaml
@@ -1,0 +1,19 @@
+---
+features:
+  - |
+    Added a ``run_async`` method to the following components so they can run natively in an ``AsyncPipeline``:
+
+    - ``LLMRanker``, ``QueryExpander``, ``LLMMessagesRouter`` and ``LLMDocumentContentExtractor`` now delegate to
+      their chat generator's ``run_async`` method when available. If the chat generator only implements a
+      synchronous ``run`` method, it is executed in a thread to avoid blocking the event loop.
+      ``LLMDocumentContentExtractor`` processes documents concurrently with ``asyncio``, bounded by ``max_workers``.
+    - ``RemoteWhisperTranscriber`` and ``OpenAIImageGenerator`` now use a native ``AsyncOpenAI`` client in their
+      ``run_async`` methods.
+enhancements:
+  - |
+    Components that delegate to sub-components in their ``run_async`` method (``LLMMetadataExtractor``,
+    ``EmbeddingBasedDocumentSplitter``, ``FallbackChatGenerator``, ``TextEmbeddingRetriever``, ``MultiRetriever``,
+    ``MultiQueryTextRetriever`` and ``MultiQueryEmbeddingRetriever``) now use a shared utility to run the
+    sub-component. If the sub-component only implements a synchronous ``run`` method, it is executed in a thread.
+    Notably, ``LLMMetadataExtractor`` and ``EmbeddingBasedDocumentSplitter`` previously fell back to their fully
+    synchronous ``run`` method in this case, which blocked the event loop for the duration of the call.

--- a/test/components/audio/test_whisper_remote.py
+++ b/test/components/audio/test_whisper_remote.py
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from openai import AsyncOpenAI
 
 from haystack.components.audio.whisper_remote import RemoteWhisperTranscriber
 from haystack.dataclasses import ByteStream
@@ -193,3 +195,61 @@ class TestRemoteWhisperTranscriber:
         assert str(test_files_path / "audio" / "the context for this answer is here.wav") == docs[1].meta["file_path"]
 
         assert docs[2].content.strip().lower() == "answer."
+
+
+class TestRemoteWhisperTranscriberAsync:
+    def test_init_async_client(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
+        transcriber = RemoteWhisperTranscriber()
+        assert isinstance(transcriber.async_client, AsyncOpenAI)
+        assert transcriber.async_client.api_key == "test_api_key"
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_file_path(self, test_files_path):
+        transcriber = RemoteWhisperTranscriber(api_key=Secret.from_token("test_api_key"))
+        transcriber.async_client = Mock()
+        transcriber.async_client.audio.transcriptions.create = AsyncMock(
+            return_value=Mock(text="this is the content of the document.")
+        )
+
+        path = test_files_path / "audio" / "this is the content of the document.wav"
+        output = await transcriber.run_async(sources=[path])
+
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert docs[0].content == "this is the content of the document."
+        assert docs[0].meta["file_path"] == path
+        transcriber.async_client.audio.transcriptions.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_bytestream(self, test_files_path):
+        transcriber = RemoteWhisperTranscriber(api_key=Secret.from_token("test_api_key"))
+        transcriber.async_client = Mock()
+        transcriber.async_client.audio.transcriptions.create = AsyncMock(return_value=Mock(text="answer."))
+
+        source = ByteStream.from_file_path(test_files_path / "audio" / "answer.wav")
+        output = await transcriber.run_async(sources=[source])
+
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert docs[0].content == "answer."
+        transcriber.async_client.audio.transcriptions.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_multiple_sources(self, test_files_path):
+        transcriber = RemoteWhisperTranscriber(api_key=Secret.from_token("test_api_key"))
+        transcriber.async_client = Mock()
+        transcriber.async_client.audio.transcriptions.create = AsyncMock(
+            side_effect=[Mock(text="this is the content of the document."), Mock(text="answer.")]
+        )
+
+        path = test_files_path / "audio" / "this is the content of the document.wav"
+        bytestream = ByteStream.from_file_path(test_files_path / "audio" / "answer.wav")
+        output = await transcriber.run_async(sources=[path, bytestream])
+
+        docs = output["documents"]
+        assert len(docs) == 2
+        assert docs[0].content == "this is the content of the document."
+        assert docs[0].meta["file_path"] == path
+        assert docs[1].content == "answer."
+        assert transcriber.async_client.audio.transcriptions.create.await_count == 2

--- a/test/components/extractors/image/test_llm_document_content_extractor.py
+++ b/test/components/extractors/image/test_llm_document_content_extractor.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -507,3 +507,110 @@ class TestLLMDocumentContentExtractor:
         assert "date" in doc.meta, "Expected 'date' key in metadata"
         assert "document_type" in doc.meta, "Expected 'document_type' key in metadata"
         assert "title" in doc.meta, "Expected 'title' key in metadata"
+
+
+class FakeChatGeneratorWithoutRunAsync:
+    """Chat generator that only implements the synchronous `run` method (no `run_async`)."""
+
+    def __init__(self, return_value):
+        self._return_value = return_value
+        self.run = Mock(return_value=return_value)
+
+
+class TestLLMDocumentContentExtractorAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_no_documents(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        chat_generator = OpenAIChatGenerator()
+        extractor = LLMDocumentContentExtractor(chat_generator=chat_generator)
+        result = await extractor.run_async(documents=[])
+        assert result["documents"] == []
+        assert result["failed_documents"] == []
+
+    @pytest.mark.asyncio
+    @patch.object(DocumentToImageContent, "run")
+    async def test_run_async_awaits_once_per_document(self, mock_doc_to_image_run):
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(
+            return_value={
+                "replies": [ChatMessage.from_assistant(text='{"document_content": "Extracted content from the image"}')]
+            }
+        )
+        mock_doc_to_image_run.return_value = {
+            "image_contents": [
+                ImageContent.from_file_path("./test/test_files/images/apple.jpg"),
+                ImageContent.from_file_path("./test/test_files/images/apple.jpg"),
+                ImageContent.from_file_path("./test/test_files/images/apple.jpg"),
+            ]
+        }
+
+        extractor = LLMDocumentContentExtractor(chat_generator=mock_chat_generator)
+
+        docs = [Document(content="", meta={"file_path": f"/path/to/image_{i}.pdf"}) for i in range(3)]
+        result = await extractor.run_async(documents=docs)
+
+        assert len(result["documents"]) == 3
+        assert len(result["failed_documents"]) == 0
+        for processed_doc in result["documents"]:
+            assert processed_doc.content == "Extracted content from the image"
+            assert "extraction_error" not in processed_doc.meta
+        assert mock_chat_generator.run_async.await_count == 3
+
+    @pytest.mark.asyncio
+    @patch.object(DocumentToImageContent, "run")
+    async def test_run_async_with_llm_failure_raise_on_failure_false(self, mock_doc_to_image_run, caplog):
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(side_effect=Exception("LLM API error"))
+        extractor = LLMDocumentContentExtractor(chat_generator=mock_chat_generator, raise_on_failure=False)
+
+        mock_doc_to_image_run.return_value = {
+            "image_contents": [ImageContent.from_file_path("./test/test_files/images/apple.jpg")]
+        }
+
+        docs = [Document(content="", meta={"file_path": "/path/to/image.pdf"})]
+        result = await extractor.run_async(documents=docs)
+
+        assert len(result["documents"]) == 0
+        assert len(result["failed_documents"]) == 1
+
+        failed_doc = result["failed_documents"][0]
+        assert failed_doc.id == docs[0].id
+        assert "extraction_error" in failed_doc.meta
+        assert "LLM failed with exception: LLM API error" in failed_doc.meta["extraction_error"]
+
+        assert "LLM" in caplog.text
+        assert "execution failed" in caplog.text
+
+    @pytest.mark.asyncio
+    @patch.object(DocumentToImageContent, "run")
+    async def test_run_async_with_llm_failure_raise_on_failure_true(self, mock_doc_to_image_run):
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(side_effect=Exception("LLM API error"))
+        extractor = LLMDocumentContentExtractor(chat_generator=mock_chat_generator, raise_on_failure=True)
+        mock_doc_to_image_run.return_value = {
+            "image_contents": [ImageContent.from_file_path("./test/test_files/images/apple.jpg")]
+        }
+        with pytest.raises(Exception, match="LLM API error"):
+            await extractor.run_async(documents=[Document(content="", meta={"file_path": "/path/to/image.pdf"})])
+
+    @pytest.mark.asyncio
+    @patch.object(DocumentToImageContent, "run")
+    async def test_run_async_falls_back_to_sync_run_without_run_async(self, mock_doc_to_image_run):
+        chat_generator = FakeChatGeneratorWithoutRunAsync(
+            return_value={
+                "replies": [ChatMessage.from_assistant(text='{"document_content": "Extracted content from the image"}')]
+            }
+        )
+        mock_doc_to_image_run.return_value = {
+            "image_contents": [ImageContent.from_file_path("./test/test_files/images/apple.jpg")]
+        }
+
+        extractor = LLMDocumentContentExtractor(chat_generator=chat_generator)
+
+        docs = [Document(content="", meta={"file_path": "/path/to/image.pdf"})]
+        result = await extractor.run_async(documents=docs)
+
+        assert len(result["documents"]) == 1
+        assert len(result["failed_documents"]) == 0
+        assert result["documents"][0].content == "Extracted content from the image"
+        chat_generator.run.assert_called_once()

--- a/test/components/generators/test_openai_image_generator.py
+++ b/test/components/generators/test_openai_image_generator.py
@@ -4,9 +4,10 @@
 
 import base64
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from openai import AsyncOpenAI
 from openai.types import ImagesResponse
 from openai.types.image import Image
 
@@ -184,3 +185,57 @@ class TestOpenAIImageGenerator:
 
         decoded = base64.b64decode(image_str, validate=True)
         assert decoded.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def _make_async_image_response():
+    return ImagesResponse(created=1630000000, data=[Image(b64_json="test-b64-json", revised_prompt="test-prompt")])
+
+
+class TestOpenAIImageGeneratorAsync:
+    def test_async_client_none_before_warm_up(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = OpenAIImageGenerator()
+        assert component.async_client is None
+
+    def test_async_client_after_warm_up(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = OpenAIImageGenerator()
+        component.warm_up()
+        assert isinstance(component.async_client, AsyncOpenAI)
+        assert component.async_client.api_key == "test-api-key"
+        assert component.async_client.timeout == 30
+        assert component.async_client.max_retries == 5
+
+    @pytest.mark.asyncio
+    async def test_run_async(self):
+        generator = OpenAIImageGenerator(api_key=Secret.from_token("test-api-key"))
+        generator.warm_up()
+        generator.async_client = Mock()
+        generator.async_client.images.generate = AsyncMock(return_value=_make_async_image_response())
+
+        response = await generator.run_async("Show me a picture of a black cat.")
+
+        assert isinstance(response, dict)
+        assert "images" in response and "revised_prompt" in response
+        assert response["images"] == ["test-b64-json"]
+        assert response["revised_prompt"] == "test-prompt"
+        generator.async_client.images.generate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_triggers_warm_up(self):
+        generator = OpenAIImageGenerator(api_key=Secret.from_token("test-api-key"))
+        assert generator.async_client is None
+
+        mock_async_client = Mock()
+        mock_async_client.images.generate = AsyncMock(return_value=_make_async_image_response())
+
+        def fake_warm_up():
+            generator.async_client = mock_async_client
+
+        with patch.object(generator, "warm_up", side_effect=fake_warm_up) as mock_warm_up:
+            response = await generator.run_async("Show me a picture of a black cat.")
+
+        mock_warm_up.assert_called_once()
+        assert response["images"] == ["test-b64-json"]
+        assert response["revised_prompt"] == "test-prompt"
+        mock_async_client.images.generate.assert_awaited_once()

--- a/test/components/query/test_query_expander.py
+++ b/test/components/query/test_query_expander.py
@@ -4,13 +4,20 @@
 
 import logging
 import os
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from haystack.components.generators.chat.openai import OpenAIChatGenerator
 from haystack.components.query.query_expander import DEFAULT_PROMPT_TEMPLATE, QueryExpander
 from haystack.dataclasses.chat_message import ChatMessage
+
+
+class SyncOnlyChatGenerator:
+    """A chat generator that only implements the synchronous `run` method (no `run_async`)."""
+
+    def __init__(self) -> None:
+        self.run = Mock()
 
 
 @pytest.fixture
@@ -398,3 +405,64 @@ class TestQueryExpanderIntegration:
 
             # Should be different from original
             assert query not in result["queries"]
+
+
+class TestQueryExpanderAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_successful_expansion(self, mock_chat_generator):
+        mock_chat_generator.run_async = AsyncMock(
+            return_value={
+                "replies": [
+                    ChatMessage.from_assistant(
+                        '{"queries": ["alternative query 1", "alternative query 2", "alternative query 3"]}'
+                    )
+                ]
+            }
+        )
+
+        expander = QueryExpander(chat_generator=mock_chat_generator, n_expansions=3)
+        result = await expander.run_async("original query")
+
+        assert result["queries"] == [
+            "alternative query 1",
+            "alternative query 2",
+            "alternative query 3",
+            "original query",
+        ]
+        mock_chat_generator.run_async.assert_awaited_once()
+        mock_chat_generator.run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_async_falls_back_to_sync_run(self):
+        mock_chat_generator = SyncOnlyChatGenerator()
+        mock_chat_generator.run.return_value = {
+            "replies": [
+                ChatMessage.from_assistant(
+                    '{"queries": ["alternative query 1", "alternative query 2", "alternative query 3"]}'
+                )
+            ]
+        }
+        assert not hasattr(mock_chat_generator, "run_async")
+
+        expander = QueryExpander(chat_generator=mock_chat_generator, n_expansions=3)
+        result = await expander.run_async("original query")
+
+        assert result["queries"] == [
+            "alternative query 1",
+            "alternative query 2",
+            "alternative query 3",
+            "original query",
+        ]
+        mock_chat_generator.run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_without_including_original(self, mock_chat_generator):
+        mock_chat_generator.run_async = AsyncMock(
+            return_value={"replies": [ChatMessage.from_assistant('{"queries": ["alt1", "alt2"]}')]}
+        )
+
+        expander = QueryExpander(chat_generator=mock_chat_generator, include_original_query=False)
+        result = await expander.run_async("original")
+
+        assert result["queries"] == ["alt1", "alt2"]
+        mock_chat_generator.run_async.assert_awaited_once()

--- a/test/components/rankers/test_llm_ranker.py
+++ b/test/components/rankers/test_llm_ranker.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from jinja2 import TemplateSyntaxError
@@ -12,6 +12,13 @@ from haystack import Document
 from haystack.components.generators.chat.openai import OpenAIChatGenerator
 from haystack.components.rankers.llm_ranker import DEFAULT_PROMPT_TEMPLATE, LLMRanker
 from haystack.dataclasses import ChatMessage
+
+
+class SyncOnlyChatGenerator:
+    """A chat generator that only implements the synchronous `run` method (no `run_async`)."""
+
+    def __init__(self) -> None:
+        self.run = Mock()
 
 
 @pytest.fixture
@@ -347,3 +354,96 @@ def test_live_run_ranks_rust_for_programming_language_query():
     result = ranker.run(query="Which document is about a programming language?", documents=documents)
 
     assert [document.id for document in result["documents"]] == ["doc-rust"]
+
+
+class TestLLMRankerAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_successful_ranking(self):
+        documents = [
+            Document(id="1", content="first"),
+            Document(id="2", content="second"),
+            Document(id="3", content="third"),
+        ]
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(
+            return_value={
+                "replies": [ChatMessage.from_assistant('{"documents": [{"index": 2}, {"index": 1}, {"index": 3}]}')]
+            }
+        )
+        ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=2)
+
+        result = await ranker.run_async(query="test query", documents=documents)
+
+        assert [document.id for document in result["documents"]] == ["2", "1"]
+        mock_chat_generator.run_async.assert_awaited_once()
+        mock_chat_generator.run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_async_falls_back_to_sync_run(self):
+        documents = [
+            Document(id="1", content="first"),
+            Document(id="2", content="second"),
+            Document(id="3", content="third"),
+        ]
+        mock_chat_generator = SyncOnlyChatGenerator()
+        mock_chat_generator.run.return_value = {
+            "replies": [ChatMessage.from_assistant('{"documents": [{"index": 2}, {"index": 1}, {"index": 3}]}')]
+        }
+        assert not hasattr(mock_chat_generator, "run_async")
+        ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=2)
+
+        result = await ranker.run_async(query="test query", documents=documents)
+
+        assert [document.id for document in result["documents"]] == ["2", "1"]
+        mock_chat_generator.run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_empty_documents(self):
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock()
+        ranker = LLMRanker(chat_generator=mock_chat_generator)
+
+        assert await ranker.run_async(query="test", documents=[]) == {"documents": []}
+        mock_chat_generator.run_async.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_async_generator_exception_falls_back(self):
+        documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(side_effect=RuntimeError("generator failed"))
+        ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=1, raise_on_failure=False)
+
+        result = await ranker.run_async(query="test query", documents=documents)
+
+        assert result == {"documents": documents}
+
+    @pytest.mark.asyncio
+    async def test_run_async_generator_exception_raises(self):
+        documents = [Document(id="1", content="first")]
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(side_effect=RuntimeError("generator failed"))
+        ranker = LLMRanker(chat_generator=mock_chat_generator, raise_on_failure=True)
+
+        with pytest.raises(RuntimeError, match="generator failed"):
+            await ranker.run_async(query="test query", documents=documents)
+
+    @pytest.mark.asyncio
+    async def test_run_async_invalid_json_falls_back(self):
+        documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("not-json")]})
+        ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=1, raise_on_failure=False)
+
+        result = await ranker.run_async(query="test query", documents=documents)
+
+        assert result == {"documents": documents}
+
+    @pytest.mark.asyncio
+    async def test_run_async_invalid_json_raises(self):
+        documents = [Document(id="1", content="first")]
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("not-json")]})
+        ranker = LLMRanker(chat_generator=mock_chat_generator, raise_on_failure=True)
+
+        with pytest.raises(ValueError):
+            await ranker.run_async(query="test query", documents=documents)

--- a/test/components/routers/test_llm_messages_router.py
+++ b/test/components/routers/test_llm_messages_router.py
@@ -5,7 +5,7 @@
 import os
 import re
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -16,6 +16,8 @@ from haystack.dataclasses import ChatMessage
 
 
 class MockChatGenerator:
+    """A chat generator that only implements the synchronous `run` method (no `run_async`)."""
+
     def __init__(self, return_text: str = "safe"):
         self.return_text = return_text
 
@@ -218,3 +220,72 @@ class TestLLMMessagesRouter:
         assert result["chat_generator_text"].lower() == "safe"
         assert "unsafe" not in result
         assert "unmatched" not in result
+
+
+class TestLLMMessagesRouterAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_routes_matched(self):
+        chat_generator = MockChatGenerator(return_text="safe")
+        chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("safe")]})
+        chat_generator.run = Mock()
+        router = LLMMessagesRouter(
+            chat_generator=chat_generator, output_names=["safe", "unsafe"], output_patterns=["safe", "unsafe"]
+        )
+
+        messages = [ChatMessage.from_user("Hello")]
+        result = await router.run_async(messages)
+
+        assert result["chat_generator_text"] == "safe"
+        assert result["safe"] == messages
+        assert "unsafe" not in result
+        assert "unmatched" not in result
+        chat_generator.run_async.assert_awaited_once()
+        chat_generator.run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_async_falls_back_to_sync_run(self):
+        chat_generator = Mock(spec=MockChatGenerator)
+        chat_generator.run.return_value = {"replies": [ChatMessage.from_assistant("safe")]}
+        assert not hasattr(chat_generator, "run_async")
+        router = LLMMessagesRouter(
+            chat_generator=chat_generator, output_names=["safe", "unsafe"], output_patterns=["safe", "unsafe"]
+        )
+
+        messages = [ChatMessage.from_user("Hello")]
+        result = await router.run_async(messages)
+
+        assert result["chat_generator_text"] == "safe"
+        assert result["safe"] == messages
+        assert "unsafe" not in result
+        assert "unmatched" not in result
+        chat_generator.run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_unmatched_output(self):
+        chat_generator = MockChatGenerator()
+        chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("irrelevant")]})
+        router = LLMMessagesRouter(
+            chat_generator=chat_generator, output_names=["safe", "unsafe"], output_patterns=["safe", "unsafe"]
+        )
+
+        messages = [ChatMessage.from_user("Hello")]
+        result = await router.run_async(messages)
+
+        assert result["chat_generator_text"] == "irrelevant"
+        assert result["unmatched"] == messages
+        assert "safe" not in result
+        assert "unsafe" not in result
+
+    @pytest.mark.asyncio
+    async def test_run_async_input_errors(self):
+        chat_generator = MockChatGenerator()
+        chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("safe")]})
+        router = LLMMessagesRouter(
+            chat_generator=chat_generator, output_names=["safe", "unsafe"], output_patterns=["safe", "unsafe"]
+        )
+
+        with pytest.raises(ValueError):
+            await router.run_async([])
+
+        with pytest.raises(ValueError):
+            await router.run_async([ChatMessage.from_system("You are a helpful assistant.")])


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
