### PR TITLE
feat(evaluators): add native run_async support to LLMEvaluator

### DIFF
--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -195,6 +195,42 @@ class ContextRelevanceEvaluator(LLMEvaluator):
 
         return result
 
+    @component.output_types(score=float, results=list[dict[str, Any]])
+    async def run_async(self, **inputs: Any) -> dict[str, Any]:
+        """
+        Run the LLM evaluator asynchronously.
+
+        :param questions:
+            A list of questions.
+        :param contexts:
+            A list of lists of contexts. Each list of contexts corresponds to one question.
+        :returns:
+            A dictionary with the following outputs:
+                - `score`: Mean context relevance score over all the provided input questions.
+                - `results`: A list of dictionaries with `relevant_statements` and `score` for each input context.
+        """
+        result = await super(ContextRelevanceEvaluator, self).run_async(**inputs)  # noqa: UP008
+
+        for idx, res in enumerate(result["results"]):
+            if res is None:
+                result["results"][idx] = {"relevant_statements": [], "score": float("nan")}
+                continue
+            if len(res["relevant_statements"]) > 0:
+                res["score"] = 1
+            else:
+                res["score"] = 0
+
+        # calculate average context relevance score over all queries
+        scores = [res["score"] for res in result["results"]]
+        valid_scores = [s for s in scores if not math.isnan(s)]
+        skipped = len(scores) - len(valid_scores)
+        if skipped:
+            logger.warning("{skipped} query(s) failed and were excluded from the score.", skipped=skipped)
+        result["score"] = mean(valid_scores) if valid_scores else float("nan")
+        result["individual_scores"] = scores  # useful for the EvaluationRunResult
+
+        return result
+
     def to_dict(self) -> dict[str, Any]:
         """
         Serialize this component to a dictionary.

--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -174,26 +174,8 @@ class ContextRelevanceEvaluator(LLMEvaluator):
                 - `results`: A list of dictionaries with `relevant_statements` and `score` for each input context.
         """
         result = super(ContextRelevanceEvaluator, self).run(**inputs)  # noqa: UP008
-
-        for idx, res in enumerate(result["results"]):
-            if res is None:
-                result["results"][idx] = {"relevant_statements": [], "score": float("nan")}
-                continue
-            if len(res["relevant_statements"]) > 0:
-                res["score"] = 1
-            else:
-                res["score"] = 0
-
-        # calculate average context relevance score over all queries
-        scores = [res["score"] for res in result["results"]]
-        valid_scores = [s for s in scores if not math.isnan(s)]
-        skipped = len(scores) - len(valid_scores)
-        if skipped:
-            logger.warning("{skipped} query(s) failed and were excluded from the score.", skipped=skipped)
-        result["score"] = mean(valid_scores) if valid_scores else float("nan")
-        result["individual_scores"] = scores  # useful for the EvaluationRunResult
-
-        return result
+        # Post-process the raw results to calculate relevance metrics and scores
+        return self._postprocess_results(result)
 
     @component.output_types(score=float, results=list[dict[str, Any]])
     async def run_async(self, **inputs: Any) -> dict[str, Any]:
@@ -210,7 +192,21 @@ class ContextRelevanceEvaluator(LLMEvaluator):
                 - `results`: A list of dictionaries with `relevant_statements` and `score` for each input context.
         """
         result = await super(ContextRelevanceEvaluator, self).run_async(**inputs)  # noqa: UP008
+        # Post-process the raw results to calculate relevance metrics and scores
+        return self._postprocess_results(result)
 
+    def _postprocess_results(self, result: dict[str, Any]) -> dict[str, Any]:
+        """
+        Post-processes raw LLM evaluator outputs to compute context relevance scores.
+
+        Calculates binary scores based on whether relevant statements were found,
+        averages the scores across all successful queries, and updates the result payload.
+
+        :param result:
+            The raw evaluation dictionary from the base LLM evaluator.
+        :returns:
+            The updated dictionary containing final scores and tracking metrics.
+        """
         for idx, res in enumerate(result["results"]):
             if res is None:
                 result["results"][idx] = {"relevant_statements": [], "score": float("nan")}

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -149,7 +149,7 @@ class FaithfulnessEvaluator(LLMEvaluator):
             progress_bar=progress_bar,
         )
 
-    @component.output_types(individual_scores=list[int], score=float, results=list[dict[str, Any]])
+    @component.output_types(individual_scores=list[float], score=float, results=list[dict[str, Any]])
     def run(self, **inputs: Any) -> dict[str, Any]:
         """
         Run the LLM evaluator.
@@ -167,29 +167,10 @@ class FaithfulnessEvaluator(LLMEvaluator):
                 - `results`: A list of dictionaries with `statements` and `statement_scores` for each input answer.
         """
         result = super(FaithfulnessEvaluator, self).run(**inputs)  # noqa: UP008
+        # Post-process the raw results to calculate relevance metrics and scores
+        return self._postprocess_results(result)
 
-        # calculate average statement faithfulness score per query
-        for idx, res in enumerate(result["results"]):
-            if res is None:
-                result["results"][idx] = {"statements": [], "statement_scores": [], "score": float("nan")}
-                continue
-            if not res["statements"]:
-                res["score"] = 0
-            else:
-                res["score"] = np_mean(res["statement_scores"])
-
-        # calculate average answer faithfulness score over all queries
-        scores = [res["score"] for res in result["results"]]
-        valid_scores = [s for s in scores if not math.isnan(s)]
-        skipped = len(scores) - len(valid_scores)
-        if skipped:
-            logger.warning("{skipped} query(s) failed and were excluded from the score.", skipped=skipped)
-        result["score"] = np_mean(valid_scores) if valid_scores else float("nan")
-        result["individual_scores"] = scores
-
-        return result
-
-    @component.output_types(individual_scores=list[int], score=float, results=list[dict[str, Any]])
+    @component.output_types(individual_scores=list[float], score=float, results=list[dict[str, Any]])
     async def run_async(self, **inputs: Any) -> dict[str, Any]:
         """
         Run the LLM evaluator asynchronously.
@@ -207,6 +188,21 @@ class FaithfulnessEvaluator(LLMEvaluator):
                 - `results`: A list of dictionaries with `statements` and `statement_scores` for each input answer.
         """
         result = await super(FaithfulnessEvaluator, self).run_async(**inputs)  # noqa: UP008
+        # Post-process the raw results to calculate relevance metrics and scores
+        return self._postprocess_results(result)
+
+    def _postprocess_results(self, result: dict[str, Any]) -> dict[str, Any]:
+        """
+        Post-processes raw LLM evaluator outputs to compute faithfulness scores.
+
+        Calculates statement-level score averages, computes the overall mean faithfulness
+        score across successful queries, and updates the result payload.
+
+        :param result:
+            The raw evaluation dictionary from the base LLM evaluator.
+        :returns:
+            The updated dictionary containing final scores and tracking metrics.
+        """
 
         # calculate average statement faithfulness score per query
         for idx, res in enumerate(result["results"]):

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -189,6 +189,46 @@ class FaithfulnessEvaluator(LLMEvaluator):
 
         return result
 
+    @component.output_types(individual_scores=list[int], score=float, results=list[dict[str, Any]])
+    async def run_async(self, **inputs: Any) -> dict[str, Any]:
+        """
+        Run the LLM evaluator asynchronously.
+
+        :param questions:
+            A list of questions.
+        :param contexts:
+            A nested list of contexts that correspond to the questions.
+        :param predicted_answers:
+            A list of predicted answers.
+        :returns:
+            A dictionary with the following outputs:
+                - `score`: Mean faithfulness score over all the provided input answers.
+                - `individual_scores`: A list of faithfulness scores for each input answer.
+                - `results`: A list of dictionaries with `statements` and `statement_scores` for each input answer.
+        """
+        result = await super(FaithfulnessEvaluator, self).run_async(**inputs)  # noqa: UP008
+
+        # calculate average statement faithfulness score per query
+        for idx, res in enumerate(result["results"]):
+            if res is None:
+                result["results"][idx] = {"statements": [], "statement_scores": [], "score": float("nan")}
+                continue
+            if not res["statements"]:
+                res["score"] = 0
+            else:
+                res["score"] = np_mean(res["statement_scores"])
+
+        # calculate average answer faithfulness score over all queries
+        scores = [res["score"] for res in result["results"]]
+        valid_scores = [s for s in scores if not math.isnan(s)]
+        skipped = len(scores) - len(valid_scores)
+        if skipped:
+            logger.warning("{skipped} query(s) failed and were excluded from the score.", skipped=skipped)
+        result["score"] = np_mean(valid_scores) if valid_scores else float("nan")
+        result["individual_scores"] = scores
+
+        return result
+
     def to_dict(self) -> dict[str, Any]:
         """
         Serialize this component to a dictionary.

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -283,7 +283,7 @@ class LLMEvaluator:
             messages = [ChatMessage.from_user(prompt["prompt"])]
             try:
                 if generator_has_async:
-                    result = await self._chat_generator.run_async(messages=messages)
+                    result = await self._chat_generator.run_async(messages=messages)  # type: ignore[attr-defined]
                 else:
                     logger.debug(
                         "{generator_type} does not implement 'run_async'."

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
 from typing import Any
 
@@ -262,12 +263,6 @@ class LLMEvaluator:
             different lengths, or if the output is not a valid JSON or doesn't contain the expected keys.
         """
 
-        if not hasattr(self._chat_generator, "run_async"):
-            raise TypeError(
-                f"The chat generator {type(self._chat_generator).__name__} does not support async execution. "
-                "Use a chat generator that implements the `run_async` method."
-            )
-
         if not self._is_warmed_up:
             self.warm_up()
 
@@ -282,11 +277,20 @@ class LLMEvaluator:
         metadata = []
         errors = 0
 
+        generator_has_async = hasattr(self._chat_generator, "run_async")
         for input_names_to_values in async_tqdm(list_of_input_names_to_values, disable=not self.progress_bar):
             prompt = self.builder.run(**input_names_to_values)
             messages = [ChatMessage.from_user(prompt["prompt"])]
             try:
-                result = await self._chat_generator.run_async(messages=messages)
+                if generator_has_async:
+                    result = await self._chat_generator.run_async(messages=messages)
+                else:
+                    logger.debug(
+                        "{generator_type} does not implement 'run_async'."
+                        " Running the synchronous 'run' method in a thread to avoid blocking the event loop.",
+                        generator_type=type(self._chat_generator).__name__,
+                    )
+                    result = await asyncio.to_thread(self._chat_generator.run, messages=messages)
             except Exception as e:
                 if self.raise_on_failure:
                     raise ValueError(f"Error while generating response for prompt: {prompt}. Error: {e}") from e

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 from tqdm import tqdm
+from tqdm.asyncio import tqdm as async_tqdm
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.builders import PromptBuilder
@@ -211,6 +212,81 @@ class LLMEvaluator:
             messages = [ChatMessage.from_user(prompt["prompt"])]
             try:
                 result = self._chat_generator.run(messages=messages)
+            except Exception as e:
+                if self.raise_on_failure:
+                    raise ValueError(f"Error while generating response for prompt: {prompt}. Error: {e}") from e
+                logger.warning("Error while generating response for prompt: {prompt}. Error: {e}", prompt=prompt, e=e)
+                results.append(None)
+                errors += 1
+                continue
+
+            parsed_result = _parse_dict_from_json(
+                result["replies"][0].text, expected_keys=self.outputs, raise_on_failure=self.raise_on_failure
+            )
+            if parsed_result is None:
+                results.append(None)
+                errors += 1
+            else:
+                results.append(parsed_result)
+
+            if result["replies"][0].meta:
+                metadata.append(result["replies"][0].meta)
+
+        if errors > 0:
+            logger.warning(
+                "LLM evaluator failed for {errors} out of {len(list_of_input_names_to_values)} inputs.",
+                errors=errors,
+                len=len(list_of_input_names_to_values),
+            )
+
+        return {"results": results, "meta": metadata or None}
+
+    @component.output_types(results=list[dict[str, Any]])
+    async def run_async(self, **inputs: Any) -> dict[str, Any]:
+        """
+        Run the LLM evaluator asynchronously
+
+        :param inputs:
+            The input values to evaluate. The keys are the input names and the values are lists of input values.
+        :returns:
+            A dictionary with a `results` entry that contains a list of results.
+            Each result is a dictionary containing the keys as defined in the `outputs` parameter of the LLMEvaluator
+            and the evaluation results as the values. If an exception occurs for a particular input value, the result
+            will be `None` for that entry.
+            If the API is "openai" and the response contains a "meta" key, the metadata from OpenAI will be included
+            in the output dictionary, under the key "meta".
+        :raises TypeError:
+            If the chat generator does not support async execution.
+        :raises ValueError:
+            Only in the case that  `raise_on_failure` is set to True and the received inputs are not lists or have
+            different lengths, or if the output is not a valid JSON or doesn't contain the expected keys.
+        """
+
+        if not hasattr(self._chat_generator, "run_async"):
+            raise TypeError(
+                f"The chat generator {type(self._chat_generator).__name__} does not support async execution. "
+                "Use a chat generator that implements the `run_async` method."
+            )
+
+        if not self._is_warmed_up:
+            self.warm_up()
+
+        self.validate_input_parameters(dict(self.inputs), inputs)
+
+        # inputs is a dictionary with keys being input names and values being a list of input values
+        # We need to iterate through the lists in parallel for all keys of the dictionary
+        input_names, values = inputs.keys(), list(zip(*inputs.values(), strict=True))
+        list_of_input_names_to_values = [dict(zip(input_names, v, strict=True)) for v in values]
+
+        results: list[dict[str, Any] | None] = []
+        metadata = []
+        errors = 0
+
+        for input_names_to_values in async_tqdm(list_of_input_names_to_values, disable=not self.progress_bar):
+            prompt = self.builder.run(**input_names_to_values)
+            messages = [ChatMessage.from_user(prompt["prompt"])]
+            try:
+                result = await self._chat_generator.run_async(messages=messages)
             except Exception as e:
                 if self.raise_on_failure:
                     raise ValueError(f"Error while generating response for prompt: {prompt}. Error: {e}") from e

--- a/releasenotes/notes/feat-llm-evaluator-run-async-3d7fb1d0991c23ce.yaml
+++ b/releasenotes/notes/feat-llm-evaluator-run-async-3d7fb1d0991c23ce.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added asynchronous support (`run_async`) to the `LLMEvaluator` component, allowing concurrent evaluation loops inside async applications like FastMCP or FastAPI without blocking the main event loop.

--- a/releasenotes/notes/feat-llm-evaluator-run-async-3d7fb1d0991c23ce.yaml
+++ b/releasenotes/notes/feat-llm-evaluator-run-async-3d7fb1d0991c23ce.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Added asynchronous support (`run_async`) to the `LLMEvaluator` component, allowing concurrent evaluation loops inside async applications like FastMCP or FastAPI without blocking the main event loop.
+    Added asynchronous support (``run_async``) to the ``LLMEvaluator`` component, allowing concurrent evaluation loops inside async applications like FastMCP or FastAPI without blocking the main event loop.

--- a/releasenotes/notes/feat-llm-evaluator-run-async-3d7fb1d0991c23ce.yaml
+++ b/releasenotes/notes/feat-llm-evaluator-run-async-3d7fb1d0991c23ce.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Added asynchronous support (``run_async``) to the ``LLMEvaluator`` component, allowing concurrent evaluation loops inside async applications like FastMCP or FastAPI without blocking the main event loop.
+    Added native asynchronous support (``run_async``) to ``LLMEvaluator``, ``FaithfulnessEvaluator``, and ``ContextRelevanceEvaluator``. This allows concurrent evaluation loops inside async applications like FastMCP or FastAPI without blocking the main event loop, while automatically falling back to thread workers for synchronous chat generators.

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -262,3 +262,61 @@ class TestContextRelevanceEvaluator:
         assert "prompt_tokens" in result["meta"][0]["usage"]
         assert "completion_tokens" in result["meta"][0]["usage"]
         assert "total_tokens" in result["meta"][0]["usage"]
+
+
+class TestContextRelevanceEvaluatorAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_calculates_mean_score(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = ContextRelevanceEvaluator()
+
+        async def chat_generator_run_async(self, *args, **kwargs):
+            if "Football" in kwargs["messages"][0].text:
+                return {"replies": [ChatMessage.from_assistant('{"relevant_statements": ["a", "b"], "score": 1}')]}
+            return {"replies": [ChatMessage.from_assistant('{"relevant_statements": [], "score": 0}')]}
+
+        monkeypatch.setattr(
+            "haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run_async", chat_generator_run_async
+        )
+
+        questions = ["Which is the most popular global sport?", "Who created the Python language?"]
+        contexts = [
+            ["Football is the world's most popular sport."],
+            ["Python is a cross-platform programming language."],
+        ]
+
+        results = await component.run_async(questions=questions, contexts=contexts)
+
+        assert results == {
+            "results": [{"score": 1, "relevant_statements": ["a", "b"]}, {"score": 0, "relevant_statements": []}],
+            "score": 0.5,
+            "meta": None,
+            "individual_scores": [1, 0],
+        }
+
+    @pytest.mark.asyncio
+    async def test_run_async_returns_nan_raise_on_failure_false(self, monkeypatch, caplog):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = ContextRelevanceEvaluator(raise_on_failure=False)
+
+        async def chat_generator_run_async(self, *args, **kwargs):
+            if "Python" in kwargs["messages"][0].text:
+                raise Exception("OpenAI API request failed.")
+            return {"replies": [ChatMessage.from_assistant('{"relevant_statements": ["c", "d"], "score": 1}')]}
+
+        monkeypatch.setattr(
+            "haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run_async", chat_generator_run_async
+        )
+
+        questions = ["Which is the most popular global sport?", "Who created the Python language?"]
+        contexts = [["Football is popular."], ["Python was created by Guido van Rossum."]]
+
+        with caplog.at_level("WARNING", logger="haystack.components.evaluators.context_relevance"):
+            results = await component.run_async(questions=questions, contexts=contexts)
+
+        assert results["score"] == 1
+        assert results["results"][0] == {"relevant_statements": ["c", "d"], "score": 1}
+        assert results["results"][1]["relevant_statements"] == []
+        assert math.isnan(results["results"][1]["score"])
+
+        assert "1 query(s) failed and were excluded from the score." in caplog.text

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -320,3 +320,26 @@ class TestContextRelevanceEvaluatorAsync:
         assert math.isnan(results["results"][1]["score"])
 
         assert "1 query(s) failed and were excluded from the score." in caplog.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    async def test_live_run_async(self):
+        questions = ["Who created the Python language?"]
+        contexts = [["Python, created by Guido van Rossum, is a high-level general-purpose programming language."]]
+
+        evaluator = ContextRelevanceEvaluator(chat_generator=OpenAIChatGenerator(model="gpt-4.1-nano"))
+        result = await evaluator.run(questions=questions, contexts=contexts)
+
+        required_fields = {"results"}
+        assert all(field in result for field in required_fields)
+        nested_required_fields = {"score", "relevant_statements"}
+        assert all(field in result["results"][0] for field in nested_required_fields)
+
+        assert "meta" in result
+        assert "prompt_tokens" in result["meta"][0]["usage"]
+        assert "completion_tokens" in result["meta"][0]["usage"]
+        assert "total_tokens" in result["meta"][0]["usage"]

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -332,7 +332,7 @@ class TestContextRelevanceEvaluatorAsync:
         contexts = [["Python, created by Guido van Rossum, is a high-level general-purpose programming language."]]
 
         evaluator = ContextRelevanceEvaluator(chat_generator=OpenAIChatGenerator(model="gpt-4.1-nano"))
-        result = await evaluator.run(questions=questions, contexts=contexts)
+        result = await evaluator.run_async(questions=questions, contexts=contexts)
 
         required_fields = {"results"}
         assert all(field in result for field in required_fields)

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -320,3 +320,63 @@ class TestFaithfulnessEvaluator:
         assert "prompt_tokens" in result["meta"][0]["usage"]
         assert "completion_tokens" in result["meta"][0]["usage"]
         assert "total_tokens" in result["meta"][0]["usage"]
+
+
+class TestFaithfulnessEvaluatorAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_calculates_mean_score(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = FaithfulnessEvaluator()
+
+        async def chat_generator_run_async(self, *args, **kwargs):
+            if "Football" in kwargs["messages"][0].text:
+                return {
+                    "replies": [ChatMessage.from_assistant('{"statements": ["a", "b"], "statement_scores": [1, 0]}')]
+                }
+            return {"replies": [ChatMessage.from_assistant('{"statements": ["c", "d"], "statement_scores": [1, 1]}')]}
+
+        monkeypatch.setattr(
+            "haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run_async", chat_generator_run_async
+        )
+
+        questions = ["Which is the most popular global sport?", "Who created the Python language?"]
+        contexts = [["Football is the world's most popular sport."], ["Python was created by Guido van Rossum."]]
+        predicted_answers = ["Football is the most popular sport.", "Python is a language created by George Lucas."]
+        results = await component.run_async(questions=questions, contexts=contexts, predicted_answers=predicted_answers)
+        assert results == {
+            "individual_scores": [0.5, 1.0],
+            "results": [
+                {"score": 0.5, "statement_scores": [1, 0], "statements": ["a", "b"]},
+                {"score": 1.0, "statement_scores": [1, 1], "statements": ["c", "d"]},
+            ],
+            "score": 0.75,
+            "meta": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_run_async_returns_nan_raise_on_failure_false(self, monkeypatch, caplog):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = FaithfulnessEvaluator(raise_on_failure=False)
+
+        async def chat_generator_run_async(self, *args, **kwargs):
+            if "Python" in kwargs["messages"][0].text:
+                raise Exception("OpenAI API request failed.")
+            return {"replies": [ChatMessage.from_assistant('{"statements": ["c", "d"], "statement_scores": [1, 1]}')]}
+
+        monkeypatch.setattr(
+            "haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run_async", chat_generator_run_async
+        )
+
+        questions = ["Which is the most popular global sport?", "Who created the Python language?"]
+        contexts = [["Football is popular."], ["Python was created by Guido."]]
+        predicted_answers = ["Football is popular.", "Guido van Rossum."]
+
+        with caplog.at_level("WARNING", logger="haystack.components.evaluators.faithfulness"):
+            results = await component.run_async(
+                questions=questions, contexts=contexts, predicted_answers=predicted_answers
+            )
+
+        assert results["score"] == 1.0
+        assert results["individual_scores"][0] == 1.0
+        assert math.isnan(results["individual_scores"][1])
+        assert "1 query(s) failed and were excluded from the score." in caplog.text

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -380,3 +380,27 @@ class TestFaithfulnessEvaluatorAsync:
         assert results["individual_scores"][0] == 1.0
         assert math.isnan(results["individual_scores"][1])
         assert "1 query(s) failed and were excluded from the score." in caplog.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    async def test_live_run_async(self):
+        questions = ["What is Python and who created it?"]
+        contexts = [["Python is a programming language created by Guido van Rossum."]]
+        predicted_answers = ["Python is a programming language created by George Lucas."]
+        evaluator = FaithfulnessEvaluator(chat_generator=OpenAIChatGenerator(model="gpt-4.1-nano"))
+        result = await evaluator.run_async(questions=questions, contexts=contexts, predicted_answers=predicted_answers)
+
+        required_fields = {"individual_scores", "results", "score"}
+        assert all(field in result for field in required_fields)
+        nested_required_fields = {"score", "statement_scores", "statements"}
+        assert all(field in result["results"][0] for field in nested_required_fields)
+
+        # assert that metadata is present in the result
+        assert "meta" in result
+        assert "prompt_tokens" in result["meta"][0]["usage"]
+        assert "completion_tokens" in result["meta"][0]["usage"]
+        assert "total_tokens" in result["meta"][0]["usage"]

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -458,3 +458,119 @@ class TestLLMEvaluator:
             ValueError
         ):  # json_utils/LLMEvaluator might raise JSONDecodeError which inherits from ValueError or wrapped
             component.run(predicted_answers=["answer"])
+
+
+class TestLLMEvaluatorAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_returns_parsed_result(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = LLMEvaluator(
+            instructions="test-instruction",
+            inputs=[("questions", list[str]), ("predicted_answers", list[str])],
+            outputs=["score"],
+            examples=[
+                {
+                    "inputs": {
+                        "questions": "What is the value of any non-zero number raised to the power of zero?",
+                        "predicted_answers": "Zero",
+                    },
+                    "outputs": {"score": 0},
+                }
+            ],
+        )
+
+        async def chat_generator_run_async(self, *args, **kwargs):
+            return {"replies": [ChatMessage.from_assistant('{"score": 1}')]}
+
+        monkeypatch.setattr(
+            "haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run_async", chat_generator_run_async
+        )
+
+        results = await component.run_async(
+            questions=["What is the perimeter of a circle called?"], predicted_answers=["Circumference"]
+        )
+        assert results == {"results": [{"score": 1}], "meta": None}
+
+    @pytest.mark.asyncio
+    async def test_run_async_raises_on_unsupported_generator(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+
+        class SyncOnlyGenerator:
+            def run(self, messages):
+                return {"replies": [ChatMessage.from_assistant('{"score": 0}')]}
+
+        component = LLMEvaluator(
+            instructions="test-instruction",
+            inputs=[("questions", list[str]), ("predicted_answers", list[str])],
+            outputs=["score"],
+            examples=[
+                {
+                    "inputs": {
+                        "questions": "What is the top sport?",
+                        "predicted_answers": "Football is the most popular sport.",
+                    },
+                    "outputs": {"score": 1},
+                }
+            ],
+            chat_generator=SyncOnlyGenerator(),
+        )
+
+        with pytest.raises(TypeError, match="does not support async execution"):
+            await component.run_async(questions=["question"], predicted_answers=["answer"])
+
+    @pytest.mark.asyncio
+    async def test_run_async_raise_on_failure_false(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = LLMEvaluator(
+            instructions="test-instruction",
+            inputs=[("questions", list[str]), ("predicted_answers", list[str])],
+            outputs=["score"],
+            examples=[
+                {
+                    "inputs": {
+                        "questions": "What is the value of any non-zero number raised to the power of zero?",
+                        "predicted_answers": "One",
+                    },
+                    "outputs": {"score": 1},
+                }
+            ],
+            raise_on_failure=False,
+        )
+
+        async def chat_generator_run_async(self, *args, **kwargs):
+            raise Exception("API error")
+
+        monkeypatch.setattr(
+            "haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run_async", chat_generator_run_async
+        )
+
+        result = await component.run_async(questions=["question"], predicted_answers=["answer"])
+        assert result["results"] == [None]
+
+    @pytest.mark.asyncio
+    async def test_run_async_raise_on_failure_true(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = LLMEvaluator(
+            instructions="test-instruction",
+            inputs=[("questions", list[str]), ("predicted_answers", list[str])],
+            outputs=["score"],
+            examples=[
+                {
+                    "inputs": {
+                        "questions": "What is the smallest unit of data in a computer?",
+                        "predicted_answers": "Bit",
+                    },
+                    "outputs": {"score": 1},
+                }
+            ],
+        )
+
+        async def chat_generator_run_async(self, *args, **kwargs):
+            raise Exception("API error")
+
+        monkeypatch.setattr(
+            "haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run_async", chat_generator_run_async
+        )
+
+        with pytest.raises(ValueError):
+            await component.run_async(questions=["question"], predicted_answers=["answer"])

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -492,7 +492,7 @@ class TestLLMEvaluatorAsync:
         assert results == {"results": [{"score": 1}], "meta": None}
 
     @pytest.mark.asyncio
-    async def test_run_async_raises_on_unsupported_generator(self, monkeypatch):
+    async def test_run_async_fallback_to_thread_with_sync_generator(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
 
         class SyncOnlyGenerator:
@@ -515,8 +515,8 @@ class TestLLMEvaluatorAsync:
             chat_generator=SyncOnlyGenerator(),
         )
 
-        with pytest.raises(TypeError, match="does not support async execution"):
-            await component.run_async(questions=["question"], predicted_answers=["answer"])
+        results = await component.run_async(questions=["question"], predicted_answers=["answer"])
+        assert results == {"results": [{"score": 0}], "meta": None}
 
     @pytest.mark.asyncio
     async def test_run_async_raise_on_failure_false(self, monkeypatch):


### PR DESCRIPTION
### Related Issues

- fixes #11579 

### Proposed Changes:

Added native asynchronous support (`run_async`) to `LLMEvaluator`, `FaithfulnessEvaluator`, and `ContextRelevanceEvaluator`.This allows evaluation pipelines to run concurrently inside asynchronous environments (like FastMCP or FastAPI) without stalling the main event loop during LLM network requests.

How it works:
* Runtime check for async support: Verifies whether the assigned chat generator natively supports async execution. If it only supports synchronous execution, it automatically drops down to a safe thread-pool fallback via `asyncio.to_thread` instead of blocking the event loop.
* Post-processing loop mirroring: `FaithfulnessEvaluator` and `ContextRelevanceEvaluator` explicitly mirror their synchronous counterparts, calling the parent async engine and running their unique metrics parsing loops over the concurrent batch results.
* Non-blocking progress bars: Processes inputs concurrently while using `async_tqdm` to keep tracking completely non-blocking.
* Monitored failure tracking: Strictly matches the existing sync error-handling configurations (`raise_on_failure`), safely caching individual row exceptions into `NaN` targets when disabled.

### How did you test it?

Added complete async test suites across all three evaluator test modules (`TestLLMEvaluatorAsync`, `TestFaithfulnessEvaluatorAsync`, and `TestContextRelevanceEvaluatorAsync`). The tests cover:
* **Standard async flow:** Verifying that concurrent evaluation batches run successfully and parse the returned JSON data accurately.
* **Thread-pool fallback execution:** Confirming that when a sync-only chat generator is passed, the engine safely offloads the execution to a worker thread via `asyncio.to_thread` without stalling the event loop.
* **Metric post-processing math:** Validating that the custom scoring and statement parsing loops in `FaithfulnessEvaluator` and `ContextRelevanceEvaluator` aggregate data identically to their synchronous counterparts.
* **Error isolation and NaN propagation:** Testing that when raise_on_failure=False, individual API failures are safely skipped, logged as warnings, and tracked as NaN values without breaking the final average score calculation.

### Notes for the reviewer

The implementation structure mirrors the synchronous run method identically to keep the component maintenance straightforward. The async test fixtures utilize standard monkeypatch strategies to mirror existing testing conventions throughout the file.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `feat: add run_async support to LLMEvaluator`
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.