### PR TITLE
fix: validate split_overlap is less than split_length in DocumentSplitter

### DIFF
--- a/haystack/components/preprocessors/document_splitter.py
+++ b/haystack/components/preprocessors/document_splitter.py
@@ -150,6 +150,9 @@ class DocumentSplitter:
         if split_overlap < 0:
             raise ValueError("split_overlap must be greater than or equal to 0.")
 
+        if split_overlap >= split_length:
+            raise ValueError("split_overlap must be less than split_length.")
+
         if respect_sentence_boundary and split_by != "word":
             logger.warning(
                 "The 'respect_sentence_boundary' option is only supported for `split_by='word'`. "

--- a/releasenotes/notes/fix-document-splitter-overlap-validation-92ea8234c2c322cc.yaml
+++ b/releasenotes/notes/fix-document-splitter-overlap-validation-92ea8234c2c322cc.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    `DocumentSplitter` now raises a clear ``ValueError`` at initialization when
+    ``split_overlap`` is greater than or equal to ``split_length``. Previously
+    this configuration was accepted and only failed later at run time with an
+    opaque error from the underlying windowing helper (the window step became
+    zero or negative).

--- a/releasenotes/notes/fix-document-splitter-overlap-validation-92ea8234c2c322cc.yaml
+++ b/releasenotes/notes/fix-document-splitter-overlap-validation-92ea8234c2c322cc.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    `DocumentSplitter` now raises a clear ``ValueError`` at initialization when
+    ``DocumentSplitter`` now raises a clear ``ValueError`` at initialization when
     ``split_overlap`` is greater than or equal to ``split_length``. Previously
     this configuration was accepted and only failed later at run time with an
     opaque error from the underlying windowing helper (the window step became

--- a/test/components/preprocessors/test_document_splitter.py
+++ b/test/components/preprocessors/test_document_splitter.py
@@ -71,6 +71,15 @@ class TestSplittingByFunctionOrCharacterRegex:
         with pytest.raises(ValueError, match="split_overlap must be greater than or equal to 0."):
             DocumentSplitter(split_overlap=-1)
 
+    def test_split_overlap_not_less_than_split_length(self):
+        # split_overlap == split_length makes the window step 0, and a larger
+        # overlap makes it negative — both crash deep in `windowed` at run time.
+        # Fail fast at init with a clear error instead.
+        with pytest.raises(ValueError, match="split_overlap must be less than split_length."):
+            DocumentSplitter(split_length=3, split_overlap=3)
+        with pytest.raises(ValueError, match="split_overlap must be less than split_length."):
+            DocumentSplitter(split_length=3, split_overlap=5)
+
     def test_split_by_word(self):
         splitter = DocumentSplitter(split_by="word", split_length=10)
         text = "This is a text with some words. There is a second sentence. And there is a third sentence."


### PR DESCRIPTION
### Related Issues
None — self-found while reviewing `DocumentSplitter` validation.

### Proposed Changes
`DocumentSplitter.__init__` validates `split_length > 0` and `split_overlap >= 0`, but not that `split_overlap < split_length`. When `split_overlap >= split_length`, the window step (`split_length - split_overlap`) becomes **zero or negative**, and `_concatenate_units` calls `more_itertools.windowed(..., step=step)`, which raises an opaque `ValueError: step must be >= 1` deep in the call stack at **run time** — long after the misconfiguration was introduced.

This adds an early, clear validation at initialization, consistent with the two checks right above it:

```python
if split_overlap >= split_length:
    raise ValueError("split_overlap must be less than split_length.")
```

### How did you test it?
- Added a regression test (`test_split_overlap_not_less_than_split_length`) covering `split_overlap == split_length` and `split_overlap > split_length`. Verified it **fails before** this change (no error at init) and **passes after**.
- `hatch run test:unit test/components/preprocessors/test_document_splitter.py` → **55 passed**.
- `hatch run test:types` (module) and `hatch run fmt` → clean.

### Notes for the reviewer
Behavior change is limited to rejecting a configuration that was already broken (it crashed at run time); valid configs (`split_overlap < split_length`) are unaffected. Release note added under `releasenotes/notes/`.