### PR TITLE
fix: `TopPSampler` integer scores and `run(top_p=0.0)` override

### DIFF
--- a/haystack/components/samplers/top_p.py
+++ b/haystack/components/samplers/top_p.py
@@ -80,7 +80,7 @@ class TopPSampler:
         if not documents:
             return {"documents": []}
 
-        top_p = top_p or self.top_p
+        top_p = top_p if top_p is not None else self.top_p
         if not 0 <= top_p <= 1:
             raise ValueError(f"top_p must be between 0 and 1. Got {top_p}.")
 
@@ -140,7 +140,9 @@ class TopPSampler:
         else:
             score = doc.score
 
-        if not isinstance(score, float):
+        # Accept both ``int`` and ``float`` scores (external rankers/APIs often emit ints),
+        # but reject ``bool`` since it is a subclass of ``int`` and is not a real score.
+        if isinstance(score, bool) or not isinstance(score, (int, float)):
             score = None
         return score
 

--- a/releasenotes/notes/fix-toppsampler-int-scores-zero-top-p-c3d4e5f607182930.yaml
+++ b/releasenotes/notes/fix-toppsampler-int-scores-zero-top-p-c3d4e5f607182930.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    `TopPSampler` now treats integer document scores like floats, so top-p filtering is no
+    longer silently skipped when scores come from external rankers or APIs as integers.
+    Booleans are still rejected as invalid scores.
+  - |
+    `TopPSampler.run(top_p=0.0)` is now respected instead of falling back to the value set in
+    the constructor. Passing `0.0` selects only the highest-scoring document, matching the
+    behavior of `TopPSampler(top_p=0.0)`.

--- a/test/components/samplers/test_top_p.py
+++ b/test/components/samplers/test_top_p.py
@@ -95,6 +95,31 @@ class TestTopPSampler:
         assert docs[0].content == "Sarajevo"
         assert "Top-p sampling with p=" in caplog.text
 
+    def test_run_integer_scores(self) -> None:
+        # Regression test for #11595: integer scores must participate in sampling
+        # rather than being treated as missing, which silently disabled filtering.
+        sampler = TopPSampler(top_p=0.5)
+        docs = [Document(content="a", score=10), Document(content="b", score=1)]
+        output = sampler.run(documents=docs)["documents"]
+        assert len(output) == 1
+        assert output[0].content == "a"
+
+    def test_run_rejects_boolean_scores(self, caplog: pytest.LogCaptureFixture) -> None:
+        # ``bool`` is a subclass of ``int`` but is not a valid score.
+        sampler = TopPSampler(top_p=0.95)
+        docs = [Document(content="a", score=True), Document(content="b", score=False)]
+        output = sampler.run(documents=docs)["documents"]
+        assert len(output) == 2
+        assert "missing scores" in caplog.text
+
+    def test_run_top_p_0_override(self, documents_with_score: list[Document]) -> None:
+        # Regression test for #11595: ``run(top_p=0.0)`` must not fall back to the
+        # constructor value just because ``0.0`` is falsy.
+        sampler = TopPSampler(top_p=1.0)
+        output = sampler.run(documents=documents_with_score, top_p=0.0)["documents"]
+        assert len(output) == 1
+        assert output[0].content == "Sarajevo"
+
     def test_run_returns_empty_list_no_documents(self) -> None:
         sampler = TopPSampler()
         output = sampler.run(documents=[])


### PR DESCRIPTION
### Related Issues

Fixes #11595

### Proposed Changes

Two related bugs caused `TopPSampler` to silently return all documents (no error):

1. **Integer scores were treated as missing.** `_get_doc_score` rejected anything that was not a `float`, so a document with `score=10` (an `int`, common when scores come from external rankers, APIs, or test data) was treated as having no score, and when all scores were integers the sampler logged a misleading "missing scores" warning and disabled filtering. Integers are now accepted; `bool` is still rejected (it is a subclass of `int` but not a valid score).

2. **`run(top_p=0.0)` was ignored.** `top_p = top_p or self.top_p` treated the falsy `0.0` override as unset and fell back to the constructor value, even though `0.0` is valid and meaningful ("keep only the highest-scoring document"). The override is now applied with an explicit `is not None` check, matching `TopPSampler(top_p=0.0)`.

### How did you test it?

Added unit tests for integer scores, boolean-score rejection, and the `run(top_p=0.0)` override. Existing `TopPSampler` tests pass.

### Notes for the reviewer

Includes a release note. Prepared with the assistance of an AI agent; reviewed and verified locally (tests + `ruff`).