### PR TITLE
fix: round-trip top-level ToolBreakpoint in PipelineSnapshot.from_dict

### DIFF
--- a/haystack/dataclasses/breakpoints.py
+++ b/haystack/dataclasses/breakpoints.py
@@ -259,6 +259,8 @@ class PipelineSnapshot:
             break_point=(
                 AgentBreakpoint.from_dict(data=data["break_point"])
                 if "agent_name" in data["break_point"]
+                else ToolBreakpoint.from_dict(data=data["break_point"])
+                if "tool_name" in data["break_point"]
                 else Breakpoint.from_dict(data=data["break_point"])
             ),
             agent_snapshot=AgentSnapshot.from_dict(data["agent_snapshot"]) if data.get("agent_snapshot") else None,

--- a/releasenotes/notes/fix-pipeline-snapshot-toolbreakpoint-roundtrip-6978ba1e155fdf0a.yaml
+++ b/releasenotes/notes/fix-pipeline-snapshot-toolbreakpoint-roundtrip-6978ba1e155fdf0a.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed `PipelineSnapshot.from_dict` raising a `TypeError` when the
+    snapshot's `break_point` is a top-level `ToolBreakpoint`. `to_dict` already
+    serializes the `tool_name` field, but `from_dict` only handled
+    `AgentBreakpoint` and `Breakpoint`, so deserializing a `ToolBreakpoint`
+    failed. `PipelineSnapshot.from_dict` now reconstructs `ToolBreakpoint`
+    correctly, matching the existing handling in `AgentBreakpoint.from_dict`.

--- a/releasenotes/notes/fix-pipeline-snapshot-toolbreakpoint-roundtrip-6978ba1e155fdf0a.yaml
+++ b/releasenotes/notes/fix-pipeline-snapshot-toolbreakpoint-roundtrip-6978ba1e155fdf0a.yaml
@@ -1,9 +1,9 @@
 ---
 fixes:
   - |
-    Fixed `PipelineSnapshot.from_dict` raising a `TypeError` when the
-    snapshot's `break_point` is a top-level `ToolBreakpoint`. `to_dict` already
-    serializes the `tool_name` field, but `from_dict` only handled
-    `AgentBreakpoint` and `Breakpoint`, so deserializing a `ToolBreakpoint`
-    failed. `PipelineSnapshot.from_dict` now reconstructs `ToolBreakpoint`
-    correctly, matching the existing handling in `AgentBreakpoint.from_dict`.
+    Fixed ``PipelineSnapshot.from_dict`` raising a ``TypeError`` when the
+    snapshot's ``break_point`` is a top-level ``ToolBreakpoint``. ``to_dict``
+    already serializes the ``tool_name`` field, but ``from_dict`` only handled
+    ``AgentBreakpoint`` and ``Breakpoint``, so deserializing a ``ToolBreakpoint``
+    failed. ``PipelineSnapshot.from_dict`` now reconstructs ``ToolBreakpoint``
+    correctly, matching the existing handling in ``AgentBreakpoint.from_dict``.

--- a/test/dataclasses/test_breakpoints.py
+++ b/test/dataclasses/test_breakpoints.py
@@ -6,7 +6,14 @@ import warnings
 
 import pytest
 
-from haystack.dataclasses.breakpoints import AgentBreakpoint, AgentSnapshot, Breakpoint, PipelineSnapshot, PipelineState
+from haystack.dataclasses.breakpoints import (
+    AgentBreakpoint,
+    AgentSnapshot,
+    Breakpoint,
+    PipelineSnapshot,
+    PipelineState,
+    ToolBreakpoint,
+)
 
 
 def test_agent_snapshot_no_warning_on_init():
@@ -51,3 +58,16 @@ def test_pipeline_snapshot_warn_on_inplace_mutation():
     )
     with pytest.warns(Warning, match="dataclasses.replace"):
         snap.original_input_data = {"new": "data"}
+
+
+def test_pipeline_snapshot_roundtrip_with_tool_breakpoint():
+    state = PipelineState(inputs={}, component_visits={"comp": 1}, pipeline_outputs={})
+    bp = ToolBreakpoint(component_name="tool_invoker", tool_name="search")
+    snap = PipelineSnapshot(
+        original_input_data={}, ordered_component_names=["comp"], pipeline_state=state, break_point=bp
+    )
+
+    restored = PipelineSnapshot.from_dict(snap.to_dict())
+
+    assert isinstance(restored.break_point, ToolBreakpoint)
+    assert restored.break_point == bp


### PR DESCRIPTION
### Related Issues

- No open issue — self-found while reviewing breakpoint serialization.

### Proposed Changes:

`PipelineSnapshot.to_dict()` serializes a `ToolBreakpoint` break point (including its `tool_name` field via `asdict`), but `PipelineSnapshot.from_dict()` only handled `AgentBreakpoint` (when `agent_name` is present) and otherwise fell back to `Breakpoint.from_dict`. For a **top-level `ToolBreakpoint`** (a type-valid `break_point`), that fallback calls `Breakpoint(**data)` and crashes:

```python
snap = PipelineSnapshot(..., break_point=ToolBreakpoint(component_name="tool_invoker", tool_name="search"))
PipelineSnapshot.from_dict(snap.to_dict())
# TypeError: Breakpoint.__init__() got an unexpected keyword argument 'tool_name'
```

The fix discriminates on `tool_name` and reconstructs a `ToolBreakpoint`, mirroring the logic already present in `AgentBreakpoint.from_dict` (which handles the nested-break-point case the same way):

```python
break_point=(
    AgentBreakpoint.from_dict(data=data["break_point"])
    if "agent_name" in data["break_point"]
    else ToolBreakpoint.from_dict(data=data["break_point"])
    if "tool_name" in data["break_point"]
    else Breakpoint.from_dict(data=data["break_point"])
),
```

### How did you test it?

Added `test_pipeline_snapshot_roundtrip_with_tool_breakpoint` in `test/dataclasses/test_breakpoints.py`: builds a `PipelineSnapshot` with a top-level `ToolBreakpoint`, round-trips it through `to_dict()`/`from_dict()`, and asserts the restored break point is an equal `ToolBreakpoint`. Fails before the change (`TypeError`), passes after. `hatch run test:unit test/dataclasses/test_breakpoints.py` → 7 passed; `hatch run fmt` clean.

### Checklist

- [x] Read contributors guidelines / code of conduct.
- [x] Added unit tests.
- [x] Conventional commit type in title (`fix:`).
- [x] Documented the change.
- [x] Added a release note in `releasenotes/notes/`.
- [x] Ran `hatch run fmt` — clean.