### PR TITLE
docs : fix qdrant retriever examples

### DIFF
--- a/docs-website/docs/pipeline-components/retrievers/qdranthybridretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/qdranthybridretriever.mdx
@@ -16,7 +16,7 @@ A Retriever based both on dense and sparse embeddings, compatible with the Qdran
 | **Most common position in a pipeline** | 1\. After a Text Embedder and before a [`PromptBuilder`](../builders/promptbuilder.mdx)  in a RAG pipeline  <br /> <br />2. The last component in a hybrid search pipeline  <br />   3. After a Text Embedder and before an [`ExtractiveReader`](../readers/extractivereader.mdx)  in an extractive QA pipeline |
 | **Mandatory init variables** | `document_store`: An instance of a [QdrantDocumentStore](../../document-stores/qdrant-document-store.mdx) |
 | **Mandatory run variables** | `query_embedding`: A dense vector representing the query (a list of floats)  <br /> <br />`query_sparse_embedding`: A [`SparseEmbedding`](../../concepts/data-classes.mdx#sparseembedding)  object containing a vectorial representation of the query |
-| **Output variables** | `document`: A list of documents |
+| **Output variables** | `documents`: A list of documents |
 | **API reference** | [Qdrant](/reference/integrations-qdrant) |
 | **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/qdrant |
 | **Package name** | `qdrant-haystack` |
@@ -170,14 +170,14 @@ querying.connect("dense_text_embedder.embedding", "retriever.query_embedding")
 
 question = "Who supports fastembed?"
 
-results = query_mix.run(
+results = querying.run(
     {
         "dense_text_embedder": {"text": question},
         "sparse_text_embedder": {"text": question},
     },
 )
 
-print(result["retriever"]["documents"][0])
+print(results["retriever"]["documents"][0])
 
 # Document(id=...,
 # content: 'fastembed is supported by and maintained by Qdrant.',

--- a/docs-website/docs/pipeline-components/retrievers/qdrantsparseembeddingretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/qdrantsparseembeddingretriever.mdx
@@ -100,8 +100,8 @@ from haystack_integrations.components.retrievers.qdrant import (
 from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
 from haystack.document_stores.types import DuplicatePolicy
 from haystack_integrations.components.embedders.fastembed import (
-    FastembedDocumentEmbedder,
-    FastembedTextEmbedder,
+    FastembedSparseDocumentEmbedder,
+    FastembedSparseTextEmbedder,
 )
 
 document_store = QdrantDocumentStore(

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/retrievers/qdranthybridretriever.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/retrievers/qdranthybridretriever.mdx
@@ -16,7 +16,7 @@ A Retriever based both on dense and sparse embeddings, compatible with the Qdran
 | **Most common position in a pipeline** | 1\. After a Text Embedder and before a [`PromptBuilder`](../builders/promptbuilder.mdx)  in a RAG pipeline  <br /> <br />2. The last component in a hybrid search pipeline  <br />   3. After a Text Embedder and before an [`ExtractiveReader`](../readers/extractivereader.mdx)  in an extractive QA pipeline |
 | **Mandatory init variables** | `document_store`: An instance of a [QdrantDocumentStore](../../document-stores/qdrant-document-store.mdx) |
 | **Mandatory run variables** | `query_embedding`: A dense vector representing the query (a list of floats)  <br /> <br />`query_sparse_embedding`: A [`SparseEmbedding`](../../concepts/data-classes.mdx#sparseembedding)  object containing a vectorial representation of the query |
-| **Output variables** | `document`: A list of documents |
+| **Output variables** | `documents`: A list of documents |
 | **API reference** | [Qdrant](/reference/integrations-qdrant) |
 | **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/qdrant |
 | **Package name** | `qdrant-haystack` |
@@ -170,14 +170,14 @@ querying.connect("dense_text_embedder.embedding", "retriever.query_embedding")
 
 question = "Who supports fastembed?"
 
-results = query_mix.run(
+results = querying.run(
     {
         "dense_text_embedder": {"text": question},
         "sparse_text_embedder": {"text": question},
     },
 )
 
-print(result["retriever"]["documents"][0])
+print(results["retriever"]["documents"][0])
 
 # Document(id=...,
 # content: 'fastembed is supported by and maintained by Qdrant.',

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/retrievers/qdrantsparseembeddingretriever.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/retrievers/qdrantsparseembeddingretriever.mdx
@@ -100,8 +100,8 @@ from haystack_integrations.components.retrievers.qdrant import (
 from haystack_integrations.document_stores.qdrant import QdrantDocumentStore
 from haystack.document_stores.types import DuplicatePolicy
 from haystack_integrations.components.embedders.fastembed import (
-    FastembedDocumentEmbedder,
-    FastembedTextEmbedder,
+    FastembedSparseDocumentEmbedder,
+    FastembedSparseTextEmbedder,
 )
 
 document_store = QdrantDocumentStore(


### PR DESCRIPTION


### Proposed Changes:
fixes Qdrant retriever documentation examples by correcting sparse Fastembed imports, the hybrid retriever output variable name, and mismatched pipeline/result variable names

see : 
https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/fastembed/src/haystack_integrations/components/embedders/fastembed/__init__.py
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->



### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [ ] I have documented my code.
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
