### PR TITLE
fix: raise a clear error for zero-sum weights in DocumentJoiner

### DIFF
--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -123,7 +123,13 @@ class DocumentJoiner:
         }
         self.join_mode_function = join_mode_functions[join_mode]
         self.join_mode = join_mode
-        self.weights = [float(i) / sum(weights) for i in weights] if weights else None
+        if weights:
+            weight_sum = sum(weights)
+            if weight_sum == 0:
+                raise ValueError("The provided `weights` must not sum to zero.")
+            self.weights: list[float] | None = [float(i) / weight_sum for i in weights]
+        else:
+            self.weights = None
         self.top_k = top_k
         self.sort_by_score = sort_by_score
 

--- a/releasenotes/notes/document-joiner-zero-sum-weights-263b18a84420f1cb.yaml
+++ b/releasenotes/notes/document-joiner-zero-sum-weights-263b18a84420f1cb.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    `DocumentJoiner` now raises a clear `ValueError` when the provided `weights`
-    sum to zero, instead of failing with an opaque `ZeroDivisionError` while
+    ``DocumentJoiner`` now raises a clear ``ValueError`` when the provided ``weights``
+    sum to zero, instead of failing with an opaque ``ZeroDivisionError`` while
     normalizing them.

--- a/releasenotes/notes/document-joiner-zero-sum-weights-263b18a84420f1cb.yaml
+++ b/releasenotes/notes/document-joiner-zero-sum-weights-263b18a84420f1cb.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    `DocumentJoiner` now raises a clear `ValueError` when the provided `weights`
+    sum to zero, instead of failing with an opaque `ZeroDivisionError` while
+    normalizing them.

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -26,6 +26,11 @@ class TestDocumentJoiner:
         assert joiner.top_k == 5
         assert not joiner.sort_by_score
 
+    def test_init_with_zero_sum_weights_raises(self):
+        # weights that sum to zero would divide by zero during normalization
+        with pytest.raises(ValueError, match="must not sum to zero"):
+            DocumentJoiner(join_mode="merge", weights=[0.0, 0.0, 0.0])
+
     def test_to_dict(self):
         joiner = DocumentJoiner()
         data = joiner.to_dict()


### PR DESCRIPTION
### Related Issues

Self-found bug (no existing issue). `DocumentJoiner` crashes with an opaque `ZeroDivisionError` at construction when the provided `weights` sum to zero.

### Proposed Changes:

`DocumentJoiner.__init__` normalized the weights with:

```python
self.weights = [float(i) / sum(weights) for i in weights] if weights else None
```

If `weights` is non-empty but sums to zero (e.g. `[0, 0, 0]`, or `[1, -1]`), `sum(weights)` is `0` and this raises a bare `ZeroDivisionError: float division by zero` with no indication of what went wrong. This change validates the sum and raises a clear `ValueError` instead.

Reproduction (before the fix):

```python
from haystack.components.joiners import DocumentJoiner
DocumentJoiner(weights=[0, 0, 0])  # ZeroDivisionError: float division by zero
```

### How did you test it?

Added `test_init_with_zero_sum_weights_raises` in `test/components/joiners/test_document_joiner.py` asserting a `ValueError` (matching "must not sum to zero") is raised. Ran `hatch run test:unit test/components/joiners/test_document_joiner.py` (33 passed), `hatch run fmt` (clean), and `hatch run test:types haystack/components/joiners/document_joiner.py` (mypy clean). Added a release note.

### Notes for the reviewer

Tiny, isolated change to the constructor; normal weights are unaffected.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used a conventional commit type for my PR title (`fix:`).
- [x] I have added a release note file.
- [x] I have run pre-commit hooks / `hatch run fmt` and fixed any issue.

> This PR was generated with the help of an AI assistant. I have reviewed the changes, reproduced the bug, and run the relevant tests locally.