### PR TITLE
fix: avoid NaN cosine scores for zero-norm embeddings in InMemoryDocumentStore

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -801,9 +801,12 @@ class InMemoryDocumentStore:
             document_embeddings = np.expand_dims(a=document_embeddings, axis=0)
 
         if self.embedding_similarity_function == "cosine":
-            # cosine similarity is a normed dot product
-            query_embedding /= np.linalg.norm(x=query_embedding, axis=1, keepdims=True)
-            document_embeddings /= np.linalg.norm(x=document_embeddings, axis=1, keepdims=True)
+            # cosine similarity is a normed dot product; guard against zero-norm vectors
+            # (e.g. a zero embedding) which would otherwise divide by zero and yield NaN scores.
+            query_norm = np.linalg.norm(x=query_embedding, axis=1, keepdims=True)
+            document_norms = np.linalg.norm(x=document_embeddings, axis=1, keepdims=True)
+            query_embedding /= np.where(query_norm == 0.0, 1.0, query_norm)
+            document_embeddings /= np.where(document_norms == 0.0, 1.0, document_norms)
 
         try:
             scores = np.dot(a=query_embedding, b=document_embeddings.T)[0].tolist()

--- a/releasenotes/notes/in-memory-cosine-zero-vector-nan-a7dcf0990d3db15c.yaml
+++ b/releasenotes/notes/in-memory-cosine-zero-vector-nan-a7dcf0990d3db15c.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixed `InMemoryDocumentStore.embedding_retrieval` producing `NaN` cosine
+    Fixed ``InMemoryDocumentStore.embedding_retrieval`` producing ``NaN`` cosine
     similarity scores when a document (or the query) had a zero-norm embedding.
     Zero-norm vectors are now handled without dividing by zero, so such documents
-    receive a score of `0.0` instead of `NaN` (which silently corrupted ranking).
+    receive a score of ``0.0`` instead of ``NaN`` (which silently corrupted ranking).

--- a/releasenotes/notes/in-memory-cosine-zero-vector-nan-a7dcf0990d3db15c.yaml
+++ b/releasenotes/notes/in-memory-cosine-zero-vector-nan-a7dcf0990d3db15c.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed `InMemoryDocumentStore.embedding_retrieval` producing `NaN` cosine
+    similarity scores when a document (or the query) had a zero-norm embedding.
+    Zero-norm vectors are now handled without dividing by zero, so such documents
+    receive a score of `0.0` instead of `NaN` (which silently corrupted ranking).

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -366,7 +366,7 @@ class TestMemoryDocumentStore(
         )
         results = docstore.embedding_retrieval(query_embedding=[1.0, 0.0, 0.0], scale_score=False)
         scores = {doc.content: doc.score for doc in results}
-        assert all(not math.isnan(score) for score in scores.values())
+        assert all(score is not None and not math.isnan(score) for score in scores.values())
         assert scores["zero"] == 0.0
 
     def test_embedding_retrieval_invalid_query(self, in_memory_doc_store):

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -5,6 +5,7 @@
 import asyncio
 import gc
 import logging
+import math
 import tempfile
 from typing import cast
 from unittest.mock import patch
@@ -355,6 +356,18 @@ class TestMemoryDocumentStore(
         )
         assert len(results) == 1
         assert results[0].content == "Haystack supports multiple languages"
+
+    def test_embedding_retrieval_with_zero_vector_does_not_produce_nan(self):
+        # A zero embedding has no direction; normalizing it must not divide by zero and
+        # produce NaN cosine scores, which would silently corrupt ranking.
+        docstore = InMemoryDocumentStore(embedding_similarity_function="cosine")
+        docstore.write_documents(
+            [Document(content="zero", embedding=[0.0, 0.0, 0.0]), Document(content="normal", embedding=[1.0, 0.0, 0.0])]
+        )
+        results = docstore.embedding_retrieval(query_embedding=[1.0, 0.0, 0.0], scale_score=False)
+        scores = {doc.content: doc.score for doc in results}
+        assert all(not math.isnan(score) for score in scores.values())
+        assert scores["zero"] == 0.0
 
     def test_embedding_retrieval_invalid_query(self, in_memory_doc_store):
         with pytest.raises(ValueError, match="query_embedding should be a non-empty list of floats"):


### PR DESCRIPTION
### Related Issues

Self-found bug (no existing issue). `InMemoryDocumentStore.embedding_retrieval` returns `NaN` similarity scores when a document (or the query) has a zero-norm embedding, silently corrupting ranking.

### Proposed Changes:

For `cosine` similarity, embeddings are normalized by their L2 norm:

```python
query_embedding /= np.linalg.norm(x=query_embedding, axis=1, keepdims=True)
document_embeddings /= np.linalg.norm(x=document_embeddings, axis=1, keepdims=True)
```

A zero-norm vector (e.g. a zero embedding, which some models emit for empty/whitespace input) makes this divide by zero, producing `NaN` scores (numpy even emits a `RuntimeWarning: invalid value encountered in divide`). `NaN` then sorts unpredictably and silently corrupts the ranking.

This guards the normalization so zero-norm vectors stay zero (denominator forced to `1.0`), giving such documents a cosine score of `0.0` instead of `NaN`. Non-zero embeddings are unaffected.

Reproduction (before the fix):

```python
from haystack import Document
from haystack.document_stores.in_memory import InMemoryDocumentStore

store = InMemoryDocumentStore(embedding_similarity_function="cosine")
store.write_documents([Document(content="zero", embedding=[0.0, 0.0, 0.0])])
print(store.embedding_retrieval(query_embedding=[1.0, 0.0, 0.0])[0].score)  # nan
```

### How did you test it?

Added `test_embedding_retrieval_with_zero_vector_does_not_produce_nan` in `test/document_stores/test_in_memory.py`: a zero-embedding document no longer yields a `NaN` score (it gets `0.0`) while a normal document is unaffected. It fails on `main` (NaN) and passes with this change. Ran `hatch run test:unit test/document_stores/test_in_memory.py` (148 passed, 4 skipped), `hatch run fmt` (clean), `hatch run test:types haystack/document_stores/in_memory/document_store.py` (mypy clean), and added a release note.

### Notes for the reviewer

Behavior for non-zero embeddings is unchanged; only the zero-norm edge case is guarded.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used a conventional commit type for my PR title (`fix:`).
- [x] I have added a release note file.
- [x] I have run pre-commit hooks / `hatch run fmt` and fixed any issue.

> This PR was generated with the help of an AI assistant. I have reviewed the changes, reproduced the bug, and run the relevant tests locally.