### PR TITLE
fix: avoid `ZeroDivisionError` in BM25 retrieval on a tokenless corpus

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -681,7 +681,16 @@ class InMemoryDocumentStore:
             logger.info("No documents found for BM25 retrieval. Returning empty list.")
             return []
 
-        results = sorted(self.bm25_algorithm_inst(query, all_documents), key=lambda x: x[1], reverse=True)[:top_k]
+        # A tokenless corpus (every stored document has empty content) has no vocabulary and an
+        # average document length of zero, which would make all three BM25 algorithms divide by
+        # zero during scoring. Score every candidate as 0.0 instead; the non-positive-score
+        # handling below then keeps them for BM25Okapi (unscaled) and drops them otherwise.
+        if self._avg_doc_len == 0:
+            scored_documents = [(doc, 0.0) for doc in all_documents]
+        else:
+            scored_documents = self.bm25_algorithm_inst(query, all_documents)
+
+        results = sorted(scored_documents, key=lambda x: x[1], reverse=True)[:top_k]
 
         # BM25Okapi can return meaningful negative values, so they should not be filtered out when scale_score is False.
         # It's the only algorithm supported by rank_bm25 at the time of writing (2024) that can return negative scores.

--- a/releasenotes/notes/fix-bm25-empty-corpus-zerodivision-d4e5f60718293041.yaml
+++ b/releasenotes/notes/fix-bm25-empty-corpus-zerodivision-d4e5f60718293041.yaml
@@ -1,10 +1,10 @@
 ---
 fixes:
   - |
-    Fixed a `ZeroDivisionError` in `InMemoryDocumentStore.bm25_retrieval` that occurred at query
-    time when every stored document had empty (but not `None`) content. Such a tokenless corpus
+    Fixed a ``ZeroDivisionError`` in ``InMemoryDocumentStore.bm25_retrieval`` that occurred at query
+    time when every stored document had empty (but not ``None``) content. Such a tokenless corpus
     has no vocabulary and an average document length of zero, which made all three BM25
-    algorithms divide by zero. Retrieval now scores every candidate as `0.0` in this case:
-    unscaled `BM25Okapi` returns the documents with score `0.0`, while `BM25L` and `BM25Plus`
+    algorithms divide by zero. Retrieval now scores every candidate as ``0.0`` in this case:
+    unscaled ``BM25Okapi`` returns the documents with score ``0.0``, while ``BM25L`` and ``BM25Plus``
     return an empty list (non-positive scores are filtered). Corpora with at least one non-empty
     document are unaffected.

--- a/releasenotes/notes/fix-bm25-empty-corpus-zerodivision-d4e5f60718293041.yaml
+++ b/releasenotes/notes/fix-bm25-empty-corpus-zerodivision-d4e5f60718293041.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed a `ZeroDivisionError` in `InMemoryDocumentStore.bm25_retrieval` that occurred at query
+    time when every stored document had empty (but not `None`) content. Such a tokenless corpus
+    has no vocabulary and an average document length of zero, which made all three BM25
+    algorithms divide by zero. Retrieval now scores every candidate as `0.0` in this case:
+    unscaled `BM25Okapi` returns the documents with score `0.0`, while `BM25L` and `BM25Plus`
+    return an empty list (non-positive scores are filtered). Corpora with at least one non-empty
+    document are unaffected.

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -6,7 +6,7 @@ import asyncio
 import gc
 import logging
 import tempfile
-from typing import cast
+from typing import cast, Literal
 from unittest.mock import patch
 
 import pytest
@@ -174,7 +174,7 @@ class TestMemoryDocumentStore(
         assert "No documents found for BM25 retrieval. Returning empty list." in caplog.text
 
     @pytest.mark.parametrize("bm25_algorithm", ["BM25Okapi", "BM25L", "BM25Plus"])
-    def test_bm25_retrieval_with_tokenless_corpus(self, bm25_algorithm: str) -> None:
+    def test_bm25_retrieval_with_tokenless_corpus(self, bm25_algorithm: Literal["BM25Okapi", "BM25L", "BM25Plus"]) -> None:
         # Regression test for #11598: a corpus where every document has empty (but not None)
         # content must not raise ZeroDivisionError at query time.
         store = InMemoryDocumentStore(bm25_algorithm=bm25_algorithm)

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -173,6 +173,21 @@ class TestMemoryDocumentStore(
         assert len(results) == 0
         assert "No documents found for BM25 retrieval. Returning empty list." in caplog.text
 
+    @pytest.mark.parametrize("bm25_algorithm", ["BM25Okapi", "BM25L", "BM25Plus"])
+    def test_bm25_retrieval_with_tokenless_corpus(self, bm25_algorithm: str) -> None:
+        # Regression test for #11598: a corpus where every document has empty (but not None)
+        # content must not raise ZeroDivisionError at query time.
+        store = InMemoryDocumentStore(bm25_algorithm=bm25_algorithm)
+        store.write_documents([Document(content="", meta={"i": 1}), Document(content="", meta={"i": 2})])
+        results = store.bm25_retrieval(query="anything")
+        if bm25_algorithm == "BM25Okapi":
+            # Unscaled BM25Okapi keeps non-positive scores, so documents are returned with score 0.0.
+            assert len(results) == 2
+            assert all(doc.score == 0.0 for doc in results)
+        else:
+            # BM25L / BM25Plus filter out non-positive scores.
+            assert results == []
+
     def test_bm25_retrieval_empty_query(self, document_store: InMemoryDocumentStore) -> None:
         # Tests if the bm25_retrieval method returns a document when the query is an empty string.
         docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -6,7 +6,7 @@ import asyncio
 import gc
 import logging
 import tempfile
-from typing import cast, Literal
+from typing import Literal, cast
 from unittest.mock import patch
 
 import pytest
@@ -174,7 +174,9 @@ class TestMemoryDocumentStore(
         assert "No documents found for BM25 retrieval. Returning empty list." in caplog.text
 
     @pytest.mark.parametrize("bm25_algorithm", ["BM25Okapi", "BM25L", "BM25Plus"])
-    def test_bm25_retrieval_with_tokenless_corpus(self, bm25_algorithm: Literal["BM25Okapi", "BM25L", "BM25Plus"]) -> None:
+    def test_bm25_retrieval_with_tokenless_corpus(
+        self, bm25_algorithm: Literal["BM25Okapi", "BM25L", "BM25Plus"]
+    ) -> None:
         # Regression test for #11598: a corpus where every document has empty (but not None)
         # content must not raise ZeroDivisionError at query time.
         store = InMemoryDocumentStore(bm25_algorithm=bm25_algorithm)


### PR DESCRIPTION
### Related Issues

Fixes #11598

### Proposed Changes

`InMemoryDocumentStore.bm25_retrieval` filters out documents whose content is `None`, but empty strings pass that filter. When every stored document has empty content, the corpus has an empty BM25 vocabulary and an average document length of zero, and all three algorithms then divide by zero at query time (`BM25Okapi` also divides by the zero vocabulary size when computing `eps`).

This happens in practice when an ingestion pipeline produces empty chunks (e.g. a converter returning empty strings for scanned/blank pages): the writes succeed and the store only blows up later, at query time.

This guards the scoring step: when the average document length is zero, every candidate is scored `0.0`. The existing non-positive-score handling then produces the expected results — unscaled `BM25Okapi` returns the documents with score `0.0`, while `BM25L`/`BM25Plus` return an empty list. Corpora with at least one non-empty document are unaffected.

### How did you test it?

Added a parametrized unit test (over all three algorithms) that writes empty-content documents and asserts retrieval no longer raises. Existing BM25 tests pass.

### Notes for the reviewer

Includes a release note. Prepared with the assistance of an AI agent; reviewed and verified locally (the issue's reproduction + tests + `ruff`).