### PR TITLE
fix: block SSRF to private/metadata addresses in LinkContentFetcher

### DIFF
--- a/haystack/components/fetchers/link_content.py
+++ b/haystack/components/fetchers/link_content.py
@@ -3,12 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import ipaddress
+import socket
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from fnmatch import fnmatch
 from typing import Any, cast
+from urllib.parse import urlsplit
 
 import httpx
 from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
@@ -51,6 +54,108 @@ def _merge_headers(*args: dict[str, str]) -> dict[str, str]:
             merged[kl] = v
 
     return {keymap[kl]: v for kl, v in merged.items()}
+
+
+class UnsafeFetchURLError(httpx.RequestError):
+    """
+    Raised when a URL is blocked by the Server-Side Request Forgery (SSRF) guard before a request is sent.
+
+    Inherits from ``httpx.RequestError`` so it integrates with the existing retry/error-handling flow:
+    ``raise_on_failure=False`` keeps logging and skipping the blocked URL, while ``raise_on_failure=True``
+    surfaces the error to the caller.
+    """
+
+
+# Schemes considered safe to fetch over the network. Other schemes (e.g. ``file://``, ``ftp://``, ``gopher://``)
+# can be abused to read local files or reach unexpected services and are rejected by the SSRF guard.
+_ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
+
+
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """
+    Determine whether an IP address points to a private, local, or otherwise non-routable network.
+
+    This blocks loopback, private (RFC1918 / unique-local), link-local (including the
+    cloud metadata address ``169.254.169.254``), reserved, multicast, and unspecified
+    addresses for both IPv4 and IPv6. IPv4-mapped IPv6 addresses are unwrapped and
+    re-checked so that, for example, ``::ffff:127.0.0.1`` is also blocked.
+
+    :param ip: The IP address to inspect.
+    :returns: ``True`` if the address must not be fetched, ``False`` otherwise.
+    """
+    # Unwrap IPv4-mapped IPv6 addresses (e.g. ::ffff:169.254.169.254) and re-check the embedded IPv4 address.
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        ip = mapped
+
+    return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+
+
+def _assert_safe_url(url: str | httpx.URL) -> None:
+    """
+    Validate that a URL is safe to fetch, raising :class:`UnsafeFetchURLError` if it is not.
+
+    The check rejects unsupported schemes and any host that resolves (via DNS) to a
+    private, loopback, link-local, or otherwise non-routable address. It is applied to
+    the initial request URL and re-applied to every redirect hop, mitigating
+    Server-Side Request Forgery (SSRF) attempts that target internal services or the
+    cloud metadata endpoint, including DNS-rebinding and redirect-based bypasses.
+
+    :param url: The URL about to be requested.
+    :raises UnsafeFetchURLError: If the scheme is unsupported, the host is missing,
+        the host cannot be resolved, or it resolves to a blocked address.
+    """
+    parts = urlsplit(str(url))
+    scheme = parts.scheme.lower()
+    if scheme not in _ALLOWED_URL_SCHEMES:
+        raise UnsafeFetchURLError(
+            f"Blocked request to '{url}': URL scheme '{parts.scheme}' is not allowed. "
+            f"Only {sorted(_ALLOWED_URL_SCHEMES)} URLs can be fetched."
+        )
+
+    host = parts.hostname
+    if not host:
+        raise UnsafeFetchURLError(f"Blocked request to '{url}': the URL does not contain a host.")
+
+    # If the host is already an IP literal, validate it directly. Otherwise resolve all
+    # addresses it maps to and reject the request if any of them is non-routable.
+    try:
+        literal_ip = ipaddress.ip_address(host)
+        resolved_ips: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = [literal_ip]
+    except ValueError:
+        try:
+            addr_infos = socket.getaddrinfo(host, parts.port, proto=socket.IPPROTO_TCP)
+        except socket.gaierror as exc:
+            raise UnsafeFetchURLError(f"Blocked request to '{url}': unable to resolve host '{host}'.") from exc
+        resolved_ips = [ipaddress.ip_address(info[4][0]) for info in addr_infos]
+
+    for ip in resolved_ips:
+        if _is_blocked_ip(ip):
+            raise UnsafeFetchURLError(
+                f"Blocked request to '{url}': host '{host}' resolves to non-routable address '{ip}'. "
+                "Fetching private, loopback, link-local, or cloud-metadata addresses is not allowed. "
+                "Set `allow_private_addresses=True` on LinkContentFetcher to permit this (use with caution)."
+            )
+
+
+def _ssrf_guard_request_hook(request: httpx.Request) -> None:
+    """
+    httpx "request" event hook (sync client) that blocks SSRF-unsafe URLs before the request is sent.
+
+    :param request: The outgoing httpx request (fired for the initial request and each redirect hop).
+    :raises UnsafeFetchURLError: If the request target is not safe to fetch.
+    """
+    _assert_safe_url(request.url)
+
+
+async def _ssrf_guard_request_hook_async(request: httpx.Request) -> None:
+    """
+    httpx "request" event hook (async client) that blocks SSRF-unsafe URLs before the request is sent.
+
+    :param request: The outgoing httpx request (fired for the initial request and each redirect hop).
+    :raises UnsafeFetchURLError: If the request target is not safe to fetch.
+    """
+    _assert_safe_url(request.url)
 
 
 def _text_content_handler(response: httpx.Response) -> ByteStream:
@@ -121,6 +226,7 @@ class LinkContentFetcher:
         http2: bool = False,
         client_kwargs: dict | None = None,
         request_headers: dict[str, str] | None = None,
+        allow_private_addresses: bool = False,
     ) -> None:
         """
         Initializes the component.
@@ -135,6 +241,11 @@ class LinkContentFetcher:
                      Requires the 'h2' package to be installed (via `pip install httpx[http2]`).
         :param client_kwargs: Additional keyword arguments to pass to the httpx client.
                      If `None`, default values are used.
+        :param allow_private_addresses: If `False` (the default), requests to hosts that resolve to private,
+            loopback, link-local, or cloud-metadata addresses are blocked before any connection is made,
+            and every redirect hop is re-validated. This mitigates Server-Side Request Forgery (SSRF) when
+            the URLs come from an untrusted source (for example, when the component is exposed to an LLM as
+            a tool). Set to `True` only if you explicitly trust the URLs and need to reach internal hosts.
         """
         self.raise_on_failure = raise_on_failure
         self.user_agents = user_agents or [DEFAULT_USER_AGENT]
@@ -144,6 +255,7 @@ class LinkContentFetcher:
         self.http2 = http2
         self.client_kwargs = client_kwargs or {}
         self.request_headers = request_headers or {}
+        self.allow_private_addresses = allow_private_addresses
 
         # Configure default client settings
         self.client_kwargs.setdefault("timeout", timeout)
@@ -165,10 +277,10 @@ class LinkContentFetcher:
                 self.http2 = False  # Update the setting to match actual capability
 
         # Initialize synchronous client
-        self._client = httpx.Client(**client_kwargs)
+        self._client = httpx.Client(**self._build_client_kwargs(client_kwargs, is_async=False))
 
         # Initialize asynchronous client
-        self._async_client = httpx.AsyncClient(**client_kwargs)
+        self._async_client = httpx.AsyncClient(**self._build_client_kwargs(client_kwargs, is_async=True))
 
         # register default content handlers that extract data from the response
         self.handlers: dict[str, Callable[[httpx.Response], ByteStream]] = defaultdict(lambda: _text_content_handler)
@@ -194,6 +306,30 @@ class LinkContentFetcher:
             return response
 
         self._get_response: Callable = get_response
+
+    def _build_client_kwargs(self, client_kwargs: dict[str, Any], is_async: bool) -> dict[str, Any]:
+        """
+        Return a copy of ``client_kwargs`` with the SSRF guard installed as a "request" event hook.
+
+        Unless ``allow_private_addresses`` is set, the guard validates the initial URL and every redirect
+        hop before the request leaves the process. httpx fires the "request" event hook for each
+        (redirected) request, so this covers both the sync and async clients without changing the fetch
+        logic. The sync client needs a regular callable while the async client needs a coroutine function,
+        hence the two variants. Any user-supplied "request" hooks are preserved and run after the guard.
+
+        :param client_kwargs: The base keyword arguments for the httpx client.
+        :param is_async: Whether the kwargs are for an ``httpx.AsyncClient`` (``True``) or ``httpx.Client``.
+        :returns: A new kwargs dict with the SSRF guard event hook merged in when enabled.
+        """
+        kwargs = {**client_kwargs}
+        if self.allow_private_addresses:
+            return kwargs
+
+        guard = _ssrf_guard_request_hook_async if is_async else _ssrf_guard_request_hook
+        event_hooks = dict(kwargs.get("event_hooks") or {})
+        request_hooks = list(event_hooks.get("request") or [])
+        kwargs["event_hooks"] = {**event_hooks, "request": [guard, *request_hooks]}
+        return kwargs
 
     def _get_headers(self) -> dict[str, str]:
         """

--- a/releasenotes/notes/link-content-fetcher-ssrf-guard-9144f8064ca03529.yaml
+++ b/releasenotes/notes/link-content-fetcher-ssrf-guard-9144f8064ca03529.yaml
@@ -1,0 +1,14 @@
+---
+security:
+  - |
+    `LinkContentFetcher` now blocks Server-Side Request Forgery (SSRF) by default. Before sending a request,
+    and on every redirect hop, it resolves the target host and rejects private, loopback, link-local,
+    unique-local, reserved, multicast, and cloud-metadata (`169.254.169.254`) addresses (IPv4 and IPv6),
+    as well as non-HTTP(S) schemes. This matters when the component is exposed to an LLM as a tool (via
+    `ComponentTool`), where model-controlled arguments choose the URLs to fetch. Set the new
+    `allow_private_addresses=True` constructor argument to restore the previous behavior when you
+    intentionally need to fetch internal hosts.
+enhancements:
+  - |
+    Added an `allow_private_addresses` argument to `LinkContentFetcher` (default `False`) to control whether
+    requests to private, loopback, link-local, or cloud-metadata addresses are permitted.

--- a/test/components/fetchers/test_link_content_fetcher.py
+++ b/test/components/fetchers/test_link_content_fetcher.py
@@ -10,7 +10,12 @@ import pytest
 from haystack.components.fetchers.link_content import (
     DEFAULT_USER_AGENT,
     LinkContentFetcher,
+    UnsafeFetchURLError,
+    _assert_safe_url,
     _binary_content_handler,
+    _is_blocked_ip,
+    _ssrf_guard_request_hook,
+    _ssrf_guard_request_hook_async,
     _text_content_handler,
 )
 
@@ -433,3 +438,157 @@ class TestLinkContentFetcherAsyncIntegration:
         streams = (await fetcher.run_async([HTML_URL]))["streams"]
         assert len(streams) == 1
         assert "Haystack" in streams[0].data.decode("utf-8")
+
+
+class TestLinkContentFetcherSSRFGuard:
+    """
+    Tests for the Server-Side Request Forgery (SSRF) guard.
+
+    LinkContentFetcher can be exposed to an LLM as a tool (via ComponentTool), which lets model-controlled
+    arguments choose the fetched URLs. Without a guard, those URLs could target loopback, private-network,
+    link-local, or cloud-metadata addresses. These tests assert the request is blocked *before* any network
+    egress and that the existing error-handling and opt-out behavior is preserved.
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/health",
+            "http://127.0.0.1:8080/health",
+            "http://localhost/admin",
+            "http://0.0.0.0/",
+            "http://10.0.0.5/internal",
+            "http://192.168.1.10/router",
+            "http://172.16.0.1/",
+            "http://169.254.169.254/latest/meta-data/",  # cloud metadata service
+            "http://[::1]/",
+            "http://[::ffff:127.0.0.1]/",  # IPv4-mapped loopback
+            "ftp://example.com/secret",  # disallowed scheme
+            "file:///etc/passwd",  # disallowed scheme
+        ],
+    )
+    def test_assert_safe_url_blocks_non_routable_targets(self, url):
+        """The guard rejects loopback / private / link-local / metadata / bad-scheme URLs."""
+        with pytest.raises(UnsafeFetchURLError):
+            _assert_safe_url(url)
+
+    @pytest.mark.parametrize(
+        "ip", ["127.0.0.1", "10.1.2.3", "192.168.0.1", "172.16.5.5", "169.254.169.254", "0.0.0.0", "::1", "fc00::1"]
+    )
+    def test_is_blocked_ip_true_for_non_routable(self, ip):
+        import ipaddress
+
+        assert _is_blocked_ip(ipaddress.ip_address(ip)) is True
+
+    @pytest.mark.parametrize("ip", ["93.184.216.34", "8.8.8.8", "2001:4860:4860::8888"])
+    def test_is_blocked_ip_false_for_public(self, ip):
+        import ipaddress
+
+        assert _is_blocked_ip(ipaddress.ip_address(ip)) is False
+
+    def test_run_blocks_localhost_and_raises(self):
+        """A model-provided localhost URL must be blocked before any network egress."""
+        sent = []
+
+        def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - must never be reached
+            sent.append(str(request.url))
+            return httpx.Response(200, text="SECRET")
+
+        fetcher = LinkContentFetcher(retry_attempts=0)
+        # Preserve the SSRF event hooks but route any *actual* request to a recording mock transport,
+        # so a failure to block would be observable as a recorded request instead of real egress.
+        fetcher._client = httpx.Client(
+            transport=httpx.MockTransport(handler), follow_redirects=True, event_hooks=fetcher._client.event_hooks
+        )
+        with pytest.raises(UnsafeFetchURLError):
+            fetcher.run(urls=["http://127.0.0.1:80/health"])
+        assert sent == []  # the guard fired before the transport was reached
+
+    def test_run_blocks_host_resolving_to_metadata_ip(self):
+        """A public-looking host that resolves to the cloud metadata IP (DNS rebinding) is blocked."""
+        sent = []
+
+        def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - must never be reached
+            sent.append(str(request.url))
+            return httpx.Response(200, text="SECRET")
+
+        with patch("haystack.components.fetchers.link_content.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [(2, 1, 6, "", ("169.254.169.254", 80))]
+            fetcher = LinkContentFetcher(retry_attempts=0)
+            fetcher._client = httpx.Client(
+                transport=httpx.MockTransport(handler), follow_redirects=True, event_hooks=fetcher._client.event_hooks
+            )
+            with pytest.raises(UnsafeFetchURLError):
+                fetcher.run(urls=["http://attacker-controlled.example/x"])
+            assert sent == []  # blocked before any connection attempt
+
+    def test_run_blocked_url_with_raise_on_failure_false_returns_empty(self):
+        """With raise_on_failure=False a blocked URL is skipped gracefully (empty stream), not raised."""
+        fetcher = LinkContentFetcher(raise_on_failure=False, retry_attempts=0)
+        result = fetcher.run(urls=["http://10.0.0.1/internal"])
+        assert len(result["streams"]) == 1
+        empty = b""
+        assert result["streams"][0].data == empty
+
+    def test_run_blocks_redirect_to_private_address(self):
+        """A public URL that redirects to a private/metadata address is blocked on the redirect hop."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.host == "public.example":
+                return httpx.Response(302, headers={"Location": "http://169.254.169.254/latest/meta-data/"})
+            return httpx.Response(200, text="SECRET")  # pragma: no cover - must never be reached
+
+        fetcher = LinkContentFetcher(retry_attempts=0)
+        # Swap in a mock transport while preserving the SSRF event hooks installed on the client.
+        fetcher._client = httpx.Client(
+            transport=httpx.MockTransport(handler), follow_redirects=True, event_hooks=fetcher._client.event_hooks
+        )
+        with pytest.raises(UnsafeFetchURLError):
+            fetcher.run(urls=["http://public.example/start"])
+
+    def test_allow_private_addresses_opts_out_of_guard(self):
+        """allow_private_addresses=True disables the guard so internal hosts can be reached intentionally."""
+        fetcher = LinkContentFetcher(allow_private_addresses=True, retry_attempts=0)
+        assert fetcher.allow_private_addresses is True
+        # No SSRF "request" event hook should be installed on either client.
+        assert _ssrf_hook_count(fetcher._client) == 0
+        assert _ssrf_hook_count(fetcher._async_client) == 0
+
+        # With the guard disabled, a localhost request reaches httpx.Client.get (here mocked) instead of
+        # being blocked by UnsafeFetchURLError.
+        with patch.object(fetcher._client, "get") as mock_get:
+            mock_get.return_value = Mock(
+                status_code=200, text="ok", headers={"Content-Type": "text/plain"}, content=b"ok"
+            )
+            result = fetcher.run(urls=["http://127.0.0.1:8080/health"])
+            mock_get.assert_called_once()
+            assert len(result["streams"]) == 1
+
+    def test_default_installs_guard_hook(self):
+        """By default (allow_private_addresses=False) the SSRF guard is installed on both clients."""
+        fetcher = LinkContentFetcher()
+        assert fetcher.allow_private_addresses is False
+        assert _ssrf_hook_count(fetcher._client) == 1
+        assert _ssrf_hook_count(fetcher._async_client) == 1
+
+    def test_user_event_hooks_are_preserved(self):
+        """User-supplied request event hooks are kept and run after the SSRF guard."""
+        user_hook = Mock()
+        fetcher = LinkContentFetcher(client_kwargs={"event_hooks": {"request": [user_hook]}})
+        request_hooks = fetcher._client.event_hooks.get("request", [])
+        assert user_hook in request_hooks
+        # Guard runs first, user hook second.
+        assert len(request_hooks) == 2
+        assert request_hooks[-1] is user_hook
+
+    async def test_run_async_blocks_localhost(self):
+        """The async path also blocks localhost before any connection."""
+        fetcher = LinkContentFetcher(retry_attempts=0)
+        with pytest.raises(UnsafeFetchURLError):
+            await fetcher.run_async(urls=["http://127.0.0.1:80/health"])
+
+
+def _ssrf_hook_count(client) -> int:
+    """Count SSRF guard request hooks installed on an httpx client."""
+    guards = {_ssrf_guard_request_hook, _ssrf_guard_request_hook_async}
+    return sum(1 for hook in client.event_hooks.get("request", []) if hook in guards)


### PR DESCRIPTION
### Related Issues

- fixes #issue-number <!-- replace with the tracking issue number before submitting, or remove this line if none -->

Hardening for Server-Side Request Forgery (SSRF) in `LinkContentFetcher`.

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

`LinkContentFetcher.run(urls=...)` fetches whatever URLs it is given and follows HTTP
redirects by default. When the component is exposed to an LLM as a tool — for example via
`ComponentTool`, as the repository's own pipeline tests do — the list of URLs is effectively
chosen by the model's tool-call arguments. With no restriction on the resolved target, a
request can be steered at internal services: loopback, private networks (RFC1918 / IPv6 ULA),
link-local, and the cloud-metadata endpoint `169.254.169.254`, and the fetched bytes are
returned through the tool/component result. Because redirects are followed, even a perfectly
public URL can redirect *into* one of these addresses.

**Root cause.** The HTTP client is created with `follow_redirects` defaulting to `True` and
no scheme/host/IP validation before the request is sent, so the target host is never checked
against private or reserved ranges.

**The change (one minimal, default-on guard).** The target is validated **before any
connection is opened** and **re-validated on every redirect hop**:

- New helper `_assert_safe_url()`:
  - rejects non-`http(s)` schemes (e.g. `file://`, `ftp://`, `gopher://`);
  - resolves the host with `socket.getaddrinfo` and rejects the request if **any** resolved
    address is non-routable; IP literals are validated directly (so DNS-rebinding shapes are
    caught).
- New helper `_is_blocked_ip()` blocks `is_private`, `is_loopback`, `is_link_local` (which
  covers the metadata IP), `is_reserved`, `is_multicast`, and `is_unspecified` for both IPv4
  and IPv6, including IPv4-mapped IPv6 (`::ffff:127.0.0.1`).
- The guard is wired as an httpx `"request"` event hook on **both** the sync and async
  clients, so it runs for the initial request and **each redirect hop** without changing the
  existing fetch/retry logic. Any user-supplied `request` hooks are preserved and run after
  the guard.
- Blocked URLs raise `UnsafeFetchURLError` (a subclass of `httpx.RequestError`), so existing
  behaviour is preserved: `raise_on_failure=True` surfaces the error, `raise_on_failure=False`
  logs it and returns an empty `ByteStream`.

Because the guard sits at the transport level (the `"request"` event hook), a single change
closes the issue for the synchronous fetch path, the asynchronous fetch path, and every
redirect hop at once.

**Affected sites (decisive lines this PR hardens):**

- `haystack/components/fetchers/link_content.py:192` — synchronous `self._client.get(url, ...)`
- `haystack/components/fetchers/link_content.py:407` — asynchronous `self._async_client.get(url, ...)` (same path, async)

**Backwards compatibility.** A new constructor argument `allow_private_addresses: bool = False`
lets operators who *intentionally* fetch internal hosts opt out and restore the previous
behaviour. The change uses only the standard library (`ipaddress`, `socket`, `urllib.parse`) —
no new dependencies — and adds only an optional keyword argument with a safe default. No
existing signature changes and the component has no `to_dict`/`from_dict`, so there is no
serialization impact.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

- Added a `TestLinkContentFetcherSSRFGuard` test class covering:
  - URL/IP classification for loopback, private, link-local, metadata, IPv6, IPv4-mapped IPv6,
    and disallowed schemes (and that public IPs are still allowed);
  - sync and async `run()` blocking localhost **before any network egress** (asserted via a
    recording `httpx.MockTransport` that is never reached);
  - a host that resolves to the metadata IP being blocked (DNS-rebinding shape, with
    `socket.getaddrinfo` mocked);
  - a public URL that **redirects** into the metadata IP being blocked on the redirect hop;
  - `raise_on_failure=False` returning an empty stream for a blocked URL;
  - the `allow_private_addresses=True` opt-out path;
  - guard-hook installation/ordering and preservation of user-supplied hooks.
- **Fail-before / pass-after:** on the unmodified base the test module cannot even import
  (the guard symbols do not exist) and a localhost / public→`169.254.169.254` redirect is
  fetched and its body returned; with this change every such request is blocked before the
  transport is reached.
- All new tests stub the network (`MockTransport` / mocked `getaddrinfo`) — **no real outbound
  requests** are made.
- Result for the file: **46 passed, 7 deselected** (the 7 deselected are pre-existing
  integration tests that perform real egress). `ruff check` / `ruff format --check` clean;
  `mypy` clean on the changed module.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

- A release note has been added under
  `releasenotes/notes/link-content-fetcher-ssrf-guard-9144f8064ca03529.yaml`.
- The guard is a resolve-then-connect check and shares the well-known TOCTOU limitation of
  that approach; the redirect-hop re-validation and the broad block-list materially reduce the
  practical risk. It deliberately does **not** block arbitrary public IPs or impose an
  allow-list, so the component's normal job of fetching the open web is unaffected.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
