### PR TITLE
fix: skip null content_key values in JSONConverter

### DIFF
--- a/haystack/components/converters/json.py
+++ b/haystack/components/converters/json.py
@@ -226,6 +226,13 @@ class JSONConverter:
                     continue
 
                 text = obj[self._content_key]
+                if text is None:
+                    logger.warning(
+                        "Content key '{content_key}' has a null value in {obj}. Skipping it.",
+                        content_key=self._content_key,
+                        obj=obj,
+                    )
+                    continue
                 if isinstance(text, (dict, list)):
                     logger.warning("Expected a scalar value but got {obj}. Skipping it.", obj=obj)
                     continue

--- a/releasenotes/notes/json-converter-skip-null-content-bf33310ae256e377.yaml
+++ b/releasenotes/notes/json-converter-skip-null-content-bf33310ae256e377.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    `JSONConverter` now skips records whose `content_key` value is `null` (with a
+    warning) instead of creating a `Document` with `content=None`. This matches the
+    existing handling of non-scalar (dict/list) values and prevents invalid
+    documents from breaking downstream text components.

--- a/test/components/converters/test_json.py
+++ b/test/components/converters/test_json.py
@@ -516,3 +516,17 @@ def test_run_with_jq_schema_content_key_and_extra_meta_fields_literal(tmpdir):
         "and for his related discovery of nuclear reactions brought about by slow neutrons"
     )
     assert result["documents"][3].meta == {"id": "46", "firstname": "Enrico", "surname": "Fermi", "share": "1"}
+
+
+def test_run_with_content_key_skips_null_value(caplog):
+    # A null value for the content key must be skipped (like dict/list values) rather
+    # than producing a Document with content=None, which breaks downstream text components.
+    valid = ByteStream.from_string(json.dumps({"text": "hello", "title": "a"}))
+    null_content = ByteStream.from_string(json.dumps({"text": None, "title": "b"}))
+    converter = JSONConverter(content_key="text")
+
+    with caplog.at_level(logging.WARNING):
+        result = converter.run(sources=[valid, null_content])
+
+    assert [doc.content for doc in result["documents"]] == ["hello"]
+    assert "null value" in caplog.text


### PR DESCRIPTION
### Related Issues

Self-found bug (no existing issue). `JSONConverter` in `content_key` mode emits a `Document` with `content=None` when the extracted value is JSON `null`, which breaks downstream text components.

### Proposed Changes:

In `content_key` mode, `_get_content_and_meta` already skips non-scalar values (dict/list) with a warning, but a `null` value passes straight through:

```python
text = obj[self._content_key]
if isinstance(text, (dict, list)):
    logger.warning("Expected a scalar value but got {obj}. Skipping it.", obj=obj)
    continue
...
document = Document(content=text, meta=merged_metadata)  # content=None when text is null
```

A `Document` with `content=None` is not usable text and raises in downstream components (e.g. `DocumentSplitter`: *"DocumentSplitter only works with text documents but content for document ID … is None"*). This change skips `null` values with a clear warning, consistent with the existing dict/list handling.

Reproduction (before the fix):

```python
import json
from haystack.components.converters.json import JSONConverter
from haystack.dataclasses import ByteStream

bs = ByteStream.from_string(json.dumps({"text": None, "title": "t"}))
docs = JSONConverter(content_key="text").run(sources=[bs])["documents"]
print(docs[0].content)  # None  -> invalid document
```

### How did you test it?

Added `test_run_with_content_key_skips_null_value` in `test/components/converters/test_json.py`: a record with a `null` content value is skipped (with a warning) while a sibling valid record is kept. It fails on `main` (the null record produces a `content=None` document) and passes with this change. Ran `hatch run test:unit test/components/converters/test_json.py` (20 passed), `hatch run fmt` (clean), `hatch run test:types haystack/components/converters/json.py` (mypy clean), and added a release note.

### Notes for the reviewer

Scoped to the `content_key` path (the one that produces an invalid `content=None` document). Existing scalar/dict/list behavior is unchanged and still covered by the existing tests.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used a conventional commit type for my PR title (`fix:`).
- [x] I have added a release note file.
- [x] I have run pre-commit hooks / `hatch run fmt` and fixed any issue.

> This PR was generated with the help of an AI assistant. I have reviewed the changes, reproduced the bug, and run the relevant tests locally.