### PR TITLE
fix: use `timedelta.total_seconds()` in telemetry throttle

### DIFF
--- a/haystack/telemetry/_telemetry.py
+++ b/haystack/telemetry/_telemetry.py
@@ -148,7 +148,7 @@ def pipeline_running(pipeline: Union["Pipeline", "AsyncPipeline"]) -> tuple[str,
     pipeline._telemetry_runs += 1
     if (
         pipeline._last_telemetry_sent
-        and (datetime.datetime.now() - pipeline._last_telemetry_sent).seconds < MIN_SECONDS_BETWEEN_EVENTS
+        and (datetime.datetime.now() - pipeline._last_telemetry_sent).total_seconds() < MIN_SECONDS_BETWEEN_EVENTS
     ):
         return None
 

--- a/releasenotes/notes/fix-telemetry-throttle-total-seconds-a1b2c3d4e5f60718.yaml
+++ b/releasenotes/notes/fix-telemetry-throttle-total-seconds-a1b2c3d4e5f60718.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed telemetry rate limiting to compare the real elapsed time using
+    `timedelta.total_seconds()` instead of `timedelta.seconds`. Previously, in long-lived
+    processes (for example notebook kernels), a pipeline run happening slightly more than a
+    whole number of days after the previous telemetry event was wrongly throttled, because
+    `timedelta.seconds` ignores the `days` component.

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -66,6 +66,35 @@ def test_pipeline_running(telemetry, pipeline_class):
 
 
 @patch("haystack.telemetry._telemetry.telemetry")
+def test_pipeline_running_sends_event_after_day_multiple_gap(telemetry):
+    """Regression test for #11589.
+
+    The throttle must compare the real elapsed time. Using `timedelta.seconds` (which
+    ignores the `days` component) wrongly suppressed events that happened slightly more
+    than a whole number of days after the previous one.
+    """
+    telemetry.send_event = Mock()
+
+    @component
+    class Component:
+        @component.output_types(value=int)
+        def run(self):
+            pass
+
+    pipe = Pipeline()
+    pipe.add_component("component", Component())
+    pipeline_running(pipe)
+    telemetry.send_event.assert_called_once()
+
+    # Pretend more than a day has passed since the last event (1 day + 5 seconds).
+    pipe._last_telemetry_sent = pipe._last_telemetry_sent - datetime.timedelta(days=1, seconds=5)
+
+    telemetry.send_event.reset_mock()
+    pipeline_running(pipe)
+    telemetry.send_event.assert_called_once()
+
+
+@patch("haystack.telemetry._telemetry.telemetry")
 def test_pipeline_running_with_non_serializable_component(telemetry):
     telemetry.send_event = Mock()
 


### PR DESCRIPTION
### Related Issues

Fixes #11589

### Proposed Changes

The telemetry rate-limit check in `pipeline_running` compared elapsed time using `timedelta.seconds`, which only holds the seconds component of the elapsed time (0–86399) and ignores the `days` component.

In a long-lived process (for example a notebook kernel), a pipeline run happening slightly more than a whole number of days after the previous telemetry event — e.g. 24 h + 10 s later — evaluates `.seconds` to `10`, so `10 < 60` is true and the event is wrongly throttled even though far more than `MIN_SECONDS_BETWEEN_EVENTS` has elapsed.

This switches the comparison to `total_seconds()`, so only events that genuinely happened within the last minute are suppressed.

### How did you test it?

Added a unit test in `test/test_telemetry.py` that advances `_last_telemetry_sent` by `1 day + 5 seconds` and asserts an event is still sent. Existing telemetry tests pass.

### Notes for the reviewer

Includes a release note. This contribution was prepared with the assistance of an AI agent; all changes were reviewed and verified locally (tests + `ruff`).