### PR TITLE
fix: TopPSampler silently skipping filtering for int scores and top_p=0.0

### DIFF
--- a/haystack/components/samplers/top_p.py
+++ b/haystack/components/samplers/top_p.py
@@ -80,7 +80,7 @@ class TopPSampler:
         if not documents:
             return {"documents": []}
 
-        top_p = top_p or self.top_p
+        top_p = top_p if top_p is not None else self.top_p
         if not 0 <= top_p <= 1:
             raise ValueError(f"top_p must be between 0 and 1. Got {top_p}.")
 
@@ -140,9 +140,10 @@ class TopPSampler:
         else:
             score = doc.score
 
-        if not isinstance(score, float):
-            score = None
-        return score
+        # bool is a subclass of int but is not a valid score
+        if isinstance(score, bool) or not isinstance(score, (int, float)):
+            return None
+        return float(score)
 
     def _get_documents_and_scores(self, documents: list[Document]) -> tuple[list[Document], list[float]]:
         """

--- a/releasenotes/notes/fix-top-p-sampler-int-scores-and-zero-override-dd3b0e65d9c0603f.yaml
+++ b/releasenotes/notes/fix-top-p-sampler-int-scores-and-zero-override-dd3b0e65d9c0603f.yaml
@@ -1,0 +1,11 @@
+﻿---
+fixes:
+  - |
+    Fixed two bugs in ``TopPSampler`` that silently disabled filtering:
+
+    * Documents with integer scores were treated as if they had no score at all, so the
+      sampler logged a warning and returned all documents unfiltered. Integer scores are
+      now handled like float scores (booleans are still rejected).
+    * Passing ``top_p=0.0`` to ``run()`` was silently replaced by the value set in the
+      constructor because of a falsy-value check. The override is now honored, returning
+      the single highest-scoring document, consistent with ``TopPSampler(top_p=0.0)``.

--- a/test/components/samplers/test_top_p.py
+++ b/test/components/samplers/test_top_p.py
@@ -95,6 +95,39 @@ class TestTopPSampler:
         assert docs[0].content == "Sarajevo"
         assert "Top-p sampling with p=" in caplog.text
 
+    def test_run_top_p_0_as_run_override(
+        self, caplog: pytest.LogCaptureFixture, documents_with_score: list[Document]
+    ) -> None:
+        # top_p=0.0 passed to run() must not be silently replaced by the init value
+        sampler = TopPSampler(top_p=1.0)
+        docs = documents_with_score
+        output = sampler.run(documents=docs, top_p=0.0)
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert docs[0].content == "Sarajevo"
+        assert "Top-p sampling with p=" in caplog.text
+
+    def test_run_with_integer_scores(self) -> None:
+        # integer scores must be treated like float scores, not as missing
+        sampler = TopPSampler(top_p=0.99)
+        docs = [
+            Document(content="Sarajevo", score=7),
+            Document(content="Belgrade", score=1),
+            Document(content="Berlin", score=-5),
+        ]
+        output = sampler.run(documents=docs)
+        docs_filtered = output["documents"]
+        assert len(docs_filtered) < len(docs)
+        assert docs_filtered[0].content == "Sarajevo"
+
+    def test_run_with_boolean_scores_treated_as_missing(self, caplog: pytest.LogCaptureFixture) -> None:
+        sampler = TopPSampler(top_p=0.95)
+        docs = [Document(content="Sarajevo", score=True), Document(content="Belgrade", score=0.5)]
+        output = sampler.run(documents=docs)
+        docs_filtered = output["documents"]
+        assert docs_filtered == [docs[1]]
+        assert "Ensure all documents have a valid score value" in caplog.text
+
     def test_run_returns_empty_list_no_documents(self) -> None:
         sampler = TopPSampler()
         output = sampler.run(documents=[])


### PR DESCRIPTION
### Related Issues

- fixes #11595

### Proposed Changes:

Two bugs made `TopPSampler` silently return all documents unfiltered:

1. `_get_doc_score` only accepted `float` scores. Documents with integer scores (common when scores come from external rankers or APIs) were treated as having no score, so the sampler logged a "missing scores" warning and skipped filtering entirely. Scores are now accepted as `int` or `float` and coerced to `float`; booleans are explicitly rejected since `bool` is a subclass of `int`.

2. `run(top_p=0.0)` was discarded by the falsy check `top_p = top_p or self.top_p`, even though `0.0` passes the component's own `0 <= top_p <= 1` validation. Replaced with an explicit `None` check, so the per-call override now behaves identically to `TopPSampler(top_p=0.0)`: it returns the single highest-scoring document with the existing warning.

### How did you test it?

- New tests: `test_run_top_p_0_as_run_override` (fails on `main`: returned all docs instead of one), `test_run_with_integer_scores` (fails on `main`: no filtering happened), and `test_run_with_boolean_scores_treated_as_missing` (guards the bool exclusion).
- `hatch run test:unit test/components/samplers/test_top_p.py` — 14 passed.
- `hatch run test:types haystack/components/samplers/top_p.py` — clean.

### Notes for the reviewer

- The existing `test_run_top_p_0` already pinned the expected semantics for `top_p=0.0` set via the constructor; the run-override fix makes the per-call path consistent with it.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
