### PR TITLE
chore: deprecate SerperDevWebSearch + update docs

### DIFF
--- a/docs-website/docs/pipeline-components/websearch/serperdevwebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/serperdevwebsearch.mdx
@@ -17,9 +17,9 @@ Search engine using SerperDev API.
 | **Mandatory init variables** | `api_key`: The SearchAPI API key. Can be set with `SERPERDEV_API_KEY` env var. |
 | **Mandatory run variables** | `query`: A string with your query |
 | **Output variables** | `documents`: A list of documents  <br /> <br />`links`: A list of strings of resulting links |
-| **API reference** | [Websearch](/reference/websearch-api) |
-| **GitHub link** | https://github.com/deepset-ai/haystack/blob/main/haystack/components/websearch/serper_dev.py |
-| **Package name** | `haystack-ai` |
+| **API reference** | [SerperDev](/reference/integrations-serperdev) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/serperdev |
+| **Package name** | `serperdev-haystack` |
 
 </div>
 
@@ -38,12 +38,18 @@ To use [Search API](https://www.searchapi.io/) as an alternative, see its respec
 
 ## Usage
 
+Install the `serperdev-haystack` package to use the `SerperDevWebSearch` component:
+
+```shell
+pip install serperdev-haystack
+```
+
 ### On its own
 
 This is an example of how `SerperDevWebSearch` looks up answers to our query on the web and converts the results into a list of documents with content snippets of the results, as well as URLs as strings.
 
 ```python
-from haystack.components.websearch import SerperDevWebSearch
+from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch
 from haystack.utils import Secret
 
 web_search = SerperDevWebSearch(api_key=Secret.from_token("<your-api-key>"))
@@ -63,7 +69,7 @@ from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
 from haystack.components.fetchers import LinkContentFetcher
 from haystack.components.converters import HTMLToDocument
 from haystack.components.generators.chat import OpenAIChatGenerator
-from haystack.components.websearch import SerperDevWebSearch
+from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch
 from haystack.dataclasses import ChatMessage
 from haystack.utils import Secret
 
@@ -181,7 +187,7 @@ components:
       exclude_subdomains: false
       search_params: {}
       top_k: 2
-    type: haystack.components.websearch.serper_dev.SerperDevWebSearch
+    type: haystack_integrations.components.websearch.serperdev.serperdev_websearch.SerperDevWebSearch
 connection_type_validation: true
 connections:
 - receiver: fetcher.urls

--- a/docs-website/docs/pipeline-components/websearch/serperdevwebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/serperdevwebsearch.mdx
@@ -187,7 +187,7 @@ components:
       exclude_subdomains: false
       search_params: {}
       top_k: 2
-    type: haystack_integrations.components.websearch.serperdev.serperdev_websearch.SerperDevWebSearch
+    type: haystack_integrations.components.websearch.serperdev.websearch.SerperDevWebSearch
 connection_type_validation: true
 connections:
 - receiver: fetcher.urls

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/websearch/serperdevwebsearch.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/websearch/serperdevwebsearch.mdx
@@ -17,9 +17,9 @@ Search engine using SerperDev API.
 | **Mandatory init variables** | `api_key`: The SearchAPI API key. Can be set with `SERPERDEV_API_KEY` env var. |
 | **Mandatory run variables** | `query`: A string with your query |
 | **Output variables** | `documents`: A list of documents  <br /> <br />`links`: A list of strings of resulting links |
-| **API reference** | [Websearch](/reference/websearch-api) |
-| **GitHub link** | https://github.com/deepset-ai/haystack/blob/main/haystack/components/websearch/serper_dev.py |
-| **Package name** | `haystack-ai` |
+| **API reference** | [SerperDev](/reference/integrations-serperdev) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/serperdev |
+| **Package name** | `serperdev-haystack` |
 
 </div>
 
@@ -38,12 +38,18 @@ To use [Search API](https://www.searchapi.io/) as an alternative, see its respec
 
 ## Usage
 
+Install the `serperdev-haystack` package to use the `SerperDevWebSearch` component:
+
+```shell
+pip install serperdev-haystack
+```
+
 ### On its own
 
 This is an example of how `SerperDevWebSearch` looks up answers to our query on the web and converts the results into a list of documents with content snippets of the results, as well as URLs as strings.
 
 ```python
-from haystack.components.websearch import SerperDevWebSearch
+from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch
 from haystack.utils import Secret
 
 web_search = SerperDevWebSearch(api_key=Secret.from_token("<your-api-key>"))
@@ -63,7 +69,7 @@ from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
 from haystack.components.fetchers import LinkContentFetcher
 from haystack.components.converters import HTMLToDocument
 from haystack.components.generators.chat import OpenAIChatGenerator
-from haystack.components.websearch import SerperDevWebSearch
+from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch
 from haystack.dataclasses import ChatMessage
 from haystack.utils import Secret
 
@@ -181,7 +187,7 @@ components:
       exclude_subdomains: false
       search_params: {}
       top_k: 2
-    type: haystack.components.websearch.serper_dev.SerperDevWebSearch
+    type: haystack_integrations.components.websearch.serperdev.serperdev_websearch.SerperDevWebSearch
 connection_type_validation: true
 connections:
 - receiver: fetcher.urls

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/websearch/serperdevwebsearch.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/websearch/serperdevwebsearch.mdx
@@ -187,7 +187,7 @@ components:
       exclude_subdomains: false
       search_params: {}
       top_k: 2
-    type: haystack_integrations.components.websearch.serperdev.serperdev_websearch.SerperDevWebSearch
+    type: haystack_integrations.components.websearch.serperdev.websearch.SerperDevWebSearch
 connection_type_validation: true
 connections:
 - receiver: fetcher.urls

--- a/haystack/components/websearch/serper_dev.py
+++ b/haystack/components/websearch/serper_dev.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from typing import Any
 from urllib.parse import urlparse
 
@@ -73,6 +74,15 @@ class SerperDevWebSearch:
             For example, you can set 'num' to 20 to increase the number of search results.
             See the [Serper website](https://serper.dev/) for more details.
         """
+        warnings.warn(
+            "`SerperDevWebSearch` will be removed from Haystack in version 3.0, as it is moving to "
+            "the `serperdev-haystack` package. To continue using it, install that package with "
+            "`pip install serperdev-haystack` and update your import to "
+            "`from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch`.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
         self.api_key = api_key
         self.top_k = top_k
         self.allowed_domains = allowed_domains

--- a/releasenotes/notes/deprecate-serperdev-websearch-9de15a703cba06cc.yaml
+++ b/releasenotes/notes/deprecate-serperdev-websearch-9de15a703cba06cc.yaml
@@ -1,0 +1,10 @@
+---
+deprecations:
+  - |
+    ``SerperDevWebSearch`` is deprecated and will be removed from Haystack in version 3.0. It is moving to
+    the ``serperdev-haystack`` package. To continue using it, install the package with
+    ``pip install serperdev-haystack`` and update your import as follows:
+
+    .. code-block:: python
+
+        from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch

--- a/test/components/websearch/test_serperdev.py
+++ b/test/components/websearch/test_serperdev.py
@@ -282,7 +282,10 @@ class TestSerperDevSearchAPI:
         results = ws.run(query="Who is the boyfriend of Olivia Wilde?")
         documents = results["documents"]
         links = results["links"]
-        assert len(documents) == len(links) == 10
+        # documents can also include answer box and "people also ask" results, so only links
+        # (which come from organic results) are guaranteed to be at most top_k
+        assert 0 < len(documents) <= 10
+        assert 0 < len(links) <= 10
         assert all(isinstance(doc, Document) for doc in documents)
         assert all(isinstance(link, str) for link in links)
         assert all(link.startswith("http") for link in links)
@@ -298,7 +301,10 @@ class TestSerperDevSearchAPI:
         results = await ws.run_async(query="Who is the boyfriend of Olivia Wilde?")
         documents = results["documents"]
         links = results["links"]
-        assert len(documents) == len(links) == 10
+        # documents can also include answer box and "people also ask" results, so only links
+        # (which come from organic results) are guaranteed to be at most top_k
+        assert 0 < len(documents) <= 10
+        assert 0 < len(links) <= 10
         assert all(isinstance(doc, Document) for doc in documents)
         assert all(isinstance(link, str) for link in links)
         assert all(link.startswith("http") for link in links)


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/369
- Similar to https://github.com/deepset-ai/haystack/pull/11513

### Proposed Changes:
- deprecate `SerperDevWebSearch` with a `FutureWarning` pointing users to the new `serperdev-haystack` package (https://github.com/deepset-ai/haystack-core-integrations/pull/3425)
- update the docs page (current and version-2.30) to show the new package name, install command, import path, and YAML type
- make the live-API integration test assertions robust: when Serper returns an answer box, `documents` (answer box + organic) and `links` (organic only) differ in length, so the old `len(documents) == len(links) == 10` assertion fails on main today

### How did you test it?

### Notes for the reviewer
- I could leave out the change that makes the tests more robust since we'll drop the component from main soon. For now it doesn't hurt to have more robust tests though.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
