### PR TITLE
fix: remove stale `State` entry from `haystack.dataclasses` lazy import structure

### DIFF
--- a/haystack/dataclasses/__init__.py
+++ b/haystack/dataclasses/__init__.py
@@ -23,7 +23,6 @@ _import_structure = {
     "file_content": ["FileContent"],
     "document": ["Document"],
     "sparse_embedding": ["SparseEmbedding"],
-    "state": ["State"],
     "streaming_chunk": [
         "AsyncStreamingCallbackT",
         "ComponentInfo",


### PR DESCRIPTION
PR #9578 removed the `state` submodule (`haystack/dataclasses/state.py`) and its `TYPE_CHECKING` import, but left the `"state": ["State"]` entry in the `_import_structure` dict that drives the lazy importer. As a result `State` still appears in `dir(haystack.dataclasses)`, yet `from haystack.dataclasses import State` raises `ModuleNotFoundError: No module named 'haystack.dataclasses.state'`. This removes the stale entry so the public namespace matches reality (the real `State` now lives in `haystack.components.agents`).