### PR TITLE
fix: prevent GeneratedAnswer.from_dict crash on empty all_messages

### DIFF
--- a/haystack/dataclasses/answer.py
+++ b/haystack/dataclasses/answer.py
@@ -139,7 +139,7 @@ class GeneratedAnswer:
             init_params["documents"] = [Document.from_dict(d) for d in documents]
 
         meta = init_params.get("meta", {})
-        if (all_messages := meta.get("all_messages")) is not None and isinstance(all_messages[0], dict):
+        if (all_messages := meta.get("all_messages")) and isinstance(all_messages[0], dict):
             meta["all_messages"] = [ChatMessage.from_dict(m) for m in all_messages]
         init_params["meta"] = meta
 

--- a/releasenotes/notes/fix-generated-answer-empty-all-messages-ffccf61b751bc344.yaml
+++ b/releasenotes/notes/fix-generated-answer-empty-all-messages-ffccf61b751bc344.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Fixed ``GeneratedAnswer.from_dict`` raising an `IndexError` when the serialized
+    Fixed ``GeneratedAnswer.from_dict`` raising an ``IndexError`` when the serialized
     `meta` contained an empty `all_messages` list. Deserialization now guards
     against the empty list (consistent with `to_dict`) and round-trips correctly.

--- a/releasenotes/notes/fix-generated-answer-empty-all-messages-ffccf61b751bc344.yaml
+++ b/releasenotes/notes/fix-generated-answer-empty-all-messages-ffccf61b751bc344.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed `GeneratedAnswer.from_dict` raising an `IndexError` when the serialized
+    `meta` contained an empty `all_messages` list. Deserialization now guards
+    against the empty list (consistent with `to_dict`) and round-trips correctly.

--- a/releasenotes/notes/fix-generated-answer-empty-all-messages-ffccf61b751bc344.yaml
+++ b/releasenotes/notes/fix-generated-answer-empty-all-messages-ffccf61b751bc344.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Fixed `GeneratedAnswer.from_dict` raising an `IndexError` when the serialized
+    Fixed ``GeneratedAnswer.from_dict`` raising an `IndexError` when the serialized
     `meta` contained an empty `all_messages` list. Deserialization now guards
     against the empty list (consistent with `to_dict`) and round-trips correctly.

--- a/releasenotes/notes/fix-generated-answer-empty-all-messages-ffccf61b751bc344.yaml
+++ b/releasenotes/notes/fix-generated-answer-empty-all-messages-ffccf61b751bc344.yaml
@@ -3,4 +3,4 @@ fixes:
   - |
     Fixed ``GeneratedAnswer.from_dict`` raising an ``IndexError`` when the serialized
     ``meta`` contained an empty ``all_messages`` list. Deserialization now guards
-    against the empty list (consistent with `to_dict`) and round-trips correctly.
+    against the empty list (consistent with ``to_dict``) and round-trips correctly.

--- a/releasenotes/notes/fix-generated-answer-empty-all-messages-ffccf61b751bc344.yaml
+++ b/releasenotes/notes/fix-generated-answer-empty-all-messages-ffccf61b751bc344.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fixed ``GeneratedAnswer.from_dict`` raising an ``IndexError`` when the serialized
-    `meta` contained an empty `all_messages` list. Deserialization now guards
+    ``meta`` contained an empty ``all_messages`` list. Deserialization now guards
     against the empty list (consistent with `to_dict`) and round-trips correctly.

--- a/test/dataclasses/test_answer.py
+++ b/test/dataclasses/test_answer.py
@@ -264,6 +264,26 @@ class TestGeneratedAnswer:
         assert answer.meta["meta_key"] == "meta_value"
         assert answer.meta["all_messages"] == [ChatMessage.from_user("What is the answer?")]
 
+    def test_from_dict_with_empty_all_messages(self):
+        # An empty `all_messages` list must not crash deserialization: `is not None`
+        # let `[]` through and then indexed `all_messages[0]`, raising IndexError.
+        answer = GeneratedAnswer.from_dict(
+            {
+                "type": "haystack.dataclasses.answer.GeneratedAnswer",
+                "init_parameters": {
+                    "data": "42",
+                    "query": "What is the answer?",
+                    "documents": [],
+                    "meta": {"all_messages": []},
+                },
+            }
+        )
+        assert answer.meta["all_messages"] == []
+
+    def test_to_dict_from_dict_round_trip_with_empty_all_messages(self):
+        answer = GeneratedAnswer(data="42", query="What is the answer?", documents=[], meta={"all_messages": []})
+        assert GeneratedAnswer.from_dict(answer.to_dict()) == answer
+
     def test_no_warning_on_init(self):
         with warnings.catch_warnings():
             warnings.simplefilter("error", Warning)


### PR DESCRIPTION
### Related Issues

Self-found bug (no existing issue). `GeneratedAnswer.from_dict` crashes with `IndexError` when the serialized `meta` contains an empty `all_messages` list — which `to_dict` itself can emit, so a plain round-trip crashes.

### Proposed Changes:

`GeneratedAnswer.from_dict` guarded the metadata branch with `is not None`:

```python
if (all_messages := meta.get("all_messages")) is not None and isinstance(all_messages[0], dict):
```

An empty list `[]` is `not None`, so it passes the guard and the immediate `all_messages[0]` access raises `IndexError: list index out of range`. `to_dict` already uses the correct truthiness guard (`if all_messages and isinstance(all_messages[0], ChatMessage)`), which leaves an empty `all_messages` untouched in the output — so `to_dict` → `from_dict` round-trips into the crash.

The fix aligns `from_dict` with `to_dict` by using the same truthiness guard, so an empty `all_messages` list round-trips correctly instead of crashing.

Reproduction (before the fix):

```python
from haystack.dataclasses.answer import GeneratedAnswer
a = GeneratedAnswer(data="ans", query="q", documents=[], meta={"all_messages": []})
GeneratedAnswer.from_dict(a.to_dict())  # IndexError: list index out of range
```

### How did you test it?

Added two unit tests in `test/dataclasses/test_answer.py`:
- `test_from_dict_with_empty_all_messages` — deserializing `meta={"all_messages": []}` no longer raises.
- `test_to_dict_from_dict_round_trip_with_empty_all_messages` — full round-trip equality.

Both fail on `main` (IndexError) and pass with this change. Ran `hatch run test:unit test/dataclasses/test_answer.py` (20 passed), `hatch run fmt` (clean), and `hatch run test:types haystack/dataclasses/answer.py` (mypy clean). Added a release note under `releasenotes/notes`.

### Notes for the reviewer

One-line behavior fix; the existing non-empty / `ChatMessage` / string `all_messages` paths are unchanged and still covered by the existing tests.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the code of conduct.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) type for my PR title (`fix:`).
- [x] I have added a release note file.
- [x] I have run pre-commit hooks / `hatch run fmt` and fixed any issue.

> This PR was generated with the help of an AI assistant. I have reviewed the changes, reproduced the bug, and run the relevant tests locally.