### PR TITLE
fix: handle non-dict intermediate value in nested metadata filters

### DIFF
--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -195,8 +195,9 @@ def _comparison_condition(condition: dict[str, Any], document: Document | ByteSt
         parts = field.split(".")
         document_value = getattr(document, parts[0])
         for part in parts[1:]:
-            if part not in document_value:
-                # If a field is not found we treat it as None
+            if not isinstance(document_value, dict) or part not in document_value:
+                # If a field is not found (or an intermediate value is not a dict,
+                # e.g. None) we treat it as None
                 document_value = None
                 break
             document_value = document_value[part]

--- a/releasenotes/notes/fix-nested-meta-filter-non-dict-intermediate-a5e768b6da3bcb37.yaml
+++ b/releasenotes/notes/fix-nested-meta-filter-non-dict-intermediate-a5e768b6da3bcb37.yaml
@@ -1,8 +1,8 @@
 ---
 fixes:
   - |
-    Fixed a `TypeError` when filtering documents on a nested metadata field
-    (e.g. `meta.user.age`) where an intermediate value is not a dictionary
-    (for example `None` or a scalar). Such intermediate values are now treated
-    as a missing field (`None`) instead of raising, which previously crashed
-    `filter_documents` for stores like `InMemoryDocumentStore`.
+    Fixed a ``TypeError`` when filtering documents on a nested metadata field
+    (e.g. ``meta.user.age``) where an intermediate value is not a dictionary
+    (for example ``None`` or a scalar). Such intermediate values are now treated
+    as a missing field (``None``) instead of raising, which previously crashed
+    ``filter_documents`` for stores like ``InMemoryDocumentStore``.

--- a/releasenotes/notes/fix-nested-meta-filter-non-dict-intermediate-a5e768b6da3bcb37.yaml
+++ b/releasenotes/notes/fix-nested-meta-filter-non-dict-intermediate-a5e768b6da3bcb37.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a `TypeError` when filtering documents on a nested metadata field
+    (e.g. `meta.user.age`) where an intermediate value is not a dictionary
+    (for example `None` or a scalar). Such intermediate values are now treated
+    as a missing field (`None`) instead of raising, which previously crashed
+    `filter_documents` for stores like `InMemoryDocumentStore`.

--- a/test/utils/test_filters.py
+++ b/test/utils/test_filters.py
@@ -46,6 +46,18 @@ document_matches_filter_data = [
         False,
         id="== operator with None filter value",
     ),
+    pytest.param(
+        {"field": "meta.user.age", "operator": "==", "value": 30},
+        Document(meta={"user": {"age": 30}}),
+        True,
+        id="== operator with nested meta field",
+    ),
+    pytest.param(
+        {"field": "meta.user.age", "operator": "==", "value": 30},
+        Document(meta={"user": None}),
+        False,
+        id="== operator with nested field on non-dict intermediate value",
+    ),
     # != operator params
     pytest.param(
         {"field": "meta.name", "operator": "!=", "value": "test"},


### PR DESCRIPTION
### Related Issues

- No open issue — self-found while reading the filter traversal code.

### Proposed Changes:

Filtering documents on a **nested** metadata field (e.g. `meta.user.age`) crashes when an intermediate value is not a dictionary:

```python
from haystack import Document
from haystack.utils.filters import document_matches_filter

document_matches_filter(
    {"field": "meta.user.age", "operator": "==", "value": 30},
    Document(meta={"user": None}),
)
# TypeError: argument of type "NoneType" is not iterable
```

In `_comparison_condition` (`haystack/utils/filters.py`), the dotted-field traversal does `if part not in document_value:` without checking that `document_value` is still a dict. Once a level resolves to `None` (or any scalar), the next `in` check raises. Because `None` is a very common metadata value, this crashes the whole query — e.g. `InMemoryDocumentStore.filter_documents` raises for a heterogeneous store where some documents have `meta={"user": {...}}` and others `meta={"user": None}`.

The loop already has a documented intent — *"If a field is not found we treat it as None"* — but only handled the missing-dict-key case. This guards the non-dict-intermediate case the same way:

```python
if not isinstance(document_value, dict) or part not in document_value:
    document_value = None
    break
```

### How did you test it?

Added two parametrized cases to `test/utils/test_filters.py`:
- nested field with a valid dict intermediate (`meta={"user": {"age": 30}}`) → still matches (happy path unaffected),
- nested field with a non-dict intermediate (`meta={"user": None}`) → returns `False` instead of raising.

The second test fails before the change (`TypeError`) and passes after. `hatch run test:unit test/utils/test_filters.py` → 90 passed; `hatch run fmt` clean.

### Checklist

- [x] Read contributors guidelines / code of conduct.
- [x] Added unit tests.
- [x] Conventional commit type in title (`fix:`).
- [x] Documented the change (code comment).
- [x] Added a release note in `releasenotes/notes/`.
- [x] Ran formatting/lint (`hatch run fmt`) — clean.