### PR TITLE
chore: deprecate langdetect components (DocumentLanguageClassifier, TextLanguageRouter)

### DIFF
--- a/docs-website/docs/pipeline-components/classifiers/documentlanguageclassifier.mdx
+++ b/docs-website/docs/pipeline-components/classifiers/documentlanguageclassifier.mdx
@@ -16,9 +16,9 @@ Use this component to classify documents by language and add language informatio
 | **Most common position in a pipeline** | Before [`MetadataRouter`](../routers/metadatarouter.mdx)                                                                    |
 | **Mandatory run variables**            | `documents`:  A list of documents                                                                                  |
 | **Output variables**                   | `documents`:  A list of documents                                                                                  |
-| **API reference**                      | [Classifiers](/reference/classifiers-api)                                                                                 |
-| **GitHub link**                        | https://github.com/deepset-ai/haystack/blob/main/haystack/components/classifiers/document_language_classifier.py |
-| **Package name** | `haystack-ai` |
+| **API reference**                      | [Langdetect](/reference/integrations-langdetect)                                                                                 |
+| **GitHub link**                        | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langdetect |
+| **Package name** | `langdetect-haystack` |
 
 </div>
 
@@ -34,10 +34,10 @@ For classifying and then routing plain text using the same logic, use the `TextL
 
 ## Usage
 
-Install the `langdetect`package to use the `DocumentLanguageClassifier`component:
+Install the `langdetect-haystack` package to use the `DocumentLanguageClassifier` component:
 
-```shell shell
-pip install langdetect
+```shell
+pip install langdetect-haystack
 ```
 
 ### On its own
@@ -45,7 +45,9 @@ pip install langdetect
 Below, we are using the `DocumentLanguageClassifier` to classify English and German documents:
 
 ```python
-from haystack.components.classifiers import DocumentLanguageClassifier
+from haystack_integrations.components.classifiers.langdetect import (
+    DocumentLanguageClassifier,
+)
 from haystack import Document
 
 documents = [
@@ -69,7 +71,9 @@ Below, we are using the `DocumentLanguageClassifier` in an indexing pipeline tha
 from haystack import Pipeline
 from haystack import Document
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-from haystack.components.classifiers import DocumentLanguageClassifier
+from haystack_integrations.components.classifiers.langdetect import (
+    DocumentLanguageClassifier,
+)
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder
 from haystack.components.writers import DocumentWriter
 from haystack.components.routers import MetadataRouter

--- a/docs-website/docs/pipeline-components/routers/textlanguagerouter.mdx
+++ b/docs-website/docs/pipeline-components/routers/textlanguagerouter.mdx
@@ -17,9 +17,9 @@ Use this component in pipelines to route a query based on its language.
 | **Mandatory init variables** | `languages`: A list of ISO language codes |
 | **Mandatory run variables** | `text`: A string |
 | **Output variables** | `unmatched`: A string  <br /> <br />`<language>`: A string (where `<language>` is defined during initialization). For example: `fr`: French language string. |
-| **API reference** | [Routers](/reference/routers-api) |
-| **GitHub link** | https://github.com/deepset-ai/haystack/blob/main/haystack/components/routers/text_language_router.py |
-| **Package name** | `haystack-ai` |
+| **API reference** | [Langdetect](/reference/integrations-langdetect) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langdetect |
+| **Package name** | `langdetect-haystack` |
 
 </div>
 
@@ -33,12 +33,18 @@ The components parameter `languages` must be a list of languages in ISO code, su
 
 ## Usage
 
+Install the `langdetect-haystack` package to use the `TextLanguageRouter` component:
+
+```shell
+pip install langdetect-haystack
+```
+
 ### On its own
 
 Below is an example where using the `TextLanguageRouter` to route only French texts to an output connection named `fr`. Other texts, such as the English text below, are routed to an output named `unmatched`.
 
 ```python
-from haystack.components.routers import TextLanguageRouter
+from haystack_integrations.components.routers.langdetect import TextLanguageRouter
 
 router = TextLanguageRouter(languages=["fr"])
 router.run(text="What's your query?")
@@ -50,7 +56,7 @@ Below is an example of a query pipeline that uses a `TextLanguageRouter` to forw
 
 ```python
 from haystack import Pipeline
-from haystack.components.routers import TextLanguageRouter
+from haystack_integrations.components.routers.langdetect import TextLanguageRouter
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/classifiers/documentlanguageclassifier.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/classifiers/documentlanguageclassifier.mdx
@@ -16,9 +16,9 @@ Use this component to classify documents by language and add language informatio
 | **Most common position in a pipeline** | Before [`MetadataRouter`](../routers/metadatarouter.mdx)                                                                    |
 | **Mandatory run variables**            | `documents`:  A list of documents                                                                                  |
 | **Output variables**                   | `documents`:  A list of documents                                                                                  |
-| **API reference**                      | [Classifiers](/reference/classifiers-api)                                                                                 |
-| **GitHub link**                        | https://github.com/deepset-ai/haystack/blob/main/haystack/components/classifiers/document_language_classifier.py |
-| **Package name** | `haystack-ai` |
+| **API reference**                      | [Langdetect](/reference/integrations-langdetect)                                                                                 |
+| **GitHub link**                        | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langdetect |
+| **Package name** | `langdetect-haystack` |
 
 </div>
 
@@ -34,10 +34,10 @@ For classifying and then routing plain text using the same logic, use the `TextL
 
 ## Usage
 
-Install the `langdetect`package to use the `DocumentLanguageClassifier`component:
+Install the `langdetect-haystack` package to use the `DocumentLanguageClassifier` component:
 
-```shell shell
-pip install langdetect
+```shell
+pip install langdetect-haystack
 ```
 
 ### On its own
@@ -45,7 +45,9 @@ pip install langdetect
 Below, we are using the `DocumentLanguageClassifier` to classify English and German documents:
 
 ```python
-from haystack.components.classifiers import DocumentLanguageClassifier
+from haystack_integrations.components.classifiers.langdetect import (
+    DocumentLanguageClassifier,
+)
 from haystack import Document
 
 documents = [
@@ -69,7 +71,9 @@ Below, we are using the `DocumentLanguageClassifier` in an indexing pipeline tha
 from haystack import Pipeline
 from haystack import Document
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-from haystack.components.classifiers import DocumentLanguageClassifier
+from haystack_integrations.components.classifiers.langdetect import (
+    DocumentLanguageClassifier,
+)
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder
 from haystack.components.writers import DocumentWriter
 from haystack.components.routers import MetadataRouter

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/routers/textlanguagerouter.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/routers/textlanguagerouter.mdx
@@ -17,9 +17,9 @@ Use this component in pipelines to route a query based on its language.
 | **Mandatory init variables** | `languages`: A list of ISO language codes |
 | **Mandatory run variables** | `text`: A string |
 | **Output variables** | `unmatched`: A string  <br /> <br />`<language>`: A string (where `<language>` is defined during initialization). For example: `fr`: French language string. |
-| **API reference** | [Routers](/reference/routers-api) |
-| **GitHub link** | https://github.com/deepset-ai/haystack/blob/main/haystack/components/routers/text_language_router.py |
-| **Package name** | `haystack-ai` |
+| **API reference** | [Langdetect](/reference/integrations-langdetect) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/langdetect |
+| **Package name** | `langdetect-haystack` |
 
 </div>
 
@@ -33,12 +33,18 @@ The components parameter `languages` must be a list of languages in ISO code, su
 
 ## Usage
 
+Install the `langdetect-haystack` package to use the `TextLanguageRouter` component:
+
+```shell
+pip install langdetect-haystack
+```
+
 ### On its own
 
 Below is an example where using the `TextLanguageRouter` to route only French texts to an output connection named `fr`. Other texts, such as the English text below, are routed to an output named `unmatched`.
 
 ```python
-from haystack.components.routers import TextLanguageRouter
+from haystack_integrations.components.routers.langdetect import TextLanguageRouter
 
 router = TextLanguageRouter(languages=["fr"])
 router.run(text="What's your query?")
@@ -50,7 +56,7 @@ Below is an example of a query pipeline that uses a `TextLanguageRouter` to forw
 
 ```python
 from haystack import Pipeline
-from haystack.components.routers import TextLanguageRouter
+from haystack_integrations.components.routers.langdetect import TextLanguageRouter
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 

--- a/haystack/components/classifiers/document_language_classifier.py
+++ b/haystack/components/classifiers/document_language_classifier.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from dataclasses import replace
 
 from haystack import Document, component, logging
@@ -68,6 +69,14 @@ class DocumentLanguageClassifier:
             See the supported languages in [`langdetect` documentation](https://github.com/Mimino666/langdetect#languages).
             If not specified, defaults to ["en"].
         """
+        warnings.warn(
+            "`DocumentLanguageClassifier` will be removed from Haystack in version 3.0, as it is moving to "
+            "the `langdetect-haystack` package. To continue using it, install that package with "
+            "`pip install langdetect-haystack` and update your import to "
+            "`from haystack_integrations.components.classifiers.langdetect import DocumentLanguageClassifier`.",
+            FutureWarning,
+            stacklevel=2,
+        )
         langdetect_import.check()
         if not languages:
             languages = ["en"]

--- a/haystack/components/routers/text_language_router.py
+++ b/haystack/components/routers/text_language_router.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 from haystack import component, logging
 from haystack.lazy_imports import LazyImport
 
@@ -53,6 +55,14 @@ class TextLanguageRouter:
             See the supported languages in [`langdetect` documentation](https://github.com/Mimino666/langdetect#languages).
             If not specified, defaults to ["en"].
         """
+        warnings.warn(
+            "`TextLanguageRouter` will be removed from Haystack in version 3.0, as it is moving to "
+            "the `langdetect-haystack` package. To continue using it, install that package with "
+            "`pip install langdetect-haystack` and update your import to "
+            "`from haystack_integrations.components.routers.langdetect import TextLanguageRouter`.",
+            FutureWarning,
+            stacklevel=2,
+        )
         langdetect_import.check()
         if not languages:
             languages = ["en"]

--- a/releasenotes/notes/deprecate-langdetect-components-7ff32c5b6d139a39.yaml
+++ b/releasenotes/notes/deprecate-langdetect-components-7ff32c5b6d139a39.yaml
@@ -1,0 +1,11 @@
+---
+deprecations:
+  - |
+    ``DocumentLanguageClassifier`` and ``TextLanguageRouter`` are deprecated and will be removed from
+    Haystack in version 3.0. They are moving to the ``langdetect-haystack`` package. To continue using them,
+    install the package with ``pip install langdetect-haystack`` and update your imports as follows:
+
+    .. code-block:: python
+
+        from haystack_integrations.components.classifiers.langdetect import DocumentLanguageClassifier
+        from haystack_integrations.components.routers.langdetect import TextLanguageRouter


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/373

### Proposed Changes:
- deprecate `DocumentLanguageClassifier` and `TextLanguageRouter` with a `FutureWarning` pointing users to the new `langdetect-haystack` package (https://github.com/deepset-ai/haystack-core-integrations/pull/3457)
- update the docs pages (current and version-2.30) for both components to show the new package name, install command, API reference, GitHub link, and import paths
- add a deprecation release note covering both components

### How did you test it?
- ran both docstring usage examples end-to-end against the new `langdetect-haystack` package in the integration branch

### Notes for the reviewer
- Same deprecation pattern as SerperDev (#11577) and SearchApi (#11611): `LazyImport` is kept here (langdetect stays an optional dependency in core), only the `FutureWarning` is added.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
