### PR TITLE
chore: rename utility function

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -38,7 +38,7 @@ from haystack.tools import (
     serialize_tools_or_toolset,
     warm_up_tools,
 )
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
 from haystack.utils.deserialization import deserialize_component_inplace
 
@@ -1016,7 +1016,7 @@ class Agent:
                 llm_span.set_content_tag("haystack.agent.step.llm.input", chat_generator_inputs)
                 # For sync-only generators, _run_component_async dispatches to a thread via asyncio.to_thread,
                 # which copies the current contextvars context — preserving the active tracing span.
-                result = await _run_component_async(self.chat_generator, **chat_generator_inputs)
+                result = await _execute_component_async(self.chat_generator, **chat_generator_inputs)
                 llm_span.set_content_tag("haystack.agent.step.llm.output", result)
             llm_messages = result["replies"]
             exe_context.state.set("messages", llm_messages)

--- a/haystack/components/extractors/image/llm_document_content_extractor.py
+++ b/haystack/components/extractors/image/llm_document_content_extractor.py
@@ -18,7 +18,7 @@ from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ImageContent, TextContent
 from haystack.dataclasses.chat_message import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.misc import _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -288,7 +288,7 @@ class LLMDocumentContentExtractor:
         message = ChatMessage.from_user(content_parts=[TextContent(text=self.prompt), image_content])
 
         try:
-            result = await _run_component_async(self._chat_generator, messages=[message])
+            result = await _execute_component_async(self._chat_generator, messages=[message])
         except Exception as e:
             if self.raise_on_failure:
                 raise e

--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -20,7 +20,7 @@ from haystack.components.preprocessors import DocumentSplitter
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace, expand_page_range
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.misc import _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -307,7 +307,7 @@ class LLMMetadataExtractor:
             return {"error": "Document has no content, skipping LLM call."}
 
         try:
-            result = await _run_component_async(self._chat_generator, messages=[prompt])
+            result = await _execute_component_async(self._chat_generator, messages=[prompt])
         except Exception as e:
             if self.raise_on_failure:
                 raise e

--- a/haystack/components/generators/chat/fallback.py
+++ b/haystack/components/generators/chat/fallback.py
@@ -11,7 +11,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.components.generators.utils import _normalize_messages
 from haystack.dataclasses import ChatMessage, StreamingCallbackT
 from haystack.tools import ToolsType
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.deserialization import deserialize_component_inplace
 
 logger = logging.getLogger(__name__)
@@ -118,7 +118,7 @@ class FallbackChatGenerator:
         tools: ToolsType | None,
         streaming_callback: StreamingCallbackT | None,
     ) -> dict[str, Any]:
-        return await _run_component_async(
+        return await _execute_component_async(
             gen,
             messages=messages,
             generation_kwargs=generation_kwargs,

--- a/haystack/components/preprocessors/embedding_based_document_splitter.py
+++ b/haystack/components/preprocessors/embedding_based_document_splitter.py
@@ -14,7 +14,7 @@ from haystack import Document, component, logging
 from haystack.components.embedders.types import DocumentEmbedder
 from haystack.components.preprocessors.sentence_tokenizer import Language, SentenceSplitter
 from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.deserialization import deserialize_component_inplace
 
 logger = logging.getLogger(__name__)
@@ -314,7 +314,7 @@ class EmbeddingBasedDocumentSplitter:
         """
         # Create Document objects for each group
         group_docs = [Document(content=group) for group in sentence_groups]
-        result = await _run_component_async(self.document_embedder, documents=group_docs)
+        result = await _execute_component_async(self.document_embedder, documents=group_docs)
         embedded_docs = result["documents"]
         return [doc.embedding for doc in embedded_docs]
 

--- a/haystack/components/query/query_expander.py
+++ b/haystack/components/query/query_expander.py
@@ -12,7 +12,7 @@ from haystack.core.component import component
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses.chat_message import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.misc import _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -279,7 +279,7 @@ class QueryExpander:
 
         try:
             prompt_result = self._prompt_builder.run(query=query.strip(), n_expansions=expansion_count)
-            generator_result = await _run_component_async(
+            generator_result = await _execute_component_async(
                 self.chat_generator, messages=[ChatMessage.from_user(prompt_result["prompt"])]
             )
 

--- a/haystack/components/rankers/llm_ranker.py
+++ b/haystack/components/rankers/llm_ranker.py
@@ -11,7 +11,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.utils import deserialize_chatgenerator_inplace
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.misc import _deduplicate_documents, _parse_dict_from_json
 
 logger = logging.getLogger(__name__)
@@ -313,7 +313,7 @@ class LLMRanker:
         prompt = self._prompt_builder.run(query=query.strip(), documents=deduplicated_documents)
 
         try:
-            result = await _run_component_async(
+            result = await _execute_component_async(
                 self._chat_generator, messages=[ChatMessage.from_user(prompt["prompt"])]
             )
         except Exception as exc:

--- a/haystack/components/retrievers/multi_query_embedding_retriever.py
+++ b/haystack/components/retrievers/multi_query_embedding_retriever.py
@@ -10,7 +10,7 @@ from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.components.embedders.types.protocol import TextEmbedder
 from haystack.components.retrievers.types import EmbeddingRetriever
 from haystack.core.serialization import component_to_dict
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.misc import _deduplicate_documents
 
 
@@ -179,11 +179,11 @@ class MultiQueryEmbeddingRetriever:
         :returns:
             List of retrieved documents or None if no results.
         """
-        embedding_result = await _run_component_async(self.query_embedder, text=query)
+        embedding_result = await _execute_component_async(self.query_embedder, text=query)
 
         query_embedding = embedding_result["embedding"]
 
-        result = await _run_component_async(self.retriever, query_embedding=query_embedding, **retriever_kwargs)
+        result = await _execute_component_async(self.retriever, query_embedding=query_embedding, **retriever_kwargs)
 
         if result and "documents" in result:
             return result["documents"]

--- a/haystack/components/retrievers/multi_query_text_retriever.py
+++ b/haystack/components/retrievers/multi_query_text_retriever.py
@@ -9,7 +9,7 @@ from typing import Any
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.components.retrievers.types import TextRetriever
 from haystack.core.serialization import component_to_dict
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.misc import _deduplicate_documents
 
 
@@ -157,7 +157,7 @@ class MultiQueryTextRetriever:
         :returns:
             List of retrieved documents or None if no results.
         """
-        result = await _run_component_async(self.retriever, query=query, **retriever_kwargs)
+        result = await _execute_component_async(self.retriever, query=query, **retriever_kwargs)
 
         if result and "documents" in result:
             return result["documents"]

--- a/haystack/components/retrievers/multi_retriever.py
+++ b/haystack/components/retrievers/multi_retriever.py
@@ -11,7 +11,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.components.retrievers.types.protocol import TextRetriever
 from haystack.core.serialization import component_from_dict, component_to_dict, import_class_by_name
 from haystack.dataclasses import Document
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.experimental import _experimental
 from haystack.utils.misc import _deduplicate_documents, _reciprocal_rank_fusion
 
@@ -247,7 +247,7 @@ class MultiRetriever:
 
         async def _run_one(name: str, retriever: TextRetriever) -> list[Document]:
             try:
-                result = await _run_component_async(
+                result = await _execute_component_async(
                     retriever, query=query, filters=resolved_filters, top_k=resolved_top_k
                 )
                 return result.get("documents", [])

--- a/haystack/components/retrievers/text_embedding_retriever.py
+++ b/haystack/components/retrievers/text_embedding_retriever.py
@@ -8,7 +8,7 @@ from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.components.embedders.types.protocol import TextEmbedder
 from haystack.components.retrievers.types import EmbeddingRetriever
 from haystack.core.serialization import component_to_dict
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 
 
 @component
@@ -125,8 +125,8 @@ class TextEmbeddingRetriever:
         if not self._is_warmed_up:
             self.warm_up()
 
-        embedding_result = await _run_component_async(self.text_embedder, text=query)
-        result = await _run_component_async(
+        embedding_result = await _execute_component_async(self.text_embedder, text=query)
+        result = await _execute_component_async(
             self.retriever, query_embedding=embedding_result["embedding"], filters=filters, top_k=top_k
         )
 

--- a/haystack/components/routers/llm_messages_router.py
+++ b/haystack/components/routers/llm_messages_router.py
@@ -10,7 +10,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage, ChatRole
 from haystack.utils import deserialize_chatgenerator_inplace
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 
 
 @component
@@ -176,7 +176,7 @@ class LLMMessagesRouter:
             messages_for_inference.append(ChatMessage.from_system(self._system_prompt))
         messages_for_inference.extend(messages)
 
-        generator_result = await _run_component_async(self._chat_generator, messages=messages_for_inference)
+        generator_result = await _execute_component_async(self._chat_generator, messages=messages_for_inference)
         chat_generator_text = generator_result["replies"][0].text
 
         output = {"chat_generator_text": chat_generator_text}

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -31,7 +31,7 @@ from haystack.dataclasses.breakpoints import Breakpoint, PipelineSnapshot
 from haystack.dataclasses.streaming_chunk import _invoke_streaming_callback
 from haystack.telemetry import pipeline_running
 from haystack.utils import _deserialize_value_with_schema
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.misc import _get_output_dir
 
 logger = logging.getLogger(__name__)
@@ -553,7 +553,7 @@ class Pipeline(PipelineBase):
             try:
                 # For sync-only components, _run_component_async dispatches to a thread via asyncio.to_thread,
                 # which copies the current contextvars context — preserving e.g. the active tracing span.
-                outputs = await _run_component_async(instance, **component_inputs_copy)
+                outputs = await _execute_component_async(instance, **component_inputs_copy)
             except Exception as error:
                 raise PipelineRuntimeError.from_exception(component_name, instance.__class__, error) from error
 

--- a/haystack/utils/async_utils.py
+++ b/haystack/utils/async_utils.py
@@ -10,7 +10,7 @@ from haystack import logging
 logger = logging.getLogger(__name__)
 
 
-async def _run_component_async(component_instance: Any, **kwargs: Any) -> dict[str, Any]:
+async def _execute_component_async(component_instance: Any, **kwargs: Any) -> dict[str, Any]:
     """
     Run a component asynchronously, preferring its `run_async` method when implemented.
 

--- a/test/utils/test_async_utils.py
+++ b/test/utils/test_async_utils.py
@@ -7,7 +7,7 @@ import logging
 
 import pytest
 
-from haystack.utils.async_utils import _run_component_async
+from haystack.utils.async_utils import _execute_component_async
 
 _test_context_var: contextvars.ContextVar[str] = contextvars.ContextVar("_test_context_var", default="unset")
 
@@ -42,26 +42,26 @@ class TestRunComponentAsync:
     @pytest.mark.asyncio
     async def test_awaits_run_async_when_available(self):
         component = ComponentWithRunAsync()
-        result = await _run_component_async(component, foo="bar", count=1)
+        result = await _execute_component_async(component, foo="bar", count=1)
         assert result == {"path": "async", "kwargs": {"foo": "bar", "count": 1}}
 
     @pytest.mark.asyncio
     async def test_falls_back_to_sync_run_when_no_run_async(self):
         component = ComponentWithoutRunAsync()
-        result = await _run_component_async(component, foo="bar", count=2)
+        result = await _execute_component_async(component, foo="bar", count=2)
         assert result == {"path": "sync", "kwargs": {"foo": "bar", "count": 2}}
 
     @pytest.mark.asyncio
     async def test_falls_back_to_sync_run_when_run_async_not_callable(self):
         component = ComponentWithNonCallableRunAsync()
-        result = await _run_component_async(component, foo="baz")
+        result = await _execute_component_async(component, foo="baz")
         assert result == {"path": "sync", "kwargs": {"foo": "baz"}}
 
     @pytest.mark.asyncio
     async def test_emits_debug_log_on_sync_fallback(self, caplog):
         component = ComponentWithoutRunAsync()
         with caplog.at_level(logging.DEBUG):
-            await _run_component_async(component)
+            await _execute_component_async(component)
         assert "does not implement 'run_async'" in caplog.text
         assert "ComponentWithoutRunAsync" in caplog.text
 
@@ -72,5 +72,5 @@ class TestRunComponentAsync:
         # current context; a plain `loop.run_in_executor` would not.
         component = ComponentReadingContextVar()
         _test_context_var.set("propagated")
-        result = await _run_component_async(component)
+        result = await _execute_component_async(component)
         assert result == {"value": "propagated"}


### PR DESCRIPTION
### Related Issues

- `_run_component_async` utility function has the same name as a Pipeline static method
- I don't want to change the name of the static method, which also has a sync corresponding method

### Proposed Changes:
- `_run_component_async` utility function -> `_execute_component_async`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
