### PR TITLE
fix: FilterError when comparing string metadata dates with datetime objects

### DIFF
--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -59,8 +59,10 @@ def _not_equal(value: Any, filter_value: Any) -> bool:
 def _prepare_ordering_comparison(value: Any, filter_value: Any) -> tuple[Any, Any]:
     """Normalize both values for ordering comparisons, parsing strings as dates."""
     if isinstance(value, str) or isinstance(filter_value, str):
-        value = _parse_date(value)
-        filter_value = _parse_date(filter_value)
+        if not isinstance(value, datetime):
+            value = _parse_date(value)
+        if not isinstance(filter_value, datetime):
+            filter_value = _parse_date(filter_value)
         value, filter_value = _ensure_both_dates_naive_or_aware(value, filter_value)
 
     if isinstance(filter_value, list):

--- a/releasenotes/notes/filter-date-comparison-056e3b2d0a159a53.yaml
+++ b/releasenotes/notes/filter-date-comparison-056e3b2d0a159a53.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed ``document_matches_filter`` raising a ``FilterError`` when comparing a string date in
+    ``Document.meta`` against a ``datetime`` object using ordering operators (``>``, ``>=``, ``<``, ``<=``).

--- a/test/utils/test_filters.py
+++ b/test/utils/test_filters.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime, timezone
+
 import pytest
 
 from haystack import Document
@@ -128,6 +130,12 @@ document_matches_filter_data = [
         Document(meta={"date": "1969-07-21T20:17:40"}),
         False,
         id="> operator with smaller ISO 8601 datetime Document value",
+    ),
+    pytest.param(
+        {"field": "meta.date", "operator": ">", "value": datetime(2023, 1, 1, tzinfo=timezone.utc)},
+        Document(meta={"date": "2024-01-01T00:00:00+00:00"}),
+        True,
+        id="> operator with datetime filter value and ISO 8601 string Document value",
     ),
     pytest.param(
         {"field": "meta.page", "operator": ">", "value": 10},

--- a/test/utils/test_filters.py
+++ b/test/utils/test_filters.py
@@ -138,6 +138,12 @@ document_matches_filter_data = [
         id="> operator with datetime filter value and ISO 8601 string Document value",
     ),
     pytest.param(
+        {"field": "meta.date", "operator": ">", "value": "2023-01-01T00:00:00+00:00"},
+        Document(meta={"date": datetime(2024, 1, 1, tzinfo=timezone.utc)}),
+        True,
+        id="> operator with ISO 8601 string filter value and datetime Document value",
+    ),
+    pytest.param(
         {"field": "meta.page", "operator": ">", "value": 10},
         Document(),
         False,


### PR DESCRIPTION
### Related Issues

- fixes #11678

### Proposed Changes:

`document_matches_filter` raised a `FilterError` when comparing a string date in `Document.meta` (e.g. `"2024-01-01"`) against a `datetime` filter value using ordering operators (`>`, `>=`, `<`, `<=`), even though storing dates as ISO strings in metadata is a common, valid pattern.

Root cause: `_prepare_ordering_comparison` in `haystack/utils/filters.py` unconditionally called `_parse_date` on both operands whenever either one was a string, but `_parse_date` only accepts `str` and raised when given an already-parsed `datetime`.

Fix: only call `_parse_date` on an operand that isn't already a `datetime`.

### How did you test it?

- Added a regression test reproducing the issue (`> operator with datetime filter value and ISO 8601 string Document value`) in `test/utils/test_filters.py`.
- Ran `hatch run test:unit -k test_filters` (91 passed, including the 4 existing tests that cover non-date string/int comparisons still raising `FilterError` as before).
- Ran `hatch run test:types` and `hatch run fmt`, both clean.

### Notes for the reviewer

The fix only skips `_parse_date` when an operand is already a `datetime`; it still attempts `_parse_date` on non-string, non-datetime operands (e.g. `int`) so existing behavior — raising `FilterError` for nonsensical string/non-date comparisons — is preserved.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title: `fix:`.
- [x] I have documented my code.
- [x] I have added a release note file.
- [x] I have run pre-commit hooks and fixed any issue.