### PR TITLE
chore: deprecate whisper components (LocalWhisperTranscriber, RemoteWhisperTranscriber)

### DIFF
--- a/docs-website/docs/pipeline-components/audio/localwhispertranscriber.mdx
+++ b/docs-website/docs/pipeline-components/audio/localwhispertranscriber.mdx
@@ -16,9 +16,9 @@ Use `LocalWhisperTranscriber` to transcribe audio files using OpenAI's Whisper m
 | **Most common position in a pipeline** | As the first component in an indexing pipeline                                                |
 | **Mandatory run variables**            | `sources`: A list of paths or binary streams that you want to transcribe                      |
 | **Output variables**                   | `documents`: A list of documents                                                              |
-| **API reference**                      | [Audio](/reference/audio-api)                                                                        |
-| **GitHub link**                        | https://github.com/deepset-ai/haystack/blob/main/haystack/components/audio/whisper_local.py |
-| **Package name** | `haystack-ai` |
+| **API reference**                      | [Whisper](/reference/integrations-whisper)                                                                        |
+| **GitHub link**                        | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/whisper |
+| **Package name** | `whisper-haystack` |
 
 </div>
 
@@ -26,14 +26,14 @@ Use `LocalWhisperTranscriber` to transcribe audio files using OpenAI's Whisper m
 
 The component also needs to know which Whisper model to work with. Specify this in the `model` parameter when initializing the component. All transcription is completed on the executing machine, and the audio is never sent to a third-party provider.
 
-See other optional parameters you can specify in our [API documentation](/reference/audio-api).
+See other optional parameters you can specify in our [API documentation](/reference/integrations-whisper).
 
 See the [Whisper API documentation](https://platform.openai.com/docs/guides/speech-to-text) and the official Whisper [GitHub repo](https://github.com/openai/whisper) for the supported audio formats and languages.
 
-To work with the `LocalWhisperTranscriber`, install torch and [Whisper](https://github.com/openai/whisper) first with the following commands:
+The `LocalWhisperTranscriber` is part of the `whisper-haystack` integration package. To work with it, install the package along with [Whisper](https://github.com/openai/whisper) (which also pulls in torch) using the following commands:
 
 ```python
-pip install 'transformers[torch]'
+pip install whisper-haystack
 pip install -U openai-whisper
 ```
 
@@ -45,7 +45,7 @@ Here’s an example of how to use `LocalWhisperTranscriber` on its own:
 
 ```python
 import requests
-from haystack.components.audio import LocalWhisperTranscriber
+from haystack_integrations.components.audio.whisper import LocalWhisperTranscriber
 
 response = requests.get(
     "https://ia903102.us.archive.org/19/items/100-Best--Speeches/EK_19690725_64kb.mp3",
@@ -64,7 +64,7 @@ print(transcription["documents"][0].content)
 The pipeline below fetches an audio file from a specified URL and transcribes it. It first retrieves the audio file using `LinkContentFetcher`, then transcribes the audio into text with `LocalWhisperTranscriber`, and finally outputs the transcription text.
 
 ```python
-from haystack.components.audio import LocalWhisperTranscriber
+from haystack_integrations.components.audio.whisper import LocalWhisperTranscriber
 from haystack.components.fetchers import LinkContentFetcher
 from haystack import Pipeline
 

--- a/docs-website/docs/pipeline-components/audio/remotewhispertranscriber.mdx
+++ b/docs-website/docs/pipeline-components/audio/remotewhispertranscriber.mdx
@@ -17,13 +17,19 @@ Use `RemoteWhisperTranscriber` to transcribe audio files using OpenAI's Whisper 
 | **Mandatory init variables**           | `api_key`: An OpenAI API key. Can be set with an environment variable `OPENAI_API_KEY`.        |
 | **Mandatory run variables**            | `sources`: A list of paths or binary streams that you want to transcribe                       |
 | **Output variables**                   | `documents`: A list of documents                                                               |
-| **API reference**                      | [Audio](/reference/audio-api)                                                                         |
-| **GitHub link**                        | https://github.com/deepset-ai/haystack/blob/main/haystack/components/audio/whisper_remote.py |
-| **Package name** | `haystack-ai` |
+| **API reference**                      | [Whisper](/reference/integrations-whisper)                                                                         |
+| **GitHub link**                        | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/whisper |
+| **Package name** | `whisper-haystack` |
 
 </div>
 
 ## Overview
+
+The `RemoteWhisperTranscriber` is part of the `whisper-haystack` integration package. Install it with:
+
+```python
+pip install whisper-haystack
+```
 
 `RemoteWhisperTranscriber` works with OpenAI-compatible clients and isn't limited to just OpenAI as a provider. For example, [Groq](https://console.groq.com/docs/speech-text) offers a drop-in replacement that can be used as well. You can set the API key in one of two ways:
 
@@ -31,7 +37,7 @@ Use `RemoteWhisperTranscriber` to transcribe audio files using OpenAI's Whisper 
 2. By setting it in the `OPENAI_API_KEY` environment variable, which the system will use to access the key.
 
 ```python
-from haystack.components.audio import RemoteWhisperTranscriber
+from haystack_integrations.components.audio.whisper import RemoteWhisperTranscriber
 
 transcriber = RemoteWhisperTranscriber()
 ```
@@ -41,7 +47,7 @@ Additionally, the component requires the following parameters to work:
 - `model` specifies the Whisper model.
 - `api_base_url` specifies the OpenAI base URL and defaults to `"https://api.openai.com/v1"`. If you are using Whisper provider other than OpenAI set this parameter according to provider's documentation.
 
-See other optional parameters in our [API documentation](/reference/audio-api).
+See other optional parameters in our [API documentation](/reference/integrations-whisper).
 
 See the [Whisper API documentation](https://platform.openai.com/docs/guides/speech-to-text) and the official Whisper [GitHub repo](https://github.com/openai/whisper) for the supported audio formats and languages.
 
@@ -53,7 +59,7 @@ Here’s an example of how to use `RemoteWhisperTranscriber` to transcribe a loc
 
 ```python
 import requests
-from haystack.components.audio import RemoteWhisperTranscriber
+from haystack_integrations.components.audio.whisper import RemoteWhisperTranscriber
 
 response = requests.get(
     "https://ia903102.us.archive.org/19/items/100-Best--Speeches/EK_19690725_64kb.mp3",
@@ -72,7 +78,7 @@ print(transcription["documents"][0].content)
 The pipeline below fetches an audio file from a specified URL and transcribes it. It first retrieves the audio file using `LinkContentFetcher`, then transcribes the audio into text with `RemoteWhisperTranscriber`, and finally outputs the transcription text.
 
 ```python
-from haystack.components.audio import RemoteWhisperTranscriber
+from haystack_integrations.components.audio.whisper import RemoteWhisperTranscriber
 from haystack.components.fetchers import LinkContentFetcher
 from haystack import Pipeline
 

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/audio/localwhispertranscriber.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/audio/localwhispertranscriber.mdx
@@ -16,9 +16,9 @@ Use `LocalWhisperTranscriber` to transcribe audio files using OpenAI's Whisper m
 | **Most common position in a pipeline** | As the first component in an indexing pipeline                                                |
 | **Mandatory run variables**            | `sources`: A list of paths or binary streams that you want to transcribe                      |
 | **Output variables**                   | `documents`: A list of documents                                                              |
-| **API reference**                      | [Audio](/reference/audio-api)                                                                        |
-| **GitHub link**                        | https://github.com/deepset-ai/haystack/blob/main/haystack/components/audio/whisper_local.py |
-| **Package name** | `haystack-ai` |
+| **API reference**                      | [Whisper](/reference/integrations-whisper)                                                                        |
+| **GitHub link**                        | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/whisper |
+| **Package name** | `whisper-haystack` |
 
 </div>
 
@@ -26,14 +26,14 @@ Use `LocalWhisperTranscriber` to transcribe audio files using OpenAI's Whisper m
 
 The component also needs to know which Whisper model to work with. Specify this in the `model` parameter when initializing the component. All transcription is completed on the executing machine, and the audio is never sent to a third-party provider.
 
-See other optional parameters you can specify in our [API documentation](/reference/audio-api).
+See other optional parameters you can specify in our [API documentation](/reference/integrations-whisper).
 
 See the [Whisper API documentation](https://platform.openai.com/docs/guides/speech-to-text) and the official Whisper [GitHub repo](https://github.com/openai/whisper) for the supported audio formats and languages.
 
-To work with the `LocalWhisperTranscriber`, install torch and [Whisper](https://github.com/openai/whisper) first with the following commands:
+The `LocalWhisperTranscriber` is part of the `whisper-haystack` integration package. To work with it, install the package along with [Whisper](https://github.com/openai/whisper) (which also pulls in torch) using the following commands:
 
 ```python
-pip install 'transformers[torch]'
+pip install whisper-haystack
 pip install -U openai-whisper
 ```
 
@@ -45,7 +45,7 @@ Here’s an example of how to use `LocalWhisperTranscriber` on its own:
 
 ```python
 import requests
-from haystack.components.audio import LocalWhisperTranscriber
+from haystack_integrations.components.audio.whisper import LocalWhisperTranscriber
 
 response = requests.get(
     "https://ia903102.us.archive.org/19/items/100-Best--Speeches/EK_19690725_64kb.mp3",
@@ -64,7 +64,7 @@ print(transcription["documents"][0].content)
 The pipeline below fetches an audio file from a specified URL and transcribes it. It first retrieves the audio file using `LinkContentFetcher`, then transcribes the audio into text with `LocalWhisperTranscriber`, and finally outputs the transcription text.
 
 ```python
-from haystack.components.audio import LocalWhisperTranscriber
+from haystack_integrations.components.audio.whisper import LocalWhisperTranscriber
 from haystack.components.fetchers import LinkContentFetcher
 from haystack import Pipeline
 

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/audio/remotewhispertranscriber.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/audio/remotewhispertranscriber.mdx
@@ -17,13 +17,19 @@ Use `RemoteWhisperTranscriber` to transcribe audio files using OpenAI's Whisper 
 | **Mandatory init variables**           | `api_key`: An OpenAI API key. Can be set with an environment variable `OPENAI_API_KEY`.        |
 | **Mandatory run variables**            | `sources`: A list of paths or binary streams that you want to transcribe                       |
 | **Output variables**                   | `documents`: A list of documents                                                               |
-| **API reference**                      | [Audio](/reference/audio-api)                                                                         |
-| **GitHub link**                        | https://github.com/deepset-ai/haystack/blob/main/haystack/components/audio/whisper_remote.py |
-| **Package name** | `haystack-ai` |
+| **API reference**                      | [Whisper](/reference/integrations-whisper)                                                                         |
+| **GitHub link**                        | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/whisper |
+| **Package name** | `whisper-haystack` |
 
 </div>
 
 ## Overview
+
+The `RemoteWhisperTranscriber` is part of the `whisper-haystack` integration package. Install it with:
+
+```python
+pip install whisper-haystack
+```
 
 `RemoteWhisperTranscriber` works with OpenAI-compatible clients and isn't limited to just OpenAI as a provider. For example, [Groq](https://console.groq.com/docs/speech-text) offers a drop-in replacement that can be used as well. You can set the API key in one of two ways:
 
@@ -31,7 +37,7 @@ Use `RemoteWhisperTranscriber` to transcribe audio files using OpenAI's Whisper 
 2. By setting it in the `OPENAI_API_KEY` environment variable, which the system will use to access the key.
 
 ```python
-from haystack.components.audio import RemoteWhisperTranscriber
+from haystack_integrations.components.audio.whisper import RemoteWhisperTranscriber
 
 transcriber = RemoteWhisperTranscriber()
 ```
@@ -41,7 +47,7 @@ Additionally, the component requires the following parameters to work:
 - `model` specifies the Whisper model.
 - `api_base_url` specifies the OpenAI base URL and defaults to `"https://api.openai.com/v1"`. If you are using Whisper provider other than OpenAI set this parameter according to provider's documentation.
 
-See other optional parameters in our [API documentation](/reference/audio-api).
+See other optional parameters in our [API documentation](/reference/integrations-whisper).
 
 See the [Whisper API documentation](https://platform.openai.com/docs/guides/speech-to-text) and the official Whisper [GitHub repo](https://github.com/openai/whisper) for the supported audio formats and languages.
 
@@ -53,7 +59,7 @@ Here’s an example of how to use `RemoteWhisperTranscriber` to transcribe a loc
 
 ```python
 import requests
-from haystack.components.audio import RemoteWhisperTranscriber
+from haystack_integrations.components.audio.whisper import RemoteWhisperTranscriber
 
 response = requests.get(
     "https://ia903102.us.archive.org/19/items/100-Best--Speeches/EK_19690725_64kb.mp3",
@@ -72,7 +78,7 @@ print(transcription["documents"][0].content)
 The pipeline below fetches an audio file from a specified URL and transcribes it. It first retrieves the audio file using `LinkContentFetcher`, then transcribes the audio into text with `RemoteWhisperTranscriber`, and finally outputs the transcription text.
 
 ```python
-from haystack.components.audio import RemoteWhisperTranscriber
+from haystack_integrations.components.audio.whisper import RemoteWhisperTranscriber
 from haystack.components.fetchers import LinkContentFetcher
 from haystack import Pipeline
 

--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import tempfile
+import warnings
 from pathlib import Path
 from typing import Any, Literal, get_args
 
@@ -70,6 +71,14 @@ class LocalWhisperTranscriber:
         :param device:
             The device for loading the model. If `None`, automatically selects the default device.
         """
+        warnings.warn(
+            "`LocalWhisperTranscriber` will be removed from Haystack in version 3.0, as it is moving to "
+            "the `whisper-haystack` package. To continue using it, install that package with "
+            "`pip install whisper-haystack` and update your import to "
+            "`from haystack_integrations.components.audio.whisper import LocalWhisperTranscriber`.",
+            FutureWarning,
+            stacklevel=2,
+        )
         whisper_import.check()
         if model not in get_args(WhisperLocalModel):
             raise ValueError(

--- a/haystack/components/audio/whisper_remote.py
+++ b/haystack/components/audio/whisper_remote.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import io
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -82,6 +83,14 @@ class RemoteWhisperTranscriber:
             uses log probability to automatically increase the
             temperature until certain thresholds are hit.
         """
+        warnings.warn(
+            "`RemoteWhisperTranscriber` will be removed from Haystack in version 3.0, as it is moving to "
+            "the `whisper-haystack` package. To continue using it, install that package with "
+            "`pip install whisper-haystack` and update your import to "
+            "`from haystack_integrations.components.audio.whisper import RemoteWhisperTranscriber`.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
         self.organization = organization
         self.model = model

--- a/releasenotes/notes/deprecate-whisper-components-95822a86cd87fdc0.yaml
+++ b/releasenotes/notes/deprecate-whisper-components-95822a86cd87fdc0.yaml
@@ -1,0 +1,11 @@
+---
+deprecations:
+  - |
+    ``LocalWhisperTranscriber`` and ``RemoteWhisperTranscriber`` are deprecated and will be removed from
+    Haystack in version 3.0. They are moving to the ``whisper-haystack`` package. To continue using them,
+    install the package with ``pip install whisper-haystack`` and update your imports as follows:
+
+    .. code-block:: python
+
+        from haystack_integrations.components.audio.whisper import LocalWhisperTranscriber
+        from haystack_integrations.components.audio.whisper import RemoteWhisperTranscriber


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/367

### Proposed Changes:
- deprecate `LocalWhisperTranscriber` and `RemoteWhisperTranscriber` with a `FutureWarning` pointing users to the new `whisper-haystack` package (https://github.com/deepset-ai/haystack-core-integrations/pull/3468)
- update the docs pages (current and version-2.30) for both components to show the new package name, install command, API reference, GitHub link, and import paths
- add a deprecation release note covering both components

### How did you test it?

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
