### PR TITLE
Fix/llm evaluator raise on failure serialization

### DIFF
--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -302,6 +302,7 @@ class LLMEvaluator:
             examples=self.examples,
             chat_generator=component_to_dict(obj=self._chat_generator, name="chat_generator"),
             progress_bar=self.progress_bar,
+            raise_on_failure=self.raise_on_failure,
         )
 
     @classmethod

--- a/releasenotes/notes/fix-llm-evaluator-raise-on-failure-serialization-187bc2d104dd2a30.yaml
+++ b/releasenotes/notes/fix-llm-evaluator-raise-on-failure-serialization-187bc2d104dd2a30.yaml
@@ -1,0 +1,5 @@
+---
+bug_fixes:
+  - |
+    Fixed ``LLMEvaluator.to_dict`` not serializing the ``raise_on_failure`` parameter,
+    causing it to silently reset to ``True`` after a pipeline round-trip.

--- a/releasenotes/notes/fix-llm-evaluator-raise-on-failure-serialization-187bc2d104dd2a30.yaml
+++ b/releasenotes/notes/fix-llm-evaluator-raise-on-failure-serialization-187bc2d104dd2a30.yaml
@@ -1,5 +1,5 @@
 ---
-bug_fixes:
+fixes:
   - |
     Fixed ``LLMEvaluator.to_dict`` not serializing the ``raise_on_failure`` parameter,
     causing it to silently reset to ``True`` after a pipeline round-trip.

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -198,6 +198,7 @@ class TestLLMEvaluator:
                 "instructions": "test-instruction",
                 "inputs": [["predicted_answers", "list[str]"]],
                 "outputs": ["score"],
+                "raise_on_failure": True,
                 "progress_bar": True,
                 "examples": [
                     {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
@@ -213,6 +214,7 @@ class TestLLMEvaluator:
             instructions="test-instruction",
             inputs=[("predicted_answers", list[str])],
             outputs=["custom_score"],
+            raise_on_failure=False,
             examples=[
                 {
                     "inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"},
@@ -232,6 +234,7 @@ class TestLLMEvaluator:
                 "instructions": "test-instruction",
                 "inputs": [["predicted_answers", "list[str]"]],
                 "outputs": ["custom_score"],
+                "raise_on_failure": False,
                 "progress_bar": True,
                 "examples": [
                     {


### PR DESCRIPTION
### Related Issues

- fixes #11551 

### Proposed Changes:

LLMEvaluator.to_dict was missing the raise_on_failure parameter. Because of this omission, saving and loading a pipeline silently reset raise_on_failure back to its default value (True).

I fixed this by explicitly adding raise_on_failure=self.raise_on_failure to the default_to_dict call inside the to_dict method of LLMEvaluator class.

### How did you test it?

I updated the core unit tests to expect the serialized key and ran them successfully on Windows via PowerShell:
hatch run test:unit test/components/evaluators/test_llm_evaluator.py

### Notes for the reviewer

The fix is a simple one-line addition to to_dict alongside matching assertions in the test file.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
