### PR TITLE
fix: make `>=` and `<` filters compare parsed datetimes, not raw strings

### DIFF
--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -56,11 +56,8 @@ def _not_equal(value: Any, filter_value: Any) -> bool:
     return not _equal(value=value, filter_value=filter_value)
 
 
-def _greater_than(value: Any, filter_value: Any) -> bool:
-    if value is None or filter_value is None:
-        # We can't compare None values reliably using operators '>', '>=', '<', '<='
-        return False
-
+def _prepare_ordering_comparison(value: Any, filter_value: Any) -> tuple[Any, Any]:
+    """Normalize both values for ordering comparisons, parsing strings as dates."""
     if isinstance(value, str) or isinstance(filter_value, str):
         value = _parse_date(value)
         filter_value = _parse_date(filter_value)
@@ -69,6 +66,15 @@ def _greater_than(value: Any, filter_value: Any) -> bool:
     if isinstance(filter_value, list):
         msg = f"Filter value can't be of type {type(filter_value)} using operators '>', '>=', '<', '<='"
         raise FilterError(msg)
+    return value, filter_value
+
+
+def _greater_than(value: Any, filter_value: Any) -> bool:
+    if value is None or filter_value is None:
+        # We can't compare None values reliably using operators '>', '>=', '<', '<='
+        return False
+
+    value, filter_value = _prepare_ordering_comparison(value=value, filter_value=filter_value)
     return value > filter_value
 
 
@@ -110,7 +116,8 @@ def _greater_than_equal(value: Any, filter_value: Any) -> bool:
         # We can't compare None values reliably using operators '>', '>=', '<', '<='
         return False
 
-    return _equal(value=value, filter_value=filter_value) or _greater_than(value=value, filter_value=filter_value)
+    value, filter_value = _prepare_ordering_comparison(value=value, filter_value=filter_value)
+    return value >= filter_value
 
 
 def _less_than(value: Any, filter_value: Any) -> bool:
@@ -118,7 +125,8 @@ def _less_than(value: Any, filter_value: Any) -> bool:
         # We can't compare None values reliably using operators '>', '>=', '<', '<='
         return False
 
-    return not _greater_than_equal(value=value, filter_value=filter_value)
+    value, filter_value = _prepare_ordering_comparison(value=value, filter_value=filter_value)
+    return value < filter_value
 
 
 def _less_than_equal(value: Any, filter_value: Any) -> bool:
@@ -126,7 +134,8 @@ def _less_than_equal(value: Any, filter_value: Any) -> bool:
         # We can't compare None values reliably using operators '>', '>=', '<', '<='
         return False
 
-    return not _greater_than(value=value, filter_value=filter_value)
+    value, filter_value = _prepare_ordering_comparison(value=value, filter_value=filter_value)
+    return value <= filter_value
 
 
 def _in(value: Any, filter_value: Any) -> bool:

--- a/releasenotes/notes/fix-date-filter-boundary-equality-1d5bb265e39dcc4a.yaml
+++ b/releasenotes/notes/fix-date-filter-boundary-equality-1d5bb265e39dcc4a.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed the ``>=`` and ``<`` metadata filter operators returning wrong results for
+    datetime strings that represent the same moment in time but are formatted differently
+    (for example ``"2025-01-01"`` vs ``"2025-01-01T00:00:00"``, or the same instant
+    expressed with different timezone offsets). Equality was previously checked by raw
+    string comparison instead of comparing the parsed datetimes, so ``>=`` evaluated to
+    ``False`` and ``<`` evaluated to ``True`` for equal datetimes. This caused
+    boundary documents to be silently dropped from date range queries in
+    ``InMemoryDocumentStore`` and any other component relying on ``document_matches_filter``.

--- a/test/utils/test_filters.py
+++ b/test/utils/test_filters.py
@@ -179,6 +179,18 @@ document_matches_filter_data = [
         id=">= operator with smaller ISO 8601 datetime Document value",
     ),
     pytest.param(
+        {"field": "meta.date", "operator": ">=", "value": "1969-07-21"},
+        Document(meta={"date": "1969-07-21T00:00:00"}),
+        True,
+        id=">= operator with equal datetime in different ISO 8601 format",
+    ),
+    pytest.param(
+        {"field": "meta.date", "operator": ">=", "value": "1969-07-21T20:17:40+00:00"},
+        Document(meta={"date": "1969-07-21T22:17:40+02:00"}),
+        True,
+        id=">= operator with equal instant in different timezone offset",
+    ),
+    pytest.param(
         {"field": "meta.page", "operator": ">=", "value": 10},
         Document(),
         False,
@@ -238,6 +250,18 @@ document_matches_filter_data = [
         Document(meta={"date": "1969-07-21T20:17:40"}),
         True,
         id="< operator with smaller ISO 8601 datetime Document value",
+    ),
+    pytest.param(
+        {"field": "meta.date", "operator": "<", "value": "1969-07-21"},
+        Document(meta={"date": "1969-07-21T00:00:00"}),
+        False,
+        id="< operator with equal datetime in different ISO 8601 format",
+    ),
+    pytest.param(
+        {"field": "meta.date", "operator": "<", "value": "1969-07-21T20:17:40+00:00"},
+        Document(meta={"date": "1969-07-21T22:17:40+02:00"}),
+        False,
+        id="< operator with equal instant in different timezone offset",
     ),
     pytest.param(
         {"field": "meta.page", "operator": "<", "value": 10},


### PR DESCRIPTION
### Related Issues

- fixes #11583

### Proposed Changes:

`_greater_than_equal` checked equality via `_equal`, which compares raw strings, while the ordering comparison parses string operands as datetimes. Two equivalent representations of the same moment (e.g. `2025-01-01` vs `2025-01-01T00:00:00`, or the same instant with different timezone offsets) therefore failed the equality check: `>=` returned `False`, and `<` (defined as `not _greater_than_equal`) returned `True`. Date range filters silently dropped boundary documents in `InMemoryDocumentStore`.

This PR extracts the operand normalization (date parsing, naive/aware alignment, list rejection) into `_prepare_ordering_comparison` and has each ordering operator (`>`, `>=`, `<`, `<=`) normalize once and apply the native comparison directly. The `not`-inversion chain between operators is removed, so each operator's semantics are self-contained.

Error behavior is unchanged: `None` operands still return `False`, list filter values still raise `FilterError`, and non-date strings still raise `FilterError`.

### How did you test it?

- Added regression test cases to `test/utils/test_filters.py` covering `>=` and `<` with an equal datetime in a different ISO 8601 format and with the same instant in different timezone offsets.
- `hatch run test:unit test/utils/test_filters.py test/document_stores/test_in_memory.py` — 235 passed, 4 skipped.
- `hatch run test:types haystack/utils/filters.py` — clean.
- Manual end-to-end check: the repro script from the issue now returns the expected results, including the `InMemoryDocumentStore` boundary document case.

### Notes for the reviewer

- `<=` and `>` were already correct (they compare parsed datetimes directly); only `>=` and `<` were affected. The refactor makes all four operators share the same normalization path so they cannot drift apart again.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)