### PR TITLE
fix: preserve telemetry function metadata with `functools.wraps`

### DIFF
--- a/haystack/telemetry/_telemetry.py
+++ b/haystack/telemetry/_telemetry.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
+import functools
 import logging
 import os
 import uuid
@@ -121,7 +122,7 @@ def send_telemetry(func: Callable[..., Any]) -> Callable[..., None]:
     The wrapped function is actually called only if telemetry is enabled.
     """
 
-    # FIXME? Somehow, functools.wraps makes `telemetry` out of scope. Let's take care of it later.
+    @functools.wraps(func)
     def send_telemetry_wrapper(*args: Any, **kwargs: Any) -> None:
         try:
             if telemetry:

--- a/releasenotes/notes/fix-telemetry-decorator-functools-wraps-b2c3d4e5f6071829.yaml
+++ b/releasenotes/notes/fix-telemetry-decorator-functools-wraps-b2c3d4e5f6071829.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The `send_telemetry` decorator now uses `functools.wraps`, so decorated telemetry
+    functions such as `pipeline_running` keep their original metadata (name, docstring, and
+    annotations). Previously this metadata was lost, which could make stack traces and
+    generated API documentation confusing.

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -65,6 +65,17 @@ def test_pipeline_running(telemetry, pipeline_class):
     )
 
 
+def test_send_telemetry_preserves_function_metadata():
+    """Regression test for #11568.
+
+    The `send_telemetry` decorator must use `functools.wraps`, so decorated functions keep
+    their original name, docstring, and annotations.
+    """
+    assert pipeline_running.__name__ == "pipeline_running"
+    assert pipeline_running.__doc__ is not None
+    assert "Collects telemetry data for a pipeline run" in pipeline_running.__doc__
+
+
 @patch("haystack.telemetry._telemetry.telemetry")
 def test_pipeline_running_with_non_serializable_component(telemetry):
     telemetry.send_event = Mock()


### PR DESCRIPTION
### Related Issues

Fixes #11568

### Proposed Changes

The `send_telemetry` decorator wrapped functions like `pipeline_running` and `tutorial_running` without `functools.wraps`, so the decorated functions lost their original metadata (`__name__`, `__doc__`, `__annotations__`). This makes stack traces and generated API docs confusing.

The old `# FIXME` comment claimed that `functools.wraps` put the global `telemetry` object "out of scope". That concern is incorrect: the global is resolved at call time, not at decoration time. (The original author most likely hit a `NameError` because `functools` was not imported.)

This change imports `functools`, applies `@functools.wraps(func)` to the wrapper, and removes the obsolete comment.

### How did you test it?

Added a unit test asserting `pipeline_running.__name__` and `__doc__` are preserved. Existing telemetry tests pass.

### Notes for the reviewer

Includes a release note. Prepared with the assistance of an AI agent; reviewed and verified locally (tests + `ruff`).