### PR TITLE
refactor: Add new `_run_component_async` utility method

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
-import contextvars
 import inspect
 import re
 from copy import deepcopy
@@ -39,6 +37,7 @@ from haystack.tools import (
     serialize_tools_or_toolset,
     warm_up_tools,
 )
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
 from haystack.utils.deserialization import deserialize_component_inplace
 
@@ -934,17 +933,9 @@ class Agent:
             }
             with tracing.tracer.trace("haystack.agent.step.llm", parent_span=step_span) as llm_span:
                 llm_span.set_content_tag("haystack.agent.step.llm.input", chat_generator_inputs)
-                if getattr(self.chat_generator, "__haystack_supports_async__", False):
-                    result = await self.chat_generator.run_async(**chat_generator_inputs)  # type: ignore[attr-defined]
-                else:
-                    # Sync-only generator: dispatch to the default executor so the event loop stays unblocked.
-                    # contextvars don't propagate to the executor by default, so we copy the current context
-                    # to preserve the active tracing span (and anything else stored in contextvars).
-                    loop = asyncio.get_running_loop()
-                    ctx = contextvars.copy_context()
-                    result = await loop.run_in_executor(
-                        None, lambda: ctx.run(lambda: self.chat_generator.run(**chat_generator_inputs))
-                    )
+                # For sync-only generators, _run_component_async dispatches to a thread via asyncio.to_thread,
+                # which copies the current contextvars context — preserving the active tracing span.
+                result = await _run_component_async(self.chat_generator, **chat_generator_inputs)
                 llm_span.set_content_tag("haystack.agent.step.llm.output", result)
             llm_messages = result["replies"]
             exe_context.state.set("messages", llm_messages)

--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -20,6 +20,7 @@ from haystack.components.preprocessors import DocumentSplitter
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace, expand_page_range
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -306,7 +307,7 @@ class LLMMetadataExtractor:
             return {"error": "Document has no content, skipping LLM call."}
 
         try:
-            result = await self._chat_generator.run_async(messages=[prompt])  # type: ignore[attr-defined]
+            result = await _run_component_async(self._chat_generator, messages=[prompt])
         except Exception as e:
             if self.raise_on_failure:
                 raise e
@@ -421,13 +422,6 @@ class LLMMetadataExtractor:
             "metadata_extraction_error" and "metadata_extraction_response" in their metadata. These documents can be
             re-run with the extractor to extract metadata.
         """
-        if not hasattr(self._chat_generator, "run_async"):
-            logger.warning(
-                "{chat_generator_type} does not implement method 'run_async'. Falling back to 'run'.",
-                chat_generator_type=type(self._chat_generator).__name__,
-            )
-            return self.run(documents, page_range)
-
         if len(documents) == 0:
             logger.warning("No documents provided. Skipping metadata extraction.")
             return {"documents": [], "failed_documents": []}

--- a/haystack/components/generators/chat/fallback.py
+++ b/haystack/components/generators/chat/fallback.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict, logging
@@ -12,6 +11,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.components.generators.utils import _normalize_messages
 from haystack.dataclasses import ChatMessage, StreamingCallbackT
 from haystack.tools import ToolsType
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.deserialization import deserialize_component_inplace
 
 logger = logging.getLogger(__name__)
@@ -118,15 +118,8 @@ class FallbackChatGenerator:
         tools: ToolsType | None,
         streaming_callback: StreamingCallbackT | None,
     ) -> dict[str, Any]:
-        if hasattr(gen, "run_async") and callable(gen.run_async):
-            return await gen.run_async(
-                messages=messages,
-                generation_kwargs=generation_kwargs,
-                tools=tools,
-                streaming_callback=streaming_callback,
-            )
-        return await asyncio.to_thread(
-            gen.run,
+        return await _run_component_async(
+            gen,
             messages=messages,
             generation_kwargs=generation_kwargs,
             tools=tools,

--- a/haystack/components/preprocessors/embedding_based_document_splitter.py
+++ b/haystack/components/preprocessors/embedding_based_document_splitter.py
@@ -14,6 +14,7 @@ from haystack import Document, component, logging
 from haystack.components.embedders.types import DocumentEmbedder
 from haystack.components.preprocessors.sentence_tokenizer import Language, SentenceSplitter
 from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.deserialization import deserialize_component_inplace
 
 logger = logging.getLogger(__name__)
@@ -194,13 +195,6 @@ class EmbeddingBasedDocumentSplitter:
         if not self._is_warmed_up:
             self.warm_up()
 
-        if not hasattr(self.document_embedder, "run_async"):
-            logger.warning(
-                "{embedder_type} does not implement method 'run_async'. Falling back to 'run'.",
-                embedder_type=type(self.document_embedder).__name__,
-            )
-            return self.run(documents)
-
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             raise TypeError("EmbeddingBasedDocumentSplitter expects a List of Documents as input.")
 
@@ -320,7 +314,7 @@ class EmbeddingBasedDocumentSplitter:
         """
         # Create Document objects for each group
         group_docs = [Document(content=group) for group in sentence_groups]
-        result = await self.document_embedder.run_async(group_docs)  # type: ignore[attr-defined]
+        result = await _run_component_async(self.document_embedder, documents=group_docs)
         embedded_docs = result["documents"]
         return [doc.embedding for doc in embedded_docs]
 

--- a/haystack/components/retrievers/multi_query_embedding_retriever.py
+++ b/haystack/components/retrievers/multi_query_embedding_retriever.py
@@ -10,6 +10,7 @@ from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.components.embedders.types.protocol import TextEmbedder
 from haystack.components.retrievers.types import EmbeddingRetriever
 from haystack.core.serialization import component_to_dict
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _deduplicate_documents
 
 
@@ -178,21 +179,11 @@ class MultiQueryEmbeddingRetriever:
         :returns:
             List of retrieved documents or None if no results.
         """
-        loop = asyncio.get_running_loop()
-
-        if hasattr(self.query_embedder, "run_async") and callable(self.query_embedder.run_async):
-            embedding_result = await self.query_embedder.run_async(text=query)
-        else:
-            embedding_result = await loop.run_in_executor(None, lambda: self.query_embedder.run(text=query))
+        embedding_result = await _run_component_async(self.query_embedder, text=query)
 
         query_embedding = embedding_result["embedding"]
 
-        if hasattr(self.retriever, "run_async") and callable(self.retriever.run_async):
-            result = await self.retriever.run_async(query_embedding=query_embedding, **retriever_kwargs)
-        else:
-            result = await loop.run_in_executor(
-                None, lambda: self.retriever.run(query_embedding=query_embedding, **retriever_kwargs)
-            )
+        result = await _run_component_async(self.retriever, query_embedding=query_embedding, **retriever_kwargs)
 
         if result and "documents" in result:
             return result["documents"]

--- a/haystack/components/retrievers/multi_query_text_retriever.py
+++ b/haystack/components/retrievers/multi_query_text_retriever.py
@@ -9,6 +9,7 @@ from typing import Any
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.components.retrievers.types import TextRetriever
 from haystack.core.serialization import component_to_dict
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _deduplicate_documents
 
 
@@ -156,12 +157,7 @@ class MultiQueryTextRetriever:
         :returns:
             List of retrieved documents or None if no results.
         """
-        loop = asyncio.get_running_loop()
-
-        if hasattr(self.retriever, "run_async") and callable(self.retriever.run_async):
-            result = await self.retriever.run_async(query=query, **retriever_kwargs)
-        else:
-            result = await loop.run_in_executor(None, lambda: self.retriever.run(query=query, **retriever_kwargs))
+        result = await _run_component_async(self.retriever, query=query, **retriever_kwargs)
 
         if result and "documents" in result:
             return result["documents"]

--- a/haystack/components/retrievers/multi_retriever.py
+++ b/haystack/components/retrievers/multi_retriever.py
@@ -11,6 +11,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.components.retrievers.types.protocol import TextRetriever
 from haystack.core.serialization import component_from_dict, component_to_dict, import_class_by_name
 from haystack.dataclasses import Document
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.experimental import _experimental
 from haystack.utils.misc import _deduplicate_documents, _reciprocal_rank_fusion
 
@@ -244,16 +245,11 @@ class MultiRetriever:
 
         retrievers_to_run = self._resolve_retrievers(active_retrievers)
 
-        loop = asyncio.get_running_loop()
-
         async def _run_one(name: str, retriever: TextRetriever) -> list[Document]:
             try:
-                if hasattr(retriever, "run_async") and callable(retriever.run_async):
-                    result = await retriever.run_async(query=query, filters=resolved_filters, top_k=resolved_top_k)
-                else:
-                    result = await loop.run_in_executor(
-                        None, lambda: retriever.run(query=query, filters=resolved_filters, top_k=resolved_top_k)
-                    )
+                result = await _run_component_async(
+                    retriever, query=query, filters=resolved_filters, top_k=resolved_top_k
+                )
                 return result.get("documents", [])
             except Exception as e:
                 raise RuntimeError(f"Retriever '{name}' failed: {e}") from e

--- a/haystack/components/retrievers/text_embedding_retriever.py
+++ b/haystack/components/retrievers/text_embedding_retriever.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.components.embedders.types.protocol import TextEmbedder
 from haystack.components.retrievers.types import EmbeddingRetriever
 from haystack.core.serialization import component_to_dict
+from haystack.utils.async_utils import _run_component_async
 
 
 @component
@@ -125,22 +125,10 @@ class TextEmbeddingRetriever:
         if not self._is_warmed_up:
             self.warm_up()
 
-        loop = asyncio.get_running_loop()
-
-        if hasattr(self.text_embedder, "run_async") and callable(self.text_embedder.run_async):
-            embedding_result = await self.text_embedder.run_async(text=query)
-        else:
-            embedding_result = await loop.run_in_executor(None, lambda: self.text_embedder.run(text=query))
-
-        if hasattr(self.retriever, "run_async") and callable(self.retriever.run_async):
-            result = await self.retriever.run_async(
-                query_embedding=embedding_result["embedding"], filters=filters, top_k=top_k
-            )
-        else:
-            result = await loop.run_in_executor(
-                None,
-                lambda: self.retriever.run(query_embedding=embedding_result["embedding"], filters=filters, top_k=top_k),
-            )
+        embedding_result = await _run_component_async(self.text_embedder, text=query)
+        result = await _run_component_async(
+            self.retriever, query_embedding=embedding_result["embedding"], filters=filters, top_k=top_k
+        )
 
         docs: list[Document] = result["documents"]
         docs.sort(key=lambda x: x.score or 0.0, reverse=True)

--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -4,7 +4,6 @@
 
 import asyncio
 import contextlib
-import contextvars
 from collections.abc import AsyncGenerator, AsyncIterator, Mapping
 from typing import Any, ClassVar, cast
 
@@ -24,6 +23,7 @@ from haystack.dataclasses import AsyncStreamingCallbackT, StreamingCallbackT, St
 from haystack.dataclasses.breakpoints import Breakpoint
 from haystack.dataclasses.streaming_chunk import _invoke_streaming_callback
 from haystack.telemetry import pipeline_running
+from haystack.utils.async_utils import _run_component_async
 
 logger = logging.getLogger(__name__)
 
@@ -154,22 +154,12 @@ class AsyncPipeline(PipelineBase):
             span.set_content_tag(_COMPONENT_INPUT, component_inputs)
             logger.info("Running component {component_name}", component_name=component_name)
 
-            if getattr(instance, "__haystack_supports_async__", False):
-                try:
-                    outputs = await instance.run_async(**component_inputs_copy)  # type: ignore
-                except Exception as error:
-                    raise PipelineRuntimeError.from_exception(component_name, instance.__class__, error) from error
-            else:
-                loop = asyncio.get_running_loop()
-                # Important: contextvars (e.g. active tracing Span) don’t propagate to running loop's ThreadPoolExecutor
-                # We use ctx.run(...) to preserve context like the active tracing span
-                ctx = contextvars.copy_context()
-                try:
-                    outputs = await loop.run_in_executor(
-                        None, lambda: ctx.run(lambda: instance.run(**component_inputs_copy))
-                    )
-                except Exception as error:
-                    raise PipelineRuntimeError.from_exception(component_name, instance.__class__, error) from error
+            try:
+                # For sync-only components, _run_component_async dispatches to a thread via asyncio.to_thread,
+                # which copies the current contextvars context — preserving e.g. the active tracing span.
+                outputs = await _run_component_async(instance, **component_inputs_copy)
+            except Exception as error:
+                raise PipelineRuntimeError.from_exception(component_name, instance.__class__, error) from error
 
             component_visits[component_name] += 1
 
@@ -225,7 +215,7 @@ class AsyncPipeline(PipelineBase):
         are already unwinding.
 
         Note: cancellation is only effective for components that run natively async. Sync components are offloaded to
-        a thread via `loop.run_in_executor` and a running thread cannot be interrupted: cancelling its task abandons
+        a thread via `asyncio.to_thread` and a running thread cannot be interrupted: cancelling its task abandons
         the await, but the thread keeps running until the component's `run` returns. Its outputs are then discarded
         (the task never writes them to the pipeline state), so state stays consistent, but side effects (e.g. API
         calls) still complete and the thread can outlive this cleanup.

--- a/haystack/utils/async_utils.py
+++ b/haystack/utils/async_utils.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from typing import Any
+
+from haystack import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def _run_component_async(component_instance: Any, **kwargs: Any) -> dict[str, Any]:
+    """
+    Run a component asynchronously, preferring its `run_async` method when implemented.
+
+    If the component does not implement `run_async`, its synchronous `run` method is executed in a thread
+    to avoid blocking the event loop.
+
+    :param component_instance: The component to run. Any object exposing a `run` method and optionally a
+        `run_async` coroutine method.
+    :param kwargs: Keyword arguments passed to the component's `run_async` or `run` method.
+    :returns:
+        The component's output dictionary.
+    """
+    run_async = getattr(component_instance, "run_async", None)
+    if callable(run_async):
+        return await run_async(**kwargs)
+
+    logger.debug(
+        "{component_type} does not implement 'run_async'. Running the synchronous 'run' method in a thread "
+        "to avoid blocking the event loop.",
+        component_type=type(component_instance).__name__,
+    )
+    return await asyncio.to_thread(component_instance.run, **kwargs)

--- a/releasenotes/notes/add-run-component-async-utility-0ffce2d49f7c4982.yaml
+++ b/releasenotes/notes/add-run-component-async-utility-0ffce2d49f7c4982.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    Components that delegate to sub-components in their ``run_async`` method (``LLMMetadataExtractor``,
+    ``EmbeddingBasedDocumentSplitter``, ``FallbackChatGenerator``, ``TextEmbeddingRetriever``, ``MultiRetriever``,
+    ``MultiQueryTextRetriever`` and ``MultiQueryEmbeddingRetriever``) now use a shared utility to run the
+    sub-component. If the sub-component only implements a synchronous ``run`` method, it is executed in a thread
+    to avoid blocking the event loop. Notably, ``LLMMetadataExtractor`` and ``EmbeddingBasedDocumentSplitter``
+    previously fell back to their fully synchronous ``run`` method in this case, which blocked the event loop for
+    the duration of the call.

--- a/test/core/pipeline/test_async_pipeline.py
+++ b/test/core/pipeline/test_async_pipeline.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import contextvars
 import logging
 from dataclasses import replace
 
@@ -11,6 +12,8 @@ import pytest
 from haystack import AsyncPipeline, Document, component
 from haystack.components.joiners import BranchJoiner
 from haystack.core.errors import PipelineRuntimeError
+
+_test_context_var: contextvars.ContextVar[str] = contextvars.ContextVar("_test_context_var", default="unset")
 
 
 def test_async_pipeline_reentrance(waiting_component, spying_tracer):
@@ -501,3 +504,27 @@ class TestInFlightTaskCleanupOnError:
         await generator.aclose()
 
         assert slow_cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_sync_component_run_in_thread_receives_contextvars():
+    """
+    Regression test: contextvars set in the calling async context (e.g. the active tracing span) must propagate
+    to sync-only components, which AsyncPipeline dispatches to a thread. `asyncio.to_thread` guarantees this by
+    copying the current context; a plain `loop.run_in_executor` would not.
+    """
+
+    @component
+    class SyncContextVarReader:
+        @component.output_types(value=str)
+        def run(self, text: str) -> dict[str, str]:
+            # Read inside the executor thread — only visible if the calling context was copied
+            return {"value": _test_context_var.get()}
+
+    pp = AsyncPipeline()
+    pp.add_component("reader", SyncContextVarReader())
+
+    _test_context_var.set("propagated")
+    result = await pp.run_async({"reader": {"text": "irrelevant"}})
+
+    assert result["reader"]["value"] == "propagated"

--- a/test/utils/test_async_utils.py
+++ b/test/utils/test_async_utils.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+import pytest
+
+from haystack.utils.async_utils import _run_component_async
+
+
+class ComponentWithRunAsync:
+    def run(self, **kwargs):
+        return {"path": "sync", "kwargs": kwargs}
+
+    async def run_async(self, **kwargs):
+        return {"path": "async", "kwargs": kwargs}
+
+
+class ComponentWithoutRunAsync:
+    def run(self, **kwargs):
+        return {"path": "sync", "kwargs": kwargs}
+
+
+class ComponentWithNonCallableRunAsync:
+    run_async = None
+
+    def run(self, **kwargs):
+        return {"path": "sync", "kwargs": kwargs}
+
+
+class TestRunComponentAsync:
+    @pytest.mark.asyncio
+    async def test_awaits_run_async_when_available(self):
+        component = ComponentWithRunAsync()
+        result = await _run_component_async(component, foo="bar", count=1)
+        assert result == {"path": "async", "kwargs": {"foo": "bar", "count": 1}}
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_sync_run_when_no_run_async(self):
+        component = ComponentWithoutRunAsync()
+        result = await _run_component_async(component, foo="bar", count=2)
+        assert result == {"path": "sync", "kwargs": {"foo": "bar", "count": 2}}
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_sync_run_when_run_async_not_callable(self):
+        component = ComponentWithNonCallableRunAsync()
+        result = await _run_component_async(component, foo="baz")
+        assert result == {"path": "sync", "kwargs": {"foo": "baz"}}
+
+    @pytest.mark.asyncio
+    async def test_emits_debug_log_on_sync_fallback(self, caplog):
+        component = ComponentWithoutRunAsync()
+        with caplog.at_level(logging.DEBUG):
+            await _run_component_async(component)
+        assert "does not implement 'run_async'" in caplog.text
+        assert "ComponentWithoutRunAsync" in caplog.text

--- a/test/utils/test_async_utils.py
+++ b/test/utils/test_async_utils.py
@@ -2,11 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import contextvars
 import logging
 
 import pytest
 
 from haystack.utils.async_utils import _run_component_async
+
+_test_context_var: contextvars.ContextVar[str] = contextvars.ContextVar("_test_context_var", default="unset")
+
+
+class ComponentReadingContextVar:
+    def run(self, **kwargs):
+        # Read inside the executor thread — only visible if the calling context was copied.
+        return {"value": _test_context_var.get()}
 
 
 class ComponentWithRunAsync:
@@ -55,3 +64,13 @@ class TestRunComponentAsync:
             await _run_component_async(component)
         assert "does not implement 'run_async'" in caplog.text
         assert "ComponentWithoutRunAsync" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_contextvars_propagate_to_sync_run_in_thread(self):
+        # Regression test: contextvars set in the calling async context (e.g. the active tracing span) must be
+        # visible inside the sync `run` executed in a thread. `asyncio.to_thread` guarantees this by copying the
+        # current context; a plain `loop.run_in_executor` would not.
+        component = ComponentReadingContextVar()
+        _test_context_var.set("propagated")
+        result = await _run_component_async(component)
+        assert result == {"value": "propagated"}


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/333

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add a new `_run_component_async` utility method to better centralize and standardize the common pattern of running a component within another component in an async context. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests and new unit tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
