### PR TITLE
feat: support Secret for azure_endpoint and api_version in AzureOpenAIChatGenerator

### DIFF
--- a/docs-website/docs/pipeline-components/generators/azureopenaichatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/azureopenaichatgenerator.mdx
@@ -43,6 +43,18 @@ client = AzureOpenAIChatGenerator(
 We recommend using environment variables instead of initialization parameters.
 :::
 
+You can also resolve `azure_endpoint` and `api_version` from environment variables at runtime by passing a `Secret` instead of a plain string. This is useful when you want to switch between environments (for example, dev and prod) without changing your pipeline definition – you only update the environment variables:
+
+```python
+from haystack.components.generators.chat import AzureOpenAIChatGenerator
+from haystack.utils import Secret
+
+client = AzureOpenAIChatGenerator(
+    azure_endpoint=Secret.from_env_var("AZURE_OPENAI_ENDPOINT"),
+    api_version=Secret.from_env_var("AZURE_OPENAI_API_VERSION"),
+)
+```
+
 Then, the component needs a list of `ChatMessage` objects to operate. `ChatMessage` is a data class that contains a message, a role (who generated the message, such as `user`, `assistant`, `system`, `function`), and optional metadata. If a string is passed, it is converted into a list containing a single `ChatMessage` with the `user` role. See the [usage](#usage) section for an example.
 
 You can pass any chat completion parameters that are valid for the `openai.ChatCompletion.create` method directly to `AzureOpenAIChatGenerator` using the `generation_kwargs` parameter, both at initialization and to `run()` method. For more details on the supported parameters, refer to the [Azure documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference).

--- a/docs-website/docs/pipeline-components/generators/azureopenaichatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/azureopenaichatgenerator.mdx
@@ -43,7 +43,7 @@ client = AzureOpenAIChatGenerator(
 We recommend using environment variables instead of initialization parameters.
 :::
 
-You can also resolve `azure_endpoint` and `api_version` from environment variables at runtime by passing a `Secret` instead of a plain string. This is useful when you want to switch between environments (for example, dev and prod) without changing your pipeline definition – you only update the environment variables:
+To switch `azure_endpoint` and `api_version` between environments without editing your pipeline, pass a Secret that resolves them from environment variables at runtime:
 
 ```python
 from haystack.components.generators.chat import AzureOpenAIChatGenerator

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/generators/azureopenaichatgenerator.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/generators/azureopenaichatgenerator.mdx
@@ -43,6 +43,18 @@ client = AzureOpenAIChatGenerator(
 We recommend using environment variables instead of initialization parameters.
 :::
 
+To switch `azure_endpoint` and `api_version` between environments without editing your pipeline, pass a Secret that resolves them from environment variables at runtime:
+
+```python
+from haystack.components.generators.chat import AzureOpenAIChatGenerator
+from haystack.utils import Secret
+
+client = AzureOpenAIChatGenerator(
+    azure_endpoint=Secret.from_env_var("AZURE_OPENAI_ENDPOINT"),
+    api_version=Secret.from_env_var("AZURE_OPENAI_API_VERSION"),
+)
+```
+
 Then, the component needs a list of `ChatMessage` objects to operate. `ChatMessage` is a data class that contains a message, a role (who generated the message, such as `user`, `assistant`, `system`, `function`), and optional metadata. If a string is passed, it is converted into a list containing a single `ChatMessage` with the `user` role. See the [usage](#usage) section for an example.
 
 You can pass any chat completion parameters that are valid for the `openai.ChatCompletion.create` method directly to `AzureOpenAIChatGenerator` using the `generation_kwargs` parameter, both at initialization and to `run()` method. For more details on the supported parameters, refer to the [Azure documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference).

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -111,8 +111,8 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
     # ruff: noqa: PLR0913
     def __init__(
         self,
-        azure_endpoint: str | None = None,
-        api_version: str | None = "2024-12-01-preview",
+        azure_endpoint: str | Secret | None = None,
+        api_version: str | Secret | None = "2024-12-01-preview",
         azure_deployment: str | None = "gpt-4.1-mini",
         api_key: Secret | None = Secret.from_env_var("AZURE_OPENAI_API_KEY", strict=False),
         azure_ad_token: Secret | None = Secret.from_env_var("AZURE_OPENAI_AD_TOKEN", strict=False),
@@ -132,7 +132,14 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         Initialize the Azure OpenAI Chat Generator component.
 
         :param azure_endpoint: The endpoint of the deployed model, for example `"https://example-resource.azure.openai.com/"`.
+            Can also be a [Secret](https://docs.haystack.deepset.ai/docs/secret-management), for example
+            `Secret.from_env_var("AZURE_OPENAI_ENDPOINT")`, to resolve the value from an environment variable at
+            runtime. This is useful to switch endpoints between environments (e.g. dev and prod) without changing the
+            serialized pipeline.
         :param api_version: The version of the API to use. Defaults to 2024-12-01-preview.
+            Can also be a [Secret](https://docs.haystack.deepset.ai/docs/secret-management), for example
+            `Secret.from_env_var("AZURE_OPENAI_API_VERSION")`, to resolve the value from an environment variable at
+            runtime.
         :param azure_deployment: The deployment of the model, usually the model name.
         :param api_key: The API key to use for authentication.
         :param azure_ad_token: [Azure Active Directory token](https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id).
@@ -194,8 +201,14 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         # None init parameters. This way we accommodate the use case where env var AZURE_OPENAI_ENDPOINT is set instead
         # of passing it as a parameter.
         azure_endpoint = azure_endpoint or os.environ.get("AZURE_OPENAI_ENDPOINT")
-        if not azure_endpoint:
+        # `azure_endpoint` and `api_version` accept either a plain string or a `Secret`. We keep the original value
+        # on the instance for serialization and resolve it to a string only when building the client.
+        resolved_azure_endpoint = (
+            azure_endpoint.resolve_value() if isinstance(azure_endpoint, Secret) else azure_endpoint
+        )
+        if not resolved_azure_endpoint:
             raise ValueError("Please provide an Azure endpoint or set the environment variable AZURE_OPENAI_ENDPOINT.")
+        resolved_api_version = api_version.resolve_value() if isinstance(api_version, Secret) else api_version
 
         if api_key is None and azure_ad_token is None:
             raise ValueError("Please provide an API key or an Azure Active Directory token.")
@@ -221,8 +234,8 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         self.tools_strict = tools_strict
 
         client_args: dict[str, Any] = {
-            "api_version": api_version,
-            "azure_endpoint": azure_endpoint,
+            "api_version": resolved_api_version,
+            "azure_endpoint": resolved_azure_endpoint,
             "azure_deployment": azure_deployment,
             "api_key": api_key.resolve_value() if api_key is not None else None,
             "azure_ad_token": azure_ad_token.resolve_value() if azure_ad_token is not None else None,
@@ -279,10 +292,12 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
             generation_kwargs["response_format"] = json_schema
         return default_to_dict(
             self,
-            azure_endpoint=self.azure_endpoint,
+            azure_endpoint=self.azure_endpoint.to_dict()
+            if isinstance(self.azure_endpoint, Secret)
+            else self.azure_endpoint,
             azure_deployment=self.azure_deployment,
             organization=self.organization,
-            api_version=self.api_version,
+            api_version=self.api_version.to_dict() if isinstance(self.api_version, Secret) else self.api_version,
             streaming_callback=callback_name,
             generation_kwargs=generation_kwargs,
             timeout=self.timeout,

--- a/releasenotes/notes/azure-chat-generator-secret-endpoint-api-version-0edaf403d50ff942.yaml
+++ b/releasenotes/notes/azure-chat-generator-secret-endpoint-api-version-0edaf403d50ff942.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    `AzureOpenAIChatGenerator` now accepts a `Secret` for the `azure_endpoint` and `api_version` parameters in
+    addition to a plain string. This makes it possible to resolve these values from environment variables at
+    runtime, for example with `Secret.from_env_var("AZURE_OPENAI_ENDPOINT")`, so the same serialized pipeline can
+    switch between environments (e.g. dev and prod) by changing environment variables instead of the pipeline
+    definition.

--- a/releasenotes/notes/azure-chat-generator-secret-endpoint-api-version-0edaf403d50ff942.yaml
+++ b/releasenotes/notes/azure-chat-generator-secret-endpoint-api-version-0edaf403d50ff942.yaml
@@ -1,8 +1,8 @@
 ---
 enhancements:
   - |
-    `AzureOpenAIChatGenerator` now accepts a `Secret` for the `azure_endpoint` and `api_version` parameters in
+    ``AzureOpenAIChatGenerator`` now accepts a ``Secret`` for the ``azure_endpoint`` and ``api_version`` parameters in
     addition to a plain string. This makes it possible to resolve these values from environment variables at
-    runtime, for example with `Secret.from_env_var("AZURE_OPENAI_ENDPOINT")`, so the same serialized pipeline can
+    runtime, for example with ``Secret.from_env_var("AZURE_OPENAI_ENDPOINT")``, so the same serialized pipeline can
     switch between environments (e.g. dev and prod) by changing environment variables instead of the pipeline
     definition.

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -137,6 +137,67 @@ class TestAzureOpenAIChatGenerator:
         assert component.azure_ad_token_provider is not None
         assert component.max_retries == 0
 
+    def test_init_with_secret_azure_endpoint_and_api_version(self, monkeypatch):
+        """`azure_endpoint` and `api_version` accept a Secret that is resolved from an environment variable."""
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://test-resource.azure.openai.com/")
+        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-08-01-preview")
+        component = AzureOpenAIChatGenerator(
+            azure_endpoint=Secret.from_env_var("AZURE_OPENAI_ENDPOINT"),
+            api_version=Secret.from_env_var("AZURE_OPENAI_API_VERSION"),
+        )
+        # The Secret objects are kept on the instance so they can be serialized
+        assert component.azure_endpoint == Secret.from_env_var("AZURE_OPENAI_ENDPOINT")
+        assert component.api_version == Secret.from_env_var("AZURE_OPENAI_API_VERSION")
+        # The clients receive the resolved string values
+        assert str(component.client._azure_endpoint) == "https://test-resource.azure.openai.com/"
+        assert component.client._api_version == "2024-08-01-preview"
+        assert str(component.async_client._azure_endpoint) == "https://test-resource.azure.openai.com/"
+        assert component.async_client._api_version == "2024-08-01-preview"
+
+    def test_init_fail_with_unset_secret_azure_endpoint(self, monkeypatch):
+        """A Secret azure_endpoint that resolves to nothing raises the same error as a missing endpoint."""
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        with pytest.raises(ValueError, match="Azure endpoint"):
+            AzureOpenAIChatGenerator(azure_endpoint=Secret.from_env_var("AZURE_OPENAI_ENDPOINT", strict=False))
+
+    def test_to_dict_with_secret_azure_endpoint_and_api_version(self, monkeypatch):
+        """Secret `azure_endpoint` and `api_version` are serialized as Secret dictionaries."""
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://test-resource.azure.openai.com/")
+        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-08-01-preview")
+        component = AzureOpenAIChatGenerator(
+            azure_endpoint=Secret.from_env_var("AZURE_OPENAI_ENDPOINT"),
+            api_version=Secret.from_env_var("AZURE_OPENAI_API_VERSION"),
+        )
+        init_params = component.to_dict()["init_parameters"]
+        assert init_params["azure_endpoint"] == {
+            "type": "env_var",
+            "env_vars": ["AZURE_OPENAI_ENDPOINT"],
+            "strict": True,
+        }
+        assert init_params["api_version"] == {
+            "type": "env_var",
+            "env_vars": ["AZURE_OPENAI_API_VERSION"],
+            "strict": True,
+        }
+
+    def test_secret_azure_endpoint_and_api_version_roundtrip(self, monkeypatch):
+        """Serializing and deserializing a component with Secret endpoint/version restores the Secrets."""
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://test-resource.azure.openai.com/")
+        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-08-01-preview")
+        component = AzureOpenAIChatGenerator(
+            azure_endpoint=Secret.from_env_var("AZURE_OPENAI_ENDPOINT"),
+            api_version=Secret.from_env_var("AZURE_OPENAI_API_VERSION"),
+        )
+        deserialized = AzureOpenAIChatGenerator.from_dict(component.to_dict())
+        assert deserialized.azure_endpoint == Secret.from_env_var("AZURE_OPENAI_ENDPOINT")
+        assert deserialized.api_version == Secret.from_env_var("AZURE_OPENAI_API_VERSION")
+        assert str(deserialized.client._azure_endpoint) == "https://test-resource.azure.openai.com/"
+        assert deserialized.client._api_version == "2024-08-01-preview"
+
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
         component = AzureOpenAIChatGenerator(azure_endpoint="some-non-existing-endpoint")

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -198,6 +198,39 @@ class TestAzureOpenAIChatGenerator:
         assert str(deserialized.client._azure_endpoint) == "https://test-resource.azure.openai.com/"
         assert deserialized.client._api_version == "2024-08-01-preview"
 
+    def test_from_dict_with_secret_azure_endpoint_and_api_version(self, monkeypatch):
+        """from_dict deserializes Secret azure_endpoint/api_version dicts and resolves them for the client."""
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://test-resource.azure.openai.com/")
+        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-08-01-preview")
+        data = {
+            "type": "haystack.components.generators.chat.azure.AzureOpenAIChatGenerator",
+            "init_parameters": {
+                "api_key": {"env_vars": ["AZURE_OPENAI_API_KEY"], "strict": False, "type": "env_var"},
+                "azure_ad_token": {"env_vars": ["AZURE_OPENAI_AD_TOKEN"], "strict": False, "type": "env_var"},
+                "azure_endpoint": {"env_vars": ["AZURE_OPENAI_ENDPOINT"], "strict": True, "type": "env_var"},
+                "api_version": {"env_vars": ["AZURE_OPENAI_API_VERSION"], "strict": True, "type": "env_var"},
+                "azure_deployment": "gpt-4.1-mini",
+                "organization": None,
+                "streaming_callback": None,
+                "generation_kwargs": {},
+                "timeout": 30.0,
+                "max_retries": 5,
+                "default_headers": {},
+                "tools": None,
+                "tools_strict": False,
+                "azure_ad_token_provider": None,
+                "http_client_kwargs": None,
+            },
+        }
+        generator = AzureOpenAIChatGenerator.from_dict(data)
+        # The Secret dicts are deserialized back into Secret objects
+        assert generator.azure_endpoint == Secret.from_env_var("AZURE_OPENAI_ENDPOINT")
+        assert generator.api_version == Secret.from_env_var("AZURE_OPENAI_API_VERSION")
+        # And they are resolved to the string values the client expects
+        assert str(generator.client._azure_endpoint) == "https://test-resource.azure.openai.com/"
+        assert generator.client._api_version == "2024-08-01-preview"
+
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
         component = AzureOpenAIChatGenerator(azure_endpoint="some-non-existing-endpoint")


### PR DESCRIPTION
## Related Issues

Closes #11559

## Proposed Changes

`AzureOpenAIChatGenerator` now accepts a `Secret` for the `azure_endpoint` and `api_version` init parameters, in addition to the existing plain-string support. This lets users resolve these values from environment variables at runtime, e.g.:

```python
from haystack.components.generators.chat import AzureOpenAIChatGenerator
from haystack.utils import Secret

generator = AzureOpenAIChatGenerator(
    azure_endpoint=Secret.from_env_var("AZURE_OPENAI_ENDPOINT"),
    api_version=Secret.from_env_var("AZURE_OPENAI_API_VERSION"),
)
```


Details:
- `__init__` keeps the original value (`str` or `Secret`) on the instance for serialization and resolves it to a string only when constructing the `AzureOpenAI`/`AsyncAzureOpenAI` clients. A `Secret` endpoint that resolves to nothing raises the same `ValueError` as a missing endpoint.
- `to_dict` serializes a `Secret` value via its `to_dict()`, and leaves plain strings untouched.
- `from_dict` needs no change: `default_from_dict` already auto-deserializes `{"type": "env_var", ...}` dicts back into `Secret` objects.
- Docs page update

## How did you test it?

- Added unit tests covering `Secret` init (resolved values reach both sync and async clients), the unset-`Secret` error path, `to_dict` serialization, and a `to_dict`/`from_dict` round-trip.

## Notes for the reviewer

> **Scope note:** The same pattern exists in `AzureOpenAIGenerator`, `AzureOpenAITextEmbedder`, and `AzureOpenAIDocumentEmbedder`. This PR intentionally limits the change to `AzureOpenAIChatGenerator` as requested in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)