### PR TITLE
fix: reject unsafe `list[T] → T` Pipeline connections to prevent silent data loss

### DIFF
--- a/haystack/core/type_utils.py
+++ b/haystack/core/type_utils.py
@@ -208,11 +208,14 @@ def _get_conversion_strategy(sender: Any, receiver: Any) -> ConversionStrategyTy
         if _contains_type(sender, str) and _contains_type(inner, ChatMessage):
             return ConversionStrategy.WRAP_STR_TO_CHAT_MESSAGE
 
-    # Unwrap: List[T] -> T - for str and ChatMessage only
+    # Unwrap: list[T] -> T, restricted to str / ChatMessage to avoid silent drop of list[1:].
     if _safe_get_origin(sender) is list and (args := get_args(sender)):
         inner = args[0]
-        # Guard against multi-level unwrap (e.g. list[list[str]] -> list[str])
-        if _safe_get_origin(receiver) is not list and _strict_types_are_compatible(inner, receiver):
+        if (
+            _safe_get_origin(receiver) is not list
+            and inner in (str, ChatMessage)
+            and _strict_types_are_compatible(inner, receiver)
+        ):
             return ConversionStrategy.UNWRAP
         # Unwrap + conversion
         # Check that all possible types in the sender list can be converted to the receiver type
@@ -261,8 +264,14 @@ def _chat_message_to_str(value: Any) -> str:
 
 
 def _get_first_item(value: list[Any]) -> Any:
+    """Returns the only element of a one-element list. Raises on empty or multi-element input."""
     if not value:
         raise ValueError("Cannot get first item of an empty list. ")
+    if len(value) > 1:
+        raise ValueError(
+            f"Cannot unwrap a list of {len(value)} items to a single value: "
+            "a list-to-scalar connection only accepts one-element lists; otherwise items would be silently dropped."
+        )
     return value[0]
 
 

--- a/haystack/core/type_utils.py
+++ b/haystack/core/type_utils.py
@@ -211,6 +211,7 @@ def _get_conversion_strategy(sender: Any, receiver: Any) -> ConversionStrategyTy
     # Unwrap: list[T] -> T, restricted to str / ChatMessage to avoid silent drop of list[1:].
     if _safe_get_origin(sender) is list and (args := get_args(sender)):
         inner = args[0]
+        # Guard against multi-level unwrap (e.g. list[list[str]] -> list[str])
         if (
             _safe_get_origin(receiver) is not list
             and inner in (str, ChatMessage)

--- a/releasenotes/notes/fix-list-to-scalar-silent-unwrap-8a58b54361ed3a2c.yaml
+++ b/releasenotes/notes/fix-list-to-scalar-silent-unwrap-8a58b54361ed3a2c.yaml
@@ -1,26 +1,14 @@
 ---
-upgrade:
-  - |
-    ``Pipeline.connect()`` no longer accepts ``list[T] -> T`` connections for inner types other
-    than ``str`` and ``ChatMessage``. Previously, any ``list[T] -> T`` connection (e.g.
-    ``list[Document] -> Document``) was silently accepted and at runtime only the first list
-    element was forwarded to the downstream component, dropping the rest. Such connections now
-    raise ``PipelineConnectError`` at ``connect()`` time. If you were relying on the previous
-    silent-unwrap behavior, change either the producer's output socket type or the consumer's
-    input socket type so the wiring no longer requires an unwrap, or perform the
-    list-to-single-item selection explicitly in a component before the consumer.
-
-    As a defense-in-depth measure, the runtime ``UNWRAP`` conversion (still allowed for
-    ``list[str] -> str`` and ``list[ChatMessage] -> ChatMessage``) now raises ``ValueError``
-    (wrapped in ``PipelineRuntimeError``) when given a multi-element list. The supported case
-    has always been a one-element list; multi-element inputs used to be silently truncated to
-    the first element. This also affects e.g. a generator using ``n>1`` whose ``replies`` are
-    wired into a single-``str`` or single-``ChatMessage`` consumer — that pipeline now raises
-    instead of silently using ``replies[0]``.
 fixes:
   - |
     Fixed a silent data-loss bug in ``Pipeline.connect()`` where any ``list[T] -> T`` connection
-    was accepted without warning and only the first list element was forwarded at runtime,
-    dropping the rest. This regressed in #10629; the restriction to ``str`` / ``ChatMessage``
-    has been restored. The fix also rejects multi-element inputs at runtime so any future
-    regression of the connect-time gate cannot silently drop data again.
+    was accepted without warning (e.g. ``list[Document] -> Document``) and only the first list
+    element was forwarded at runtime, dropping the rest. The conversion is now restricted to
+    inner types ``str`` and ``ChatMessage``, matching the original intent; any other
+    ``list[T] -> T`` wiring now raises ``PipelineConnectError`` at ``connect()`` time. As a
+    defense-in-depth measure, the runtime ``UNWRAP`` conversion also raises ``ValueError``
+    (wrapped in ``PipelineRuntimeError``) when given a multi-element list, so any future
+    regression of the connect-time gate cannot silently drop items. This also affects e.g. a
+    generator using ``n>1`` whose ``replies`` are wired into a single-``str`` or
+    single-``ChatMessage`` consumer — that pipeline now raises instead of silently using
+    ``replies[0]``.

--- a/releasenotes/notes/fix-list-to-scalar-silent-unwrap-8a58b54361ed3a2c.yaml
+++ b/releasenotes/notes/fix-list-to-scalar-silent-unwrap-8a58b54361ed3a2c.yaml
@@ -1,0 +1,26 @@
+---
+upgrade:
+  - |
+    ``Pipeline.connect()`` no longer accepts ``list[T] -> T`` connections for inner types other
+    than ``str`` and ``ChatMessage``. Previously, any ``list[T] -> T`` connection (e.g.
+    ``list[Document] -> Document``) was silently accepted and at runtime only the first list
+    element was forwarded to the downstream component, dropping the rest. Such connections now
+    raise ``PipelineConnectError`` at ``connect()`` time. If you were relying on the previous
+    silent-unwrap behavior, change either the producer's output socket type or the consumer's
+    input socket type so the wiring no longer requires an unwrap, or perform the
+    list-to-single-item selection explicitly in a component before the consumer.
+
+    As a defense-in-depth measure, the runtime ``UNWRAP`` conversion (still allowed for
+    ``list[str] -> str`` and ``list[ChatMessage] -> ChatMessage``) now raises ``ValueError``
+    (wrapped in ``PipelineRuntimeError``) when given a multi-element list. The supported case
+    has always been a one-element list; multi-element inputs used to be silently truncated to
+    the first element. This also affects e.g. a generator using ``n>1`` whose ``replies`` are
+    wired into a single-``str`` or single-``ChatMessage`` consumer — that pipeline now raises
+    instead of silently using ``replies[0]``.
+fixes:
+  - |
+    Fixed a silent data-loss bug in ``Pipeline.connect()`` where any ``list[T] -> T`` connection
+    was accepted without warning and only the first list element was forwarded at runtime,
+    dropping the rest. This regressed in #10629; the restriction to ``str`` / ``ChatMessage``
+    has been restored. The fix also rejects multi-element inputs at runtime so any future
+    regression of the connect-time gate cannot silently drop data again.

--- a/test/core/pipeline/test_async_pipeline.py
+++ b/test/core/pipeline/test_async_pipeline.py
@@ -9,6 +9,7 @@ from dataclasses import replace
 import pytest
 
 from haystack import AsyncPipeline, Document, component
+from haystack.core.errors import PipelineRuntimeError
 
 
 def test_async_pipeline_reentrance(waiting_component, spying_tracer):
@@ -280,3 +281,26 @@ def test_async_pipeline_does_not_corrupt_outputs():
 
     assert result["producer"]["doc"].content == "original"
     assert result["mutator"]["doc"].content == "mutated"
+
+
+@pytest.mark.asyncio
+async def test_run_async_raises_when_multi_element_list_is_unwrapped_at_runtime():
+    @component
+    class MultiStrProducer:
+        @component.output_types(texts=list[str])
+        def run(self) -> dict[str, list[str]]:
+            return {"texts": ["first", "second", "third"]}
+
+    @component
+    class SingleStrConsumer:
+        @component.output_types(out=str)
+        def run(self, text: str) -> dict[str, str]:
+            return {"out": text}
+
+    pipe = AsyncPipeline()
+    pipe.add_component("producer", MultiStrProducer())
+    pipe.add_component("consumer", SingleStrConsumer())
+    pipe.connect("producer.texts", "consumer.text")
+
+    with pytest.raises(PipelineRuntimeError, match="Cannot unwrap a list of 3 items"):
+        await pipe.run_async({})

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -10,7 +10,7 @@ import pytest
 from haystack.components.agents import Agent
 from haystack.components.joiners import BranchJoiner
 from haystack.core.component import component
-from haystack.core.errors import PipelineRuntimeError
+from haystack.core.errors import PipelineConnectError, PipelineRuntimeError
 from haystack.core.pipeline import Pipeline
 from haystack.dataclasses import ChatMessage, Document
 
@@ -498,3 +498,62 @@ class TestPipeline:
         p.connect("list_producer.messages", "receiver.messages")
         result = p.run({})
         assert [m.text for m in result["receiver"]["result"]] == ["hello", "world", "!"]
+
+    def test_connect_rejects_list_of_documents_to_single_document(self):
+        @component
+        class DocsProducer:
+            @component.output_types(docs=list[Document])
+            def run(self) -> dict[str, list[Document]]:
+                return {"docs": [Document(content="a"), Document(content="b"), Document(content="c")]}
+
+        @component
+        class DocConsumer:
+            @component.output_types(out=Document)
+            def run(self, doc: Document) -> dict[str, Document]:
+                return {"out": doc}
+
+        p = Pipeline()
+        p.add_component("producer", DocsProducer())
+        p.add_component("consumer", DocConsumer())
+        with pytest.raises(PipelineConnectError):
+            p.connect("producer.docs", "consumer.doc")
+
+    def test_run_raises_when_multi_element_list_is_unwrapped_at_runtime(self):
+        @component
+        class MultiStrProducer:
+            @component.output_types(texts=list[str])
+            def run(self) -> dict[str, list[str]]:
+                return {"texts": ["first", "second", "third"]}
+
+        @component
+        class SingleStrConsumer:
+            @component.output_types(out=str)
+            def run(self, text: str) -> dict[str, str]:
+                return {"out": text}
+
+        p = Pipeline()
+        p.add_component("producer", MultiStrProducer())
+        p.add_component("consumer", SingleStrConsumer())
+        p.connect("producer.texts", "consumer.text")
+
+        with pytest.raises(PipelineRuntimeError, match="Cannot unwrap a list of 3 items"):
+            p.run({})
+
+    def test_run_single_element_list_unwrap_still_works(self):
+        @component
+        class SingleStrProducer:
+            @component.output_types(texts=list[str])
+            def run(self) -> dict[str, list[str]]:
+                return {"texts": ["only-one"]}
+
+        @component
+        class SingleStrConsumer:
+            @component.output_types(out=str)
+            def run(self, text: str) -> dict[str, str]:
+                return {"out": text}
+
+        p = Pipeline()
+        p.add_component("producer", SingleStrProducer())
+        p.add_component("consumer", SingleStrConsumer())
+        p.connect("producer.texts", "consumer.text")
+        assert p.run({}) == {"consumer": {"out": "only-one"}}

--- a/test/core/test_type_utils.py
+++ b/test/core/test_type_utils.py
@@ -1119,7 +1119,7 @@ class TestConversion:
         # so callers must use the base types directly. Pins the behavior change vs the prior
         # `_strict_types_are_compatible` gate which accepted subclasses.
         class MyStr(str):
-            pass
+            __slots__ = ()
 
         assert _types_are_compatible(sender=list[MyStr], receiver=str) == (False, None)
 

--- a/test/core/test_type_utils.py
+++ b/test/core/test_type_utils.py
@@ -915,6 +915,12 @@ class TestConversion:
         assert _get_first_item(value=["Hello"]) == "Hello"
         assert _get_first_item(value=[ChatMessage.from_assistant("Hello")]) == ChatMessage.from_assistant("Hello")
 
+    def test_get_first_item_rejects_multi_element_list(self):
+        with pytest.raises(ValueError, match="Cannot unwrap a list of 2 items to a single value"):
+            _get_first_item(value=["a", "b"])
+        with pytest.raises(ValueError, match="Cannot unwrap a list of 3 items to a single value"):
+            _get_first_item(value=[1, 2, 3])
+
     def test_types_are_compatible_with_conversion(self):
         assert _types_are_compatible(sender=Optional[str], receiver=str) == (False, None)
         assert _types_are_compatible(sender=str | None, receiver=str) == (False, None)
@@ -1086,6 +1092,68 @@ class TestConversion:
             )
             == "Hello"
         )
+
+    def test_unwrap_rejects_non_str_chatmessage_inner_types(self):
+        assert _types_are_compatible(sender=List[Document], receiver=Document) == (False, None)
+        assert _types_are_compatible(sender=list[Document], receiver=Document) == (False, None)
+        assert _types_are_compatible(sender=List[GeneratedAnswer], receiver=GeneratedAnswer) == (False, None)
+        assert _types_are_compatible(sender=list[GeneratedAnswer], receiver=GeneratedAnswer) == (False, None)
+        assert _types_are_compatible(sender=List[ByteStream], receiver=ByteStream) == (False, None)
+        assert _types_are_compatible(sender=list[ByteStream], receiver=ByteStream) == (False, None)
+
+        assert _types_are_compatible(sender=List[int], receiver=int) == (False, None)
+        assert _types_are_compatible(sender=list[int], receiver=int) == (False, None)
+        assert _types_are_compatible(sender=List[float], receiver=float) == (False, None)
+        assert _types_are_compatible(sender=List[bytes], receiver=bytes) == (False, None)
+        assert _types_are_compatible(sender=List[dict], receiver=dict) == (False, None)
+
+        assert _types_are_compatible(sender=List[Class1], receiver=Class1) == (False, None)
+        assert _types_are_compatible(sender=list[Class1], receiver=Class1) == (False, None)
+        assert _types_are_compatible(sender=List[Class3], receiver=Class1) == (False, None)
+
+        assert _types_are_compatible(sender=list[Document], receiver=Optional[Document]) == (False, None)
+        assert _types_are_compatible(sender=list[Document], receiver=Document | None) == (False, None)
+        assert _types_are_compatible(sender=list[Document], receiver=Union[Document, int]) == (False, None)
+
+        # subclasses of str / ChatMessage are intentionally NOT allowed: the gate is identity-based,
+        # so callers must use the base types directly. Pins the behavior change vs the prior
+        # `_strict_types_are_compatible` gate which accepted subclasses.
+        class MyStr(str):
+            pass
+
+        assert _types_are_compatible(sender=list[MyStr], receiver=str) == (False, None)
+
+        # Other shapes that should never unwrap
+        assert _types_are_compatible(sender=list[Any], receiver=str) == (False, None)
+        assert _types_are_compatible(sender=list[list[str]], receiver=str) == (False, None)
+        assert _types_are_compatible(sender=list[str | None], receiver=ChatMessage) == (False, None)
+        assert _types_are_compatible(sender=list[ChatMessage | None], receiver=str) == (False, None)
+
+        assert _types_are_compatible(sender=List[str], receiver=str) == (True, ConversionStrategy.UNWRAP)
+        assert _types_are_compatible(sender=List[ChatMessage], receiver=ChatMessage) == (
+            True,
+            ConversionStrategy.UNWRAP,
+        )
+        assert _types_are_compatible(sender=List[str], receiver=ChatMessage) == (
+            True,
+            ConversionStrategy.UNWRAP_STR_TO_CHAT_MESSAGE,
+        )
+        assert _types_are_compatible(sender=List[ChatMessage], receiver=str) == (
+            True,
+            ConversionStrategy.UNWRAP_CHAT_MESSAGE_TO_STR,
+        )
+
+    def test_convert_value_unwrap_raises_on_multi_element_list(self):
+        with pytest.raises(ValueError, match="Cannot unwrap a list of 2 items to a single value"):
+            _convert_value(value=["a", "b"], conversion_strategy=ConversionStrategy.UNWRAP)
+        with pytest.raises(ValueError, match="Cannot unwrap a list of 2 items to a single value"):
+            _convert_value(value=["a", "b"], conversion_strategy=ConversionStrategy.UNWRAP_STR_TO_CHAT_MESSAGE)
+        with pytest.raises(ValueError, match="Cannot unwrap a list of 2 items to a single value"):
+            _convert_value(
+                value=[ChatMessage.from_assistant("x"), ChatMessage.from_assistant("y")],
+                conversion_strategy=ConversionStrategy.UNWRAP_CHAT_MESSAGE_TO_STR,
+            )
+        assert _convert_value(value=["only"], conversion_strategy=ConversionStrategy.UNWRAP) == "only"
 
     def test_union_in_sender_problem(self):
         # Case 1: sender is a union that includes the type that can be converted

--- a/test/core/test_type_utils.py
+++ b/test/core/test_type_utils.py
@@ -1115,9 +1115,7 @@ class TestConversion:
         assert _types_are_compatible(sender=list[Document], receiver=Document | None) == (False, None)
         assert _types_are_compatible(sender=list[Document], receiver=Union[Document, int]) == (False, None)
 
-        # subclasses of str / ChatMessage are intentionally NOT allowed: the gate is identity-based,
-        # so callers must use the base types directly. Pins the behavior change vs the prior
-        # `_strict_types_are_compatible` gate which accepted subclasses.
+        # subclasses of str / ChatMessage are intentionally NOT allowed
         class MyStr(str):
             __slots__ = ()
 
@@ -1141,6 +1139,11 @@ class TestConversion:
         assert _types_are_compatible(sender=List[ChatMessage], receiver=str) == (
             True,
             ConversionStrategy.UNWRAP_CHAT_MESSAGE_TO_STR,
+        )
+        assert _types_are_compatible(sender=list[str], receiver=Optional[str]) == (True, ConversionStrategy.UNWRAP)
+        assert _types_are_compatible(sender=list[ChatMessage], receiver=Optional[ChatMessage]) == (
+            True,
+            ConversionStrategy.UNWRAP,
         )
 
     def test_convert_value_unwrap_raises_on_multi_element_list(self):


### PR DESCRIPTION
### Related Issues

- fixes #11563

### Proposed Changes:

Pipeline.connect() was silently accepting any list[T] → T connection (e.g. list[Document] → Document) and at runtime forwarding only the first list element to the receiver, silently dropping the rest. The inline comment in _get_conversion_strategy claimed the unwrap was meant for str and ChatMessage only, but the gate had been replaced with a generic _strict_types_are_compatible check in #10629, so the restriction was documented but no longer enforced.

This PR restores the explicit str / ChatMessage allowlist at connect time, so list[Document] → Document, list[Answer] → Answer, list[<custom-class>] → <custom-class>, etc. now raise PipelineConnectError instead of silently losing data.

As a defense-in-depth measure, _get_first_item (the runtime helper behind all three UNWRAP* strategies) also raises on multi-element input. So any future regression of the connect-time gate still surfaces loudly at runtime instead of silently dropping items.

### How did you test it?

- Unit tests in test/core/test_type_utils.py:
  - Connect-time rejection for list[Document], list[GeneratedAnswer], list[ByteStream], primitives, custom classes, Optional[T] / Union[T, X] receivers, subclasses of str, list[Any], list[list[str]], list[str | None] → ChatMessage.
  - Runtime guard on _get_first_item and on all three UNWRAP* strategies via _convert_value.
  - Regression assertions that the supported str / ChatMessage paths and the UNWRAP_*_TO_* cross-conversions still work.
- Integration tests in test/core/pipeline/test_pipeline.py and test/core/pipeline/test_async_pipeline.py:
  - Pipeline.connect("producer.docs", "consumer.doc") for list[Document] → Document now raises PipelineConnectError.
  - Pipeline.run and AsyncPipeline.run_async raise PipelineRuntimeError when a multi-element list[str] reaches a str-typed socket.
  - Counter-test confirming the one-element list[str] → str happy path still works end-to-end.
- Full unit suite: 5157 passed, hatch run fmt-check clean, hatch run test:types clean across 365 source files.

### Notes for the reviewer

- The behavior change is intentional but worth a careful look at the upgrade: section of the release note, pipelines that wired any list[T] → T for T not in {str, ChatMessage} will now fail at connect() instead of silently dropping. The most likely real-world break is an LLM generator running with n>1 whose replies are wired into a single-str / single-ChatMessage consumer.
- The new gate is identity-based (inner in (str, ChatMessage)): it intentionally rejects subclasses of str/ChatMessage. There's an explicit MyStr(str) test pinning this. Open to broadening to issubclass if that's preferred, but I think strict identity matches the spirit of the fix.
- _get_first_item is private and was only ever called from _convert_value (grep confirms), so adding the multi-element raise has no external blast radius.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
