### PR TITLE
Add missing docs pages for cognee and mem0 integrations

### DIFF
--- a/docs-website/docs/memory-stores/cogneememorystore.mdx
+++ b/docs-website/docs/memory-stores/cogneememorystore.mdx
@@ -1,0 +1,124 @@
+---
+title: "CogneeMemoryStore"
+id: cogneememorystore
+slug: "/cogneememorystore"
+description: "A persistent memory store backed by Cognee's knowledge graph API."
+---
+
+# CogneeMemoryStore
+
+`CogneeMemoryStore` is a persistent memory store backed by Cognee's knowledge graph API. It is the shared data layer used by [`CogneeRetriever`](../pipeline-components/retrievers/cogneeretriever.mdx) and [`CogneeWriter`](../pipeline-components/writers/cogneewriter.mdx).
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Used by** | [`CogneeRetriever`](../pipeline-components/retrievers/cogneeretriever.mdx), [`CogneeWriter`](../pipeline-components/writers/cogneewriter.mdx) |
+| **Optional init variables** | `search_type`, `top_k`, `dataset_name`, `session_id`, `self_improvement`, `timeout` |
+| **API reference** | [Cognee](/reference/integrations-cognee#cogneememorystore) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cognee |
+| **Package name** | `cognee-haystack` |
+
+</div>
+
+## Overview
+
+`CogneeMemoryStore` wraps Cognee's V2 memory API:
+
+- `add_memories` → `cognee.remember`
+- `search_memories` → `cognee.recall`
+- `improve` → `cognee.improve`
+- `delete_all_memories` → `cognee.forget`
+
+Cognee supports two memory tiers. Set `session_id` to use the **session cache** — fast writes with no LLM extraction, session-aware recall. Leave `session_id` as `None` to write to the **permanent knowledge graph**, which uses LLM extraction during ingestion and supports richer graph-completion queries.
+
+Cognee configuration (LLM provider, database, vector store) is read from environment variables. See the [Cognee documentation](https://docs.cognee.ai) for setup instructions.
+
+### Parameters
+
+- `search_type` is *optional* and defaults to `"GRAPH_COMPLETION"`. Controls which Cognee recall strategy is used. Other useful values include `"CHUNKS"` for raw retrieval and `"SUMMARIES"` for summarized graph nodes.
+- `top_k` is *optional* and defaults to `5`. Sets the default maximum number of memories returned per search.
+- `dataset_name` is *optional* and defaults to `"haystack_memory"`. Names the Cognee dataset backing this store.
+- `session_id` is *optional* and defaults to `None`. When set, reads and writes target the session-cache tier. When `None`, the permanent knowledge graph is used.
+- `self_improvement` is *optional* and defaults to `True`. When `True`, Cognee runs graph improvement inline after every write. Set to `False` when you want `improve()` to be the sole improvement trigger.
+- `timeout` is *optional* and defaults to `300`. Per-call timeout in seconds for any Cognee operation.
+
+### Installation
+
+Install the Cognee integration:
+
+```bash
+pip install cognee-haystack
+```
+
+Set your LLM API key (used by Cognee for graph extraction and queries):
+
+```bash
+export LLM_API_KEY="your-llm-api-key"
+```
+
+Optionally, set a separate embedding API key (defaults to `LLM_API_KEY` when unset):
+
+```bash
+export EMBEDDING_API_KEY="your-embedding-api-key"
+```
+
+## Usage
+
+### On its own
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore(search_type="GRAPH_COMPLETION", top_k=5)
+
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice enjoys hiking and outdoor activities.")],
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+
+memories = store.search_memories(
+    query="What does Alice like?",
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+print([msg.text for msg in memories])
+```
+
+### Session tier vs permanent graph
+
+Use `session_id` to control which memory tier is targeted. A single store can serve both tiers — the writer's `session_id` overrides the store's `session_id` per call.
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore(dataset_name="my_agent_memory", self_improvement=False)
+
+# Write long-lived facts to the permanent graph (no session_id).
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice is a senior data scientist at Acme Corp.")],
+)
+
+# Write transient session context to the session cache.
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice is currently debugging a vector store issue.")],
+    session_id="alice_session_1",
+)
+
+# Promote the session cache into the permanent graph.
+store.improve(session_id="alice_session_1")
+```
+
+### Delete all memories
+
+```python
+# Delete only this store's dataset (session cache is unaffected).
+store.delete_all_memories()
+
+# To wipe everything including the session cache, call cognee directly:
+import asyncio
+import cognee
+
+asyncio.run(cognee.forget(everything=True))
+```

--- a/docs-website/docs/memory-stores/mem0memorystore.mdx
+++ b/docs-website/docs/memory-stores/mem0memorystore.mdx
@@ -1,0 +1,103 @@
+---
+title: "Mem0MemoryStore"
+id: mem0memorystore
+slug: "/mem0memorystore"
+description: "A memory store backed by the Mem0 cloud API."
+---
+
+# Mem0MemoryStore
+
+`Mem0MemoryStore` is a memory store backed by the Mem0 cloud API. It is the shared data layer used by [`Mem0MemoryRetriever`](../pipeline-components/retrievers/mem0memoryretriever.mdx), [`Mem0MemoryWriter`](../pipeline-components/writers/mem0memorywriter.mdx), and the [Mem0 Memory Tools](../tools/ready-made-tools/mem0memorytools.mdx).
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Used by** | [`Mem0MemoryRetriever`](../pipeline-components/retrievers/mem0memoryretriever.mdx), [`Mem0MemoryWriter`](../pipeline-components/writers/mem0memorywriter.mdx), [`Mem0MemoryRetrieverTool`, `Mem0MemoryWriterTool`](../tools/ready-made-tools/mem0memorytools.mdx) |
+| **Optional init variables** | `api_key`: Defaults to `MEM0_API_KEY` environment variable |
+| **API reference** | [Mem0](/reference/integrations-mem0#mem0memorystore) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/mem0 |
+| **Package name** | `mem0-haystack` |
+
+</div>
+
+## Overview
+
+`Mem0MemoryStore` wraps the Mem0 cloud API and provides two core methods:
+
+- `add_memories` — stores a list of `ChatMessage` objects as memories in Mem0.
+- `search_memories` — retrieves memories from Mem0 that are relevant to a query.
+
+Scope memories with at least one Mem0 entity ID: `user_id`, `run_id`, `agent_id`, or `app_id`. These are runtime parameters, so a single store instance can serve multiple users or sessions.
+
+The `infer` parameter on `add_memories` controls how Mem0 processes incoming messages:
+
+- `infer=True` lets Mem0 extract memories from the messages automatically. This is useful when storing a full Agent turn.
+- `infer=False` stores the supplied message text as-is. This is useful when the exact memory text has already been selected upstream.
+
+### Installation
+
+Install the Mem0 integration:
+
+```bash
+pip install mem0-haystack
+```
+
+Set your Mem0 API key:
+
+```bash
+export MEM0_API_KEY="your-mem0-api-key"
+```
+
+## Usage
+
+### On its own
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.memory_stores.mem0 import Mem0MemoryStore
+
+store = Mem0MemoryStore()
+
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice prefers concise Python examples.")],
+    user_id="alice",
+    infer=False,
+)
+
+memories = store.search_memories(
+    query="What does Alice prefer?",
+    user_id="alice",
+    top_k=3,
+)
+print([msg.text for msg in memories])
+```
+
+### Scoping with multiple entity IDs
+
+Mem0 supports narrowing the scope of reads and writes with `user_id`, `run_id`, `agent_id`, and `app_id`. Pass any combination at call time:
+
+```python
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice is working on a documentation search system.")],
+    user_id="alice",
+    run_id="docs-assistant-session-1",
+    infer=True,
+)
+
+memories = store.search_memories(
+    query="What project is Alice working on?",
+    user_id="alice",
+    run_id="docs-assistant-session-1",
+)
+print([msg.text for msg in memories])
+```
+
+### Retrieving all memories in scope
+
+Pass `query=None` to return all memories matching the provided scope without a relevance search:
+
+```python
+all_memories = store.search_memories(query=None, user_id="alice")
+print([msg.text for msg in all_memories])
+```

--- a/docs-website/docs/pipeline-components/retrievers/cogneeretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/cogneeretriever.mdx
@@ -1,0 +1,139 @@
+---
+title: "CogneeRetriever"
+id: cogneeretriever
+slug: "/cogneeretriever"
+description: "Retrieves memories from a CogneeMemoryStore and returns them as system ChatMessage objects."
+---
+
+# CogneeRetriever
+
+Retrieves memories from a `CogneeMemoryStore` and returns them as system `ChatMessage` objects.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | Before an [`Agent`](../agents-1/agent.mdx) or Chat Generator in memory-augmented pipelines |
+| **Mandatory init variables** | `memory_store`: A `CogneeMemoryStore` instance |
+| **Optional init variables** | `top_k`: Maximum number of memories to return (defaults to the store's `top_k`) |
+| **Mandatory run variables** | `query`: A text query to search memories |
+| **Optional run variables** | `user_id`: Cognee user ID to scope the retrieval; pass `None` to use Cognee's default user |
+| **Output variables** | `messages`: A list of system `ChatMessage` objects |
+| **API reference** | [Cognee](/reference/integrations-cognee#cogneeretriever) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cognee |
+| **Package name** | `cognee-haystack` |
+
+</div>
+
+## Overview
+
+`CogneeRetriever` retrieves memories from a `CogneeMemoryStore` and returns them as system `ChatMessage` objects.
+
+Use it to inject long-term memory into an Agent or a chat generation pipeline before the model produces a response.
+
+Search behavior — including the search strategy (`search_type`), dataset, and session tier — is configured on the `CogneeMemoryStore`. The retriever is a thin pipeline adapter over `search_memories`.
+
+The `user_id` parameter scopes the retrieval to a specific Cognee user. Pass `None` to use Cognee's default user.
+
+## Installation
+
+Install the Cognee integration:
+
+```bash
+pip install cognee-haystack
+```
+
+Set your LLM API key (used by Cognee for graph extraction and queries):
+
+```bash
+export LLM_API_KEY="your-llm-api-key"
+```
+
+Optionally, set a separate embedding API key (defaults to `LLM_API_KEY` when unset):
+
+```bash
+export EMBEDDING_API_KEY="your-embedding-api-key"
+```
+
+## Usage
+
+### On its own
+
+```python
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.components.retrievers.cognee import CogneeRetriever
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore(search_type="GRAPH_COMPLETION", top_k=5)
+
+# Write some memories first
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice prefers concise Python examples.")],
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+
+retriever = CogneeRetriever(memory_store=store, top_k=3)
+
+result = retriever.run(
+    query="What does Alice prefer?",
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+memories = result["messages"]
+print([message.text for message in memories])
+```
+
+### In a Pipeline
+
+This example retrieves memories, prepends them to the current user message, and passes the combined message list to an Agent.
+
+```python
+from haystack import Pipeline
+from haystack.components.agents import Agent
+from haystack.components.converters import OutputAdapter
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.components.retrievers.cognee import CogneeRetriever
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore(dataset_name="my_agent_memory", session_id="alice_session_1")
+
+pipeline = Pipeline()
+pipeline.add_component("retriever", CogneeRetriever(memory_store=store, top_k=5))
+pipeline.add_component(
+    "memory_context",
+    OutputAdapter(
+        template="{{ memories + user_messages }}",
+        output_type=list[ChatMessage],
+        unsafe=True,
+    ),
+)
+pipeline.add_component(
+    "agent",
+    Agent(
+        chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+        system_prompt=(
+            "Use any system messages at the start of the conversation as long-term memory. "
+            "Answer concisely."
+        ),
+    ),
+)
+
+pipeline.connect("retriever.messages", "memory_context.memories")
+pipeline.connect("memory_context.output", "agent.messages")
+
+query = "Give me a short implementation tip."
+
+pipeline.run(
+    {
+        "retriever": {
+            "query": query,
+            "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        },
+        "memory_context": {
+            "user_messages": [ChatMessage.from_user(query)],
+        },
+    }
+)
+```

--- a/docs-website/docs/pipeline-components/writers/cogneewriter.mdx
+++ b/docs-website/docs/pipeline-components/writers/cogneewriter.mdx
@@ -1,0 +1,136 @@
+---
+title: "CogneeWriter"
+id: cogneewriter
+slug: "/cogneewriter"
+description: "Writes ChatMessage objects to a CogneeMemoryStore as long-term memories."
+---
+
+# CogneeWriter
+
+Writes `ChatMessage` objects to a `CogneeMemoryStore` as long-term memories.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | After an [`Agent`](../agents-1/agent.mdx) or Chat Generator in memory-augmented pipelines |
+| **Mandatory init variables** | `memory_store`: A `CogneeMemoryStore` instance |
+| **Optional init variables** | `session_id`: When set, writes target the session-cache tier; when `None`, writes go to the permanent knowledge graph |
+| **Mandatory run variables** | `messages`: A list of `ChatMessage` objects |
+| **Optional run variables** | `user_id`: Cognee user ID to scope the write; pass `None` to use Cognee's default user |
+| **Output variables** | `messages_written`: The list of `ChatMessage` objects that were written (passed through unchanged) |
+| **API reference** | [Cognee](/reference/integrations-cognee#cogneewriter) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cognee |
+| **Package name** | `cognee-haystack` |
+
+</div>
+
+## Overview
+
+`CogneeWriter` persists a list of `ChatMessage` objects into a `CogneeMemoryStore`. Use it in a Haystack Pipeline to store conversation facts or user preferences after an Agent turn.
+
+Messages are passed through unchanged to the pipeline output (`messages_written`), making this component easy to chain after an Agent or generator without breaking the pipeline flow.
+
+The `session_id` init parameter controls which Cognee memory tier is targeted:
+
+- Omit `session_id` (or set it to `None`) to write to the **permanent knowledge graph** — Cognee runs LLM extraction during ingestion, producing rich graph-completion-ready nodes.
+- Set `session_id` to write to the **session cache** — fast writes with no LLM extraction, scoped to that session. Session content can later be promoted to the permanent graph via `CogneeMemoryStore.improve()`.
+
+The writer's `session_id` overrides the store's `session_id` per call, so a single store can back multiple writers targeting different memory tiers.
+
+## Installation
+
+Install the Cognee integration:
+
+```bash
+pip install cognee-haystack
+```
+
+Set your LLM API key (used by Cognee for graph extraction):
+
+```bash
+export LLM_API_KEY="your-llm-api-key"
+```
+
+Optionally, set a separate embedding API key (defaults to `LLM_API_KEY` when unset):
+
+```bash
+export EMBEDDING_API_KEY="your-embedding-api-key"
+```
+
+## Usage
+
+### On its own
+
+```python
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.components.writers.cognee import CogneeWriter
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore()
+writer = CogneeWriter(memory_store=store)
+
+result = writer.run(
+    messages=[ChatMessage.from_user("Alice prefers concise Python examples.")],
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+print(result["messages_written"])
+```
+
+To write to the session cache instead of the permanent graph, pass a `session_id`:
+
+```python
+session_writer = CogneeWriter(memory_store=store, session_id="alice_session_1")
+session_writer.run(
+    messages=[ChatMessage.from_user("Alice is currently debugging a vector store issue.")],
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+```
+
+### In a Pipeline
+
+This example connects an Agent's full `messages` output to `CogneeWriter`, so Cognee stores the conversation turn in the permanent graph.
+
+```python
+from haystack import Pipeline
+from haystack.components.agents import Agent
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.components.writers.cognee import CogneeWriter
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore(dataset_name="my_agent_memory")
+
+pipeline = Pipeline()
+pipeline.add_component(
+    "agent",
+    Agent(
+        chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+        system_prompt=(
+            "Answer the user and preserve durable user facts or preferences for future conversations."
+        ),
+    ),
+)
+pipeline.add_component("writer", CogneeWriter(memory_store=store))
+
+pipeline.connect("agent.messages", "writer.messages")
+
+result = pipeline.run(
+    {
+        "agent": {
+            "messages": [
+                ChatMessage.from_user(
+                    "My name is Alice and I prefer concise Python examples.",
+                ),
+            ],
+        },
+        "writer": {
+            "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        },
+    },
+)
+
+print(result["writer"]["messages_written"])
+```

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -563,6 +563,7 @@ export default {
             'pipeline-components/retrievers/filterretriever',
             'pipeline-components/retrievers/inmemorybm25retriever',
             'pipeline-components/retrievers/inmemoryembeddingretriever',
+            'pipeline-components/retrievers/cogneeretriever',
             'pipeline-components/retrievers/mem0memoryretriever',
             'pipeline-components/retrievers/mongodbatlasembeddingretriever',
             'pipeline-components/retrievers/mongodbatlasfulltextretriever',
@@ -662,6 +663,7 @@ export default {
           type: 'category',
           label: 'Writers',
           items: [
+            'pipeline-components/writers/cogneewriter',
             'pipeline-components/writers/documentwriter',
             'pipeline-components/writers/mem0memorywriter',
           ],
@@ -696,6 +698,14 @@ export default {
             'tools/ready-made-tools/mem0memorytools',
           ],
         },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Memory Stores',
+      items: [
+        'memory-stores/cogneememorystore',
+        'memory-stores/mem0memorystore',
       ],
     },
     {

--- a/docs-website/versioned_docs/version-2.30/memory-stores/cogneememorystore.mdx
+++ b/docs-website/versioned_docs/version-2.30/memory-stores/cogneememorystore.mdx
@@ -1,0 +1,124 @@
+---
+title: "CogneeMemoryStore"
+id: cogneememorystore
+slug: "/cogneememorystore"
+description: "A persistent memory store backed by Cognee's knowledge graph API."
+---
+
+# CogneeMemoryStore
+
+`CogneeMemoryStore` is a persistent memory store backed by Cognee's knowledge graph API. It is the shared data layer used by [`CogneeRetriever`](../pipeline-components/retrievers/cogneeretriever.mdx) and [`CogneeWriter`](../pipeline-components/writers/cogneewriter.mdx).
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Used by** | [`CogneeRetriever`](../pipeline-components/retrievers/cogneeretriever.mdx), [`CogneeWriter`](../pipeline-components/writers/cogneewriter.mdx) |
+| **Optional init variables** | `search_type`, `top_k`, `dataset_name`, `session_id`, `self_improvement`, `timeout` |
+| **API reference** | [Cognee](/reference/integrations-cognee#cogneememorystore) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cognee |
+| **Package name** | `cognee-haystack` |
+
+</div>
+
+## Overview
+
+`CogneeMemoryStore` wraps Cognee's V2 memory API:
+
+- `add_memories` → `cognee.remember`
+- `search_memories` → `cognee.recall`
+- `improve` → `cognee.improve`
+- `delete_all_memories` → `cognee.forget`
+
+Cognee supports two memory tiers. Set `session_id` to use the **session cache** — fast writes with no LLM extraction, session-aware recall. Leave `session_id` as `None` to write to the **permanent knowledge graph**, which uses LLM extraction during ingestion and supports richer graph-completion queries.
+
+Cognee configuration (LLM provider, database, vector store) is read from environment variables. See the [Cognee documentation](https://docs.cognee.ai) for setup instructions.
+
+### Parameters
+
+- `search_type` is *optional* and defaults to `"GRAPH_COMPLETION"`. Controls which Cognee recall strategy is used. Other useful values include `"CHUNKS"` for raw retrieval and `"SUMMARIES"` for summarized graph nodes.
+- `top_k` is *optional* and defaults to `5`. Sets the default maximum number of memories returned per search.
+- `dataset_name` is *optional* and defaults to `"haystack_memory"`. Names the Cognee dataset backing this store.
+- `session_id` is *optional* and defaults to `None`. When set, reads and writes target the session-cache tier. When `None`, the permanent knowledge graph is used.
+- `self_improvement` is *optional* and defaults to `True`. When `True`, Cognee runs graph improvement inline after every write. Set to `False` when you want `improve()` to be the sole improvement trigger.
+- `timeout` is *optional* and defaults to `300`. Per-call timeout in seconds for any Cognee operation.
+
+### Installation
+
+Install the Cognee integration:
+
+```bash
+pip install cognee-haystack
+```
+
+Set your LLM API key (used by Cognee for graph extraction and queries):
+
+```bash
+export LLM_API_KEY="your-llm-api-key"
+```
+
+Optionally, set a separate embedding API key (defaults to `LLM_API_KEY` when unset):
+
+```bash
+export EMBEDDING_API_KEY="your-embedding-api-key"
+```
+
+## Usage
+
+### On its own
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore(search_type="GRAPH_COMPLETION", top_k=5)
+
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice enjoys hiking and outdoor activities.")],
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+
+memories = store.search_memories(
+    query="What does Alice like?",
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+print([msg.text for msg in memories])
+```
+
+### Session tier vs permanent graph
+
+Use `session_id` to control which memory tier is targeted. A single store can serve both tiers — the writer's `session_id` overrides the store's `session_id` per call.
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore(dataset_name="my_agent_memory", self_improvement=False)
+
+# Write long-lived facts to the permanent graph (no session_id).
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice is a senior data scientist at Acme Corp.")],
+)
+
+# Write transient session context to the session cache.
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice is currently debugging a vector store issue.")],
+    session_id="alice_session_1",
+)
+
+# Promote the session cache into the permanent graph.
+store.improve(session_id="alice_session_1")
+```
+
+### Delete all memories
+
+```python
+# Delete only this store's dataset (session cache is unaffected).
+store.delete_all_memories()
+
+# To wipe everything including the session cache, call cognee directly:
+import asyncio
+import cognee
+
+asyncio.run(cognee.forget(everything=True))
+```

--- a/docs-website/versioned_docs/version-2.30/memory-stores/mem0memorystore.mdx
+++ b/docs-website/versioned_docs/version-2.30/memory-stores/mem0memorystore.mdx
@@ -1,0 +1,103 @@
+---
+title: "Mem0MemoryStore"
+id: mem0memorystore
+slug: "/mem0memorystore"
+description: "A memory store backed by the Mem0 cloud API."
+---
+
+# Mem0MemoryStore
+
+`Mem0MemoryStore` is a memory store backed by the Mem0 cloud API. It is the shared data layer used by [`Mem0MemoryRetriever`](../pipeline-components/retrievers/mem0memoryretriever.mdx), [`Mem0MemoryWriter`](../pipeline-components/writers/mem0memorywriter.mdx), and the [Mem0 Memory Tools](../tools/ready-made-tools/mem0memorytools.mdx).
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Used by** | [`Mem0MemoryRetriever`](../pipeline-components/retrievers/mem0memoryretriever.mdx), [`Mem0MemoryWriter`](../pipeline-components/writers/mem0memorywriter.mdx), [`Mem0MemoryRetrieverTool`, `Mem0MemoryWriterTool`](../tools/ready-made-tools/mem0memorytools.mdx) |
+| **Optional init variables** | `api_key`: Defaults to `MEM0_API_KEY` environment variable |
+| **API reference** | [Mem0](/reference/integrations-mem0#mem0memorystore) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/mem0 |
+| **Package name** | `mem0-haystack` |
+
+</div>
+
+## Overview
+
+`Mem0MemoryStore` wraps the Mem0 cloud API and provides two core methods:
+
+- `add_memories` — stores a list of `ChatMessage` objects as memories in Mem0.
+- `search_memories` — retrieves memories from Mem0 that are relevant to a query.
+
+Scope memories with at least one Mem0 entity ID: `user_id`, `run_id`, `agent_id`, or `app_id`. These are runtime parameters, so a single store instance can serve multiple users or sessions.
+
+The `infer` parameter on `add_memories` controls how Mem0 processes incoming messages:
+
+- `infer=True` lets Mem0 extract memories from the messages automatically. This is useful when storing a full Agent turn.
+- `infer=False` stores the supplied message text as-is. This is useful when the exact memory text has already been selected upstream.
+
+### Installation
+
+Install the Mem0 integration:
+
+```bash
+pip install mem0-haystack
+```
+
+Set your Mem0 API key:
+
+```bash
+export MEM0_API_KEY="your-mem0-api-key"
+```
+
+## Usage
+
+### On its own
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.memory_stores.mem0 import Mem0MemoryStore
+
+store = Mem0MemoryStore()
+
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice prefers concise Python examples.")],
+    user_id="alice",
+    infer=False,
+)
+
+memories = store.search_memories(
+    query="What does Alice prefer?",
+    user_id="alice",
+    top_k=3,
+)
+print([msg.text for msg in memories])
+```
+
+### Scoping with multiple entity IDs
+
+Mem0 supports narrowing the scope of reads and writes with `user_id`, `run_id`, `agent_id`, and `app_id`. Pass any combination at call time:
+
+```python
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice is working on a documentation search system.")],
+    user_id="alice",
+    run_id="docs-assistant-session-1",
+    infer=True,
+)
+
+memories = store.search_memories(
+    query="What project is Alice working on?",
+    user_id="alice",
+    run_id="docs-assistant-session-1",
+)
+print([msg.text for msg in memories])
+```
+
+### Retrieving all memories in scope
+
+Pass `query=None` to return all memories matching the provided scope without a relevance search:
+
+```python
+all_memories = store.search_memories(query=None, user_id="alice")
+print([msg.text for msg in all_memories])
+```

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/retrievers/cogneeretriever.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/retrievers/cogneeretriever.mdx
@@ -1,0 +1,139 @@
+---
+title: "CogneeRetriever"
+id: cogneeretriever
+slug: "/cogneeretriever"
+description: "Retrieves memories from a CogneeMemoryStore and returns them as system ChatMessage objects."
+---
+
+# CogneeRetriever
+
+Retrieves memories from a `CogneeMemoryStore` and returns them as system `ChatMessage` objects.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | Before an [`Agent`](../agents-1/agent.mdx) or Chat Generator in memory-augmented pipelines |
+| **Mandatory init variables** | `memory_store`: A `CogneeMemoryStore` instance |
+| **Optional init variables** | `top_k`: Maximum number of memories to return (defaults to the store's `top_k`) |
+| **Mandatory run variables** | `query`: A text query to search memories |
+| **Optional run variables** | `user_id`: Cognee user ID to scope the retrieval; pass `None` to use Cognee's default user |
+| **Output variables** | `messages`: A list of system `ChatMessage` objects |
+| **API reference** | [Cognee](/reference/integrations-cognee#cogneeretriever) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cognee |
+| **Package name** | `cognee-haystack` |
+
+</div>
+
+## Overview
+
+`CogneeRetriever` retrieves memories from a `CogneeMemoryStore` and returns them as system `ChatMessage` objects.
+
+Use it to inject long-term memory into an Agent or a chat generation pipeline before the model produces a response.
+
+Search behavior — including the search strategy (`search_type`), dataset, and session tier — is configured on the `CogneeMemoryStore`. The retriever is a thin pipeline adapter over `search_memories`.
+
+The `user_id` parameter scopes the retrieval to a specific Cognee user. Pass `None` to use Cognee's default user.
+
+## Installation
+
+Install the Cognee integration:
+
+```bash
+pip install cognee-haystack
+```
+
+Set your LLM API key (used by Cognee for graph extraction and queries):
+
+```bash
+export LLM_API_KEY="your-llm-api-key"
+```
+
+Optionally, set a separate embedding API key (defaults to `LLM_API_KEY` when unset):
+
+```bash
+export EMBEDDING_API_KEY="your-embedding-api-key"
+```
+
+## Usage
+
+### On its own
+
+```python
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.components.retrievers.cognee import CogneeRetriever
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore(search_type="GRAPH_COMPLETION", top_k=5)
+
+# Write some memories first
+store.add_memories(
+    messages=[ChatMessage.from_user("Alice prefers concise Python examples.")],
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+
+retriever = CogneeRetriever(memory_store=store, top_k=3)
+
+result = retriever.run(
+    query="What does Alice prefer?",
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+memories = result["messages"]
+print([message.text for message in memories])
+```
+
+### In a Pipeline
+
+This example retrieves memories, prepends them to the current user message, and passes the combined message list to an Agent.
+
+```python
+from haystack import Pipeline
+from haystack.components.agents import Agent
+from haystack.components.converters import OutputAdapter
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.components.retrievers.cognee import CogneeRetriever
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore(dataset_name="my_agent_memory", session_id="alice_session_1")
+
+pipeline = Pipeline()
+pipeline.add_component("retriever", CogneeRetriever(memory_store=store, top_k=5))
+pipeline.add_component(
+    "memory_context",
+    OutputAdapter(
+        template="{{ memories + user_messages }}",
+        output_type=list[ChatMessage],
+        unsafe=True,
+    ),
+)
+pipeline.add_component(
+    "agent",
+    Agent(
+        chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+        system_prompt=(
+            "Use any system messages at the start of the conversation as long-term memory. "
+            "Answer concisely."
+        ),
+    ),
+)
+
+pipeline.connect("retriever.messages", "memory_context.memories")
+pipeline.connect("memory_context.output", "agent.messages")
+
+query = "Give me a short implementation tip."
+
+pipeline.run(
+    {
+        "retriever": {
+            "query": query,
+            "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        },
+        "memory_context": {
+            "user_messages": [ChatMessage.from_user(query)],
+        },
+    }
+)
+```

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/writers/cogneewriter.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/writers/cogneewriter.mdx
@@ -1,0 +1,136 @@
+---
+title: "CogneeWriter"
+id: cogneewriter
+slug: "/cogneewriter"
+description: "Writes ChatMessage objects to a CogneeMemoryStore as long-term memories."
+---
+
+# CogneeWriter
+
+Writes `ChatMessage` objects to a `CogneeMemoryStore` as long-term memories.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | After an [`Agent`](../agents-1/agent.mdx) or Chat Generator in memory-augmented pipelines |
+| **Mandatory init variables** | `memory_store`: A `CogneeMemoryStore` instance |
+| **Optional init variables** | `session_id`: When set, writes target the session-cache tier; when `None`, writes go to the permanent knowledge graph |
+| **Mandatory run variables** | `messages`: A list of `ChatMessage` objects |
+| **Optional run variables** | `user_id`: Cognee user ID to scope the write; pass `None` to use Cognee's default user |
+| **Output variables** | `messages_written`: The list of `ChatMessage` objects that were written (passed through unchanged) |
+| **API reference** | [Cognee](/reference/integrations-cognee#cogneewriter) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/cognee |
+| **Package name** | `cognee-haystack` |
+
+</div>
+
+## Overview
+
+`CogneeWriter` persists a list of `ChatMessage` objects into a `CogneeMemoryStore`. Use it in a Haystack Pipeline to store conversation facts or user preferences after an Agent turn.
+
+Messages are passed through unchanged to the pipeline output (`messages_written`), making this component easy to chain after an Agent or generator without breaking the pipeline flow.
+
+The `session_id` init parameter controls which Cognee memory tier is targeted:
+
+- Omit `session_id` (or set it to `None`) to write to the **permanent knowledge graph** — Cognee runs LLM extraction during ingestion, producing rich graph-completion-ready nodes.
+- Set `session_id` to write to the **session cache** — fast writes with no LLM extraction, scoped to that session. Session content can later be promoted to the permanent graph via `CogneeMemoryStore.improve()`.
+
+The writer's `session_id` overrides the store's `session_id` per call, so a single store can back multiple writers targeting different memory tiers.
+
+## Installation
+
+Install the Cognee integration:
+
+```bash
+pip install cognee-haystack
+```
+
+Set your LLM API key (used by Cognee for graph extraction):
+
+```bash
+export LLM_API_KEY="your-llm-api-key"
+```
+
+Optionally, set a separate embedding API key (defaults to `LLM_API_KEY` when unset):
+
+```bash
+export EMBEDDING_API_KEY="your-embedding-api-key"
+```
+
+## Usage
+
+### On its own
+
+```python
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.components.writers.cognee import CogneeWriter
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore()
+writer = CogneeWriter(memory_store=store)
+
+result = writer.run(
+    messages=[ChatMessage.from_user("Alice prefers concise Python examples.")],
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+print(result["messages_written"])
+```
+
+To write to the session cache instead of the permanent graph, pass a `session_id`:
+
+```python
+session_writer = CogneeWriter(memory_store=store, session_id="alice_session_1")
+session_writer.run(
+    messages=[ChatMessage.from_user("Alice is currently debugging a vector store issue.")],
+    user_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+)
+```
+
+### In a Pipeline
+
+This example connects an Agent's full `messages` output to `CogneeWriter`, so Cognee stores the conversation turn in the permanent graph.
+
+```python
+from haystack import Pipeline
+from haystack.components.agents import Agent
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.components.writers.cognee import CogneeWriter
+from haystack_integrations.memory_stores.cognee import CogneeMemoryStore
+
+store = CogneeMemoryStore(dataset_name="my_agent_memory")
+
+pipeline = Pipeline()
+pipeline.add_component(
+    "agent",
+    Agent(
+        chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+        system_prompt=(
+            "Answer the user and preserve durable user facts or preferences for future conversations."
+        ),
+    ),
+)
+pipeline.add_component("writer", CogneeWriter(memory_store=store))
+
+pipeline.connect("agent.messages", "writer.messages")
+
+result = pipeline.run(
+    {
+        "agent": {
+            "messages": [
+                ChatMessage.from_user(
+                    "My name is Alice and I prefer concise Python examples.",
+                ),
+            ],
+        },
+        "writer": {
+            "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        },
+    },
+)
+
+print(result["writer"]["messages_written"])
+```

--- a/docs-website/versioned_sidebars/version-2.30-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.30-sidebars.json
@@ -559,6 +559,7 @@
             "pipeline-components/retrievers/filterretriever",
             "pipeline-components/retrievers/inmemorybm25retriever",
             "pipeline-components/retrievers/inmemoryembeddingretriever",
+            "pipeline-components/retrievers/cogneeretriever",
             "pipeline-components/retrievers/mem0memoryretriever",
             "pipeline-components/retrievers/mongodbatlasembeddingretriever",
             "pipeline-components/retrievers/mongodbatlasfulltextretriever",
@@ -658,6 +659,7 @@
           "type": "category",
           "label": "Writers",
           "items": [
+            "pipeline-components/writers/cogneewriter",
             "pipeline-components/writers/documentwriter",
             "pipeline-components/writers/mem0memorywriter"
           ]
@@ -692,6 +694,14 @@
             "tools/ready-made-tools/mem0memorytools"
           ]
         }
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Memory Stores",
+      "items": [
+        "memory-stores/cogneememorystore",
+        "memory-stores/mem0memorystore"
       ]
     },
     {


### PR DESCRIPTION
### Related Issues

- partially handles https://github.com/deepset-ai/haystack-core-integrations/issues/3366

### Proposed Changes:

* Add a new section to the sidebar: Memory Stores
* Add docs pages for Cognee retriever and writer

### How did you test it?

local deployment

### Notes for the reviewer

I'm open to any other ideas on how to display memory stores. We can revisit this idea based on how we want to handle memory with upcoming versions. 
Alternatively, we can have `Memory` as a new section and display memory stores, memory writers and memory retrievers there

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
