### PR TITLE
fix: Fix parallel tool calling when tools interact with `State`

### DIFF
--- a/haystack/components/agents/tool_calling.py
+++ b/haystack/components/agents/tool_calling.py
@@ -24,6 +24,21 @@ from haystack.tracing.utils import _serializable_value
 logger = logging.getLogger(__name__)
 
 
+class _AllStateKeys:
+    """Sentinel representing "every state key", used for tools that receive the live State object."""
+
+    def __repr__(self) -> str:
+        return "<all state keys>"
+
+
+# A tool annotated with a `State` parameter can read from and write to any key, so it acts as a full barrier
+# against every other state-touching tool call in the same step.
+_ALL_STATE_KEYS = _AllStateKeys()
+
+# A set of state keys, or the _ALL_STATE_KEYS sentinel meaning "every key".
+_StateKeys = set[str] | _AllStateKeys
+
+
 class ToolNotFoundException(Exception):
     """Exception raised when a tool is not found in the list of available tools."""
 
@@ -150,20 +165,21 @@ def _build_tool_result_message(result: Any, tool_call: ToolCall, tool: Tool, *, 
     return ChatMessage.from_tool(tool_result=_result_to_string(tool_result_dict), origin=tool_call)
 
 
-def _create_tool_result_streaming_chunk(tool_messages: list[ChatMessage], tool_call: ToolCall) -> StreamingChunk:
+def _create_tool_result_streaming_chunk(tool_message: ChatMessage, tool_call: ToolCall, index: int) -> StreamingChunk:
     """
-    Create a streaming chunk that carries the latest tool result.
+    Create a streaming chunk that carries a tool result.
 
-    :param tool_messages: The list of tool result messages so far, with the latest result at the end.
+    :param tool_message: The tool result message to stream.
     :param tool_call: The ToolCall object that triggered the tool invocation.
-    :returns: A StreamingChunk containing the latest tool result and metadata about the tool call.
+    :param index: The position of this tool result in the stream (in execution order).
+    :returns: A StreamingChunk containing the tool result and metadata about the tool call.
     """
     return StreamingChunk(
         content="",
-        index=len(tool_messages) - 1,
-        tool_call_result=tool_messages[-1].tool_call_results[0],
+        index=index,
+        tool_call_result=tool_message.tool_call_results[0],
         start=True,
-        meta={"tool_result": tool_messages[-1].tool_call_results[0].result, "tool_call": tool_call},
+        meta={"tool_result": tool_message.tool_call_results[0].result, "tool_call": tool_call},
     )
 
 
@@ -229,6 +245,24 @@ def _get_func_params(tool: Tool) -> dict[str, Any]:
     return {name: param.annotation for name, param in inspect.signature(target).parameters.items()}  # type: ignore[arg-type]
 
 
+def _state_param_mappings(tool: Tool, func_params: dict[str, Any]) -> dict[str, str]:
+    """
+    Resolve the `{state_key: param_name}` mapping a tool uses to pull inputs from State.
+
+    Tools may declare this explicitly via `inputs_from_state`; otherwise every parameter is treated as a potential
+    state key by name. This is the single source of truth shared by `_inject_state_args` (which reads the actual
+    values) and `_state_io_for_call` (which derives the read set for scheduling).
+
+    :param tool: The tool whose state-input mapping to resolve.
+    :param func_params: The tool's parameter names mapped to their annotations (from `_get_func_params`).
+    :returns: A mapping of state key to the tool parameter it feeds.
+    """
+    inputs_from_state = getattr(tool, "inputs_from_state", None)
+    if isinstance(inputs_from_state, dict):
+        return inputs_from_state
+    return {name: name for name in func_params}
+
+
 def _inject_state_args(tool: Tool, llm_args: dict[str, Any], state: State) -> dict[str, Any]:
     """
     Merge LLM-provided arguments with state-sourced arguments.
@@ -245,13 +279,7 @@ def _inject_state_args(tool: Tool, llm_args: dict[str, Any], state: State) -> di
     final_args = dict(llm_args)
     func_params = _get_func_params(tool)
 
-    param_mappings: dict[str, str]
-    if hasattr(tool, "inputs_from_state") and isinstance(tool.inputs_from_state, dict):
-        param_mappings = tool.inputs_from_state
-    else:
-        param_mappings = {name: name for name in func_params}
-
-    for state_key, param_name in param_mappings.items():
+    for state_key, param_name in _state_param_mappings(tool, func_params).items():
         if param_name not in final_args and state.has(state_key):
             final_args[param_name] = state.get(state_key)
 
@@ -300,25 +328,23 @@ def _prepare_tool_args(
     return final_args
 
 
-def _collect_tool_call_params(
-    messages_with_tool_calls: list[ChatMessage],
-    state: State,
-    tools_with_names: dict[str, Tool],
-    streaming_callback: StreamingCallbackT | None,
-    *,
-    raise_on_failure: bool,
-    enable_streaming_callback_passthrough: bool,
-) -> tuple[list[ToolCall], list[dict[str, Any]], list[ChatMessage]]:
+def _resolve_tool_calls(
+    messages_with_tool_calls: list[ChatMessage], tools_with_names: dict[str, Tool], *, raise_on_failure: bool
+) -> tuple[list[ToolCall], list[Tool], list[ChatMessage]]:
     """
-    Walk all tool calls in `messages_with_tool_calls` and prepare their execution parameters.
+    Walk all tool calls in `messages_with_tool_calls` and resolve each to its Tool.
 
-    :returns: (tool_calls, tool_call_params, error_messages)
-        - tool_calls: ToolCall objects for each valid call
-        - tool_call_params: {"tool": ..., "args": ...} dicts ready for _make_context_bound_invoke
+    Argument preparation is deliberately *not* done here: args are prepared per execution batch (see
+    `_schedule_tool_calls`) so that a tool reading from State observes writes made by tools that ran earlier
+    in the same step.
+
+    :returns: (tool_calls, resolved_tools, error_messages)
+        - tool_calls: ToolCall objects for each valid call, in call order
+        - resolved_tools: the resolved Tool for each entry in `tool_calls` (parallel list)
         - error_messages: ChatMessages for tool-not-found errors (when raise_on_failure is False)
     """
     tool_calls: list[ToolCall] = []
-    tool_call_params: list[dict[str, Any]] = []
+    resolved_tools: list[Tool] = []
     error_messages: list[ChatMessage] = []
 
     for message in messages_with_tool_calls:
@@ -333,20 +359,134 @@ def _collect_tool_call_params(
                 error_messages.append(ChatMessage.from_tool(tool_result=str(error), origin=tool_call, error=True))
                 continue
 
-            tool = tools_with_names[tool_name]
-
-            final_args = _prepare_tool_args(
-                tool=tool,
-                tool_call_arguments=tool_call.arguments,
-                state=state,
-                streaming_callback=streaming_callback,
-                enable_streaming_passthrough=enable_streaming_callback_passthrough,
-            )
-
             tool_calls.append(tool_call)
-            tool_call_params.append({"tool": tool, "args": final_args})
+            resolved_tools.append(tools_with_names[tool_name])
 
-    return tool_calls, tool_call_params, error_messages
+    return tool_calls, resolved_tools, error_messages
+
+
+def _keys_intersect(a: _StateKeys, b: _StateKeys) -> bool:
+    """
+    Return whether two State-key sets share at least one key, treating `_ALL_STATE_KEYS` as a wildcard.
+
+    Used to detect read-after-write dependencies between tool calls: the reader's read set is tested against the
+    writer's write set.
+
+    :param a: A set of state keys, or the `_ALL_STATE_KEYS` wildcard meaning "every key".
+    :param b: A set of state keys, or the `_ALL_STATE_KEYS` wildcard meaning "every key".
+    :returns: True if the sets overlap (a wildcard overlaps any non-empty set, and two wildcards always overlap).
+    """
+    if a is _ALL_STATE_KEYS:
+        # `a` covers every key, so it overlaps `b` as long as `b` touches any key. Two wildcards always overlap;
+        # otherwise `bool(b)` is True iff the concrete set `b` is non-empty.
+        return b is _ALL_STATE_KEYS or bool(b)
+    if b is _ALL_STATE_KEYS:
+        # Symmetric case: wildcard `b` overlaps `a` iff the concrete set `a` is non-empty (`bool(set)` == non-empty).
+        return bool(a)
+    # Both are concrete sets: they overlap iff their set intersection is non-empty.
+    return bool(a & b)  # type: ignore[operator]
+
+
+def _state_io_for_call(tool: Tool, llm_args: dict[str, Any]) -> tuple[_StateKeys, _StateKeys]:
+    """
+    Compute the State keys a tool call reads from and writes to.
+
+    Mirrors the resolution logic in `_inject_state_args`:
+    - A tool with a `State`-annotated parameter can read/write any key, so both sets are the `_ALL_STATE_KEYS`
+      wildcard.
+    - Otherwise reads come from `inputs_from_state` (or parameter-name matching when it is not set), excluding
+      any parameter the LLM already supplied (LLM args take precedence and short-circuit the state lookup).
+    - Writes are the keys in `outputs_to_state`.
+
+    :returns: A `(reads, writes)` tuple of state-key sets (or the `_ALL_STATE_KEYS` wildcard).
+    """
+    func_params = _get_func_params(tool)
+    if any(_unwrap_optional(param_type) is State for param_type in func_params.values()):
+        return _ALL_STATE_KEYS, _ALL_STATE_KEYS
+
+    param_mappings = _state_param_mappings(tool, func_params)
+    reads = {state_key for state_key, param_name in param_mappings.items() if param_name not in llm_args}
+
+    outputs_to_state = getattr(tool, "outputs_to_state", None)
+    writes = set(outputs_to_state.keys()) if isinstance(outputs_to_state, dict) else set()
+
+    return reads, writes
+
+
+def _schedule_tool_calls(tool_calls: list[ToolCall], tools: list[Tool]) -> list[list[int]]:
+    """
+    Group tool calls into ordered execution batches based on their State read/write sets.
+
+    Calls within a batch are mutually independent and run in parallel; batches run sequentially. The schedule
+    guarantees that a call reading a State key always runs in a later batch than any call (in the same step)
+    that writes that key — so read-after-write dependencies are honored regardless of the order the LLM
+    requested the calls in.
+
+    This is a layered topological sort (Kahn's algorithm): each round, every call whose dependencies have all
+    been scheduled forms the next parallel batch. Dependency cycles — e.g. a tool that both reads and writes the
+    same key, requested more than once — cannot be ordered by the read-after-write rule alone, so they are broken
+    deterministically by call order (the lowest-index remaining call runs next, on its own).
+
+    Pure write-write overlaps create no dependency: nobody reads the contended key, and outputs are merged into
+    State sequentially in call order afterward, so the result stays deterministic without serializing execution.
+
+    :param tool_calls: The tool calls to schedule, in call order.
+    :param tools: The resolved Tool for each entry in `tool_calls` (parallel list).
+    :returns: A list of batches, each a list of indices into `tool_calls`.
+    """
+    # Per-call (reads, writes) State-key sets, in call order.
+    io_list = [_state_io_for_call(tool, tc.arguments) for tc, tool in zip(tool_calls, tools, strict=True)]
+    n = len(io_list)
+
+    # deps[j] = indices that must run before j because j reads a key they write (read-after-write).
+    deps: list[set[int]] = [set() for _ in range(n)]
+    for j in range(n):
+        reads_j, _ = io_list[j]
+        for i in range(n):
+            if i == j:
+                continue
+            _, writes_i = io_list[i]
+            if _keys_intersect(reads_j, writes_i):
+                deps[j].add(i)
+
+    scheduled = [False] * n
+    done: set[int] = set()
+    batches: list[list[int]] = []
+
+    while len(done) < n:
+        # A call is ready once every writer it depends on has already been scheduled (`deps[k] <= done`, i.e. its
+        # dependency set is a subset of the already-done set). All ready calls have no dependency on each other —
+        # if one read a key another writes, it would still be waiting — so the whole `ready` list runs in parallel.
+        ready = [k for k in range(n) if not scheduled[k] and deps[k] <= done]
+        if not ready:
+            # A dependency cycle remains: break it deterministically by running the lowest-index call next.
+            ready = [next(k for k in range(n) if not scheduled[k])]
+        for k in ready:
+            scheduled[k] = True
+        done.update(ready)
+        batches.append(ready)
+
+    return batches
+
+
+def _finalize_tool_result(
+    result: Any, tool_call: ToolCall, tool: Tool, state: State, *, raise_on_failure: bool
+) -> ChatMessage:
+    """
+    Turn a single tool invocation result into a tool-result ChatMessage, merging outputs into State.
+
+    On a `ToolInvocationError`, either re-raise (when `raise_on_failure`) or return an error message. Otherwise
+    merge the tool's outputs into State (in call order, so write-write merges stay deterministic) and build the
+    result message.
+    """
+    if isinstance(result, ToolInvocationError):
+        if raise_on_failure:
+            raise result
+        logger.error("{error_exception}", error_exception=result)
+        return ChatMessage.from_tool(tool_result=str(result), origin=tool_call, error=True)
+
+    _merge_tool_outputs_into_state(tool, result, state)
+    return _build_tool_result_message(result, tool_call, tool, raise_on_failure=raise_on_failure)
 
 
 def _run_tool(
@@ -377,38 +517,50 @@ def _run_tool(
     if not messages_with_tool_calls:
         return [], state
 
-    tool_calls, tool_call_params, tool_messages = _collect_tool_call_params(
-        messages_with_tool_calls=messages_with_tool_calls,
-        state=state,
-        tools_with_names=tools_with_names,
-        streaming_callback=streaming_callback,
-        raise_on_failure=raise_on_failure,
-        enable_streaming_callback_passthrough=enable_streaming_callback_passthrough,
+    tool_calls, resolved_tools, error_messages = _resolve_tool_calls(
+        messages_with_tool_calls, tools_with_names, raise_on_failure=raise_on_failure
     )
+    if not tool_calls:
+        return error_messages, state
 
-    if not tool_call_params:
-        return tool_messages, state
+    # Group the calls into batches that honor read-after-write dependencies on State (see `_schedule_tool_calls`).
+    batches = _schedule_tool_calls(tool_calls, resolved_tools)
+
+    # Results are indexed by call position so the returned messages stay in call order, even though batches may
+    # execute the calls in a different order.
+    results: list[ChatMessage | None] = [None] * len(tool_calls)
+    stream_index = 0
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = [executor.submit(_make_context_bound_invoke(p["tool"], p["args"])) for p in tool_call_params]
-
-        for future, tool_call in zip(futures, tool_calls, strict=True):
-            result = future.result()
-
-            if isinstance(result, ToolInvocationError):
-                if raise_on_failure:
-                    raise result
-                logger.error("{error_exception}", error_exception=result)
-                tool_messages.append(ChatMessage.from_tool(tool_result=str(result), origin=tool_call, error=True))
-            else:
-                tool = tools_with_names[tool_call.tool_name]
-                _merge_tool_outputs_into_state(tool, result, state)
-                tool_messages.append(
-                    _build_tool_result_message(result, tool_call, tool, raise_on_failure=raise_on_failure)
+        for batch in batches:
+            # Prepare args at the start of each batch so tools that read from State observe writes merged by earlier
+            # batches.
+            futures = {}
+            for idx in batch:
+                args = _prepare_tool_args(
+                    tool=resolved_tools[idx],
+                    tool_call_arguments=tool_calls[idx].arguments,
+                    state=state,
+                    streaming_callback=streaming_callback,
+                    enable_streaming_passthrough=enable_streaming_callback_passthrough,
                 )
+                futures[idx] = executor.submit(_make_context_bound_invoke(resolved_tools[idx], args))
 
-            if streaming_callback is not None:
-                streaming_callback(_create_tool_result_streaming_chunk(tool_messages, tool_call))
+            # Merge results in call order within the batch so write-write merges stay deterministic.
+            for idx in batch:
+                message = _finalize_tool_result(
+                    futures[idx].result(),
+                    tool_calls[idx],
+                    resolved_tools[idx],
+                    state,
+                    raise_on_failure=raise_on_failure,
+                )
+                results[idx] = message
+                if streaming_callback is not None:
+                    streaming_callback(_create_tool_result_streaming_chunk(message, tool_calls[idx], stream_index))
+                    stream_index += 1
+
+    tool_messages = error_messages + [m for m in results if m is not None]
 
     # We emit a final empty chunk with finish_reason "tool_call_results" to signal the end of the tool results stream.
     if tool_messages and streaming_callback is not None:
@@ -447,39 +599,51 @@ async def _run_tool_async(
     if not messages_with_tool_calls:
         return [], state
 
-    tool_calls, tool_call_params, tool_messages = _collect_tool_call_params(
-        messages_with_tool_calls=messages_with_tool_calls,
-        state=state,
-        tools_with_names=tools_with_names,
-        streaming_callback=streaming_callback,
-        raise_on_failure=raise_on_failure,
-        enable_streaming_callback_passthrough=enable_streaming_callback_passthrough,
+    tool_calls, resolved_tools, error_messages = _resolve_tool_calls(
+        messages_with_tool_calls, tools_with_names, raise_on_failure=raise_on_failure
     )
+    if not tool_calls:
+        return error_messages, state
 
-    if not tool_call_params:
-        return tool_messages, state
+    # Group the calls into batches that honor read-after-write dependencies on State (see `_schedule_tool_calls`).
+    batches = _schedule_tool_calls(tool_calls, resolved_tools)
+
+    # Results are indexed by call position so the returned messages stay in call order, even though batches may
+    # execute the calls in a different order.
+    results: list[ChatMessage | None] = [None] * len(tool_calls)
+    stream_index = 0
 
     # `max_workers` + Semaphore bounds concurrency for both sync and async tool calls async tools are awaited directly,
     # and sync tools are dispatched to a worker thread inside `Tool.invoke_async`.
     semaphore = asyncio.Semaphore(max_workers)
-    tasks = [_make_bounded_invoke_async(p["tool"], p["args"], semaphore)() for p in tool_call_params]
-    results = await asyncio.gather(*tasks)
 
-    for result, tool_call in zip(results, tool_calls, strict=True):
-        if isinstance(result, ToolInvocationError):
-            if raise_on_failure:
-                raise result
-            logger.error("{error_exception}", error_exception=result)
-            tool_messages.append(ChatMessage.from_tool(tool_result=str(result), origin=tool_call, error=True))
-        else:
-            tool = tools_with_names[tool_call.tool_name]
-            _merge_tool_outputs_into_state(tool, result, state)
-            tool_messages.append(_build_tool_result_message(result, tool_call, tool, raise_on_failure=raise_on_failure))
-
-        if streaming_callback is not None:
-            await _invoke_streaming_callback(
-                streaming_callback, _create_tool_result_streaming_chunk(tool_messages, tool_call)
+    for batch in batches:
+        # Prepare args at the start of each batch so readers observe writes merged by earlier batches.
+        tasks = {}
+        for idx in batch:
+            args = _prepare_tool_args(
+                tool=resolved_tools[idx],
+                tool_call_arguments=tool_calls[idx].arguments,
+                state=state,
+                streaming_callback=streaming_callback,
+                enable_streaming_passthrough=enable_streaming_callback_passthrough,
             )
+            tasks[idx] = _make_bounded_invoke_async(resolved_tools[idx], args, semaphore)()
+        batch_results = await asyncio.gather(*tasks.values())
+
+        # Merge results in call order within the batch so write-write merges stay deterministic.
+        for idx, result in zip(tasks.keys(), batch_results, strict=True):
+            message = _finalize_tool_result(
+                result, tool_calls[idx], resolved_tools[idx], state, raise_on_failure=raise_on_failure
+            )
+            results[idx] = message
+            if streaming_callback is not None:
+                await _invoke_streaming_callback(
+                    streaming_callback, _create_tool_result_streaming_chunk(message, tool_calls[idx], stream_index)
+                )
+                stream_index += 1
+
+    tool_messages = error_messages + [m for m in results if m is not None]
 
     # We emit a final empty chunk with finish_reason "tool_call_results" to signal the end of the tool results stream.
     if tool_messages and streaming_callback is not None:

--- a/haystack/components/agents/tool_calling.py
+++ b/haystack/components/agents/tool_calling.py
@@ -25,14 +25,12 @@ logger = logging.getLogger(__name__)
 
 
 class _AllStateKeys:
-    """Sentinel representing "every state key", used for tools that receive the live State object."""
+    """Sentinel representing "every state key", used for tools that receive the full State object."""
 
     def __repr__(self) -> str:
         return "<all state keys>"
 
 
-# A tool annotated with a `State` parameter can read from and write to any key, so it acts as a full barrier
-# against every other state-touching tool call in the same step.
 _ALL_STATE_KEYS = _AllStateKeys()
 
 # A set of state keys, or the _ALL_STATE_KEYS sentinel meaning "every key".
@@ -249,9 +247,9 @@ def _state_param_mappings(tool: Tool, func_params: dict[str, Any]) -> dict[str, 
     """
     Resolve the `{state_key: param_name}` mapping a tool uses to pull inputs from State.
 
-    Tools may declare this explicitly via `inputs_from_state`; otherwise every parameter is treated as a potential
-    state key by name. This is the single source of truth shared by `_inject_state_args` (which reads the actual
-    values) and `_state_io_for_call` (which derives the read set for scheduling).
+    Tools may declare this explicitly via `inputs_from_state`; otherwise every parameter is treated as a potential state
+     key by name. This is the single source of truth shared by `_inject_state_args` (which reads the actual values) and
+     `_state_io_for_call` (which derives the read set for scheduling).
 
     :param tool: The tool whose state-input mapping to resolve.
     :param func_params: The tool's parameter names mapped to their annotations (from `_get_func_params`).
@@ -335,8 +333,8 @@ def _resolve_tool_calls(
     Walk all tool calls in `messages_with_tool_calls` and resolve each to its Tool.
 
     Argument preparation is deliberately *not* done here: args are prepared per execution batch (see
-    `_schedule_tool_calls`) so that a tool reading from State observes writes made by tools that ran earlier
-    in the same step.
+    `_schedule_tool_calls`) so that a tool reading from State observes writes made by tools that ran earlier in the same
+     step.
 
     :returns: (tool_calls, resolved_tools, error_messages)
         - tool_calls: ToolCall objects for each valid call, in call order
@@ -392,21 +390,22 @@ def _state_io_for_call(tool: Tool, llm_args: dict[str, Any]) -> tuple[_StateKeys
     Compute the State keys a tool call reads from and writes to.
 
     Mirrors the resolution logic in `_inject_state_args`:
-    - A tool with a `State`-annotated parameter can read/write any key, so both sets are the `_ALL_STATE_KEYS`
-      wildcard.
-    - Otherwise reads come from `inputs_from_state` (or parameter-name matching when it is not set), excluding
-      any parameter the LLM already supplied (LLM args take precedence and short-circuit the state lookup).
+    - A tool with a `State`-annotated parameter can read/write any key, so both sets are the `_ALL_STATE_KEYS` wildcard.
+    - Otherwise reads come from `inputs_from_state` (or parameter-name matching when it is not set), excluding any
+      parameter the LLM already supplied (LLM args take precedence and short-circuit the state lookup).
     - Writes are the keys in `outputs_to_state`.
 
     :returns: A `(reads, writes)` tuple of state-key sets (or the `_ALL_STATE_KEYS` wildcard).
     """
     func_params = _get_func_params(tool)
+    # Check if State is in func_params
     if any(_unwrap_optional(param_type) is State for param_type in func_params.values()):
         return _ALL_STATE_KEYS, _ALL_STATE_KEYS
 
+    # Calculate reads
     param_mappings = _state_param_mappings(tool, func_params)
     reads = {state_key for state_key, param_name in param_mappings.items() if param_name not in llm_args}
-
+    # Calculate writes
     outputs_to_state = getattr(tool, "outputs_to_state", None)
     writes = set(outputs_to_state.keys()) if isinstance(outputs_to_state, dict) else set()
 
@@ -417,18 +416,17 @@ def _schedule_tool_calls(tool_calls: list[ToolCall], tools: list[Tool]) -> list[
     """
     Group tool calls into ordered execution batches based on their State read/write sets.
 
-    Calls within a batch are mutually independent and run in parallel; batches run sequentially. The schedule
-    guarantees that a call reading a State key always runs in a later batch than any call (in the same step)
-    that writes that key — so read-after-write dependencies are honored regardless of the order the LLM
-    requested the calls in.
+    Calls within a batch are mutually independent and run in parallel; batches run sequentially. The schedule guarantees
+    that a call reading a State key always runs in a later batch than any call (in the same step) that writes that
+    key — so read-after-write dependencies are honored regardless of the order the LLM requested the calls in.
 
-    This is a layered topological sort (Kahn's algorithm): each round, every call whose dependencies have all
-    been scheduled forms the next parallel batch. Dependency cycles — e.g. a tool that both reads and writes the
-    same key, requested more than once — cannot be ordered by the read-after-write rule alone, so they are broken
-    deterministically by call order (the lowest-index remaining call runs next, on its own).
+    This is a layered topological sort: each round, every call whose dependencies have all been scheduled forms the
+    next parallel batch. Dependency cycles — e.g. a tool that both reads and writes the same key, requested more than
+    once — cannot be ordered by the read-after-write rule alone, so they are broken deterministically by call order
+    (the lowest-index remaining call runs next, on its own).
 
-    Pure write-write overlaps create no dependency: nobody reads the contended key, and outputs are merged into
-    State sequentially in call order afterward, so the result stays deterministic without serializing execution.
+    Pure write-write overlaps create no dependency: nobody reads the contended key, and outputs are merged into State
+    sequentially in call order afterward, so the result stays deterministic without serializing execution.
 
     :param tool_calls: The tool calls to schedule, in call order.
     :param tools: The resolved Tool for each entry in `tool_calls` (parallel list).

--- a/releasenotes/notes/agent-parallel-tool-calls-state-dependencies-7b3c1f9a4e2d6c80.yaml
+++ b/releasenotes/notes/agent-parallel-tool-calls-state-dependencies-7b3c1f9a4e2d6c80.yaml
@@ -1,0 +1,16 @@
+---
+fixes:
+  - |
+    Fixed a bug in ``Agent`` (and the underlying tool invocation) where parallel tool calls in a single
+    step did not respect read/write dependencies on ``State``. Tool arguments were prepared once, up front,
+    from the initial state, so a tool reading a ``State`` key via ``inputs_from_state`` never observed a write
+    made by another tool in the same step via ``outputs_to_state``. For example, two calls to a retrieval tool
+    that both reads and writes the ``documents`` key would each see the original documents instead of the second
+    call seeing the first call's results.
+
+    Tool calls within a step are now scheduled into batches based on their ``inputs_from_state`` and
+    ``outputs_to_state`` mappings. Calls that only read, or that touch disjoint keys, still run in parallel;
+    a call that reads a key another call writes is run in a later batch, after that write has been merged into
+    ``State``, with its arguments re-prepared so it sees the updated value. Tools that receive the live
+    ``State`` object are treated as reading and writing every key and run on their own. The order the LLM
+    requested the calls in no longer affects correctness.

--- a/test/components/agents/test_tool_calling.py
+++ b/test/components/agents/test_tool_calling.py
@@ -22,6 +22,7 @@ from haystack.components.agents.tool_calling import (
     _result_to_string,
     _run_tool,
     _run_tool_async,
+    _schedule_tool_calls,
     _validate_and_prepare_tools,
 )
 from haystack.components.builders.prompt_builder import PromptBuilder
@@ -629,61 +630,6 @@ def _make_retrieval_tool():
     )
 
 
-class TestStateDependencyScheduling:
-    def test_read_write_same_key_runs_sequentially(self):
-        """Two calls to a tool that reads and writes the same key must serialize; the second sees the first's write."""
-        retrieval_tool = _make_retrieval_tool()
-        state = State(schema={"documents": {"type": list[Document]}})
-        message = ChatMessage.from_assistant(
-            tool_calls=[
-                ToolCall(id="1", tool_name="retrieval_tool", arguments={}),
-                ToolCall(id="2", tool_name="retrieval_tool", arguments={}),
-            ]
-        )
-
-        _run_tool(messages=[message], state=state, tools=[retrieval_tool])
-
-        assert [doc.content for doc in state.get("documents")] == ["doc-0", "doc-1"]
-
-    def test_reader_requested_before_writer_still_sees_write(self):
-        """A reader listed before a writer of the same key must still run after the writer (forced read-after-write)."""
-        seen = []
-
-        def reader_fn(val=None):
-            seen.append(val)
-            return {"ok": True}
-
-        def writer_fn():
-            return {"value": "written"}
-
-        reader_tool = Tool(
-            name="reader_tool",
-            description="Reads the value state key.",
-            parameters={"type": "object", "properties": {}},
-            function=reader_fn,
-            inputs_from_state={"value": "val"},
-        )
-        writer_tool = Tool(
-            name="writer_tool",
-            description="Writes the value state key.",
-            parameters={"type": "object", "properties": {}},
-            function=writer_fn,
-            outputs_to_state={"value": {"source": "value"}},
-        )
-        state = State(schema={"value": {"type": str}})
-        # Reader is listed *before* the writer; it must still observe the writer's output.
-        message = ChatMessage.from_assistant(
-            tool_calls=[
-                ToolCall(id="1", tool_name="reader_tool", arguments={}),
-                ToolCall(id="2", tool_name="writer_tool", arguments={}),
-            ]
-        )
-
-        _run_tool(messages=[message], state=state, tools=[reader_tool, writer_tool])
-
-        assert seen == ["written"]
-
-
 class TestRunToolErrorHandling:
     def test_tool_not_found_error(self, weather_tool):
         tool_call = ToolCall(tool_name="non_existent_tool", arguments={"location": "Berlin"})
@@ -991,6 +937,152 @@ class TestUtilities:
             TextContent(text="weather: mostly sunny"),
             TextContent(text="temperature: 7 celsius"),
         ]
+
+
+def _reader_tool(state_key: str = "documents", seen: list | None = None):
+    """A tool that reads `state_key` from State into its `value` param (no writes).
+
+    If `seen` is provided, the value the tool received is appended to it, so behavioral tests can assert what the
+    reader observed.
+    """
+
+    def reader_fn(value=None):
+        if seen is not None:
+            seen.append(value)
+        return {"ok": True}
+
+    return Tool(
+        name="reader_tool",
+        description="Reads from state.",
+        parameters={"type": "object", "properties": {}},
+        function=reader_fn,
+        inputs_from_state={state_key: "value"},
+    )
+
+
+def _writer_tool(state_key: str = "documents", value: str = "written"):
+    """A tool that writes `value` to `state_key` in State (no reads)."""
+
+    def writer_fn():
+        return {"out": value}
+
+    return Tool(
+        name="writer_tool",
+        description="Writes to state.",
+        parameters={"type": "object", "properties": {}},
+        function=writer_fn,
+        outputs_to_state={state_key: {"source": "out"}},
+    )
+
+
+def _state_param_tool():
+    """A tool that receives the live State object, so it may read/write any key."""
+
+    def fn(state: State) -> str:
+        return "done"
+
+    return Tool(
+        name="state_tool",
+        description="Receives the live State.",
+        parameters={"type": "object", "properties": {}},
+        function=fn,
+    )
+
+
+class TestScheduleToolCalls:
+    def test_no_calls_returns_no_batches(self):
+        assert _schedule_tool_calls([], []) == []
+
+    def test_single_call_is_one_batch(self):
+        assert _schedule_tool_calls([ToolCall(tool_name="writer_tool", arguments={})], [_writer_tool()]) == [[0]]
+
+    def test_read_only_calls_run_in_one_batch(self):
+        # Two readers of the same key: no writer, so no dependency — they run together.
+        calls = [ToolCall(tool_name="reader_tool", arguments={}), ToolCall(tool_name="reader_tool", arguments={})]
+        tools = [_reader_tool(), _reader_tool()]
+        assert _schedule_tool_calls(calls, tools) == [[0, 1]]
+
+    def test_disjoint_keys_run_in_one_batch(self):
+        # A writer of "a" and a reader of "b" don't overlap, so they run in parallel.
+        calls = [ToolCall(tool_name="writer_tool", arguments={}), ToolCall(tool_name="reader_tool", arguments={})]
+        tools = [_writer_tool("a"), _reader_tool("b")]
+        assert _schedule_tool_calls(calls, tools) == [[0, 1]]
+
+    def test_writer_then_reader_serializes(self):
+        # Writer listed first, reader second: reader depends on writer -> two batches.
+        calls = [ToolCall(tool_name="writer_tool", arguments={}), ToolCall(tool_name="reader_tool", arguments={})]
+        tools = [_writer_tool("docs"), _reader_tool("docs")]
+        assert _schedule_tool_calls(calls, tools) == [[0], [1]]
+
+    def test_reader_before_writer_is_reordered(self):
+        # Reader listed first, writer second: the writer must still run first.
+        calls = [ToolCall(tool_name="reader_tool", arguments={}), ToolCall(tool_name="writer_tool", arguments={})]
+        tools = [_reader_tool("docs"), _writer_tool("docs")]
+        assert _schedule_tool_calls(calls, tools) == [[1], [0]]
+
+    def test_pure_write_write_runs_in_one_batch(self):
+        # Two writers of the same key, neither reads it: no read-after-write dependency, so they run together.
+        calls = [ToolCall(tool_name="writer_tool", arguments={}), ToolCall(tool_name="writer_tool", arguments={})]
+        tools = [_writer_tool("docs"), _writer_tool("docs")]
+        assert _schedule_tool_calls(calls, tools) == [[0, 1]]
+
+    def test_read_write_cycle_breaks_by_call_order(self):
+        # Two retrieval tools that both read and write "documents" form a cycle; broken by call order.
+        calls = [ToolCall(tool_name="retrieval_tool", arguments={}), ToolCall(tool_name="retrieval_tool", arguments={})]
+        tools = [_make_retrieval_tool(), _make_retrieval_tool()]
+        assert _schedule_tool_calls(calls, tools) == [[0], [1]]
+
+    def test_state_param_tool_is_a_barrier(self):
+        # A State-typed tool reads/writes every key, so it serializes everything around it even when the other
+        # calls touch disjoint keys ("a" and "b"): writer("b") must run before the state tool (which reads "b"),
+        # and reader("a") must run after it (the state tool may write "a").
+        calls = [
+            ToolCall(tool_name="reader_tool", arguments={}),
+            ToolCall(tool_name="state_tool", arguments={}),
+            ToolCall(tool_name="writer_tool", arguments={}),
+        ]
+        tools = [_reader_tool("a"), _state_param_tool(), _writer_tool("b")]
+        assert _schedule_tool_calls(calls, tools) == [[2], [1], [0]]
+
+    def test_llm_supplied_arg_is_not_a_state_read(self):
+        # The reader's `value` param is supplied by the LLM, so it is not read from state -> no dep on the writer.
+        calls = [
+            ToolCall(tool_name="reader_tool", arguments={"value": "provided"}),
+            ToolCall(tool_name="writer_tool", arguments={}),
+        ]
+        tools = [_reader_tool("docs"), _writer_tool("docs")]
+        assert _schedule_tool_calls(calls, tools) == [[0, 1]]
+
+
+class TestStateDependencyScheduling:
+    def test_read_write_same_key_runs_sequentially(self):
+        """Two calls to a tool that reads and writes the same key must serialize; the second sees the first's write."""
+        retrieval_tool = _make_retrieval_tool()
+        state = State(schema={"documents": {"type": list[Document]}})
+        message = ChatMessage.from_assistant(
+            tool_calls=[
+                ToolCall(id="1", tool_name="retrieval_tool", arguments={}),
+                ToolCall(id="2", tool_name="retrieval_tool", arguments={}),
+            ]
+        )
+        _run_tool(messages=[message], state=state, tools=[retrieval_tool])
+        assert [doc.content for doc in state.get("documents")] == ["doc-0", "doc-1"]
+
+    def test_reader_requested_before_writer_still_sees_write(self):
+        """A reader listed before a writer of the same key must still run after the writer (forced read-after-write)."""
+        seen = []
+        reader_tool = _reader_tool("value", seen=seen)
+        writer_tool = _writer_tool("value")
+        state = State(schema={"value": {"type": str}})
+        # Reader is listed *before* the writer; it must still observe the writer's output.
+        message = ChatMessage.from_assistant(
+            tool_calls=[
+                ToolCall(id="1", tool_name="reader_tool", arguments={}),
+                ToolCall(id="2", tool_name="writer_tool", arguments={}),
+            ]
+        )
+        _run_tool(messages=[message], state=state, tools=[reader_tool, writer_tool])
+        assert seen == ["written"]
 
 
 class TestRunToolAsync:

--- a/test/components/agents/test_tool_calling.py
+++ b/test/components/agents/test_tool_calling.py
@@ -608,6 +608,82 @@ class TestRunTool:
         assert received_state["state"] is state
 
 
+def _make_retrieval_tool():
+    """A retrieval-like tool that both reads and writes the `documents` state key.
+
+    Each invocation returns a single Document labelled with the number of documents it observed in state,
+    so the result reveals whether it saw writes from earlier tool calls in the same step.
+    """
+
+    def retrieval_function(documents=None):
+        seen = len(documents) if documents else 0
+        return {"documents": [Document(content=f"doc-{seen}")]}
+
+    return Tool(
+        name="retrieval_tool",
+        description="Retrieves documents.",
+        parameters={"type": "object", "properties": {}},
+        function=retrieval_function,
+        inputs_from_state={"documents": "documents"},
+        outputs_to_state={"documents": {"source": "documents"}},
+    )
+
+
+class TestStateDependencyScheduling:
+    def test_read_write_same_key_runs_sequentially(self):
+        """Two calls to a tool that reads and writes the same key must serialize; the second sees the first's write."""
+        retrieval_tool = _make_retrieval_tool()
+        state = State(schema={"documents": {"type": list[Document]}})
+        message = ChatMessage.from_assistant(
+            tool_calls=[
+                ToolCall(id="1", tool_name="retrieval_tool", arguments={}),
+                ToolCall(id="2", tool_name="retrieval_tool", arguments={}),
+            ]
+        )
+
+        _run_tool(messages=[message], state=state, tools=[retrieval_tool])
+
+        assert [doc.content for doc in state.get("documents")] == ["doc-0", "doc-1"]
+
+    def test_reader_requested_before_writer_still_sees_write(self):
+        """A reader listed before a writer of the same key must still run after the writer (forced read-after-write)."""
+        seen = []
+
+        def reader_fn(val=None):
+            seen.append(val)
+            return {"ok": True}
+
+        def writer_fn():
+            return {"value": "written"}
+
+        reader_tool = Tool(
+            name="reader_tool",
+            description="Reads the value state key.",
+            parameters={"type": "object", "properties": {}},
+            function=reader_fn,
+            inputs_from_state={"value": "val"},
+        )
+        writer_tool = Tool(
+            name="writer_tool",
+            description="Writes the value state key.",
+            parameters={"type": "object", "properties": {}},
+            function=writer_fn,
+            outputs_to_state={"value": {"source": "value"}},
+        )
+        state = State(schema={"value": {"type": str}})
+        # Reader is listed *before* the writer; it must still observe the writer's output.
+        message = ChatMessage.from_assistant(
+            tool_calls=[
+                ToolCall(id="1", tool_name="reader_tool", arguments={}),
+                ToolCall(id="2", tool_name="writer_tool", arguments={}),
+            ]
+        )
+
+        _run_tool(messages=[message], state=state, tools=[reader_tool, writer_tool])
+
+        assert seen == ["written"]
+
+
 class TestRunToolErrorHandling:
     def test_tool_not_found_error(self, weather_tool):
         tool_call = ToolCall(tool_name="non_existent_tool", arguments={"location": "Berlin"})
@@ -972,3 +1048,19 @@ class TestRunToolAsync:
         await _run_tool_async(messages=[message], state=State(schema={}), tools=[slow_tool], max_workers=1)
 
         assert max_active == 1
+
+    @pytest.mark.asyncio
+    async def test_read_write_same_key_runs_sequentially(self):
+        """Two calls to a tool that reads and writes the same key must serialize; the second sees the first's write."""
+        retrieval_tool = _make_retrieval_tool()
+        state = State(schema={"documents": {"type": list[Document]}})
+        message = ChatMessage.from_assistant(
+            tool_calls=[
+                ToolCall(id="1", tool_name="retrieval_tool", arguments={}),
+                ToolCall(id="2", tool_name="retrieval_tool", arguments={}),
+            ]
+        )
+
+        await _run_tool_async(messages=[message], state=state, tools=[retrieval_tool])
+
+        assert [doc.content for doc in state.get("documents")] == ["doc-0", "doc-1"]


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/408

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fixed a bug in ``Agent`` (and the underlying tool invocation) where parallel tool calls in a single step did not respect read/write dependencies on ``State``. Tool arguments were prepared once, up front, from the initial state, so a tool reading a ``State`` key via ``inputs_from_state`` never observed a write made by another tool in the same step via ``outputs_to_state``. For example, two calls to a retrieval tool that both reads and writes the ``documents`` key would each see the original documents instead of the second call seeing the first call's results.

Tool calls within a step are now scheduled into batches based on their ``inputs_from_state`` and ``outputs_to_state`` mappings. Calls that only read, or that touch disjoint keys, still run in parallel; a call that reads a key another call writes is run in a later batch, after that write has been merged into ``State``, with its arguments re-prepared so it sees the updated value. Tools that receive the live ``State`` object are treated as reading and writing every key and run on their own. The order the LLM requested the calls in no longer affects correctness.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests and added regression tests exemplifying the previous incorrect behavior. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
