### PR TITLE
feat: add run_async to DocumentLengthRouter

### DIFF
--- a/haystack/components/routers/document_length_router.py
+++ b/haystack/components/routers/document_length_router.py
@@ -52,6 +52,23 @@ class DocumentLengthRouter:
         self.threshold = threshold
 
     @component.output_types(short_documents=list[Document], long_documents=list[Document])
+    async def run_async(self, documents: list[Document]) -> dict[str, list[Document]]:
+        """
+        Asynchronously categorize input documents into groups based on the length of the `content` field.
+
+        Delegates to the synchronous :meth:`run` since this component performs no I/O.
+
+        :param documents:
+            A list of documents to be categorized.
+
+        :returns: A dictionary with the following keys:
+            - `short_documents`: A list of documents where `content` is None or the length of `content` is less than or
+               equal to the threshold.
+            - `long_documents`: A list of documents where the length of `content` is greater than the threshold.
+        """
+        return self.run(documents=documents)
+
+    @component.output_types(short_documents=list[Document], long_documents=list[Document])
     def run(self, documents: list[Document]) -> dict[str, list[Document]]:
         """
         Categorize input documents into groups based on the length of the `content` field.

--- a/releasenotes/notes/add-run-async-to-documentlengthrouter-d56d9d380cedd67e.yaml
+++ b/releasenotes/notes/add-run-async-to-documentlengthrouter-d56d9d380cedd67e.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add ``run_async`` to ``DocumentLengthRouter``, enabling it to be used
+    in ``AsyncPipeline`` without blocking the event loop.

--- a/test/components/routers/test_document_length_router.py
+++ b/test/components/routers/test_document_length_router.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
 from haystack.components.routers import DocumentLengthRouter
 from haystack.core.serialization import component_from_dict, component_to_dict
 from haystack.dataclasses import Document
@@ -60,3 +62,27 @@ class TestDocumentLengthRouter:
 
         assert isinstance(loaded_router, DocumentLengthRouter)
         assert loaded_router.threshold == 10
+
+
+class TestDocumentLengthRouterAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_routes_correctly(self):
+        docs = [Document(content="Hi"), Document(content="Long document " * 20)]
+        router = DocumentLengthRouter(threshold=10)
+        result = await router.run_async(documents=docs)
+        assert result["short_documents"] == [docs[0]]
+        assert result["long_documents"] == [docs[1]]
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_null_content(self):
+        docs = [Document(content=None), Document(content="Long document " * 20)]
+        router = DocumentLengthRouter(threshold=10)
+        result = await router.run_async(documents=docs)
+        assert result["short_documents"] == [docs[0]]
+        assert result["long_documents"] == [docs[1]]
+
+    @pytest.mark.asyncio
+    async def test_run_async_matches_sync(self):
+        docs = [Document(content="Short"), Document(content="Long " * 20)]
+        router = DocumentLengthRouter(threshold=10)
+        assert await router.run_async(documents=docs) == router.run(documents=docs)


### PR DESCRIPTION
**Related Issues**
No related issue (new feature / async coverage gap)

**Proposed Changes**
DocumentLengthRouter lacked a run_async method, making it unusable in AsyncPipeline without blocking the event loop. This PR adds a run_async method that delegates to the synchronous run, following the same pattern used by other pure-Python components in the codebase (e.g. FilterRetriever, CacheChecker). No logic is duplicated — since this component performs no I/O, the async variant simply wraps the sync one.

**How did you test it?**
Added TestDocumentLengthRouterAsync in test/components/routers/test_document_length_router.py with three unit tests:
test_run_async_routes_correctly — verifies short/long routing
test_run_async_with_null_content — verifies None content goes to short
test_run_async_matches_sync — asserts async and sync outputs are identical

**Notes for the reviewer**
The implementation is intentionally minimal — run_async delegates to run() rather than duplicating logic, consistent with how other side-effect-free components in this repo handle async (see BranchJoiner, InMemoryBM25Retriever). No behaviour change to the sync path.

**Checklist**
 I have read the contributors guidelines and the code of conduct.
 I have updated the related issue with new insights and changes. (N/A — no linked issue)
 I have added unit tests and updated the docstrings.
 I've used one of the conventional commit types for my PR title: feat:
 I have documented my code.
 I have added a release note file (releasenotes/notes/add-run-async-to-documentlengthrouter-d56d9d380cedd67e.yaml).
 I have run pre-commit hooks and fixed any issue.