### PR TITLE
test: fix NameError after AsyncPipeline was merged into Pipeline

### DIFF
--- a/test/core/pipeline/test_async_pipeline.py
+++ b/test/core/pipeline/test_async_pipeline.py
@@ -543,7 +543,7 @@ async def test_run_async_raises_when_multi_element_list_is_unwrapped_at_runtime(
         def run(self, text: str) -> dict[str, str]:
             return {"out": text}
 
-    pipe = AsyncPipeline()
+    pipe = Pipeline()
     pipe.add_component("producer", MultiStrProducer())
     pipe.add_component("consumer", SingleStrConsumer())
     pipe.connect("producer.texts", "consumer.text")


### PR DESCRIPTION
### Related Issues

- None

### Proposed Changes:

- fix a `NameError` on the `v3` branch: `test_run_async_raises_when_multi_element_list_is_unwrapped_at_runtime` still instantiates `AsyncPipeline`, which was removed when it was merged into `Pipeline` (#11587). The test arrived via the main merge (#11603) shortly before the refactor landed, so the two PRs crossed paths.
- this currently breaks `mypy` and the unit suite on `v3`, failing CI for every open v3 PR

### How did you test it?

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
