### PR TITLE
fix: FileTypeRouter no longer silently drops "+"-containing MIME types

### DIFF
--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -20,6 +20,11 @@ from haystack.utils.misc import CUSTOM_MIMETYPES  # noqa: F401
 logger = logging.getLogger(__name__)
 
 
+# Strings matching this shape are treated as literal MIMEs (escaped before compile); anything else
+# is compiled as a regex, preserving the documented regex support.
+_LITERAL_MIME_RE = re.compile(r"\A[a-zA-Z0-9][a-zA-Z0-9.+_\-]*/[a-zA-Z0-9][a-zA-Z0-9.+_\-]*\Z")
+
+
 @component
 class FileTypeRouter:
     """
@@ -27,10 +32,11 @@ class FileTypeRouter:
 
     FileTypeRouter supports both exact MIME type matching and regex patterns.
 
-    For file paths, MIME types come from extensions, while byte streams use metadata.
-    You can use regex patterns in the `mime_types` parameter to set broad categories
-    (such as 'audio/*' or 'text/*') or specific types.
-    MIME types without regex patterns are treated as exact matches.
+    For file paths, MIME types come from extensions; byte streams use metadata.
+    Entries in `mime_types` are classified automatically: strings made up only of IANA-valid
+    characters (alphanumerics and `.`, `+`, `_`, `-` on each side of the `/`) are matched literally,
+    so `"image/svg+xml"` matches only `image/svg+xml`. Anything else (for example `"audio/.*"`) is
+    compiled as a regex.
 
     ### Usage example
 
@@ -38,10 +44,10 @@ class FileTypeRouter:
     from haystack.components.routers import FileTypeRouter
     from pathlib import Path
 
-    # For exact MIME type matching
-    router = FileTypeRouter(mime_types=["text/plain", "application/pdf"])
+    # Exact MIME matching — `+`-containing IANA types like image/svg+xml work correctly
+    router = FileTypeRouter(mime_types=["text/plain", "application/pdf", "image/svg+xml"])
 
-    # For flexible matching using regex, to handle all audio types
+    # Regex matching — catch every audio subtype
     router_with_regex = FileTypeRouter(mime_types=[r"audio/.*", r"text/plain"])
 
     sources = [Path("file.txt"), Path("document.pdf"), Path("song.mp3")]
@@ -86,10 +92,14 @@ class FileTypeRouter:
 
         self.mime_type_patterns = []
         for mime_type in mime_types:
-            try:
-                pattern = re.compile(mime_type)
-            except re.error as e:
-                raise ValueError(f"Invalid regex pattern '{mime_type}'.") from e
+            if _LITERAL_MIME_RE.fullmatch(mime_type):
+                # Escape so `.` and `+` in real MIME types match themselves, not regex wildcards.
+                pattern = re.compile(re.escape(mime_type))
+            else:
+                try:
+                    pattern = re.compile(mime_type)
+                except re.error as e:
+                    raise ValueError(f"Invalid MIME type or regex pattern '{mime_type}'.") from e
             self.mime_type_patterns.append(pattern)
 
         # the actual output type is list[Union[Path, ByteStream]],
@@ -189,9 +199,11 @@ class FileTypeRouter:
 
             matched = False
             if mime_type:
-                for pattern in self.mime_type_patterns:
+                # Bucket key is the user's original string — keeps it aligned with the output socket
+                # name; `pattern.pattern` would be the escaped form for literals.
+                for bucket_key, pattern in zip(self.mime_types, self.mime_type_patterns, strict=True):
                     if pattern.fullmatch(mime_type):
-                        mime_types[pattern.pattern].append(source)
+                        mime_types[bucket_key].append(source)
                         matched = True
                         break
             if not matched:

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -20,11 +20,6 @@ from haystack.utils.misc import CUSTOM_MIMETYPES  # noqa: F401
 logger = logging.getLogger(__name__)
 
 
-# Strings matching this shape are treated as literal MIMEs (escaped before compile); anything else
-# is compiled as a regex, preserving the documented regex support.
-_LITERAL_MIME_RE = re.compile(r"\A[a-zA-Z0-9][a-zA-Z0-9.+_\-]*/[a-zA-Z0-9][a-zA-Z0-9.+_\-]*\Z")
-
-
 @component
 class FileTypeRouter:
     """
@@ -33,10 +28,10 @@ class FileTypeRouter:
     FileTypeRouter supports both exact MIME type matching and regex patterns.
 
     For file paths, MIME types come from extensions; byte streams use metadata.
-    Entries in `mime_types` are classified automatically: strings made up only of IANA-valid
-    characters (alphanumerics and `.`, `+`, `_`, `-` on each side of the `/`) are matched literally,
-    so `"image/svg+xml"` matches only `image/svg+xml`. Anything else (for example `"audio/.*"`) is
-    compiled as a regex.
+    Each entry in `mime_types` is matched against a source's MIME type by exact equality first,
+    falling back to regex `fullmatch` if equality misses. So `"image/svg+xml"` routes
+    `image/svg+xml` streams correctly via the equality check (without `+` being interpreted as a
+    regex quantifier), and patterns like `"audio/.*"` keep matching every audio subtype.
 
     ### Usage example
 
@@ -92,14 +87,10 @@ class FileTypeRouter:
 
         self.mime_type_patterns = []
         for mime_type in mime_types:
-            if _LITERAL_MIME_RE.fullmatch(mime_type):
-                # Escape so `.` and `+` in real MIME types match themselves, not regex wildcards.
-                pattern = re.compile(re.escape(mime_type))
-            else:
-                try:
-                    pattern = re.compile(mime_type)
-                except re.error as e:
-                    raise ValueError(f"Invalid MIME type or regex pattern '{mime_type}'.") from e
+            try:
+                pattern = re.compile(mime_type)
+            except re.error as e:
+                raise ValueError(f"Invalid MIME type or regex pattern '{mime_type}'.") from e
             self.mime_type_patterns.append(pattern)
 
         # the actual output type is list[Union[Path, ByteStream]],
@@ -199,10 +190,10 @@ class FileTypeRouter:
 
             matched = False
             if mime_type:
-                # Bucket key is the user's original string — keeps it aligned with the output socket
-                # name; `pattern.pattern` would be the escaped form for literals.
+                # Try exact equality first so MIMEs containing regex metacharacters (e.g. the `+` in
+                # `image/svg+xml`) match themselves before the regex fallback gets a chance to misread them.
                 for bucket_key, pattern in zip(self.mime_types, self.mime_type_patterns, strict=True):
-                    if pattern.fullmatch(mime_type):
+                    if mime_type == bucket_key or pattern.fullmatch(mime_type):
                         mime_types[bucket_key].append(source)
                         matched = True
                         break

--- a/releasenotes/notes/fix-file-type-router-literal-mime-matching-14f1cbe772005d1d.yaml
+++ b/releasenotes/notes/fix-file-type-router-literal-mime-matching-14f1cbe772005d1d.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed ``FileTypeRouter`` to match literal MIME types exactly, as its docstring promised.
+    Strings in ``mime_types`` were compiled as regex without ``re.escape``, so ``+``-containing
+    IANA types (``image/svg+xml``, ``application/ld+json``, every ``application/*+xml`` and
+    ``application/*+json``) silently fell through to ``unclassified`` and ``.`` in literals like
+    ``application/pdf`` could match unrelated MIMEs such as ``applicationXpdf``. Strings made up
+    only of IANA-valid characters are now matched literally; anything else (for example
+    ``audio/.*``) is still compiled as a regex.

--- a/releasenotes/notes/fix-file-type-router-literal-mime-matching-14f1cbe772005d1d.yaml
+++ b/releasenotes/notes/fix-file-type-router-literal-mime-matching-14f1cbe772005d1d.yaml
@@ -1,10 +1,10 @@
 ---
 fixes:
   - |
-    Fixed ``FileTypeRouter`` to match literal MIME types exactly, as its docstring promised.
-    Strings in ``mime_types`` were compiled as regex without ``re.escape``, so ``+``-containing
-    IANA types (``image/svg+xml``, ``application/ld+json``, every ``application/*+xml`` and
-    ``application/*+json``) silently fell through to ``unclassified`` and ``.`` in literals like
-    ``application/pdf`` could match unrelated MIMEs such as ``applicationXpdf``. Strings made up
-    only of IANA-valid characters are now matched literally; anything else (for example
-    ``audio/.*``) is still compiled as a regex.
+    Fixed ``FileTypeRouter`` silently routing MIME types containing ``+`` (such as
+    ``image/svg+xml``, ``application/ld+json``, and every ``application/*+xml`` / ``application/*+json``)
+    into the ``unclassified`` bucket. Entries in ``mime_types`` were being compiled as regex,
+    so the ``+`` was interpreted as a quantifier and the type never matched itself. Each source's
+    MIME type is now checked against ``mime_types`` by exact equality first, falling back to the
+    existing regex match — so literal MIMEs route correctly and patterns like ``audio/.*`` keep
+    working unchanged.

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -10,7 +10,7 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
-from haystack import Pipeline
+from haystack import Pipeline, component
 from haystack.components.converters import PyPDFToDocument, TextFileToDocument
 from haystack.components.routers.file_type_router import FileTypeRouter
 from haystack.dataclasses import ByteStream
@@ -289,7 +289,7 @@ class TestFileTypeRouter:
         """
         Test that the component raises a ValueError for invalid regex patterns.
         """
-        with pytest.raises(ValueError, match="Invalid regex pattern"):
+        with pytest.raises(ValueError, match="Invalid MIME type or regex pattern"):
             FileTypeRouter(mime_types=["[Invalid-Regex"])
 
     def test_regex_mime_type_matching(self, test_files_path):
@@ -328,6 +328,123 @@ class TestFileTypeRouter:
 
         assert len(output.get("unclassified")) == 1, "Failed to handle unclassified file types"
         assert mp3_stream in output["unclassified"], "'sound.mp3' ByteStream should be unclassified but is not"
+
+    @pytest.mark.parametrize(
+        "literal_mime",
+        [
+            "image/svg+xml",
+            "application/ld+json",
+            "application/rss+xml",
+            "application/atom+xml",
+            "application/vnd.api+json",
+        ],
+    )
+    def test_literal_mime_with_plus_matches_self(self, literal_mime):
+        """`+`-containing IANA types match themselves (used to be compiled as regex and silently dropped)."""
+        router = FileTypeRouter(mime_types=[literal_mime])
+        bs = ByteStream(b"x", mime_type=literal_mime)
+        output = router.run(sources=[bs])
+
+        assert literal_mime in output
+        assert output[literal_mime] == [bs]
+        assert "unclassified" not in output
+
+    def test_literal_mime_with_plus_does_not_cross_contaminate(self):
+        """Streams that would fullmatch the buggy regex form of `image/svg+xml` must not be misrouted."""
+        router = FileTypeRouter(mime_types=["image/svg+xml"])
+        bs_no_plus = ByteStream(b"x", mime_type="image/svgxml")
+        bs_extra_g = ByteStream(b"x", mime_type="image/svggxml")
+        bs_real = ByteStream(b"x", mime_type="image/svg+xml")
+
+        output = router.run(sources=[bs_no_plus, bs_extra_g, bs_real])
+
+        assert output["image/svg+xml"] == [bs_real]
+        assert sorted(output["unclassified"], key=id) == sorted([bs_no_plus, bs_extra_g], key=id)
+
+    def test_literal_mime_with_dot_does_not_cross_contaminate(self):
+        """`.` in a literal MIME shouldn't act as a wildcard (e.g. `application/pdf` vs `applicationXpdf`)."""
+        router = FileTypeRouter(mime_types=["application/pdf"])
+        bs_real = ByteStream(b"x", mime_type="application/pdf")
+        bs_wildcard_collision = ByteStream(b"x", mime_type="applicationXpdf")
+
+        output = router.run(sources=[bs_real, bs_wildcard_collision])
+
+        assert output["application/pdf"] == [bs_real]
+        assert output["unclassified"] == [bs_wildcard_collision]
+
+    def test_long_realistic_literal_mime_matches(self):
+        """A long dotted-and-hyphenated IANA type (OOXML document) routes correctly as a literal."""
+        ooxml = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        router = FileTypeRouter(mime_types=[ooxml])
+        bs = ByteStream(b"x", mime_type=ooxml)
+
+        output = router.run(sources=[bs])
+
+        assert output[ooxml] == [bs]
+        assert "unclassified" not in output
+
+    def test_explicit_regex_pattern_still_works(self, test_files_path):
+        """Regex patterns (anything outside the literal IANA char set) keep their regex semantics."""
+        router = FileTypeRouter(mime_types=[r"audio/.*", r"text\/.*"])
+        file_paths = [
+            test_files_path / "txt" / "doc_1.txt",
+            test_files_path / "audio" / "the context for this answer is here.wav",
+            test_files_path / "pdf" / "sample_pdf_1.pdf",
+        ]
+
+        output = router.run(sources=file_paths)
+
+        assert len(output[r"audio/.*"]) == 1
+        assert len(output[r"text\/.*"]) == 1
+        assert len(output["unclassified"]) == 1
+
+    def test_to_dict_from_dict_preserves_literal_and_regex_mix(self):
+        """A literal + regex mix survives serde and still routes correctly."""
+        router = FileTypeRouter(mime_types=["image/svg+xml", r"audio/.*"])
+
+        loaded = FileTypeRouter.from_dict(router.to_dict())
+        assert loaded.mime_types == ["image/svg+xml", r"audio/.*"]
+
+        svg = ByteStream(b"<svg/>", mime_type="image/svg+xml")
+        wav = ByteStream(b"x", mime_type="audio/x-wav")
+        output = loaded.run(sources=[svg, wav])
+
+        assert output["image/svg+xml"] == [svg]
+        assert output[r"audio/.*"] == [wav]
+        assert "unclassified" not in output
+
+    def test_pipeline_output_socket_name_matches_literal_mime_with_plus(self):
+        """A downstream component wired to `router.image/svg+xml` actually receives the SVG stream."""
+
+        @component
+        class _Sink:
+            @component.output_types(received=list)
+            def run(self, value: list) -> dict:
+                return {"received": value}
+
+        pipe = Pipeline()
+        pipe.add_component(instance=FileTypeRouter(mime_types=["image/svg+xml"]), name="router")
+        pipe.add_component(instance=_Sink(), name="sink")
+        pipe.connect("router.image/svg+xml", "sink.value")
+
+        svg = ByteStream(b"<svg/>", mime_type="image/svg+xml")
+        output = pipe.run(data={"router": {"sources": [svg]}})
+
+        assert output["sink"]["received"] == [svg]
+
+    def test_additional_mimetypes_with_literal_plus(self, tmp_path):
+        """Custom `additional_mimetypes` registration still works for `+`-containing literal MIMEs."""
+        custom_mime = "application/x-custom+xml"
+        custom_extension = ".cxml"
+        test_file = tmp_path / f"test{custom_extension}"
+        test_file.touch()
+
+        router = FileTypeRouter(mime_types=[custom_mime], additional_mimetypes={custom_mime: custom_extension})
+        output = router.run(sources=[test_file])
+
+        assert custom_mime in output
+        assert test_file in output[custom_mime]
+        assert "unclassified" not in output
 
     def test_serde_in_pipeline(self):
         """

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -334,69 +334,19 @@ class TestFileTypeRouter:
         [
             "image/svg+xml",
             "application/ld+json",
-            "application/rss+xml",
             "application/atom+xml",
             "application/vnd.api+json",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         ],
     )
-    def test_literal_mime_with_plus_matches_self(self, literal_mime):
-        """`+`-containing IANA types match themselves (used to be compiled as regex and silently dropped)."""
+    def test_literal_mime_with_regex_metacharacters_matches_self(self, literal_mime):
+        """MIME types with regex metacharacters (`+`, `.`) match themselves via the equality short-circuit."""
         router = FileTypeRouter(mime_types=[literal_mime])
         bs = ByteStream(b"x", mime_type=literal_mime)
         output = router.run(sources=[bs])
 
-        assert literal_mime in output
         assert output[literal_mime] == [bs]
         assert "unclassified" not in output
-
-    def test_literal_mime_with_plus_does_not_cross_contaminate(self):
-        """Streams that would fullmatch the buggy regex form of `image/svg+xml` must not be misrouted."""
-        router = FileTypeRouter(mime_types=["image/svg+xml"])
-        bs_no_plus = ByteStream(b"x", mime_type="image/svgxml")
-        bs_extra_g = ByteStream(b"x", mime_type="image/svggxml")
-        bs_real = ByteStream(b"x", mime_type="image/svg+xml")
-
-        output = router.run(sources=[bs_no_plus, bs_extra_g, bs_real])
-
-        assert output["image/svg+xml"] == [bs_real]
-        assert sorted(output["unclassified"], key=id) == sorted([bs_no_plus, bs_extra_g], key=id)
-
-    def test_literal_mime_with_dot_does_not_cross_contaminate(self):
-        """`.` in a literal MIME shouldn't act as a wildcard (e.g. `application/pdf` vs `applicationXpdf`)."""
-        router = FileTypeRouter(mime_types=["application/pdf"])
-        bs_real = ByteStream(b"x", mime_type="application/pdf")
-        bs_wildcard_collision = ByteStream(b"x", mime_type="applicationXpdf")
-
-        output = router.run(sources=[bs_real, bs_wildcard_collision])
-
-        assert output["application/pdf"] == [bs_real]
-        assert output["unclassified"] == [bs_wildcard_collision]
-
-    def test_long_realistic_literal_mime_matches(self):
-        """A long dotted-and-hyphenated IANA type (OOXML document) routes correctly as a literal."""
-        ooxml = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-        router = FileTypeRouter(mime_types=[ooxml])
-        bs = ByteStream(b"x", mime_type=ooxml)
-
-        output = router.run(sources=[bs])
-
-        assert output[ooxml] == [bs]
-        assert "unclassified" not in output
-
-    def test_explicit_regex_pattern_still_works(self, test_files_path):
-        """Regex patterns (anything outside the literal IANA char set) keep their regex semantics."""
-        router = FileTypeRouter(mime_types=[r"audio/.*", r"text\/.*"])
-        file_paths = [
-            test_files_path / "txt" / "doc_1.txt",
-            test_files_path / "audio" / "the context for this answer is here.wav",
-            test_files_path / "pdf" / "sample_pdf_1.pdf",
-        ]
-
-        output = router.run(sources=file_paths)
-
-        assert len(output[r"audio/.*"]) == 1
-        assert len(output[r"text\/.*"]) == 1
-        assert len(output["unclassified"]) == 1
 
     def test_to_dict_from_dict_preserves_literal_and_regex_mix(self):
         """A literal + regex mix survives serde and still routes correctly."""


### PR DESCRIPTION
### Related Issues

- fixes #11647

### Proposed Changes:

FileTypeRouter.__init__ was compiling every entry in mime_types as a regex, so any +-containing IANA type (image/svg+xml, application/ld+json, every application/*+xml and application/*+json) had its + read as a regex quantifier and silently fell into the unclassified bucket, no error, no warning.

Fix: in run, check each source's MIME type against mime_types by exact equality first, then fall back to the existing regex fullmatch. Literal MIMEs now route correctly without re.escape or any init-time classification; explicit regex patterns like audio/.* keep working unchanged.

### How did you test it?

Added 4 new unit tests in test/components/routers/test_file_router.py:

- test_literal_mime_with_regex_metacharacters_matches_self (parametrized across 5 MIMEs containing + or dotted IANA segments, including OOXML)
- test_to_dict_from_dict_preserves_literal_and_regex_mix
- test_pipeline_output_socket_name_matches_literal_mime_with_plus (end-to-end Pipeline, guards that the output socket name preserves the user's original +-bearing string)
- test_additional_mimetypes_with_literal_plus

Also updated the pre-existing test_invalid_regex_pattern to match the widened error message.

Wider verification:

- test/components/routers/ — 30/30 pass
- test/components/routers/ + test/core/pipeline/ — 491/491 pass
- hatch run fmt-check clean
- hatch run test:types haystack/components/routers/file_type_router.py clean
- Manual repro of the original image/svg+xml failure now routes correctly

### Notes for the reviewer

- Bucket key stays the user's original mime_types entry, so output socket names, pipe.connect("router.image/svg+xml", ...), and to_dict / from_dict round-trips are unaffected. The pipeline-socket test guards this explicitly.
- The error message for invalid input was widened from "Invalid regex pattern" to "Invalid MIME type or regex pattern" to reflect that the parameter formally accepts both. The existing test was updated accordingly.
- No public API change, no serialization change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
