### PR TITLE
feat: Add `run_async` methods that use `chat_generator` internally

### DIFF
--- a/haystack/components/extractors/image/llm_document_content_extractor.py
+++ b/haystack/components/extractors/image/llm_document_content_extractor.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
@@ -17,6 +18,7 @@ from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ImageContent, TextContent
 from haystack.dataclasses.chat_message import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -271,6 +273,34 @@ class LLMDocumentContentExtractor:
 
         return result
 
+    async def _run_async(self, image_content: ImageContent | None) -> dict[str, Any]:
+        """
+        Execute the LLM inference asynchronously for each document.
+
+        :param image_content: The image content for one document, or None if conversion failed.
+        :returns:
+            The LLM response if successful, or a dictionary with an "error" key on failure.
+        """
+        if image_content is None:
+            return {"error": "Document has no content, skipping LLM call."}
+
+        # the prompt is the same for all documents, so we can set it up once here for each document
+        message = ChatMessage.from_user(content_parts=[TextContent(text=self.prompt), image_content])
+
+        try:
+            result = await _run_component_async(self._chat_generator, messages=[message])
+        except Exception as e:
+            if self.raise_on_failure:
+                raise e
+            logger.exception(
+                "LLM {class_name} execution failed. Skipping metadata extraction. Failed with exception '{error}'.",
+                class_name=self._chat_generator.__class__.__name__,
+                error=e,
+            )
+            result = {"error": "LLM failed with exception: " + str(e)}
+
+        return result
+
     @staticmethod
     def _process_llm_results(document: Document, result: dict[str, Any]) -> tuple[Document, bool]:
         """
@@ -317,6 +347,48 @@ class LLMDocumentContentExtractor:
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             results = executor.map(self._run_on_thread, image_contents)
+
+        successful_documents = []
+        failed_documents = []
+        for document, result in zip(documents, results, strict=True):
+            doc, success = self._process_llm_results(document, result)
+            if success:
+                successful_documents.append(doc)
+            else:
+                failed_documents.append(doc)
+
+        return {"documents": successful_documents, "failed_documents": failed_documents}
+
+    @component.output_types(documents=list[Document], failed_documents=list[Document])
+    async def run_async(self, documents: list[Document]) -> dict[str, list[Document]]:
+        """
+        Asynchronously run extraction on image-based documents. One LLM call per document.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code. LLM calls are made concurrently, bounded by `max_workers`.
+        If the chat generator only implements a synchronous `run` method, it is executed in a thread to avoid
+        blocking the event loop.
+
+        :param documents: A list of image-based documents to process. Each must have a valid file path in its metadata.
+        :returns:
+            A dictionary with "documents" (successfully processed) and "failed_documents" (with failure metadata).
+        """
+        if not documents:
+            return {"documents": [], "failed_documents": []}
+
+        if not self._is_warmed_up:
+            self.warm_up()
+
+        image_contents = self._document_to_image_content.run(documents=documents)["image_contents"]
+
+        # Run the LLM on each image content, bounding concurrency per task so max_workers is enforced.
+        sem = asyncio.Semaphore(max(1, self.max_workers))
+
+        async def _bounded_run(image_content: ImageContent | None) -> dict[str, Any]:
+            async with sem:
+                return await self._run_async(image_content)
+
+        results = await asyncio.gather(*[_bounded_run(image_content) for image_content in image_contents])
 
         successful_documents = []
         failed_documents = []

--- a/haystack/components/query/query_expander.py
+++ b/haystack/components/query/query_expander.py
@@ -12,6 +12,7 @@ from haystack.core.component import component
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses.chat_message import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -211,6 +212,76 @@ class QueryExpander:
         try:
             prompt_result = self._prompt_builder.run(query=query.strip(), n_expansions=expansion_count)
             generator_result = self.chat_generator.run(messages=[ChatMessage.from_user(prompt_result["prompt"])])
+
+            if not generator_result.get("replies") or len(generator_result["replies"]) == 0:
+                logger.warning("ChatGenerator returned no replies for query: {query}", query=query)
+                return response
+
+            expanded_text = generator_result["replies"][0].text.strip()
+            expanded_queries = self._parse_expanded_queries(expanded_text)
+
+            # Limit the number of expanded queries to the requested amount
+            if len(expanded_queries) > expansion_count:
+                logger.warning(
+                    "Generated {generated_count} queries but only {requested_count} were requested. "
+                    "Truncating to the first {requested_count} queries. ",
+                    generated_count=len(expanded_queries),
+                    requested_count=expansion_count,
+                )
+                expanded_queries = expanded_queries[:expansion_count]
+
+            # Add original query if requested and remove duplicates
+            if self.include_original_query:
+                expanded_queries_lower = [q.lower() for q in expanded_queries]
+                if query.lower() not in expanded_queries_lower:
+                    expanded_queries.append(query)
+
+            response["queries"] = expanded_queries
+            return response
+
+        except Exception as e:
+            # Fallback: return original query to maintain pipeline functionality
+            logger.exception("Failed to expand query {query}: {error}", query=query, error=str(e))
+            return response
+
+    @component.output_types(queries=list[str])
+    async def run_async(self, query: str, n_expansions: int | None = None) -> dict[str, list[str]]:
+        """
+        Asynchronously expand the input query into multiple semantically similar queries.
+
+        The language of the original query is preserved in the expanded queries.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code. If the chat generator only implements a synchronous
+        `run` method, it is executed in a thread to avoid blocking the event loop.
+
+        :param query: The original query to expand.
+        :param n_expansions: Number of additional queries to generate (not including the original).
+            If None, uses the value from initialization. Can be 0 to generate no additional queries.
+        :return: Dictionary with "queries" key containing the list of expanded queries.
+            If include_original_query=True, the original query will be included in addition
+            to the n_expansions alternative queries.
+        :raises ValueError: If n_expansions is not positive (less than or equal to 0).
+        """
+
+        if not self._is_warmed_up:
+            self.warm_up()
+
+        response = {"queries": [query] if self.include_original_query else []}
+
+        if not query.strip():
+            logger.warning("Empty query provided to QueryExpander")
+            return response
+
+        expansion_count = n_expansions if n_expansions is not None else self.n_expansions
+        if expansion_count <= 0:
+            raise ValueError("n_expansions must be positive")
+
+        try:
+            prompt_result = self._prompt_builder.run(query=query.strip(), n_expansions=expansion_count)
+            generator_result = await _run_component_async(
+                self.chat_generator, messages=[ChatMessage.from_user(prompt_result["prompt"])]
+            )
 
             if not generator_result.get("replies") or len(generator_result["replies"]) == 0:
                 logger.warning("ChatGenerator returned no replies for query: {query}", query=query)

--- a/haystack/components/query/query_expander.py
+++ b/haystack/components/query/query_expander.py
@@ -189,7 +189,7 @@ class QueryExpander:
 
         :param query: The original query to expand.
         :param n_expansions: Number of additional queries to generate (not including the original).
-            If None, uses the value from initialization. Can be 0 to generate no additional queries.
+            If None, uses the value from initialization. Must be a positive integer.
         :return: Dictionary with "queries" key containing the list of expanded queries.
             If include_original_query=True, the original query will be included in addition
             to the n_expansions alternative queries.
@@ -257,7 +257,7 @@ class QueryExpander:
 
         :param query: The original query to expand.
         :param n_expansions: Number of additional queries to generate (not including the original).
-            If None, uses the value from initialization. Can be 0 to generate no additional queries.
+            If None, uses the value from initialization. Must be a positive integer.
         :return: Dictionary with "queries" key containing the list of expanded queries.
             If include_original_query=True, the original query will be included in addition
             to the n_expansions alternative queries.

--- a/haystack/components/rankers/llm_ranker.py
+++ b/haystack/components/rankers/llm_ranker.py
@@ -11,6 +11,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace
+from haystack.utils.async_utils import _run_component_async
 from haystack.utils.misc import _deduplicate_documents, _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -248,6 +249,73 @@ class LLMRanker:
 
         try:
             result = self._chat_generator.run(messages=[ChatMessage.from_user(prompt["prompt"])])
+        except Exception as exc:
+            if self.raise_on_failure:
+                raise
+            logger.warning(
+                "LLMRanker failed during chat generation. Returning fallback order. Error: {error}", error=exc
+            )
+            return {"documents": fallback_documents}
+
+        try:
+            reply_text = self._get_reply_text(result)
+            ranked_documents = self._rank_documents_from_reply(reply_text=reply_text, documents=deduplicated_documents)
+        except (TypeError, ValueError) as exc:
+            if self.raise_on_failure:
+                raise
+            logger.warning(
+                "LLMRanker failed while processing the chat response. Returning fallback order. Error: {error}",
+                error=exc,
+            )
+            return {"documents": fallback_documents}
+
+        return {"documents": ranked_documents[:top_k]}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self, query: str, documents: list[Document], top_k: int | None = None
+    ) -> dict[str, list[Document]]:
+        """
+        Asynchronously rank documents for a query using an LLM.
+
+        Before ranking, duplicate documents are removed.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code. If the chat generator only implements a synchronous
+        `run` method, it is executed in a thread to avoid blocking the event loop.
+
+        :param query:
+            The query used for reranking.
+        :param documents:
+            Candidate documents to rerank.
+        :param top_k:
+            The maximum number of documents to return. Overrides the instance's `top_k` if provided.
+        :returns:
+            A dictionary with the ranked documents under the `documents` key.
+        """
+        if top_k is not None and top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {top_k}")
+
+        if not documents:
+            return {"documents": []}
+
+        top_k = self.top_k if top_k is None else top_k
+        deduplicated_documents = _deduplicate_documents(documents)
+        fallback_documents = deduplicated_documents
+
+        if not query.strip():
+            logger.warning("Empty query provided to LLMRanker. Returning documents without reranking.")
+            return {"documents": fallback_documents}
+
+        if not self._is_warmed_up:
+            self.warm_up()
+
+        prompt = self._prompt_builder.run(query=query.strip(), documents=deduplicated_documents)
+
+        try:
+            result = await _run_component_async(
+                self._chat_generator, messages=[ChatMessage.from_user(prompt["prompt"])]
+            )
         except Exception as exc:
             if self.raise_on_failure:
                 raise

--- a/haystack/components/routers/llm_messages_router.py
+++ b/haystack/components/routers/llm_messages_router.py
@@ -10,6 +10,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage, ChatRole
 from haystack.utils import deserialize_chatgenerator_inplace
+from haystack.utils.async_utils import _run_component_async
 
 
 @component
@@ -129,6 +130,54 @@ class LLMMessagesRouter:
         messages_for_inference.extend(messages)
 
         chat_generator_text = self._chat_generator.run(messages=messages_for_inference)["replies"][0].text
+
+        output = {"chat_generator_text": chat_generator_text}
+
+        for output_name, pattern in zip(self._output_names, self._compiled_patterns, strict=True):
+            if pattern.search(chat_generator_text):
+                output[output_name] = messages
+                break
+        else:
+            output["unmatched"] = messages
+
+        return output
+
+    async def run_async(self, messages: list[ChatMessage]) -> dict[str, str | list[ChatMessage]]:
+        """
+        Asynchronously classify the messages based on LLM output and route them to the appropriate output connection.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code. If the chat generator only implements a synchronous
+        `run` method, it is executed in a thread to avoid blocking the event loop.
+
+        :param messages: A list of ChatMessages to be routed. Only user and assistant messages are supported.
+
+        :returns: A dictionary with the following keys:
+            - "chat_generator_text": The text output of the LLM, useful for debugging.
+            - "output_names": Each contains the list of messages that matched the corresponding pattern.
+            - "unmatched": The messages that did not match any of the output patterns.
+
+        :raises ValueError: If messages is an empty list or contains messages with unsupported roles.
+        """
+        if not messages:
+            raise ValueError("`messages` must be a non-empty list.")
+        if not all(message.is_from(ChatRole.USER) or message.is_from(ChatRole.ASSISTANT) for message in messages):
+            msg = (
+                "`messages` must contain only user and assistant messages. To customize the behavior of the "
+                "`chat_generator`, you can use the `system_prompt` parameter."
+            )
+            raise ValueError(msg)
+
+        if not self._is_warmed_up:
+            self.warm_up()
+
+        messages_for_inference = []
+        if self._system_prompt:
+            messages_for_inference.append(ChatMessage.from_system(self._system_prompt))
+        messages_for_inference.extend(messages)
+
+        generator_result = await _run_component_async(self._chat_generator, messages=messages_for_inference)
+        chat_generator_text = generator_result["replies"][0].text
 
         output = {"chat_generator_text": chat_generator_text}
 

--- a/releasenotes/notes/add-run-async-to-llm-components-01ad9a8076fd6349.yaml
+++ b/releasenotes/notes/add-run-async-to-llm-components-01ad9a8076fd6349.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added a ``run_async`` method to ``LLMRanker``, ``QueryExpander``, ``LLMMessagesRouter`` and
+    ``LLMDocumentContentExtractor`` so they can run natively in an ``AsyncPipeline``. The method delegates to the
+    chat generator's ``run_async`` method when available. If the chat generator only implements a synchronous
+    ``run`` method, it is executed in a thread to avoid blocking the event loop.
+    ``LLMDocumentContentExtractor`` processes documents concurrently with ``asyncio``, bounded by ``max_workers``.

--- a/test/components/extractors/image/test_llm_document_content_extractor.py
+++ b/test/components/extractors/image/test_llm_document_content_extractor.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -507,3 +508,153 @@ class TestLLMDocumentContentExtractor:
         assert "date" in doc.meta, "Expected 'date' key in metadata"
         assert "document_type" in doc.meta, "Expected 'document_type' key in metadata"
         assert "title" in doc.meta, "Expected 'title' key in metadata"
+
+
+class TestLLMDocumentContentExtractorAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_no_documents(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        chat_generator = OpenAIChatGenerator()
+        extractor = LLMDocumentContentExtractor(chat_generator=chat_generator)
+        result = await extractor.run_async(documents=[])
+        assert result["documents"] == []
+        assert result["failed_documents"] == []
+
+    @pytest.mark.asyncio
+    @patch.object(DocumentToImageContent, "run")
+    async def test_run_async_success(self, mock_doc_to_image_run):
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(
+            return_value={
+                "replies": [ChatMessage.from_assistant(text='{"document_content": "Extracted content from the image"}')]
+            }
+        )
+        mock_doc_to_image_run.return_value = {
+            "image_contents": [
+                ImageContent.from_file_path("./test/test_files/images/apple.jpg"),
+                ImageContent.from_file_path("./test/test_files/images/apple.jpg"),
+            ]
+        }
+
+        extractor = LLMDocumentContentExtractor(chat_generator=mock_chat_generator)
+
+        docs = [
+            Document(content="", meta={"file_path": "/path/to/image1.pdf"}),
+            Document(content="", meta={"file_path": "/path/to/image2.pdf"}),
+        ]
+        result = await extractor.run_async(documents=docs)
+
+        assert len(result["documents"]) == 2
+        assert len(result["failed_documents"]) == 0
+        for processed_doc in result["documents"]:
+            assert processed_doc.content == "Extracted content from the image"
+            assert "extraction_error" not in processed_doc.meta
+        # one async LLM call per document
+        assert mock_chat_generator.run_async.await_count == 2
+
+    @pytest.mark.asyncio
+    @patch.object(DocumentToImageContent, "run")
+    async def test_run_async_with_llm_failure_raise_on_failure_false(self, mock_doc_to_image_run):
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(side_effect=Exception("LLM API error"))
+        extractor = LLMDocumentContentExtractor(chat_generator=mock_chat_generator, raise_on_failure=False)
+
+        mock_doc_to_image_run.return_value = {
+            "image_contents": [ImageContent.from_file_path("./test/test_files/images/apple.jpg")]
+        }
+
+        docs = [Document(content="", meta={"file_path": "/path/to/image.pdf"})]
+        result = await extractor.run_async(documents=docs)
+
+        assert len(result["documents"]) == 0
+        assert len(result["failed_documents"]) == 1
+
+        failed_doc = result["failed_documents"][0]
+        assert failed_doc.id == docs[0].id
+        assert "extraction_error" in failed_doc.meta
+        assert "LLM failed with exception: LLM API error" in failed_doc.meta["extraction_error"]
+
+    @pytest.mark.asyncio
+    @patch.object(DocumentToImageContent, "run")
+    async def test_run_async_with_llm_failure_raise_on_failure_true(self, mock_doc_to_image_run):
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(side_effect=Exception("LLM API error"))
+        extractor = LLMDocumentContentExtractor(chat_generator=mock_chat_generator, raise_on_failure=True)
+
+        mock_doc_to_image_run.return_value = {
+            "image_contents": [ImageContent.from_file_path("./test/test_files/images/apple.jpg")]
+        }
+
+        with pytest.raises(Exception, match="LLM API error"):
+            await extractor.run_async(documents=[Document(content="", meta={"file_path": "/path/to/image.pdf"})])
+
+    @pytest.mark.asyncio
+    @patch.object(DocumentToImageContent, "run")
+    async def test_run_async_falls_back_to_sync_run(self, mock_doc_to_image_run):
+        """If the chat generator has no run_async, the sync run is used and output is still correct."""
+
+        class SyncOnlyChatGenerator:
+            def run(self, messages, **kwargs):
+                return {"replies": [ChatMessage.from_assistant(text='{"document_content": "Extracted via sync run"}')]}
+
+        mock_doc_to_image_run.return_value = {
+            "image_contents": [ImageContent.from_file_path("./test/test_files/images/apple.jpg")]
+        }
+
+        extractor = LLMDocumentContentExtractor(chat_generator=SyncOnlyChatGenerator())
+
+        docs = [Document(content="", meta={"file_path": "/path/to/image.pdf"})]
+        result = await extractor.run_async(documents=docs)
+
+        assert len(result["documents"]) == 1
+        assert len(result["failed_documents"]) == 0
+        assert result["documents"][0].content == "Extracted via sync run"
+
+    @pytest.mark.asyncio
+    @patch.object(DocumentToImageContent, "run")
+    async def test_run_async_respects_max_workers(self, mock_doc_to_image_run):
+        max_workers = 2
+        in_flight = 0
+        peak_in_flight = 0
+
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+
+        async def fake_run_async(messages, **kwargs):
+            nonlocal in_flight, peak_in_flight
+            in_flight += 1
+            peak_in_flight = max(peak_in_flight, in_flight)
+            try:
+                await asyncio.sleep(0.01)
+                return {"replies": [ChatMessage.from_assistant(text='{"document_content": "content"}')]}
+            finally:
+                in_flight -= 1
+
+        mock_chat_generator.run_async = fake_run_async
+
+        extractor = LLMDocumentContentExtractor(chat_generator=mock_chat_generator, max_workers=max_workers)
+
+        mock_doc_to_image_run.return_value = {
+            "image_contents": [ImageContent.from_file_path("./test/test_files/images/apple.jpg") for _ in range(10)]
+        }
+
+        docs = [Document(content="", meta={"file_path": f"/path/to/image{i}.pdf"}) for i in range(10)]
+        result = await extractor.run_async(documents=docs)
+
+        assert len(result["documents"]) == 10
+        assert peak_in_flight <= max_workers
+
+    @pytest.mark.integration
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.asyncio
+    async def test_live_run_async(self):
+        docs = [Document(content="", meta={"file_path": "./test/test_files/images/apple.jpg"})]
+        extractor = LLMDocumentContentExtractor(chat_generator=OpenAIChatGenerator(model="gpt-4.1-nano"))
+
+        result = await extractor.run_async(documents=docs)
+
+        assert len(result["failed_documents"]) == 0
+        assert len(result["documents"]) == 1
+        assert len(result["documents"][0].content) > 0

--- a/test/components/query/test_query_expander.py
+++ b/test/components/query/test_query_expander.py
@@ -4,7 +4,7 @@
 
 import logging
 import os
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -344,6 +344,76 @@ class TestQueryExpander:
         assert expander.chat_generator.model == "gpt-4.1-mini"
 
 
+class FakeSyncOnlyChatGenerator:
+    """A chat generator exposing only a synchronous `run` (no `run_async`) for the fallback path."""
+
+    def __init__(self):
+        self.run = Mock()
+
+
+class TestQueryExpanderAsync:
+    @pytest.mark.asyncio
+    async def test_run_async(self):
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(
+            return_value={
+                "replies": [
+                    ChatMessage.from_assistant(
+                        '{"queries": ["alternative query 1", "alternative query 2", "alternative query 3"]}'
+                    )
+                ]
+            }
+        )
+
+        expander = QueryExpander(chat_generator=mock_chat_generator, n_expansions=3)
+        result = await expander.run_async("original query")
+
+        assert result["queries"] == [
+            "alternative query 1",
+            "alternative query 2",
+            "alternative query 3",
+            "original query",
+        ]
+        mock_chat_generator.run_async.assert_awaited_once()
+        mock_chat_generator.run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_async_without_including_original(self):
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(
+            return_value={"replies": [ChatMessage.from_assistant('{"queries": ["alt1", "alt2"]}')]}
+        )
+
+        expander = QueryExpander(chat_generator=mock_chat_generator, include_original_query=False)
+        result = await expander.run_async("original")
+
+        assert result["queries"] == ["alt1", "alt2"]
+        mock_chat_generator.run_async.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_fallback_to_sync_run(self):
+        fake_chat_generator = FakeSyncOnlyChatGenerator()
+        fake_chat_generator.run.return_value = {
+            "replies": [
+                ChatMessage.from_assistant(
+                    '{"queries": ["alternative query 1", "alternative query 2", "alternative query 3"]}'
+                )
+            ]
+        }
+        assert not hasattr(fake_chat_generator, "run_async")
+
+        expander = QueryExpander(chat_generator=fake_chat_generator, n_expansions=3)
+        result = await expander.run_async("original query")
+
+        assert result["queries"] == [
+            "alternative query 1",
+            "alternative query 2",
+            "alternative query 3",
+            "original query",
+        ]
+        fake_chat_generator.run.assert_called_once()
+
+
 @pytest.mark.integration
 class TestQueryExpanderIntegration:
     @pytest.fixture
@@ -376,6 +446,19 @@ class TestQueryExpanderIntegration:
     def test_query_expansion(self, chat_generator):
         expander = QueryExpander(n_expansions=2, chat_generator=chat_generator)
         result = expander.run("renewable energy sources")
+
+        assert len(result["queries"]) == 3
+        assert all(len(q.strip()) > 0 for q in result["queries"])
+        assert "renewable energy sources" in result["queries"]
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.asyncio
+    async def test_query_expansion_async(self, chat_generator):
+        expander = QueryExpander(n_expansions=2, chat_generator=chat_generator)
+        result = await expander.run_async("renewable energy sources")
 
         assert len(result["queries"]) == 3
         assert all(len(q.strip()) > 0 for q in result["queries"])

--- a/test/components/rankers/test_llm_ranker.py
+++ b/test/components/rankers/test_llm_ranker.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from jinja2 import TemplateSyntaxError
@@ -347,3 +347,93 @@ def test_live_run_ranks_rust_for_programming_language_query():
     result = ranker.run(query="Which document is about a programming language?", documents=documents)
 
     assert [document.id for document in result["documents"]] == ["doc-rust"]
+
+
+class FakeSyncOnlyChatGenerator:
+    """A chat generator exposing only a synchronous `run` (no `run_async`) for the fallback path."""
+
+    def __init__(self):
+        self.run = Mock()
+
+
+class TestLLMRankerAsync:
+    @pytest.mark.asyncio
+    async def test_run_async(self):
+        documents = [
+            Document(id="1", content="first"),
+            Document(id="2", content="second"),
+            Document(id="3", content="third"),
+        ]
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(
+            return_value={
+                "replies": [ChatMessage.from_assistant('{"documents": [{"index": 2}, {"index": 1}, {"index": 3}]}')]
+            }
+        )
+        ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=2)
+
+        result = await ranker.run_async(query="test query", documents=documents)
+
+        assert [document.id for document in result["documents"]] == ["2", "1"]
+        mock_chat_generator.run_async.assert_awaited_once()
+        mock_chat_generator.run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_async_fallback_to_sync_run(self):
+        documents = [
+            Document(id="1", content="first"),
+            Document(id="2", content="second"),
+            Document(id="3", content="third"),
+        ]
+        fake_chat_generator = FakeSyncOnlyChatGenerator()
+        fake_chat_generator.run.return_value = {
+            "replies": [ChatMessage.from_assistant('{"documents": [{"index": 2}, {"index": 1}, {"index": 3}]}')]
+        }
+        assert not hasattr(fake_chat_generator, "run_async")
+        ranker = LLMRanker(chat_generator=fake_chat_generator, top_k=2)
+
+        result = await ranker.run_async(query="test query", documents=documents)
+
+        assert [document.id for document in result["documents"]] == ["2", "1"]
+        fake_chat_generator.run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_generator_exception_falls_back(self):
+        documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(side_effect=RuntimeError("generator failed"))
+        ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=1, raise_on_failure=False)
+
+        result = await ranker.run_async(query="test query", documents=documents)
+
+        assert result == {"documents": documents}
+
+    @pytest.mark.asyncio
+    async def test_run_async_generator_exception_raises(self):
+        documents = [Document(id="1", content="first")]
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(side_effect=RuntimeError("generator failed"))
+        ranker = LLMRanker(chat_generator=mock_chat_generator, raise_on_failure=True)
+
+        with pytest.raises(RuntimeError, match="generator failed"):
+            await ranker.run_async(query="test query", documents=documents)
+
+    @pytest.mark.integration
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.asyncio
+    async def test_live_run_async_ranks_berlin_first_for_germany_query(self):
+        documents = [
+            Document(id="doc-berlin", content="Berlin is the capital of Germany."),
+            Document(id="doc-paris", content="Paris is the capital of France."),
+            Document(id="doc-rust", content="Rust is a systems programming language focused on safety."),
+        ]
+        ranker = LLMRanker(top_k=2)
+
+        result = await ranker.run_async(query="What is the capital of Germany?", documents=documents)
+
+        assert result["documents"]
+        assert result["documents"][0].id == "doc-berlin"
+        assert len(result["documents"]) <= 2

--- a/test/components/routers/test_llm_messages_router.py
+++ b/test/components/routers/test_llm_messages_router.py
@@ -5,7 +5,7 @@
 import os
 import re
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -213,6 +213,103 @@ class TestLLMMessagesRouter:
         messages = [ChatMessage.from_user("Hello")]
         result = router.run(messages)
         print(result)
+
+        assert result["safe"] == messages
+        assert result["chat_generator_text"].lower() == "safe"
+        assert "unsafe" not in result
+        assert "unmatched" not in result
+
+
+class TestLLMMessagesRouterAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_matched_output(self):
+        chat_generator = Mock(spec=OpenAIChatGenerator)
+        chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("safe")]})
+        router = LLMMessagesRouter(
+            chat_generator=chat_generator, output_names=["safe", "unsafe"], output_patterns=["safe", "unsafe"]
+        )
+
+        messages = [ChatMessage.from_user("Hello")]
+        result = await router.run_async(messages)
+
+        assert result["chat_generator_text"] == "safe"
+        assert result["safe"] == messages
+        assert "unsafe" not in result
+        assert "unmatched" not in result
+        chat_generator.run_async.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_unmatched_output(self):
+        chat_generator = Mock(spec=OpenAIChatGenerator)
+        chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("irrelevant")]})
+        router = LLMMessagesRouter(
+            chat_generator=chat_generator, output_names=["safe", "unsafe"], output_patterns=["safe", "unsafe"]
+        )
+
+        messages = [ChatMessage.from_user("Hello")]
+        result = await router.run_async(messages)
+
+        assert result["chat_generator_text"] == "irrelevant"
+        assert result["unmatched"] == messages
+        assert "safe" not in result
+        assert "unsafe" not in result
+
+    @pytest.mark.asyncio
+    async def test_run_async_fallback_to_sync_run(self):
+        # MockChatGenerator defines only a synchronous `run`, so the utility falls back to it.
+        chat_generator = MockChatGenerator(return_text="safe")
+        assert not hasattr(chat_generator, "run_async")
+        router = LLMMessagesRouter(
+            chat_generator=chat_generator, output_names=["safe", "unsafe"], output_patterns=["safe", "unsafe"]
+        )
+
+        messages = [ChatMessage.from_user("Hello")]
+        result = await router.run_async(messages)
+
+        assert result["chat_generator_text"] == "safe"
+        assert result["safe"] == messages
+        assert "unsafe" not in result
+        assert "unmatched" not in result
+
+    @pytest.mark.asyncio
+    async def test_run_async_empty_messages_raises(self):
+        chat_generator = Mock(spec=OpenAIChatGenerator)
+        chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("safe")]})
+        router = LLMMessagesRouter(
+            chat_generator=chat_generator, output_names=["safe", "unsafe"], output_patterns=["safe", "unsafe"]
+        )
+
+        with pytest.raises(ValueError):
+            await router.run_async([])
+
+    @pytest.mark.asyncio
+    async def test_run_async_unsupported_role_raises(self):
+        chat_generator = Mock(spec=OpenAIChatGenerator)
+        chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("safe")]})
+        router = LLMMessagesRouter(
+            chat_generator=chat_generator, output_names=["safe", "unsafe"], output_patterns=["safe", "unsafe"]
+        )
+
+        with pytest.raises(ValueError):
+            await router.run_async([ChatMessage.from_system("You are a helpful assistant.")])
+
+    @pytest.mark.integration
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.asyncio
+    async def test_live_run_async(self):
+        system_prompt = "Classify the messages into safe or unsafe. Respond with the label only, no other text."
+        router = LLMMessagesRouter(
+            chat_generator=OpenAIChatGenerator(model="gpt-4.1-nano"),
+            system_prompt=system_prompt,
+            output_names=["safe", "unsafe"],
+            output_patterns=[r"(?i)safe", r"(?i)unsafe"],
+        )
+
+        messages = [ChatMessage.from_user("Hello")]
+        result = await router.run_async(messages)
 
         assert result["safe"] == messages
         assert result["chat_generator_text"].lower() == "safe"


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/333

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Adds `run_async` methods to components that use a `ChatGenerator` internally to help Haystack better support fully native async workloads. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added new unit and integration tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
