### PR TITLE
fix: Fix `"text"` Agent exit condition

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -857,8 +857,17 @@ class Agent:
                     llm_messages = result["replies"]
                     exe_context.state.set("messages", llm_messages)
 
-                # Check if any of the LLM responses contain a tool call or if the LLM is not using tools
-                if not any(msg.tool_call for msg in llm_messages) or self._tool_invoker is None:
+                # Exit for `exit_conditions=["text"]` behavior: the agent stops when there is no tool invoker, or when
+                # the model returns a plain text response (no tool calls). We require the last message to be a non-empty
+                # assistant text message so that an invalid response (e.g. a message with no tool calls or text) won't
+                # trigger an exit.
+                last_message = llm_messages[-1] if llm_messages else None
+                if self._tool_invoker is None or (
+                    last_message is not None
+                    and not any(msg.tool_call for msg in llm_messages)
+                    and last_message.is_from(ChatRole.ASSISTANT)
+                    and last_message.text
+                ):
                     exe_context.counter += 1
                     break
 
@@ -1092,8 +1101,17 @@ class Agent:
                     llm_messages = result["replies"]
                     exe_context.state.set("messages", llm_messages)
 
-                # Check if any of the LLM responses contain a tool call or if the LLM is not using tools
-                if not any(msg.tool_call for msg in llm_messages) or self._tool_invoker is None:
+                # Exit for `exit_conditions=["text"]` behavior: the agent stops when there is no tool invoker, or when
+                # the model returns a plain text response (no tool calls). We require the last message to be a non-empty
+                # assistant text message so that an invalid response (e.g. a message with no tool calls or text) won't
+                # trigger an exit.
+                last_message = llm_messages[-1] if llm_messages else None
+                if self._tool_invoker is None or (
+                    last_message is not None
+                    and not any(msg.tool_call for msg in llm_messages)
+                    and last_message.is_from(ChatRole.ASSISTANT)
+                    and last_message.text
+                ):
                     exe_context.counter += 1
                     break
 

--- a/releasenotes/notes/agent-text-exit-condition-empty-message-d1eac980a4036306.yaml
+++ b/releasenotes/notes/agent-text-exit-condition-empty-message-d1eac980a4036306.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed the ``Agent`` exiting prematurely under the default ``exit_conditions=["text"]``.
+    The agent now only stops when the last message is an assistant message with non-empty text
+    (or when no tool invoker is configured). Previously, if the LLM produced an invalid tool call
+    that was discarded, the resulting assistant message with empty text and no tool calls would
+    trigger an exit, preventing the agent from recovering. The agent now continues looping so the
+    model can recover on the next iteration.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -792,6 +792,23 @@ class TestAgent:
         assert isinstance(result["last_message"], ChatMessage)
         assert result["messages"][-1] == result["last_message"]
 
+    def test_does_not_exit_on_empty_assistant_message(self, monkeypatch, weather_tool):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        generator = OpenAIChatGenerator()
+        agent = Agent(chat_generator=generator, tools=[weather_tool], exit_conditions=["text"])
+
+        # The first reply simulates the LLM producing an invalid tool call that our code discards,
+        # leaving an assistant message with empty text and no tool calls. This must not be treated as a
+        # "text" exit condition, so the agent keeps looping and recovers on the second reply.
+        empty_reply = {"replies": [ChatMessage.from_assistant(text="")]}
+        recovered_reply = {"replies": [ChatMessage.from_assistant(text="The weather is sunny.")]}
+        agent.chat_generator.run = MagicMock(side_effect=[empty_reply, recovered_reply])
+
+        result = agent.run([ChatMessage.from_user("What's the weather?")])
+
+        assert agent.chat_generator.run.call_count == 2
+        assert result["last_message"].text == "The weather is sunny."
+
     def test_check_exit_conditions_parallel_tool_calls(self, monkeypatch, weather_tool):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
         agent = Agent(chat_generator=OpenAIChatGenerator(), tools=[weather_tool], exit_conditions=["weather_tool"])
@@ -1076,6 +1093,24 @@ class TestAgent:
         assert result["messages"] is not None
         assert result["last_message"] is not None
         assert streaming_callback_called
+
+    @pytest.mark.asyncio
+    async def test_does_not_exit_on_empty_assistant_message_async(self, monkeypatch, weather_tool):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        generator = OpenAIChatGenerator()
+        agent = Agent(chat_generator=generator, tools=[weather_tool], exit_conditions=["text"])
+
+        # The first reply simulates the LLM producing an invalid tool call that our code discards,
+        # leaving an assistant message with empty text and no tool calls. This must not be treated as a
+        # "text" exit condition, so the agent keeps looping and recovers on the second reply.
+        empty_reply = {"replies": [ChatMessage.from_assistant(text="")]}
+        recovered_reply = {"replies": [ChatMessage.from_assistant(text="The weather is sunny.")]}
+        agent.chat_generator.run_async = AsyncMock(side_effect=[empty_reply, recovered_reply])
+
+        result = await agent.run_async([ChatMessage.from_user("What's the weather?")])
+
+        assert agent.chat_generator.run_async.call_count == 2
+        assert result["last_message"].text == "The weather is sunny."
 
     @pytest.mark.asyncio
     async def test_run_async_with_async_streaming_callback(self, weather_tool):

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -794,12 +794,11 @@ class TestAgent:
 
     def test_does_not_exit_on_empty_assistant_message(self, monkeypatch, weather_tool):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
-        generator = OpenAIChatGenerator()
-        agent = Agent(chat_generator=generator, tools=[weather_tool], exit_conditions=["text"])
+        agent = Agent(chat_generator=OpenAIChatGenerator(), tools=[weather_tool], exit_conditions=["text"])
 
-        # The first reply simulates the LLM producing an invalid tool call that our code discards,
-        # leaving an assistant message with empty text and no tool calls. This must not be treated as a
-        # "text" exit condition, so the agent keeps looping and recovers on the second reply.
+        # The first reply simulates the LLM producing an invalid tool call that our code discards,leaving an assistant
+        # message with empty text and no tool calls. This must not be treated as a "text" exit condition, so the agent
+        # keeps looping and recovers on the second reply.
         empty_reply = {"replies": [ChatMessage.from_assistant(text="")]}
         recovered_reply = {"replies": [ChatMessage.from_assistant(text="The weather is sunny.")]}
         agent.chat_generator.run = MagicMock(side_effect=[empty_reply, recovered_reply])
@@ -1097,12 +1096,11 @@ class TestAgent:
     @pytest.mark.asyncio
     async def test_does_not_exit_on_empty_assistant_message_async(self, monkeypatch, weather_tool):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
-        generator = OpenAIChatGenerator()
-        agent = Agent(chat_generator=generator, tools=[weather_tool], exit_conditions=["text"])
+        agent = Agent(chat_generator=OpenAIChatGenerator(), tools=[weather_tool], exit_conditions=["text"])
 
-        # The first reply simulates the LLM producing an invalid tool call that our code discards,
-        # leaving an assistant message with empty text and no tool calls. This must not be treated as a
-        # "text" exit condition, so the agent keeps looping and recovers on the second reply.
+        # The first reply simulates the LLM producing an invalid tool call that our code discards,leaving an assistant
+        # message with empty text and no tool calls. This must not be treated as a "text" exit condition, so the agent
+        # keeps looping and recovers on the second reply.
         empty_reply = {"replies": [ChatMessage.from_assistant(text="")]}
         recovered_reply = {"replies": [ChatMessage.from_assistant(text="The weather is sunny.")]}
         agent.chat_generator.run_async = AsyncMock(side_effect=[empty_reply, recovered_reply])


### PR DESCRIPTION
### Related Issues

- fixes issue in AI agent used in platform

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fixed the ``Agent`` exiting prematurely under the default ``exit_conditions=["text"]``. The agent now only stops when the last message is an assistant message with non-empty text (or when no tool invoker is configured). Previously, if the LLM produced an invalid tool call that was discarded, the resulting assistant message with empty text and no tool calls would trigger an exit, preventing the agent from recovering. The agent now continues looping so the model can recover on the next iteration.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added new tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

cc @tstadel 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
