### PR TITLE
fix: use total_seconds() in telemetry rate limiting check

### DIFF
--- a/haystack/telemetry/_telemetry.py
+++ b/haystack/telemetry/_telemetry.py
@@ -148,7 +148,7 @@ def pipeline_running(pipeline: Union["Pipeline", "AsyncPipeline"]) -> tuple[str,
     pipeline._telemetry_runs += 1
     if (
         pipeline._last_telemetry_sent
-        and (datetime.datetime.now() - pipeline._last_telemetry_sent).seconds < MIN_SECONDS_BETWEEN_EVENTS
+        and (datetime.datetime.now() - pipeline._last_telemetry_sent).total_seconds() < MIN_SECONDS_BETWEEN_EVENTS
     ):
         return None
 

--- a/releasenotes/notes/fix-telemetry-throttle-total-seconds-7e61f84644a1fb4a.yaml
+++ b/releasenotes/notes/fix-telemetry-throttle-total-seconds-7e61f84644a1fb4a.yaml
@@ -1,8 +1,0 @@
----
-fixes:
-  - |
-    Fixed the telemetry rate limiting check using ``timedelta.seconds`` instead of
-    ``timedelta.total_seconds()``. ``timedelta.seconds`` only reflects the seconds component
-    of the elapsed time (0-86399) and ignores full days, so a pipeline run happening slightly
-    more than a whole number of days after the previous telemetry event could be wrongly
-    throttled as if it had run within the last minute.

--- a/releasenotes/notes/fix-telemetry-throttle-total-seconds-7e61f84644a1fb4a.yaml
+++ b/releasenotes/notes/fix-telemetry-throttle-total-seconds-7e61f84644a1fb4a.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed the telemetry rate limiting check using ``timedelta.seconds`` instead of
+    ``timedelta.total_seconds()``. ``timedelta.seconds`` only reflects the seconds component
+    of the elapsed time (0-86399) and ignores full days, so a pipeline run happening slightly
+    more than a whole number of days after the previous telemetry event could be wrongly
+    throttled as if it had run within the last minute.

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -64,6 +64,22 @@ def test_pipeline_running(telemetry, pipeline_class):
         },
     )
 
+    # More than a day has passed but the seconds component of the timedelta is below the threshold:
+    # the event must still be sent (regression test for using timedelta.seconds instead of total_seconds())
+    pipe._last_telemetry_sent = datetime.datetime.now() - datetime.timedelta(days=1, seconds=5)
+
+    telemetry.send_event.reset_mock()
+    pipeline_running(pipe)
+    telemetry.send_event.assert_called_once_with(
+        "Pipeline run (2.x)",
+        {
+            "pipeline_id": str(id(pipe)),
+            "pipeline_type": expected_type,
+            "runs": 4,
+            "components": {"test.test_telemetry.Component": [{"name": "component", "key": "values"}]},
+        },
+    )
+
 
 @patch("haystack.telemetry._telemetry.telemetry")
 def test_pipeline_running_with_non_serializable_component(telemetry):


### PR DESCRIPTION
### Related Issues

- fixes #11589

### Proposed Changes:

The throttling condition in `pipeline_running` used `timedelta.seconds`, which only holds the seconds component of the elapsed time (0-86399) and ignores full days. A pipeline run happening slightly more than a whole number of days after the previous telemetry event (e.g. 24h + 10s, in a long-lived process or notebook kernel) was treated as if it had run within the last minute, and the event was wrongly dropped.

One-line fix: use `timedelta.total_seconds()`, which returns the real elapsed time.

### How did you test it?

- Added a regression case to the existing `test_pipeline_running` test in `test/test_telemetry.py`: with `_last_telemetry_sent` set 1 day + 5 seconds in the past, the event must be sent. The case fails on `main` and passes with this fix.
- `hatch run test:unit test/test_telemetry.py` — 4 passed.

### Notes for the reviewer

- Behavior change is limited to telemetry event frequency: long-running pipelines that previously hit the day-boundary window are no longer underreported. No public API changes.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
