### PR TITLE
chore: deprecate SearchApiWebSearch + update docs

### DIFF
--- a/docs-website/docs/pipeline-components/websearch/searchapiwebsearch.mdx
+++ b/docs-website/docs/pipeline-components/websearch/searchapiwebsearch.mdx
@@ -17,9 +17,9 @@ Search engine using Search API.
 | **Mandatory init variables** | `api_key`: The SearchAPI API key. Can be set with `SEARCHAPI_API_KEY` env var. |
 | **Mandatory run variables** | `query`: A string with your query |
 | **Output variables** | `documents`: A list of documents  <br /> <br />`links`: A list of strings of resulting links |
-| **API reference** | [Websearch](/reference/websearch-api) |
-| **GitHub link** | https://github.com/deepset-ai/haystack/blob/main/haystack/components/websearch/searchapi.py |
-| **Package name** | `haystack-ai` |
+| **API reference** | [SearchApi](/reference/integrations-searchapi) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/searchapi |
+| **Package name** | `searchapi-haystack` |
 
 </div>
 
@@ -38,12 +38,18 @@ To use [Serper Dev](https://serper.dev/?gclid=Cj0KCQiAgqGrBhDtARIsAM5s0_kPElllv3
 
 ## Usage
 
+Install the `searchapi-haystack` package to use the `SearchApiWebSearch` component:
+
+```shell
+pip install searchapi-haystack
+```
+
 ### On its own
 
 This is an example of how `SearchApiWebSearch` looks up answers to our query on the web and converts the results into a list of documents with content snippets of the results, as well as URLs as strings.
 
 ```python
-from haystack.components.websearch import SearchApiWebSearch
+from haystack_integrations.components.websearch.searchapi import SearchApiWebSearch
 
 web_search = SearchApiWebSearch(api_key=Secret.from_token("<your-api-key>"))
 query = "What is the capital of Germany?"
@@ -62,7 +68,7 @@ from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
 from haystack.components.fetchers import LinkContentFetcher
 from haystack.components.converters import HTMLToDocument
 from haystack.components.generators.chat import OpenAIChatGenerator
-from haystack.components.websearch import SearchApiWebSearch
+from haystack_integrations.components.websearch.searchapi import SearchApiWebSearch
 from haystack.dataclasses import ChatMessage
 
 web_search = SearchApiWebSearch(api_key=Secret.from_token("<your-api-key>"), top_k=2)

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/websearch/searchapiwebsearch.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/websearch/searchapiwebsearch.mdx
@@ -17,9 +17,9 @@ Search engine using Search API.
 | **Mandatory init variables** | `api_key`: The SearchAPI API key. Can be set with `SEARCHAPI_API_KEY` env var. |
 | **Mandatory run variables** | `query`: A string with your query |
 | **Output variables** | `documents`: A list of documents  <br /> <br />`links`: A list of strings of resulting links |
-| **API reference** | [Websearch](/reference/websearch-api) |
-| **GitHub link** | https://github.com/deepset-ai/haystack/blob/main/haystack/components/websearch/searchapi.py |
-| **Package name** | `haystack-ai` |
+| **API reference** | [SearchApi](/reference/integrations-searchapi) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/searchapi |
+| **Package name** | `searchapi-haystack` |
 
 </div>
 
@@ -38,12 +38,18 @@ To use [Serper Dev](https://serper.dev/?gclid=Cj0KCQiAgqGrBhDtARIsAM5s0_kPElllv3
 
 ## Usage
 
+Install the `searchapi-haystack` package to use the `SearchApiWebSearch` component:
+
+```shell
+pip install searchapi-haystack
+```
+
 ### On its own
 
 This is an example of how `SearchApiWebSearch` looks up answers to our query on the web and converts the results into a list of documents with content snippets of the results, as well as URLs as strings.
 
 ```python
-from haystack.components.websearch import SearchApiWebSearch
+from haystack_integrations.components.websearch.searchapi import SearchApiWebSearch
 
 web_search = SearchApiWebSearch(api_key=Secret.from_token("<your-api-key>"))
 query = "What is the capital of Germany?"
@@ -62,7 +68,7 @@ from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
 from haystack.components.fetchers import LinkContentFetcher
 from haystack.components.converters import HTMLToDocument
 from haystack.components.generators.chat import OpenAIChatGenerator
-from haystack.components.websearch import SearchApiWebSearch
+from haystack_integrations.components.websearch.searchapi import SearchApiWebSearch
 from haystack.dataclasses import ChatMessage
 
 web_search = SearchApiWebSearch(api_key=Secret.from_token("<your-api-key>"), top_k=2)

--- a/haystack/components/websearch/searchapi.py
+++ b/haystack/components/websearch/searchapi.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from typing import Any
 
 import httpx
@@ -29,7 +30,7 @@ class SearchApiWebSearch:
     from haystack.components.websearch import SearchApiWebSearch
     from haystack.utils import Secret
 
-    websearch = SearchApiWebSearch(top_k=10, api_key=Secret.from_env_var("SERPERDEV_API_KEY"))
+    websearch = SearchApiWebSearch(top_k=10, api_key=Secret.from_env_var("SEARCHAPI_API_KEY"))
     results = websearch.run(query="Who is the boyfriend of Olivia Wilde?")
 
     assert results["documents"]
@@ -57,6 +58,14 @@ class SearchApiWebSearch:
             The default search engine is Google, however, users can change it by setting the `engine`
             parameter in the `search_params`.
         """
+        warnings.warn(
+            "`SearchApiWebSearch` will be removed from Haystack in version 3.0, as it is moving to "
+            "the `searchapi-haystack` package. To continue using it, install that package with "
+            "`pip install searchapi-haystack` and update your import to "
+            "`from haystack_integrations.components.websearch.searchapi import SearchApiWebSearch`.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
         self.api_key = api_key
         self.top_k = top_k

--- a/releasenotes/notes/deprecate-searchapi-websearch-4299713d280ac478.yaml
+++ b/releasenotes/notes/deprecate-searchapi-websearch-4299713d280ac478.yaml
@@ -1,0 +1,10 @@
+---
+deprecations:
+  - |
+    ``SearchApiWebSearch`` is deprecated and will be removed from Haystack in version 3.0. It is moving to
+    the ``searchapi-haystack`` package. To continue using it, install the package with
+    ``pip install searchapi-haystack`` and update your import as follows:
+
+    .. code-block:: python
+
+        from haystack_integrations.components.websearch.searchapi import SearchApiWebSearch

--- a/test/components/websearch/test_searchapi.py
+++ b/test/components/websearch/test_searchapi.py
@@ -518,7 +518,10 @@ class TestSearchApiSearchAPI:
         results = ws.run(query="Who is CEO of Microsoft?")
         documents = results["documents"]
         links = results["links"]
-        assert len(documents) == len(links) == 10
+        # documents can also include answer box, knowledge graph, and related questions, so only
+        # links (which come from organic results) are guaranteed to be at most top_k
+        assert 0 < len(documents) <= 10
+        assert 0 < len(links) <= 10
         assert all(isinstance(doc, Document) for doc in documents)
         assert all(isinstance(link, str) for link in links)
         assert all(link.startswith("http") for link in links)
@@ -534,7 +537,10 @@ class TestSearchApiSearchAPI:
         results = await ws.run_async(query="Who is CEO of Microsoft?")
         documents = results["documents"]
         links = results["links"]
-        assert len(documents) == len(links) == 10
+        # documents can also include answer box, knowledge graph, and related questions, so only
+        # links (which come from organic results) are guaranteed to be at most top_k
+        assert 0 < len(documents) <= 10
+        assert 0 < len(links) <= 10
         assert all(isinstance(doc, Document) for doc in documents)
         assert all(isinstance(link, str) for link in links)
         assert all(link.startswith("http") for link in links)


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/370

### Proposed Changes:
- deprecate `SearchApiWebSearch` with a `FutureWarning` pointing users to the new `searchapi-haystack` package (https://github.com/deepset-ai/haystack-core-integrations/pull/3437)
- update the docs page (current and version-2.30) to show the new package name, install command, and import path
- fix the docstring usage example, which wrongly referenced `SERPERDEV_API_KEY` instead of `SEARCHAPI_API_KEY`
- make the live-API integration test assertions robust: when SearchApi returns an answer box or knowledge graph, `documents` and `links` (organic results only) differ in length, so the old `len(documents) == len(links) == 10` assertion fails on main today (same fix as for SerperDev in #11577)

### How did you test it?
- `hatch run test:integration test/components/websearch/test_searchapi.py` with a real `SEARCHAPI_API_KEY` locally (we don't have one set in the CI in haystack. only in haystack-core-integrations): 2 passed (failed before the assertion fix)

### Notes for the reviewer
- **Merge order**: the Vercel docs build will fail with broken links to `/reference/integrations-searchapi` until the API reference page is added by the Docusaurus sync workflow when `integrations/searchapi-v0.1.0` is tagged in haystack-core-integrations. Once that sync PR lands on `main`, rebasing this branch turns the docs build green — same process as the SerperDev (#11577) and HuggingFace API (#11513) migrations.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
