### PR TITLE
Fix/ordering filter mixed str datetime

### DIFF
--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -59,9 +59,10 @@ def _not_equal(value: Any, filter_value: Any) -> bool:
 def _prepare_ordering_comparison(value: Any, filter_value: Any) -> tuple[Any, Any]:
     """Normalize both values for ordering comparisons, parsing strings as dates."""
     if isinstance(value, str) or isinstance(filter_value, str):
-        value = _parse_date(value)
-        filter_value = _parse_date(filter_value)
-        value, filter_value = _ensure_both_dates_naive_or_aware(value, filter_value)
+        value = _parse_date(value) if isinstance(value, str) else value
+        filter_value = _parse_date(filter_value) if isinstance(filter_value, str) else filter_value
+        if isinstance(value, datetime) and isinstance(filter_value, datetime):
+            value, filter_value = _ensure_both_dates_naive_or_aware(value, filter_value)
 
     if isinstance(filter_value, list):
         msg = f"Filter value can't be of type {type(filter_value)} using operators '>', '>=', '<', '<='"
@@ -75,7 +76,11 @@ def _greater_than(value: Any, filter_value: Any) -> bool:
         return False
 
     value, filter_value = _prepare_ordering_comparison(value=value, filter_value=filter_value)
-    return value > filter_value
+    try:
+        return value > filter_value
+    except TypeError as exc:
+        msg = f"Can't compare {type(value)} with {type(filter_value)} using operator '>'"
+        raise FilterError(msg) from exc
 
 
 def _parse_date(value: str) -> datetime:
@@ -117,7 +122,11 @@ def _greater_than_equal(value: Any, filter_value: Any) -> bool:
         return False
 
     value, filter_value = _prepare_ordering_comparison(value=value, filter_value=filter_value)
-    return value >= filter_value
+    try:
+        return value >= filter_value
+    except TypeError as exc:
+        msg = f"Can't compare {type(value)} with {type(filter_value)} using operator '>='"
+        raise FilterError(msg) from exc
 
 
 def _less_than(value: Any, filter_value: Any) -> bool:
@@ -126,7 +135,11 @@ def _less_than(value: Any, filter_value: Any) -> bool:
         return False
 
     value, filter_value = _prepare_ordering_comparison(value=value, filter_value=filter_value)
-    return value < filter_value
+    try:
+        return value < filter_value
+    except TypeError as exc:
+        msg = f"Can't compare {type(value)} with {type(filter_value)} using operator '<'"
+        raise FilterError(msg) from exc
 
 
 def _less_than_equal(value: Any, filter_value: Any) -> bool:
@@ -135,7 +148,11 @@ def _less_than_equal(value: Any, filter_value: Any) -> bool:
         return False
 
     value, filter_value = _prepare_ordering_comparison(value=value, filter_value=filter_value)
-    return value <= filter_value
+    try:
+        return value <= filter_value
+    except TypeError as exc:
+        msg = f"Can't compare {type(value)} with {type(filter_value)} using operator '<='"
+        raise FilterError(msg) from exc
 
 
 def _in(value: Any, filter_value: Any) -> bool:

--- a/releasenotes/notes/fix-ordering-filter-comparison-for-mixed-string-and-datetime-operands-85578989b814261a.yaml
+++ b/releasenotes/notes/fix-ordering-filter-comparison-for-mixed-string-and-datetime-operands-85578989b814261a.yaml
@@ -1,0 +1,32 @@
+---
+highlights: >
+    Replace this text with content to appear at the top of the section for this
+    release. The highlights might repeat some details that are also present in other notes
+    from the same release, that's ok. Not every release note requires highlights,
+    use this section only to describe major features or notable changes.
+upgrade:
+  - |
+    List upgrade notes here, or remove this section.
+    Upgrade notes should be rare: only list known/potential breaking changes,
+    or major changes that require user action before the upgrade.
+    Notes here must include steps that users can follow to 1. know if they're
+    affected and 2. handle the change gracefully on their end.
+features:
+  - |
+    List new features here, or remove this section.
+enhancements:
+  - |
+    List new behavior that is too small to be
+    considered a new feature, or remove this section.
+issues:
+  - |
+    List known issues here, or remove this section. For example, if some change is experimental or known to not work in some cases, it should be mentioned here.
+deprecations:
+  - |
+    List deprecations notes here, or remove this section. Deprecations should not be used for something that is removed in the release, use upgrade section instead. Deprecation should allow time for users to make necessary changes for the removal to happen in a future release.
+security:
+  - |
+    Add security notes here, or remove this section.
+fixes:
+  - |
+    Add normal bug fixes here, or remove this section.

--- a/test/utils/test_filters.py
+++ b/test/utils/test_filters.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from datetime import datetime, timezone
 
 from haystack import Document
 from haystack.errors import FilterError
@@ -508,6 +509,18 @@ document_matches_filter_data = [
         Document(meta={"date": "2025-02-03T12:45:46.435816Z"}),
         True,
         id=">= operator with naive and aware ISO 8601 datetime Document value",
+    ),
+    pytest.param(
+        {"field": "meta.date", "operator": ">", "value": datetime(2023, 1, 1, tzinfo=timezone.utc)},
+        Document(meta={"date": "2024-01-01"}),
+        True,
+        id="> operator with aware datetime filter and string date Document",
+    ),
+    pytest.param(
+        {"field": "meta.date", "operator": "<", "value": datetime(2025, 1, 1)},
+        Document(meta={"date": "2024-01-01T12:00:00+00:00"}),
+        True,
+        id="< operator with naive datetime filter and aware string date Document",
     ),
 ]
 

--- a/test/utils/test_filters.py
+++ b/test/utils/test_filters.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 from datetime import datetime, timezone
+
+import pytest
 
 from haystack import Document
 from haystack.errors import FilterError


### PR DESCRIPTION


**Related Issues**

fixes #11678

**Proposed Changes**

- Update `_prepare_ordering_comparison()` to only call `_parse_date()` on operands that are actually strings.
- Normalize naive/aware datetimes via `_ensure_both_dates_naive_or_aware()` when both operands resolve to `datetime`.
- Wrap `>`, `>=`, `<`, `<=` operators in `try/except TypeError` → `FilterError` to preserve existing error behavior.
- Added regression tests for aware datetime vs string date and naive datetime vs aware ISO string.
- Added release note.

**How did you test it?**

```bash
hatch run test:unit test/utils/test_filters.py -k document_matches_filter
```

92 tests passed.

**Notes for the reviewer**

- Root cause: `_prepare_ordering_comparison()` called `_parse_date()` on both operands when either was a string, crashing when the other was already a `datetime`.
- Mixed string/`datetime` comparisons are valid — ISO date strings in `Document.meta` compared against `datetime` filter values is a real use case.
- `TypeError` wrapping keeps error behavior consistent with existing Haystack conventions.

**Checklist**
- [ ] Read contributors guidelines and code of conduct
- [ ] Updated related issue
- [x] Added unit tests and updated docstrings
- [ ] Used conventional commit type in PR title
- [x] Documented code
- [x] Added release note
- [ ] Run pre-commit hooks and fixed any issues