### PR TITLE
fix: ZeroDivisionError in BM25 scoring when all documents have empty content

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -218,7 +218,9 @@ class InMemoryDocumentStore:
         def _compute_tf(token: str, freq: dict[str, int], doc_len: int) -> float:
             """Per-token BM25L computation."""
             freq_term = freq.get(token, 0.0)
-            ctd = freq_term / (1 - b + b * doc_len / self._avg_doc_len)
+            norm_len = doc_len / self._avg_doc_len if self._avg_doc_len > 0 else 0.0
+            denom = 1 - b + b * norm_len
+            ctd = freq_term / denom if denom > 0 else 0.0
             return (1.0 + k) * (ctd + delta) / (k + ctd + delta)
 
         idf = _compute_idf(self._tokenize_bm25(query))
@@ -268,7 +270,7 @@ class InMemoryDocumentStore:
                 if idf[tok] < 0:
                     neg_idf_tokens.append(tok)
 
-            eps = epsilon * sum_idf / len(self._freq_vocab_for_idf)
+            eps = epsilon * sum_idf / len(self._freq_vocab_for_idf) if self._freq_vocab_for_idf else 0.0
             for tok in neg_idf_tokens:
                 idf[tok] = eps
             return {tok: idf.get(tok, 0.0) for tok in tokens}
@@ -276,8 +278,9 @@ class InMemoryDocumentStore:
         def _compute_tf(token: str, freq: dict[str, int], doc_len: int) -> float:
             """Per-token BM25Okapi computation."""
             freq_term = freq.get(token, 0.0)
-            freq_norm = freq_term + k * (1 - b + b * doc_len / self._avg_doc_len)
-            return freq_term * (1.0 + k) / freq_norm
+            norm_len = doc_len / self._avg_doc_len if self._avg_doc_len > 0 else 0.0
+            freq_norm = freq_term + k * (1 - b + b * norm_len)
+            return freq_term * (1.0 + k) / freq_norm if freq_norm > 0 else 0.0
 
         idf = _compute_idf(self._tokenize_bm25(query))
         bm25_attr = {doc.id: self._bm25_attr[doc.id] for doc in documents}
@@ -326,8 +329,10 @@ class InMemoryDocumentStore:
         def _compute_tf(token: str, freq: dict[str, int], doc_len: float) -> float:
             """Per-token normalized term frequency."""
             freq_term = freq.get(token, 0.0)
-            freq_damp = k * (1 - b + b * doc_len / self._avg_doc_len)
-            return freq_term * (1.0 + k) / (freq_term + freq_damp) + delta
+            norm_len = doc_len / self._avg_doc_len if self._avg_doc_len > 0 else 0.0
+            freq_damp = k * (1 - b + b * norm_len)
+            denom = freq_term + freq_damp
+            return (freq_term * (1.0 + k) / denom if denom > 0 else 0.0) + delta
 
         idf = _compute_idf(self._tokenize_bm25(query))
         bm25_attr = {doc.id: self._bm25_attr[doc.id] for doc in documents}

--- a/releasenotes/notes/fix-bm25-zero-division-empty-corpus-ec8658d608dd4a96.yaml
+++ b/releasenotes/notes/fix-bm25-zero-division-empty-corpus-ec8658d608dd4a96.yaml
@@ -1,0 +1,9 @@
+﻿---
+fixes:
+  - |
+    Fixed ``InMemoryDocumentStore.bm25_retrieval`` raising ``ZeroDivisionError`` when all
+    stored documents have empty (but not ``None``) content. With an empty BM25 vocabulary
+    and an average document length of zero, all three BM25 algorithms (``BM25Okapi``,
+    ``BM25L``, ``BM25Plus``) divided by zero while computing term frequencies (and, for
+    ``BM25Okapi``, the IDF epsilon). Retrieval now returns zero scores for such corpora
+    instead of crashing; scoring of corpora with at least one non-empty document is unchanged.

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -173,6 +173,16 @@ class TestMemoryDocumentStore(
         assert len(results) == 0
         assert "No documents found for BM25 retrieval. Returning empty list." in caplog.text
 
+    @pytest.mark.parametrize("bm25_algorithm", ["BM25Okapi", "BM25L", "BM25Plus"])
+    def test_bm25_retrieval_with_only_empty_content_documents(self, bm25_algorithm) -> None:
+        # All stored documents have empty (but not None) content, so the BM25 statistics are all zero.
+        # Retrieval must not raise ZeroDivisionError.
+        document_store = InMemoryDocumentStore(bm25_algorithm=bm25_algorithm)
+        document_store.write_documents([Document(content="", meta={"i": 1}), Document(content="", meta={"i": 2})])
+        results = document_store.bm25_retrieval(query="anything")
+        assert all(doc.score == 0.0 for doc in results)
+        document_store.shutdown()
+
     def test_bm25_retrieval_empty_query(self, document_store: InMemoryDocumentStore) -> None:
         # Tests if the bm25_retrieval method returns a document when the query is an empty string.
         docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]


### PR DESCRIPTION
### Related Issues

- fixes #11598

### Proposed Changes:

A store containing only empty-string (not `None`) documents has an empty BM25 vocabulary and an average document length of zero. All three BM25 algorithms divided by zero at query time:

- `BM25Okapi`: the epsilon computation divides by `len(self._freq_vocab_for_idf)`, and `_compute_tf` divides by `self._avg_doc_len`.
- `BM25L` / `BM25Plus`: `_compute_tf` divides by `self._avg_doc_len`.

Each scorer now guards the average-document-length ratio (`doc_len / avg_doc_len` falls back to `0.0` when the average is zero) and the term-frequency denominator (zero denominator yields a zero term-frequency contribution). `BM25Okapi`'s epsilon falls back to `0.0` for an empty vocabulary.

Resulting behavior for a tokenless corpus: all scores are `0.0`, so `BM25Okapi` without score scaling returns the documents with score `0.0` (consistent with its documented handling of non-positive scores), while `BM25L`/`BM25Plus` return an empty list. Scoring for corpora with at least one non-empty document is unchanged.

### How did you test it?

- New parametrized regression test `test_bm25_retrieval_with_only_empty_content_documents` covering all three algorithms. Fails on `main` with `ZeroDivisionError` for each algorithm, passes with this fix.
- Manual check that mixed corpora (one empty doc among normal ones) score identically before and after the change.
- `hatch run test:unit test/document_stores/test_in_memory.py` — 150 passed, 4 skipped.
- `hatch run test:types haystack/document_stores/in_memory/document_store.py` — clean.

### Notes for the reviewer

- The denominator guards also harden the scorers against the `b=1.0` parameter edge case (an empty document in an otherwise non-empty corpus makes the Okapi term-frequency denominator zero for absent tokens), though the regression test focuses on the all-empty corpus reported in the issue.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
