### PR TITLE
feat: Add `run_async` to `OpenAIImageGenerator` and `RemoteWhisperTranscriber`

### DIFF
--- a/haystack/components/audio/whisper_remote.py
+++ b/haystack/components/audio/whisper_remote.py
@@ -6,7 +6,7 @@ import io
 from pathlib import Path
 from typing import Any
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import ByteStream
@@ -104,6 +104,12 @@ class RemoteWhisperTranscriber:
             base_url=api_base_url,
             http_client=init_http_client(self.http_client_kwargs, async_client=False),
         )
+        self.async_client = AsyncOpenAI(
+            api_key=api_key.resolve_value(),
+            organization=organization,
+            base_url=api_base_url,
+            http_client=init_http_client(self.http_client_kwargs, async_client=True),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -158,6 +164,40 @@ class RemoteWhisperTranscriber:
             file.name = str(source.meta["file_path"]) if "file_path" in source.meta else "__fallback__.wav"
 
             content = self.client.audio.transcriptions.create(file=file, model=self.model, **self.whisper_params)
+            doc = Document(content=content.text, meta=source.meta)
+            documents.append(doc)
+
+        return {"documents": documents}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(self, sources: list[str | Path | ByteStream]) -> dict[str, Any]:
+        """
+        Asynchronously transcribes the list of audio files into a list of documents.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code.
+
+        :param sources:
+            A list of file paths or `ByteStream` objects containing the audio files to transcribe.
+
+        :returns: A dictionary with the following keys:
+            - `documents`: A list of documents, one document for each file.
+                The content of each document is the transcribed text.
+        """
+        documents = []
+
+        for source in sources:
+            if not isinstance(source, ByteStream):
+                path = source
+                source = ByteStream.from_file_path(Path(source))
+                source.meta["file_path"] = path
+
+            file = io.BytesIO(source.data)
+            file.name = str(source.meta["file_path"]) if "file_path" in source.meta else "__fallback__.wav"
+
+            content = await self.async_client.audio.transcriptions.create(
+                file=file, model=self.model, **self.whisper_params
+            )
             doc = Document(content=content.text, meta=source.meta)
             documents.append(doc)
 

--- a/haystack/components/generators/openai_image_generator.py
+++ b/haystack/components/generators/openai_image_generator.py
@@ -5,7 +5,7 @@
 import os
 from typing import Any, Literal
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 from openai.types.image import Image
 
 from haystack import component, default_from_dict, default_to_dict, logging
@@ -85,6 +85,7 @@ class OpenAIImageGenerator:
         self.http_client_kwargs = http_client_kwargs
 
         self.client: OpenAI | None = None
+        self.async_client: AsyncOpenAI | None = None
 
     def warm_up(self) -> None:
         """
@@ -98,6 +99,15 @@ class OpenAIImageGenerator:
                 timeout=self.timeout,
                 max_retries=self.max_retries,
                 http_client=init_http_client(self.http_client_kwargs, async_client=False),
+            )
+        if self.async_client is None:
+            self.async_client = AsyncOpenAI(
+                api_key=self.api_key.resolve_value(),
+                organization=self.organization,
+                base_url=self.api_base_url,
+                timeout=self.timeout,
+                max_retries=self.max_retries,
+                http_client=init_http_client(self.http_client_kwargs, async_client=True),
             )
 
     @component.output_types(images=list[str], revised_prompt=str)
@@ -130,6 +140,50 @@ class OpenAIImageGenerator:
         size = size or self.size
         quality = quality or self.quality
         response = self.client.images.generate(model=self.model, prompt=prompt, size=size, quality=quality, n=1)
+        image_str = ""
+        revised_prompt = ""
+        if response.data is not None:
+            image: Image = response.data[0]
+            image_str = image.b64_json or ""
+            revised_prompt = image.revised_prompt or ""
+
+        return {"images": [image_str], "revised_prompt": revised_prompt}
+
+    @component.output_types(images=list[str], revised_prompt=str)
+    async def run_async(
+        self,
+        prompt: str,
+        size: Literal["1024x1024", "1024x1536", "1536x1024", "auto"] | None = None,
+        quality: Literal["auto", "high", "medium", "low"] | None = None,
+        response_format: Literal["b64_json"] | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        """
+        Asynchronously invokes the image generation inference based on the provided prompt and generation parameters.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in an async code.
+
+        :param prompt: The prompt to generate the image.
+        :param size: If provided, overrides the size provided during initialization.
+        :param quality: If provided, overrides the quality provided during initialization.
+        :param response_format: This parameter is ignored and only kept for backward compatibility.
+
+        :returns:
+            A dictionary containing the generated list of images as base64 encoded JSON strings and the revised prompt.
+            The revised prompt is the prompt that was used to generate the image, if there was any revision
+            to the prompt made by OpenAI.
+        """
+        if self.async_client is None:
+            self.warm_up()
+
+        # at this point the client is initialized, but mypy doesn't know that
+        assert self.async_client is not None
+
+        size = size or self.size
+        quality = quality or self.quality
+        response = await self.async_client.images.generate(
+            model=self.model, prompt=prompt, size=size, quality=quality, n=1
+        )
         image_str = ""
         revised_prompt = ""
         if response.data is not None:

--- a/releasenotes/notes/add-run-async-whisper-image-generator-850fa600c24c0a96.yaml
+++ b/releasenotes/notes/add-run-async-whisper-image-generator-850fa600c24c0a96.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added a ``run_async`` method to ``RemoteWhisperTranscriber`` and ``OpenAIImageGenerator`` so they can run
+    natively in an ``AsyncPipeline``. Both components now hold an ``AsyncOpenAI`` client alongside the existing
+    synchronous client and call the OpenAI API without blocking the event loop.

--- a/test/components/audio/test_whisper_remote.py
+++ b/test/components/audio/test_whisper_remote.py
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from openai import AsyncOpenAI
 
 from haystack.components.audio.whisper_remote import RemoteWhisperTranscriber
 from haystack.dataclasses import ByteStream
@@ -183,6 +185,79 @@ class TestRemoteWhisperTranscriber:
         ]
 
         output = transcriber.run(sources=paths)
+
+        docs = output["documents"]
+        assert len(docs) == 3
+        assert docs[0].content.strip().lower() == "this is the content of the document."
+        assert test_files_path / "audio" / "this is the content of the document.wav" == docs[0].meta["file_path"]
+
+        assert docs[1].content.strip().lower() == "the context for this answer is here."
+        assert str(test_files_path / "audio" / "the context for this answer is here.wav") == docs[1].meta["file_path"]
+
+        assert docs[2].content.strip().lower() == "answer."
+
+
+class TestRemoteWhisperTranscriberAsync:
+    def test_init_async_client(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
+        transcriber = RemoteWhisperTranscriber()
+        assert isinstance(transcriber.async_client, AsyncOpenAI)
+        assert transcriber.async_client.api_key == "test_api_key"
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_path(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
+        transcriber = RemoteWhisperTranscriber()
+
+        mock_client = Mock()
+        mock_client.audio.transcriptions.create = AsyncMock(
+            return_value=Mock(text="this is the content of the document.")
+        )
+        transcriber.async_client = mock_client
+
+        output = await transcriber.run_async(sources=["test/test_files/audio/this is the content of the document.wav"])
+
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert docs[0].content == "this is the content of the document."
+        assert docs[0].meta["file_path"] == "test/test_files/audio/this is the content of the document.wav"
+        mock_client.audio.transcriptions.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_bytestream(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test_api_key")
+        transcriber = RemoteWhisperTranscriber()
+
+        mock_client = Mock()
+        mock_client.audio.transcriptions.create = AsyncMock(return_value=Mock(text="answer."))
+        transcriber.async_client = mock_client
+
+        source = ByteStream(data=b"fake audio bytes")
+        source.meta["file_path"] = "answer.wav"
+        output = await transcriber.run_async(sources=[source])
+
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert docs[0].content == "answer."
+        assert docs[0].meta["file_path"] == "answer.wav"
+        mock_client.audio.transcriptions.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    async def test_whisper_remote_transcriber_async(self, test_files_path):
+        transcriber = RemoteWhisperTranscriber()
+
+        paths = [
+            test_files_path / "audio" / "this is the content of the document.wav",
+            str(test_files_path / "audio" / "the context for this answer is here.wav"),
+            ByteStream.from_file_path(test_files_path / "audio" / "answer.wav"),
+        ]
+
+        output = await transcriber.run_async(sources=paths)
 
         docs = output["documents"]
         assert len(docs) == 3

--- a/test/components/generators/test_openai_image_generator.py
+++ b/test/components/generators/test_openai_image_generator.py
@@ -4,9 +4,10 @@
 
 import base64
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from openai import AsyncOpenAI
 from openai.types import ImagesResponse
 from openai.types.image import Image
 
@@ -176,6 +177,75 @@ class TestOpenAIImageGenerator:
     def test_live_run(self):
         generator = OpenAIImageGenerator(model="gpt-image-1-mini", size="1024x1024", quality="low")
         response = generator.run("A nice cat")
+        assert isinstance(response, dict)
+        assert isinstance(response["revised_prompt"], str)
+
+        image_str = response["images"][0]
+        assert isinstance(image_str, str) and image_str
+
+        decoded = base64.b64decode(image_str, validate=True)
+        assert decoded.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+class TestOpenAIImageGeneratorAsync:
+    def test_async_client_none_before_warm_up(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = OpenAIImageGenerator()
+        assert component.async_client is None
+
+    def test_async_client_after_warm_up(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = OpenAIImageGenerator()
+        component.warm_up()
+        assert isinstance(component.async_client, AsyncOpenAI)
+        assert component.async_client.api_key == "test-api-key"
+
+    @pytest.mark.asyncio
+    async def test_run_async(self):
+        generator = OpenAIImageGenerator(api_key=Secret.from_token("test-api-key"))
+        generator.warm_up()
+
+        image_response = ImagesResponse(
+            created=1630000000, data=[Image(b64_json="test-b64-json", revised_prompt="test-prompt")]
+        )
+        mock_async_client = Mock()
+        mock_async_client.images.generate = AsyncMock(return_value=image_response)
+        generator.async_client = mock_async_client
+
+        response = await generator.run_async("Show me a picture of a black cat.")
+        assert isinstance(response, dict)
+        assert "images" in response and "revised_prompt" in response
+        assert response["images"] == ["test-b64-json"]
+        assert response["revised_prompt"] == "test-prompt"
+        mock_async_client.images.generate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_async_triggers_warm_up(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        generator = OpenAIImageGenerator()
+        assert generator.async_client is None
+
+        image_response = ImagesResponse(
+            created=1630000000, data=[Image(b64_json="test-b64-json", revised_prompt="test-prompt")]
+        )
+
+        with patch("openai.resources.images.AsyncImages.generate", new=AsyncMock(return_value=image_response)):
+            response = await generator.run_async("Show me a picture of a black cat.")
+
+        assert isinstance(generator.async_client, AsyncOpenAI)
+        assert response["images"] == ["test-b64-json"]
+        assert response["revised_prompt"] == "test-prompt"
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    @pytest.mark.slow
+    async def test_live_run_async(self):
+        generator = OpenAIImageGenerator(model="gpt-image-1-mini", size="1024x1024", quality="low")
+        response = await generator.run_async("A nice cat")
         assert isinstance(response, dict)
         assert isinstance(response["revised_prompt"], str)
 


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/333

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add `run_async` methods to `OpenAIImageGenerator` and `RemoteWhisperTranscriber` using the async openai client.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added new unit tests and integration tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
