### PR TITLE
fix: telemetry decorator overwrites original function metadata

### DIFF
--- a/haystack/telemetry/_telemetry.py
+++ b/haystack/telemetry/_telemetry.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
+import functools
 import logging
 import os
 import uuid
@@ -121,7 +122,7 @@ def send_telemetry(func: Callable[..., Any]) -> Callable[..., None]:
     The wrapped function is actually called only if telemetry is enabled.
     """
 
-    # FIXME? Somehow, functools.wraps makes `telemetry` out of scope. Let's take care of it later.
+    @functools.wraps(func)
     def send_telemetry_wrapper(*args: Any, **kwargs: Any) -> None:
         try:
             if telemetry:

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -10,7 +10,7 @@ import pytest
 
 from haystack import AsyncPipeline, Pipeline, component
 from haystack.core.serialization import generate_qualified_class_name
-from haystack.telemetry._telemetry import pipeline_running
+from haystack.telemetry._telemetry import pipeline_running, tutorial_running
 from haystack.utils.auth import Secret, TokenSecret
 
 
@@ -114,3 +114,27 @@ def test_pipeline_running_with_non_dict_telemetry_data(caplog):
     with caplog.at_level(logging.DEBUG):
         pipeline_running(pipe)
         assert "TypeError: Telemetry data for component my_component must be a dictionary" in caplog.text
+
+
+def test_send_telemetry_preserves_function_metadata():
+    """
+    Regression test for https://github.com/deepset-ai/haystack/issues/11568.
+
+    The ``send_telemetry`` decorator must use ``functools.wraps`` so that decorated functions such as
+    ``pipeline_running`` and ``tutorial_running`` keep their own metadata (``__name__``, ``__doc__`` and
+    ``__annotations__``) instead of exposing the ``send_telemetry_wrapper`` wrapper's.
+    """
+    # ``__name__`` comes from the wrapped function, not the wrapper.
+    assert pipeline_running.__name__ == "pipeline_running"
+    assert tutorial_running.__name__ == "tutorial_running"
+
+    # ``__doc__`` is preserved.
+    assert pipeline_running.__doc__ is not None
+    assert "Collects telemetry data for a pipeline run" in pipeline_running.__doc__
+
+    # ``__annotations__`` are preserved, e.g. the wrapped functions' parameters.
+    assert "pipeline" in pipeline_running.__annotations__
+    assert "tutorial_id" in tutorial_running.__annotations__
+
+    # ``functools.wraps`` also exposes the undecorated function through ``__wrapped__``.
+    assert pipeline_running.__wrapped__.__name__ == "pipeline_running"


### PR DESCRIPTION
### Related Issues

- fixes #11568

### Proposed Changes:

- Added `import functools` to `haystack/telemetry/_telemetry.py`.
- Applied the `@functools.wraps(func)` decorator to `send_telemetry_wrapper`.
- Removed the obsolete `# FIXME` comment suggesting that `functools.wraps` makes the global `telemetry` variable out of scope.

This ensures that any telemetry-wrapped functions (such as `pipeline_running` and `tutorial_running`) retain their original metadata, such as `__name__`, `__doc__`, and `__annotations__`.

### How did you test it?

- Ran the local telemetry test suite to verify no scope or runtime errors occur:
  ```bash
  hatch -e test run python -m pytest test/test_telemetry.py
  ```
- All 4 tests passed successfully.

### Notes for the reviewer

The original `# FIXME` was likely caused by a missing `functools` import in this file rather than an actual scoping issue. Python resolves global variables at execution time, and `functools.wraps` merely copies function metadata at decoration time, meaning it has no effect on the runtime scope of the global `telemetry` variable.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings. *(N/A: Existing telemetry tests were run and passed).*
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix: telemetry decorator overwrites original function metadata`.
- [x] I have documented my code.
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes). *(Note: If needed, you can generate this by running `hatch run release-note "Fix telemetry decorator metadata loss"`)*
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
```