### PR TITLE
fix: Refactor SearchableToolset and fix serialization of `catalog=Toolset`

### DIFF
--- a/haystack/tools/searchable_toolset.py
+++ b/haystack/tools/searchable_toolset.py
@@ -224,6 +224,11 @@ class SearchableToolset(Toolset):
             # discovered tools.
             # The return message here just confirms what was found; actual tool availability comes through the dynamic
             # iteration mechanism. This way we also save tokens by not returning the full tool definitions.
+            #
+            # NOTE: The Agent can run tool calls in a step concurrently (ThreadPoolExecutor), so multiple search_tools
+            # calls can mutate self._discovered_tools from different threads at once. This is currently safe only
+            # because CPython's GIL makes individual dict assignments atomic; on a free-threaded (no-GIL) build these
+            # unguarded writes could corrupt the dict.
             tool_names = []
             for doc in results:
                 tool = tool_by_name[doc.meta["tool_name"]]

--- a/haystack/tools/searchable_toolset.py
+++ b/haystack/tools/searchable_toolset.py
@@ -62,7 +62,7 @@ class SearchableToolset(Toolset):
     # `search_tools` tool and must search to load the others (set it higher for larger catalogs).
     toolset = SearchableToolset(catalog=[get_weather, search_web, convert_currency], search_threshold=2)
 
-    agent = Agent(chat_generator=OpenAIChatGenerator(model="gpt-5.4-nano"), tools=toolset)
+    agent = Agent(chat_generator=OpenAIChatGenerator(), tools=toolset)
 
     # The agent is initially provided only with the search_tools tool and will use it to find relevant tools.
     result = agent.run(messages=[ChatMessage.from_user("What's the weather in Milan?")])

--- a/haystack/tools/searchable_toolset.py
+++ b/haystack/tools/searchable_toolset.py
@@ -5,12 +5,13 @@
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Annotated, Any
 
-from haystack.core.serialization import generate_qualified_class_name, import_class_by_name
+from haystack.core.serialization import generate_qualified_class_name
 from haystack.dataclasses import Document
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.document_stores.types import DuplicatePolicy
 from haystack.tools.from_function import create_tool_from_function
-from haystack.tools.tool import Tool
+from haystack.tools.serde_utils import deserialize_tools_or_toolset_inplace, serialize_tools_or_toolset
+from haystack.tools.tool import Tool, _check_duplicate_tool_names
 from haystack.tools.toolset import Toolset
 from haystack.tools.utils import flatten_tools_or_toolsets, warm_up_tools
 
@@ -22,36 +23,50 @@ class SearchableToolset(Toolset):
     """
     Dynamic tool discovery from large catalogs using BM25 search.
 
-    This Toolset enables LLMs to discover and use tools from large catalogs through
-    BM25-based search. Instead of exposing all tools at once (which can overwhelm the
-    LLM context), it provides a `search_tools` bootstrap tool that allows the LLM to
-    find and load specific tools as needed.
+    This Toolset enables LLMs to discover and use tools from large catalogs through BM25-based search.
+    Instead of exposing all tools at once (which can overwhelm the LLM context), it provides a `search_tools` bootstrap
+    tool that allows the LLM to find and load specific tools as needed.
 
-    For very small catalogs (below `search_threshold`), acts as a simple passthrough
-    exposing all tools directly without any discovery mechanism.
+    For very small catalogs (below `search_threshold`), acts as a simple passthrough exposing all tools directly
+    without any discovery mechanism.
 
     ### Usage Example
 
     ```python
+    from typing import Annotated
+
     from haystack.components.agents import Agent
     from haystack.components.generators.chat import OpenAIChatGenerator
     from haystack.dataclasses import ChatMessage
-    from haystack.tools import Tool, SearchableToolset
+    from haystack.tools import SearchableToolset, tool
 
-    # Create a catalog of tools
-    catalog = [
-        Tool(name="get_weather", description="Get weather for a city",
-             parameters={}, function=lambda: None),
-        Tool(name="search_web", description="Search the web",
-             parameters={}, function=lambda: None),
-        # ... 100s more tools
-    ]
-    toolset = SearchableToolset(catalog=catalog)
+    @tool
+    def get_weather(city: Annotated[str, "The city to get the weather for"]) -> str:
+        '''Get the current weather for a city.'''
+        return f"The weather in {city} is 22°C and sunny."
 
-    agent = Agent(chat_generator=OpenAIChatGenerator(), tools=toolset)
+    @tool
+    def search_web(query: Annotated[str, "The query to search the web for"]) -> str:
+        '''Search the web for a query.'''
+        return f"Top result for '{query}': ..."
+
+    @tool
+    def convert_currency(
+        amount: Annotated[float, "The amount to convert"],
+        to_currency: Annotated[str, "The currency to convert to, e.g. 'EUR'"],
+    ) -> str:
+        '''Convert an amount in USD to another currency.'''
+        return f"{amount} USD is {amount * 0.9} {to_currency}"
+
+    # search_threshold=2 means a catalog of 2+ tools activates discovery: the agent only sees the
+    # `search_tools` tool and must search to load the others (set it higher for larger catalogs).
+    toolset = SearchableToolset(catalog=[get_weather, search_web, convert_currency], search_threshold=2)
+
+    agent = Agent(chat_generator=OpenAIChatGenerator(model="gpt-5.4-nano"), tools=toolset)
 
     # The agent is initially provided only with the search_tools tool and will use it to find relevant tools.
     result = agent.run(messages=[ChatMessage.from_user("What's the weather in Milan?")])
+    print(result["last_message"].text)
     ```
     """
 
@@ -72,12 +87,11 @@ class SearchableToolset(Toolset):
 
         :param catalog: Source of tools - a list of Tools, list of Toolsets, or a single Toolset.
         :param top_k: Default number of results for search_tools.
-        :param search_threshold: Minimum catalog size to activate search.
-            If catalog has fewer tools, acts as passthrough (all tools visible).
-            Default is 8.
+        :param search_threshold: Minimum catalog size to activate search. If catalog has fewer tools, acts as
+            passthrough (all tools visible). Default is 8.
         :param search_tool_name: Custom name for the bootstrap search tool. Default is "search_tools".
-        :param search_tool_description: Custom description for the bootstrap search tool.
-            If not provided, uses a default description.
+        :param search_tool_description: Custom description for the bootstrap search tool. If not provided, uses a
+            default description.
         :param search_tool_parameters_description: Custom descriptions for the bootstrap search tool's parameters.
             Keys must be a subset of `{"tool_keywords", "k"}`.
             Example: `{"tool_keywords": "Keywords to find tools, e.g. 'email send'"}`
@@ -98,8 +112,8 @@ class SearchableToolset(Toolset):
                     f"Valid keys are: {self._VALID_SEARCH_TOOL_PARAMS}"
                 )
 
-        # Store raw catalog; flattening is deferred to warm_up() so that lazy
-        # toolsets (e.g. MCPToolset with eager_connect=False) can connect first.
+        # Store raw catalog; flattening is deferred to warm_up() so that lazy toolsets
+        # (e.g. MCPToolset with eager_connect=False) can connect first.
         self._raw_catalog: "ToolsType" = catalog
         self._catalog: list[Tool] = []
 
@@ -113,7 +127,8 @@ class SearchableToolset(Toolset):
         self._discovered_tools: dict[str, Tool] = {}
         self._bootstrap_tool: Tool | None = None
         self._document_store: InMemoryDocumentStore | None = None
-        self._warmed_up = False
+        self._passthrough: bool | None = None
+        self._is_warmed_up = False
 
         # Initialize parent with empty tools list - we manage tools dynamically
         super().__init__(tools=[])
@@ -126,35 +141,30 @@ class SearchableToolset(Toolset):
         """Adding new tools after initialization is not supported for SearchableToolset."""
         raise NotImplementedError("SearchableToolset does not support adding new tools after initialization.")
 
-    def _is_passthrough(self) -> bool:
-        """
-        Internal method to check if operating in passthrough mode (small catalog). Must be called after warm_up().
-        """
-        return len(self._catalog) < self._search_threshold
-
     def warm_up(self) -> None:
         """
         Prepare the toolset for use.
 
-        Warms up child toolsets first (so lazy toolsets like MCPToolset can connect),
-        then flattens the catalog, indexes it, and creates the search_tools bootstrap tool.
-        In passthrough mode, it warms up all catalog tools directly.
-        Must be called before using the toolset with an Agent.
+        Warms up the catalog (so lazy toolsets like MCPToolset can connect) and flattens it. Above the passthrough
+        threshold, it also indexes the catalog and creates the search_tools bootstrap tool.
+
+        This method is idempotent: it only warms up the toolset the first time it is called.
+
+        :raises ValueError: If the flattened catalog contains tools with duplicate names.
         """
-        if self._warmed_up:
+        if self._is_warmed_up:
             return
 
-        # Warm up child toolsets first (triggers lazy connections like MCPToolset)
+        # Warm up the catalog first (triggers lazy connections like MCPToolset), then flatten — lazy toolsets will
+        # have their real tools available.
         warm_up_tools(self._raw_catalog)
-        # Now flatten — lazy toolsets will have their real tools available
         self._catalog = flatten_tools_or_toolsets(self._raw_catalog)
+        _check_duplicate_tool_names(self._catalog)
+        self._passthrough = len(self._catalog) < self._search_threshold
 
-        if self._is_passthrough():
-            for tool in self._catalog:
-                tool.warm_up()
-        else:
+        # Build the BM25 search index only when the catalog is large enough to need discovery.
+        if not self._passthrough:
             self._document_store = InMemoryDocumentStore()
-            self._tool_by_name = {tool.name: tool for tool in self._catalog}
             documents = [
                 Document(content=f"{tool.name} {tool.description}", meta={"tool_name": tool.name})
                 for tool in self._catalog
@@ -162,15 +172,14 @@ class SearchableToolset(Toolset):
             self._document_store.write_documents(documents, policy=DuplicatePolicy.OVERWRITE)
             self._bootstrap_tool = self._create_search_tool()
 
-        self._warmed_up = True
+        self._is_warmed_up = True
 
     def clear(self) -> None:
         """
         Clear all discovered tools.
 
-        This method allows resetting the toolset's discovered tools between agent runs
-        when the same toolset instance is reused. This can be useful for long-running
-        applications to control memory usage or to start fresh searches.
+        This method allows resetting the toolset's discovered tools between agent runs when the same toolset instance
+        is reused. This can be useful for long-running applications to control memory usage or to start fresh searches.
         """
         self._discovered_tools.clear()
 
@@ -191,9 +200,10 @@ class SearchableToolset(Toolset):
             ALWAYS use this tool FIRST when you need to invoke some tools but don't have the right one loaded yet.
 
             Provide space separated tool keywords likely to appear in tool names/descriptions
-            (e.g. 'route distance weather', 'search email'). Do NOT pass the user's request or task (e.g.
-            'things to do in X', 'user question'); matching is keyword-based. Returns loaded
-            tool names; they become available immediately.
+            (e.g. 'route distance weather', 'search email').
+            Do NOT pass the user's request or task (e.g. 'things to do in X', 'user question'); matching is
+            keyword-based.
+            Returns loaded tool names; they become available immediately.
             """
             num_results = k if k is not None else self._top_k
 
@@ -209,16 +219,14 @@ class SearchableToolset(Toolset):
             if not results:
                 return "No tools found matching these keywords. Try different keywords."
 
-            # Add found tools to _discovered_tools. These become available to the LLM
-            # on the next agent iteration when __iter__ is called again - the Agent
-            # re-iterates over the toolset each loop, picking up newly discovered tools.
-            # The return message here just confirms what was found; actual tool availability
-            # comes through the dynamic iteration mechanism. This way we also save tokens
-            # by not returning the full tool definitions.
+            # Add found tools to _discovered_tools. These become available to the LLM on the next agent iteration
+            # when __iter__ is called again - the Agent re-iterates over the toolset each loop, picking up newly
+            # discovered tools.
+            # The return message here just confirms what was found; actual tool availability comes through the dynamic
+            # iteration mechanism. This way we also save tokens by not returning the full tool definitions.
             tool_names = []
             for doc in results:
                 tool = tool_by_name[doc.meta["tool_name"]]
-                tool.warm_up()
                 self._discovered_tools[tool.name] = tool
                 tool_names.append(tool.name)
 
@@ -244,9 +252,13 @@ class SearchableToolset(Toolset):
         Otherwise, yields bootstrap tool + discovered tools.
         Automatically calls warm_up() if needed to ensure bootstrap tool is available.
         """
-        if not self._warmed_up:
+        # Unlike base Toolset/MCPToolset, which expose a placeholder tool before warm_up, this toolset materializes
+        # everything (flattened catalog, bootstrap tool, passthrough decision) in warm_up.
+        # Without warming here, iterating before warm_up would yield nothing, so we warm up to make the toolset usable
+        # at all.
+        if not self._is_warmed_up:
             self.warm_up()
-        if self._is_passthrough():
+        if self._passthrough:
             yield from self._catalog
         else:
             if self._bootstrap_tool is not None:
@@ -287,12 +299,8 @@ class SearchableToolset(Toolset):
 
         :returns: Dictionary representation of the toolset.
         """
-        catalog_items: list[Tool | Toolset] = (
-            [self._raw_catalog] if isinstance(self._raw_catalog, Toolset) else list(self._raw_catalog)
-        )
-
         data: dict[str, Any] = {
-            "catalog": [item.to_dict() for item in catalog_items],
+            "catalog": serialize_tools_or_toolset(self._raw_catalog),
             "top_k": self._top_k,
             "search_threshold": self._search_threshold,
             "search_tool_name": self._search_tool_name,
@@ -309,18 +317,10 @@ class SearchableToolset(Toolset):
 
         :param data: Dictionary representation of the toolset.
         :returns: New SearchableToolset instance.
+        :raises TypeError: If a serialized catalog entry is not a subclass of Tool or Toolset.
         """
         inner_data = data["data"]
-
-        # Deserialize catalog items (may be Tool or Toolset instances)
-        catalog_data = inner_data.get("catalog", [])
-        catalog: list[Tool | Toolset] = []
-        for item_data in catalog_data:
-            item_class = import_class_by_name(item_data["type"])
-            if not issubclass(item_class, (Tool, Toolset)):
-                raise TypeError(f"Class '{item_class}' is not a subclass of Tool or Toolset")
-            catalog.append(item_class.from_dict(item_data))
-
+        deserialize_tools_or_toolset_inplace(inner_data, key="catalog")
         optional_keys = (
             "top_k",
             "search_threshold",
@@ -328,4 +328,4 @@ class SearchableToolset(Toolset):
             "search_tool_description",
             "search_tool_parameters_description",
         )
-        return cls(catalog=catalog, **{k: inner_data[k] for k in optional_keys if k in inner_data})
+        return cls(catalog=inner_data["catalog"], **{k: inner_data[k] for k in optional_keys if k in inner_data})

--- a/releasenotes/notes/searchable-toolset-fixes-c1aa8c0f0d242b20.yaml
+++ b/releasenotes/notes/searchable-toolset-fixes-c1aa8c0f0d242b20.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    ``SearchableToolset`` now raises a ``ValueError`` during ``warm_up()`` when its catalog
+    contains tools with duplicate names. Previously duplicates were silently collapsed, which
+    could cause a search hit to resolve to the wrong tool.
+  - |
+    ``SearchableToolset`` serialization now preserves the catalog shape: a catalog passed as a
+    single ``Toolset`` round-trips back to a ``Toolset`` (previously it was always rebuilt as a
+    list). Serialization now reuses ``serialize_tools_or_toolset`` / ``deserialize_tools_or_toolset_inplace``.

--- a/test/tools/test_searchable_toolset.py
+++ b/test/tools/test_searchable_toolset.py
@@ -5,51 +5,64 @@
 
 import os
 from collections.abc import Callable
-from typing import Any
+from typing import Annotated, Any
 
 import pytest
 
+from haystack.components.agents import Agent
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
 from haystack.tools import SearchableToolset, Tool, Toolset
 from haystack.tools.from_function import create_tool_from_function
 
 
 # Test helper functions
-def get_weather(city: str) -> str:
+def get_weather(city: Annotated[str, "The city to get the weather for"]) -> str:
     """Get current weather for a city."""
     return f"Weather in {city}: 22°C, sunny"
 
 
-def add_numbers(a: int, b: int) -> int:
+def add_numbers(a: Annotated[int, "The first number"], b: Annotated[int, "The second number"]) -> int:
     """Add two numbers together."""
     return a + b
 
 
-def multiply_numbers(a: int, b: int) -> int:
+def multiply_numbers(a: Annotated[int, "The first number"], b: Annotated[int, "The second number"]) -> int:
     """Multiply two numbers."""
     return a * b
 
 
-def get_stock_price(symbol: str) -> str:
+def get_stock_price(symbol: Annotated[str, "The ticker symbol, e.g. 'AAPL'"]) -> str:
     """Get stock price by ticker symbol."""
     return f"{symbol}: $150.00"
 
 
-def search_database(query: str) -> str:
+def search_database(query: Annotated[str, "The query to search records for"]) -> str:
     """Search the database for records."""
     return f"Found 5 records matching '{query}'"
 
 
-def send_email(to: str, subject: str, body: str) -> str:
+def send_email(
+    to: Annotated[str, "The recipient email address"],
+    subject: Annotated[str, "The email subject"],
+    body: Annotated[str, "The email body"],
+) -> str:
     """Send an email to a recipient."""
     return f"Email sent to {to}"
 
 
-def calculate_tax(amount: float, rate: float) -> float:
+def calculate_tax(
+    amount: Annotated[float, "The amount to tax"], rate: Annotated[float, "The tax rate as a fraction, e.g. 0.2"]
+) -> float:
     """Calculate tax on an amount."""
     return amount * rate
 
 
-def convert_currency(amount: float, from_currency: str, to_currency: str) -> float:
+def convert_currency(
+    amount: Annotated[float, "The amount to convert"],
+    from_currency: Annotated[str, "The source currency, e.g. 'USD'"],
+    to_currency: Annotated[str, "The target currency, e.g. 'EUR'"],
+) -> float:
     """Convert currency from one to another."""
     return amount * 1.1  # Simplified conversion
 
@@ -146,33 +159,31 @@ class TestSearchableToolsetPassthrough:
         """Test that small catalogs trigger passthrough mode."""
         toolset = SearchableToolset(catalog=small_catalog)
         toolset.warm_up()
-
-        assert toolset._is_passthrough() is True
+        assert toolset._passthrough is True
 
     def test_passthrough_exposes_all_tools(self, small_catalog):
         """Test that passthrough mode exposes all catalog tools."""
         toolset = SearchableToolset(catalog=small_catalog)
         toolset.warm_up()
-
         assert len(toolset) == len(small_catalog)
-
         tool_names = [tool.name for tool in toolset]
         assert "get_weather" in tool_names
         assert "add_numbers" in tool_names
         assert "multiply_numbers" in tool_names
 
     def test_passthrough_no_bootstrap_tool(self, small_catalog):
-        """Test that passthrough mode doesn't create bootstrap tool."""
+        """Test that passthrough mode neither creates nor exposes the search bootstrap tool."""
         toolset = SearchableToolset(catalog=small_catalog)
         toolset.warm_up()
-
         assert toolset._bootstrap_tool is None
+        # The search tool must never be present in passthrough mode.
+        assert "search_tools" not in toolset
+        assert all(tool.name != "search_tools" for tool in toolset)
 
     def test_passthrough_contains_by_name(self, small_catalog):
         """Test __contains__ by name in passthrough mode."""
         toolset = SearchableToolset(catalog=small_catalog)
         toolset.warm_up()
-
         assert "get_weather" in toolset
         assert "nonexistent" not in toolset
 
@@ -180,7 +191,6 @@ class TestSearchableToolsetPassthrough:
         """Test __contains__ by tool instance in passthrough mode."""
         toolset = SearchableToolset(catalog=small_catalog)
         toolset.warm_up()
-
         assert weather_tool in toolset
 
     def test_passthrough_contains_by_tool_invalid_type(self, small_catalog):
@@ -195,8 +205,7 @@ class TestSearchableToolsetPassthrough:
         # With threshold of 10, 8 tools should be passthrough
         toolset = SearchableToolset(catalog=large_catalog, search_threshold=10)
         toolset.warm_up()
-
-        assert toolset._is_passthrough() is True
+        assert toolset._passthrough is True
         assert len(list(toolset)) == 8
 
 
@@ -308,10 +317,10 @@ class TestSearchableToolsetIteration:
 
     def test_iter_automatically_warms_up(self, large_catalog):
         toolset = SearchableToolset(catalog=large_catalog)
-        assert not toolset._warmed_up
+        assert not toolset._is_warmed_up
 
         list(toolset)
-        assert toolset._warmed_up
+        assert toolset._is_warmed_up
 
     def test_contains_bootstrap_tool(self, large_catalog):
         """Test __contains__ for bootstrap tool."""
@@ -358,7 +367,6 @@ class TestSearchableToolsetSerialization:
         assert len(data["data"]["catalog"]) == len(large_catalog)
 
     def test_to_dict_with_toolset(self, large_catalog):
-
         toolset = Toolset(tools=large_catalog)
 
         searchable_toolset = SearchableToolset(catalog=toolset)
@@ -368,8 +376,17 @@ class TestSearchableToolsetSerialization:
         assert "data" in data
         assert data["data"]["top_k"] == 3
         assert data["data"]["search_threshold"] == 8
-        assert len(data["data"]["catalog"]) == 1
-        assert data["data"]["catalog"][0]["type"] == "haystack.tools.toolset.Toolset"
+        # A single Toolset catalog serializes as that toolset, not wrapped in a list.
+        assert isinstance(data["data"]["catalog"], dict)
+        assert data["data"]["catalog"]["type"] == "haystack.tools.toolset.Toolset"
+
+    def test_serde_roundtrip_with_toolset_catalog(self, large_catalog):
+        """A single Toolset catalog round-trips back to a Toolset, not a list."""
+        searchable_toolset = SearchableToolset(catalog=Toolset(tools=large_catalog))
+        restored = SearchableToolset.from_dict(searchable_toolset.to_dict())
+        assert isinstance(restored._raw_catalog, Toolset)
+        restored.warm_up()
+        assert len(restored._catalog) == len(large_catalog)
 
     def test_from_dict(self, large_catalog):
         """Test deserialization from dict."""
@@ -404,7 +421,7 @@ class TestSearchableToolsetSerialization:
         assert restored._bootstrap_tool is not None
 
         # Verify behavior matches
-        assert restored._is_passthrough() == toolset._is_passthrough()
+        assert restored._passthrough == toolset._passthrough
 
         # Verify bootstrap tool works
         result = restored._bootstrap_tool.invoke(tool_keywords="weather")
@@ -447,7 +464,7 @@ class TestSearchableToolsetWithToolset:
         search_toolset = SearchableToolset(catalog=base_toolset)
         search_toolset.warm_up()
 
-        assert search_toolset._is_passthrough() is True
+        assert search_toolset._passthrough is True
         assert len(list(search_toolset)) == len(small_catalog)
 
     def test_accepts_list_of_toolsets(self, weather_tool, add_tool, multiply_tool, stock_tool):
@@ -510,6 +527,16 @@ class TestSearchableToolsetWarmUp:
 
         assert toolset._bootstrap_tool is None
 
+    def test_warm_up_raises_on_duplicate_tool_names(self):
+        """Test that warm_up raises when the flattened catalog has duplicate tool names."""
+        params = {"type": "object", "properties": {}}
+        tool1 = Tool(name="dup", description="first", parameters=params, function=lambda: 1)
+        tool2 = Tool(name="dup", description="second", parameters=params, function=lambda: 2)
+        toolset = SearchableToolset(catalog=[tool1, tool2])
+
+        with pytest.raises(ValueError, match="Duplicate tool names found"):
+            toolset.warm_up()
+
 
 class TestSearchableToolsetEdgeCases:
     """Tests for edge cases and error handling."""
@@ -518,16 +545,14 @@ class TestSearchableToolsetEdgeCases:
         """Test with empty catalog."""
         toolset = SearchableToolset(catalog=[])
         toolset.warm_up()
-
-        assert toolset._is_passthrough() is True
+        assert toolset._passthrough is True
         assert len(list(toolset)) == 0
 
     def test_single_tool_catalog(self, weather_tool):
         """Test with single tool catalog."""
         toolset = SearchableToolset(catalog=[weather_tool])
         toolset.warm_up()
-
-        assert toolset._is_passthrough() is True
+        assert toolset._passthrough is True
         assert len(list(toolset)) == 1
 
     def test_exactly_at_threshold(self):
@@ -544,9 +569,8 @@ class TestSearchableToolsetEdgeCases:
 
         toolset = SearchableToolset(catalog=tools, search_threshold=8)
         toolset.warm_up()
-
         # Should NOT be passthrough (>= threshold triggers discovery)
-        assert toolset._is_passthrough() is False
+        assert toolset._passthrough is False
 
     def test_one_below_threshold(self):
         """Test catalog size one below threshold."""
@@ -562,9 +586,8 @@ class TestSearchableToolsetEdgeCases:
 
         toolset = SearchableToolset(catalog=tools, search_threshold=8)
         toolset.warm_up()
-
         # Should be passthrough
-        assert toolset._is_passthrough() is True
+        assert toolset._passthrough is True
 
     def test_multiple_loads_same_tool(self, large_catalog):
         """Test searching for the same tool multiple times."""
@@ -623,7 +646,7 @@ class TestSearchableToolsetLazyToolset:
         # After warm_up, all 10 lazy tools should be in the catalog
         assert len(toolset._catalog) == 10
         # 10 tools >= 8 threshold -> BM25 mode
-        assert toolset._is_passthrough() is False
+        assert toolset._passthrough is False
         assert toolset._bootstrap_tool is not None
 
         # Search should find lazy tools
@@ -650,7 +673,7 @@ class TestSearchableToolsetLazyToolset:
         toolset = SearchableToolset(catalog=SmallLazyToolset())
         toolset.warm_up()
 
-        assert toolset._is_passthrough() is True
+        assert toolset._passthrough is True
         assert len(list(toolset)) == 1
         assert "lazy_single" in toolset
 
@@ -687,7 +710,7 @@ class TestSearchableToolsetLazyToolset:
 
         # Should have 5 lazy + 5 eager = 10 tools
         assert len(toolset._catalog) == 10
-        assert toolset._is_passthrough() is False
+        assert toolset._passthrough is False
         assert any(t.name == "lazy_0" for t in toolset._catalog)
         assert any(t.name == "eager_0" for t in toolset._catalog)
 
@@ -763,10 +786,6 @@ class TestSearchableToolsetAgentIntegration:
 
     def test_agent_discovers_and_uses_tools(self, large_catalog):
         """Agent discovers tools via BM25 search and uses them."""
-        from haystack.components.agents import Agent
-        from haystack.components.generators.chat import OpenAIChatGenerator
-        from haystack.dataclasses import ChatMessage
-
         toolset = SearchableToolset(catalog=large_catalog, top_k=2, search_threshold=3)
         agent = Agent(chat_generator=OpenAIChatGenerator(model="gpt-4.1-nano"), tools=toolset, max_agent_steps=5)
 
@@ -783,3 +802,41 @@ class TestSearchableToolsetAgentIntegration:
         assert any(tool_call.tool_name == "search_tools" for tool_call in tool_calls)
         assert any(tool_call.tool_name == "get_weather" for tool_call in tool_calls)
         assert "22" in messages[-1].text
+
+    def test_agent_discovers_multiple_tools_across_steps(self, large_catalog):
+        """A task needing two different tools forces the agent to search for and load each one."""
+        # Use two tools the model cannot answer on its own (live weather and stock price) so it is forced
+        # to call both. top_k=1 means a single search returns at most one tool, so the agent must search
+        # again for the second tool — exercising that discovered tools accumulate across agent steps.
+        toolset = SearchableToolset(catalog=large_catalog, top_k=1, search_threshold=3)
+        agent = Agent(chat_generator=OpenAIChatGenerator(model="gpt-4.1-nano"), tools=toolset, max_agent_steps=8)
+
+        result = agent.run(
+            messages=[
+                ChatMessage.from_user(
+                    "What is the current weather in Milan, and what is the current stock price of AAPL? "
+                    "Use the available tools to look up both."
+                )
+            ]
+        )
+
+        tool_calls = [tool_call for msg in result["messages"] if msg.tool_calls for tool_call in msg.tool_calls]
+        called = {tc.tool_name for tc in tool_calls}
+        # The agent had to search (more than once given top_k=1) and use both discovered tools.
+        assert sum(tc.tool_name == "search_tools" for tc in tool_calls) >= 2
+        assert "get_weather" in called
+        assert "get_stock_price" in called
+
+    def test_agent_handles_no_matching_tool_gracefully(self, large_catalog):
+        """When no tool matches, the agent should not invoke a domain tool and should still answer."""
+        toolset = SearchableToolset(catalog=large_catalog, top_k=2, search_threshold=3)
+        agent = Agent(chat_generator=OpenAIChatGenerator(model="gpt-4.1-nano"), tools=toolset, max_agent_steps=5)
+
+        result = agent.run(messages=[ChatMessage.from_user("Translate the word 'hello' into French.")])
+
+        tool_calls = [tool_call for msg in result["messages"] if msg.tool_calls for tool_call in msg.tool_calls]
+        domain_tool_names = {tool.name for tool in large_catalog}
+        # No domain tool matches "translate", so none should have been invoked (only search_tools is allowed).
+        assert not (domain_tool_names & {tc.tool_name for tc in tool_calls})
+        # The agent still returns a non-empty text answer rather than erroring out.
+        assert result["last_message"].text.strip()

--- a/test/tools/test_searchable_toolset.py
+++ b/test/tools/test_searchable_toolset.py
@@ -826,17 +826,3 @@ class TestSearchableToolsetAgentIntegration:
         assert sum(tc.tool_name == "search_tools" for tc in tool_calls) >= 2
         assert "get_weather" in called
         assert "get_stock_price" in called
-
-    def test_agent_handles_no_matching_tool_gracefully(self, large_catalog):
-        """When no tool matches, the agent should not invoke a domain tool and should still answer."""
-        toolset = SearchableToolset(catalog=large_catalog, top_k=2, search_threshold=3)
-        agent = Agent(chat_generator=OpenAIChatGenerator(model="gpt-4.1-nano"), tools=toolset, max_agent_steps=5)
-
-        result = agent.run(messages=[ChatMessage.from_user("Translate the word 'hello' into French.")])
-
-        tool_calls = [tool_call for msg in result["messages"] if msg.tool_calls for tool_call in msg.tool_calls]
-        domain_tool_names = {tool.name for tool in large_catalog}
-        # No domain tool matches "translate", so none should have been invoked (only search_tools is allowed).
-        assert not (domain_tool_names & {tc.tool_name for tc in tool_calls})
-        # The agent still returns a non-empty text answer rather than erroring out.
-        assert result["last_message"].text.strip()


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/329
- related to https://github.com/deepset-ai/haystack/pull/11545

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

- ``SearchableToolset`` now raises a ``ValueError`` during ``warm_up()`` when its catalog
    contains tools with duplicate names. Previously duplicates were silently collapsed, which
    could cause a search hit to resolve to the wrong tool.

-``SearchableToolset`` serialization now preserves the catalog shape: a catalog passed as a
    single ``Toolset`` round-trips back to a ``Toolset`` (previously it was always rebuilt as a
    list). Serialization now reuses ``serialize_tools_or_toolset`` / ``deserialize_tools_or_toolset_inplace``.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
