### PR TITLE
fix: skip empty ByteStream in HTMLToDocument to avoid noisy lxml logs

### DIFF
--- a/haystack/components/converters/html.py
+++ b/haystack/components/converters/html.py
@@ -111,6 +111,10 @@ class HTMLToDocument:
                 logger.warning("Could not read {source}. Skipping it. Error: {error}", source=source, error=e)
                 continue
 
+            if not bytestream.data:
+                logger.warning("Skipping {source} because it is empty.", source=source)
+                continue
+
             try:
                 text = extract(bytestream.data.decode("utf-8"), **merged_extraction_kwargs)
             except Exception as conversion_e:

--- a/releasenotes/notes/fix-html-empty-bytestream-logs-75830aa240c6ea44.yaml
+++ b/releasenotes/notes/fix-html-empty-bytestream-logs-75830aa240c6ea44.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    ``HTMLToDocument`` now skips ``ByteStream`` objects with empty content instead of
+    passing them to trafilatura. This prevents noisy lxml parse error logs (such as
+    "Document is empty") when a fetcher emits an empty stream.

--- a/test/components/converters/test_html_to_document.py
+++ b/test/components/converters/test_html_to_document.py
@@ -156,6 +156,23 @@ class TestHTMLToDocument:
             assert "Could not read non_existing_file.html" in caplog.text
             assert results["documents"] == []
 
+    def test_run_empty_bytestream(self, caplog):
+        """
+        Test that an empty ByteStream is skipped without invoking extraction,
+        so no noisy lxml parse errors are emitted.
+        """
+        empty_stream = ByteStream(data=b"")
+        empty_stream.mime_type = "text/html"
+        converter = HTMLToDocument()
+
+        with patch("haystack.components.converters.html.extract") as mock_extract:
+            with caplog.at_level(logging.WARNING):
+                results = converter.run(sources=[empty_stream])
+
+        assert results["documents"] == []
+        mock_extract.assert_not_called()
+        assert "because it is empty" in caplog.text
+
     def test_mixed_sources_run(self, test_files_path):
         """
         Test if the component runs correctly if the input is a mix of paths and ByteStreams.


### PR DESCRIPTION
### Related Issues

- fixes #11668

### Proposed Changes:

When `HTMLToDocument` receives a `ByteStream` with empty data (`b""`), it passes the empty content to trafilatura's `extract()`. Internally lxml then emits several ERROR/WARNING log lines (e.g. `Document is empty`, `discarding data: None`) that surface as noise in production logs, even though the component already skips the source gracefully.

The existing `try/except` around `extract()` cannot suppress these because lxml *logs* the problem internally rather than raising an exception.

This PR adds a guard that skips any `ByteStream` whose `data` is empty **before** `extract()` is called, so lxml is never invoked and no noisy logs are produced. The empty source is skipped with a single `WARNING`-level message, consistent with the component's other skip paths.

### How did you test it?

- Added a unit test `test_run_empty_bytestream` that runs the converter on an empty `ByteStream` and asserts:
  - no documents are produced,
  - `trafilatura.extract` is never called (`mock_extract.assert_not_called()`),
  - the skip is logged.
- Ran locally:
  - `hatch run test:unit test/components/converters/test_html_to_document.py` — 14 passed
  - `hatch run test:types` — success, no issues
  - `hatch run fmt` — all checks passed

### Notes for the reviewer

The fix is intentionally minimal and placed right after the source is read, mirroring the existing skip-on-error pattern in `run()`. A release note has been added under `releasenotes/notes/`.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.