### PR TITLE
fix: validate block_sizes and split_overlap in HierarchicalDocumentSplitter

### DIFF
--- a/haystack/components/preprocessors/hierarchical_document_splitter.py
+++ b/haystack/components/preprocessors/hierarchical_document_splitter.py
@@ -1,4 +1,3 @@
-# haystack/components/preprocessors/hierarchical_document_splitter.py
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -13,26 +12,26 @@ from haystack.components.preprocessors import DocumentSplitter
 @component
 class HierarchicalDocumentSplitter:
     """
-        Splits a documents into different block sizes building a hierarchical tree structure of blocks of different sizes.
+    Splits a documents into different block sizes building a hierarchical tree structure of blocks of different sizes.
 
-        The root node of the tree is the original document, the leaf nodes are the smallest blocks. The blocks in between
-        are connected such that the smaller blocks are children of the parent-larger blocks.
+    The root node of the tree is the original document, the leaf nodes are the smallest blocks. The blocks in between
+    are connected such that the smaller blocks are children of the parent-larger blocks.
 
-        ## Usage example
+    ## Usage example
     ```python
-        from haystack import Document
-        from haystack.components.preprocessors import HierarchicalDocumentSplitter
+    from haystack import Document
+    from haystack.components.preprocessors import HierarchicalDocumentSplitter
 
-        doc = Document(content="This is a simple test document")
-        splitter = HierarchicalDocumentSplitter(block_sizes={3, 2}, split_overlap=0, split_by="word")
-        splitter.run([doc])
-        # >> {'documents': [Document(id=3f7..., content: 'This is a simple test document', meta: {'block_size': 0, 'parent_id': None, 'children_ids': ['5ff..', '8dc..'], 'level': 0}),
-        # >> Document(id=5ff.., content: 'This is a ', meta: {'block_size': 3, 'parent_id': '3f7..', 'children_ids': ['f19..', '52c..'], 'level': 1, 'source_id': '3f7..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
-        # >> Document(id=8dc.., content: 'simple test document', meta: {'block_size': 3, 'parent_id': '3f7..', 'children_ids': ['39d..', 'e23..'], 'level': 1, 'source_id': '3f7..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 10}),
-        # >> Document(id=f19.., content: 'This is ', meta: {'block_size': 2, 'parent_id': '5ff..', 'children_ids': [], 'level': 2, 'source_id': '5ff..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
-        # >> Document(id=52c.., content: 'a ', meta: {'block_size': 2, 'parent_id': '5ff..', 'children_ids': [], 'level': 2, 'source_id': '5ff..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 8}),
-        # >> Document(id=39d.., content: 'simple test ', meta: {'block_size': 2, 'parent_id': '8dc..', 'children_ids': [], 'level': 2, 'source_id': '8dc..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
-        # >> Document(id=e23.., content: 'document', meta: {'block_size': 2, 'parent_id': '8dc..', 'children_ids': [], 'level': 2, 'source_id': '8dc..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 12})]}
+    doc = Document(content="This is a simple test document")
+    splitter = HierarchicalDocumentSplitter(block_sizes={3, 2}, split_overlap=0, split_by="word")
+    splitter.run([doc])
+    # >> {'documents': [Document(id=3f7..., content: 'This is a simple test document', meta: {'block_size': 0, 'parent_id': None, 'children_ids': ['5ff..', '8dc..'], 'level': 0}),
+    # >> Document(id=5ff.., content: 'This is a ', meta: {'block_size': 3, 'parent_id': '3f7..', 'children_ids': ['f19..', '52c..'], 'level': 1, 'source_id': '3f7..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
+    # >> Document(id=8dc.., content: 'simple test document', meta: {'block_size': 3, 'parent_id': '3f7..', 'children_ids': ['39d..', 'e23..'], 'level': 1, 'source_id': '3f7..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 10}),
+    # >> Document(id=f19.., content: 'This is ', meta: {'block_size': 2, 'parent_id': '5ff..', 'children_ids': [], 'level': 2, 'source_id': '5ff..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
+    # >> Document(id=52c.., content: 'a ', meta: {'block_size': 2, 'parent_id': '5ff..', 'children_ids': [], 'level': 2, 'source_id': '5ff..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 8}),
+    # >> Document(id=39d.., content: 'simple test ', meta: {'block_size': 2, 'parent_id': '8dc..', 'children_ids': [], 'level': 2, 'source_id': '8dc..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
+    # >> Document(id=e23.., content: 'document', meta: {'block_size': 2, 'parent_id': '8dc..', 'children_ids': [], 'level': 2, 'source_id': '8dc..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 12})]}
     ```
     """  # noqa: E501
 
@@ -51,6 +50,7 @@ class HierarchicalDocumentSplitter:
         :raises ValueError: If `block_sizes` is empty, if `split_overlap` is negative, or if `split_overlap` is
             greater than or equal to the smallest value in `block_sizes`.
         """
+
         if not block_sizes:
             raise ValueError("block_sizes must not be empty. Provide at least one block size.")
 

--- a/haystack/components/preprocessors/hierarchical_document_splitter.py
+++ b/haystack/components/preprocessors/hierarchical_document_splitter.py
@@ -1,3 +1,4 @@
+# haystack/components/preprocessors/hierarchical_document_splitter.py
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -12,26 +13,26 @@ from haystack.components.preprocessors import DocumentSplitter
 @component
 class HierarchicalDocumentSplitter:
     """
-    Splits a documents into different block sizes building a hierarchical tree structure of blocks of different sizes.
+        Splits a documents into different block sizes building a hierarchical tree structure of blocks of different sizes.
 
-    The root node of the tree is the original document, the leaf nodes are the smallest blocks. The blocks in between
-    are connected such that the smaller blocks are children of the parent-larger blocks.
+        The root node of the tree is the original document, the leaf nodes are the smallest blocks. The blocks in between
+        are connected such that the smaller blocks are children of the parent-larger blocks.
 
-    ## Usage example
+        ## Usage example
     ```python
-    from haystack import Document
-    from haystack.components.preprocessors import HierarchicalDocumentSplitter
+        from haystack import Document
+        from haystack.components.preprocessors import HierarchicalDocumentSplitter
 
-    doc = Document(content="This is a simple test document")
-    splitter = HierarchicalDocumentSplitter(block_sizes={3, 2}, split_overlap=0, split_by="word")
-    splitter.run([doc])
-    # >> {'documents': [Document(id=3f7..., content: 'This is a simple test document', meta: {'block_size': 0, 'parent_id': None, 'children_ids': ['5ff..', '8dc..'], 'level': 0}),
-    # >> Document(id=5ff.., content: 'This is a ', meta: {'block_size': 3, 'parent_id': '3f7..', 'children_ids': ['f19..', '52c..'], 'level': 1, 'source_id': '3f7..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
-    # >> Document(id=8dc.., content: 'simple test document', meta: {'block_size': 3, 'parent_id': '3f7..', 'children_ids': ['39d..', 'e23..'], 'level': 1, 'source_id': '3f7..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 10}),
-    # >> Document(id=f19.., content: 'This is ', meta: {'block_size': 2, 'parent_id': '5ff..', 'children_ids': [], 'level': 2, 'source_id': '5ff..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
-    # >> Document(id=52c.., content: 'a ', meta: {'block_size': 2, 'parent_id': '5ff..', 'children_ids': [], 'level': 2, 'source_id': '5ff..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 8}),
-    # >> Document(id=39d.., content: 'simple test ', meta: {'block_size': 2, 'parent_id': '8dc..', 'children_ids': [], 'level': 2, 'source_id': '8dc..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
-    # >> Document(id=e23.., content: 'document', meta: {'block_size': 2, 'parent_id': '8dc..', 'children_ids': [], 'level': 2, 'source_id': '8dc..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 12})]}
+        doc = Document(content="This is a simple test document")
+        splitter = HierarchicalDocumentSplitter(block_sizes={3, 2}, split_overlap=0, split_by="word")
+        splitter.run([doc])
+        # >> {'documents': [Document(id=3f7..., content: 'This is a simple test document', meta: {'block_size': 0, 'parent_id': None, 'children_ids': ['5ff..', '8dc..'], 'level': 0}),
+        # >> Document(id=5ff.., content: 'This is a ', meta: {'block_size': 3, 'parent_id': '3f7..', 'children_ids': ['f19..', '52c..'], 'level': 1, 'source_id': '3f7..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
+        # >> Document(id=8dc.., content: 'simple test document', meta: {'block_size': 3, 'parent_id': '3f7..', 'children_ids': ['39d..', 'e23..'], 'level': 1, 'source_id': '3f7..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 10}),
+        # >> Document(id=f19.., content: 'This is ', meta: {'block_size': 2, 'parent_id': '5ff..', 'children_ids': [], 'level': 2, 'source_id': '5ff..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
+        # >> Document(id=52c.., content: 'a ', meta: {'block_size': 2, 'parent_id': '5ff..', 'children_ids': [], 'level': 2, 'source_id': '5ff..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 8}),
+        # >> Document(id=39d.., content: 'simple test ', meta: {'block_size': 2, 'parent_id': '8dc..', 'children_ids': [], 'level': 2, 'source_id': '8dc..', 'page_number': 1, 'split_id': 0, 'split_idx_start': 0}),
+        # >> Document(id=e23.., content: 'document', meta: {'block_size': 2, 'parent_id': '8dc..', 'children_ids': [], 'level': 2, 'source_id': '8dc..', 'page_number': 1, 'split_id': 1, 'split_idx_start': 12})]}
     ```
     """  # noqa: E501
 
@@ -47,7 +48,21 @@ class HierarchicalDocumentSplitter:
         :param block_sizes: Set of block sizes to split the document into. The blocks are split in descending order.
         :param split_overlap: The number of overlapping units for each split.
         :param split_by: The unit for splitting your documents.
+        :raises ValueError: If `block_sizes` is empty, if `split_overlap` is negative, or if `split_overlap` is
+            greater than or equal to the smallest value in `block_sizes`.
         """
+        if not block_sizes:
+            raise ValueError("block_sizes must not be empty. Provide at least one block size.")
+
+        if split_overlap < 0:
+            raise ValueError("split_overlap must be greater than or equal to 0.")
+
+        smallest_block_size = min(block_sizes)
+        if split_overlap >= smallest_block_size:
+            raise ValueError(
+                f"split_overlap ({split_overlap}) must be less than the smallest value in block_sizes "
+                f"({smallest_block_size}). Reduce split_overlap or increase the smallest block size."
+            )
 
         self.block_sizes = sorted(set(block_sizes), reverse=True)
         self.splitters: dict[int, DocumentSplitter] = {}

--- a/releasenotes/notes/hierarchical-splitter-validation-68ae54e878c47abf.yaml
+++ b/releasenotes/notes/hierarchical-splitter-validation-68ae54e878c47abf.yaml
@@ -1,0 +1,10 @@
+fixes:
+  - |
+    ``HierarchicalDocumentSplitter`` now validates its ``block_sizes`` and
+    ``split_overlap`` parameters at construction time. Previously, an empty
+    ``block_sizes`` set silently produced no splits, and a ``split_overlap``
+    too large relative to the smallest block size raised a confusing error
+    referencing ``split_length``, a parameter that doesn't exist on this
+    component. ``HierarchicalDocumentSplitter`` now raises a clear
+    ``ValueError`` in both cases, using its own parameter names and
+    identifying the offending value.

--- a/test/components/preprocessors/test_hierarchical_doc_splitter.py
+++ b/test/components/preprocessors/test_hierarchical_doc_splitter.py
@@ -38,27 +38,6 @@ class TestHierarchicalDocumentSplitter:
         with pytest.raises(ValueError, match="split_overlap .* must be less than the smallest value in block_sizes"):
             HierarchicalDocumentSplitter(block_sizes={10, 5, 2}, split_overlap=3)
 
-    def test_init_error_message_references_smallest_block_size_not_largest(self):
-        """
-        Regression test: previously the error from the internal DocumentSplitter referenced
-        'split_length', a parameter name that doesn't exist on HierarchicalDocumentSplitter,
-        and gave no indication of which block_size was the problem. The new error must use
-        HierarchicalDocumentSplitter's own parameter names and identify the smallest block size.
-        """
-        with pytest.raises(ValueError) as exc_info:
-            HierarchicalDocumentSplitter(block_sizes={100, 50, 5}, split_overlap=10)
-        error_message = str(exc_info.value)
-        assert "split_length" not in error_message
-        assert "5" in error_message
-        assert "split_overlap" in error_message
-        assert "block_sizes" in error_message
-
-    def test_init_with_split_overlap_valid_for_smallest_block_size(self):
-        # split_overlap one less than the smallest block size should succeed
-        builder = HierarchicalDocumentSplitter(block_sizes={10, 5, 2}, split_overlap=1)
-        assert builder.split_overlap == 1
-        assert builder.block_sizes == [10, 5, 2]
-
     def test_to_dict(self):
         builder = HierarchicalDocumentSplitter(block_sizes={100, 200, 300}, split_overlap=25, split_by="word")
         expected = builder.to_dict()

--- a/test/components/preprocessors/test_hierarchical_doc_splitter.py
+++ b/test/components/preprocessors/test_hierarchical_doc_splitter.py
@@ -22,6 +22,43 @@ class TestHierarchicalDocumentSplitter:
         assert builder.split_overlap == 25
         assert builder.split_by == "word"
 
+    def test_init_with_empty_block_sizes_raises(self):
+        with pytest.raises(ValueError, match="block_sizes must not be empty"):
+            HierarchicalDocumentSplitter(block_sizes=set())
+
+    def test_init_with_negative_split_overlap_raises(self):
+        with pytest.raises(ValueError, match="split_overlap must be greater than or equal to 0"):
+            HierarchicalDocumentSplitter(block_sizes={10, 5, 2}, split_overlap=-1)
+
+    def test_init_with_split_overlap_equal_to_smallest_block_size_raises(self):
+        with pytest.raises(ValueError, match="split_overlap .* must be less than the smallest value in block_sizes"):
+            HierarchicalDocumentSplitter(block_sizes={10, 5, 2}, split_overlap=2)
+
+    def test_init_with_split_overlap_greater_than_smallest_block_size_raises(self):
+        with pytest.raises(ValueError, match="split_overlap .* must be less than the smallest value in block_sizes"):
+            HierarchicalDocumentSplitter(block_sizes={10, 5, 2}, split_overlap=3)
+
+    def test_init_error_message_references_smallest_block_size_not_largest(self):
+        """
+        Regression test: previously the error from the internal DocumentSplitter referenced
+        'split_length', a parameter name that doesn't exist on HierarchicalDocumentSplitter,
+        and gave no indication of which block_size was the problem. The new error must use
+        HierarchicalDocumentSplitter's own parameter names and identify the smallest block size.
+        """
+        with pytest.raises(ValueError) as exc_info:
+            HierarchicalDocumentSplitter(block_sizes={100, 50, 5}, split_overlap=10)
+        error_message = str(exc_info.value)
+        assert "split_length" not in error_message
+        assert "5" in error_message
+        assert "split_overlap" in error_message
+        assert "block_sizes" in error_message
+
+    def test_init_with_split_overlap_valid_for_smallest_block_size(self):
+        # split_overlap one less than the smallest block size should succeed
+        builder = HierarchicalDocumentSplitter(block_sizes={10, 5, 2}, split_overlap=1)
+        assert builder.split_overlap == 1
+        assert builder.block_sizes == [10, 5, 2]
+
     def test_to_dict(self):
         builder = HierarchicalDocumentSplitter(block_sizes={100, 200, 300}, split_overlap=25, split_by="word")
         expected = builder.to_dict()


### PR DESCRIPTION
### Related Issues
- No related issue (discovered while reviewing validation parity across preprocessor/splitter components)

### Proposed Changes:
`HierarchicalDocumentSplitter` had two validation gaps that produced either silent wrong behavior or a confusing error:

1. **Empty `block_sizes`**: Constructing `HierarchicalDocumentSplitter(block_sizes=set())` succeeded with no error. Calling `run()` then silently returned the input document unsplit, with no warning that nothing was split.

2. **`split_overlap` too large**: Constructing `HierarchicalDocumentSplitter(block_sizes={5, 3}, split_overlap=4)` raised: **ValueError**: `split_overlap` must be less than `split_length`.

This error originates from the internal `DocumentSplitter` that `HierarchicalDocumentSplitter` builds per block size. It references `split_length`, a parameter name that does not exist on `HierarchicalDocumentSplitter`'s public API, and gives no indication of which `block_size` triggered the failure.

I fixed this by adding explicit validation in `HierarchicalDocumentSplitter.__init__`, before delegating to the internal `DocumentSplitter` instances:
- Raises `ValueError` if `block_sizes` is empty
- Raises `ValueError` if `split_overlap` is negative
- Raises `ValueError` if `split_overlap >= min(block_sizes)`, with a message that uses `HierarchicalDocumentSplitter`'s own parameter names and states the exact smallest block size that's the problem

### How did you test it?
- Reproduced both issues manually against the unpatched code to confirm they were real before writing any fix
- Ran the full preprocessor test suite locally: `PYTHONPATH="" hatch run test:unit test/components/preprocessors/test_hierarchical_doc_splitter.py` - 17 passed (11 existing + 6 new)
- Ran type checks: `hatch run test:types` - no issues in 365 source files
- Ran formatter: `hatch run fmt` - auto-fixed one formatting issue, all checks now pass
- Confirmed 100% statement coverage on the modified file

### Notes for the reviewer
This is not a breaking change for any valid existing usage - only inputs that previously either silently did nothing or raised a confusing, implementation-leaking error now raise a clear, actionable `ValueError`. No `upgrade:` note was added to the release note for this reason; it's filed under `fixes:` only.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.