### PR TITLE
fix: ignore non-list QueryExpander replies

### DIFF
--- a/haystack/components/query/query_expander.py
+++ b/haystack/components/query/query_expander.py
@@ -265,6 +265,13 @@ class QueryExpander:
         if parsed is None:
             return []
 
+        if not isinstance(parsed["queries"], list):
+            logger.warning(
+                "Expected 'queries' to be a list but got {type}. Returning no expanded queries.",
+                type=type(parsed["queries"]).__name__,
+            )
+            return []
+
         queries = []
         for item in parsed["queries"]:
             if isinstance(item, str) and item.strip():

--- a/releasenotes/notes/query-expander-reject-non-list-queries-6f3b1c2d8e9a4b70.yaml
+++ b/releasenotes/notes/query-expander-reject-non-list-queries-6f3b1c2d8e9a4b70.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    `QueryExpander` now ignores malformed responses where `queries` is not a list, so a string response is no longer
+    split into single-character queries.

--- a/releasenotes/notes/query-expander-reject-non-list-queries-6f3b1c2d8e9a4b70.yaml
+++ b/releasenotes/notes/query-expander-reject-non-list-queries-6f3b1c2d8e9a4b70.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    `QueryExpander` now ignores malformed responses where `queries` is not a list, so a string response is no longer
+    ``QueryExpander`` now ignores malformed responses where ``queries`` is not a list, so a string response is no longer
     split into single-character queries.

--- a/test/components/query/test_query_expander.py
+++ b/test/components/query/test_query_expander.py
@@ -193,6 +193,17 @@ class TestQueryExpander:
         queries = expander._parse_expanded_queries('{"not": "a list"}')
         assert queries == []
 
+    @pytest.mark.parametrize("queries_value", ['"single query"', '{"query": "value"}', "null"])
+    def test_parse_expanded_queries_rejects_non_list_queries_value(self, monkeypatch, caplog, queries_value):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key-12345")
+        expander = QueryExpander()
+
+        with caplog.at_level(logging.WARNING):
+            queries = expander._parse_expanded_queries(f'{{"queries": {queries_value}}}')
+
+        assert queries == []
+        assert "Expected 'queries' to be a list" in caplog.text
+
     def test_parse_expanded_queries_mixed_types(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key-12345")
         expander = QueryExpander()


### PR DESCRIPTION
### What changed

`QueryExpander` now checks that `queries` is a list before iterating over it.

Before this, a response like `{"queries": "search term"}` was treated as an iterable, so it produced single-character queries.

### Testing

- `hatch run test:unit test/components/query/test_query_expander.py -q`
- `hatch run fmt-check haystack/components/query/query_expander.py test/components/query/test_query_expander.py`
- `hatch run test:types haystack/components/query/query_expander.py test/components/query/test_query_expander.py`
