### PR TITLE
fix: AnswerJoiner no longer crashes when sorting answers with a None score

### DIFF
--- a/haystack/components/joiners/answer_joiner.py
+++ b/haystack/components/joiners/answer_joiner.py
@@ -130,7 +130,9 @@ class AnswerJoiner:
 
         if self.sort_by_score:
             output_answers = sorted(
-                output_answers, key=lambda answer: answer.score if hasattr(answer, "score") else -inf, reverse=True
+                output_answers,
+                key=lambda answer: score if (score := getattr(answer, "score", None)) is not None else -inf,
+                reverse=True,
             )
 
         top_k = top_k or self.top_k

--- a/releasenotes/notes/fix-answerjoiner-sort-by-score-none-30d33e2bc93fd668.yaml
+++ b/releasenotes/notes/fix-answerjoiner-sort-by-score-none-30d33e2bc93fd668.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a ``TypeError`` in ``AnswerJoiner`` when running with ``sort_by_score=True`` and at least one
+    answer had a ``score`` of ``None``. As documented, an answer without a score is now treated as if its
+    score were negative infinity and sorted last, instead of raising
+    ``TypeError: '<' not supported between instances of 'float' and 'NoneType'``.

--- a/test/components/joiners/test_answer_joiner.py
+++ b/test/components/joiners/test_answer_joiner.py
@@ -100,3 +100,31 @@ class TestAnswerJoiner:
         unsupported_mode = "unsupported_mode"
         with pytest.raises(ValueError):
             AnswerJoiner(join_mode=unsupported_mode)
+
+    def test_sort_by_score(self):
+        joiner = AnswerJoiner(sort_by_score=True)
+        answers1 = [ExtractedAnswer(query="a", score=0.3, meta={}, document=Document(content="a"))]
+        answers2 = [ExtractedAnswer(query="b", score=0.9, meta={}, document=Document(content="b"))]
+        result = joiner.run([answers1, answers2])
+        scores = [answer.score for answer in result["answers"]]
+        assert scores == [0.9, 0.3]
+
+    def test_sort_by_score_with_none_score(self):
+        # The docstring promises that an answer with no score is handled as if its score is -infinity.
+        # ExtractedAnswer with score=None must not raise a TypeError during sorting and must be sorted last.
+        joiner = AnswerJoiner(sort_by_score=True)
+        answers1 = [ExtractedAnswer(query="a", score=0.5, meta={}, document=Document(content="a"))]
+        answers2 = [ExtractedAnswer(query="b", score=None, meta={}, document=Document(content="b"))]  # type: ignore[arg-type]
+        result = joiner.run([answers1, answers2])
+        assert [answer.data for answer in result["answers"]] == [None, None]
+        assert [answer.score for answer in result["answers"]] == [0.5, None]
+
+    def test_sort_by_score_with_answers_missing_score_attribute(self):
+        # GeneratedAnswer has no score attribute at all; it must be handled as -infinity and sorted last.
+        joiner = AnswerJoiner(sort_by_score=True)
+        answers1 = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
+        answers2 = [ExtractedAnswer(query="b", score=0.9, meta={}, document=Document(content="b"))]
+        result = joiner.run([answers1, answers2])
+        # The ExtractedAnswer (score 0.9) comes first, the GeneratedAnswer (no score) comes last.
+        assert isinstance(result["answers"][0], ExtractedAnswer)
+        assert isinstance(result["answers"][1], GeneratedAnswer)


### PR DESCRIPTION
### Related Issues

None. Bug found during code review; no existing tracking issue.

### Proposed Changes:

`AnswerJoiner.run(sort_by_score=True)` raised `TypeError: '<' not supported between instances of 'float' and 'NoneType'` whenever any answer had `score=None`. The docstring states that an answer without a score is treated as if its score were negative infinity, but the sort key guarded on `hasattr(answer, "score")`, which is `True` for an `ExtractedAnswer` whose `score` is `None`. The key now uses `getattr(answer, "score", None)` and falls back to `-inf` when the value is missing or `None`, so such answers sort last as documented.

### How did you test it?

Added three regression tests to `test/components/joiners/test_answer_joiner.py`: a `None` score, an answer type with no `score` attribute (`GeneratedAnswer`), and ordinary score ordering. Verified that the new `None`-score test fails against the pre-fix code with the exact `TypeError`, then passes with the fix. `hatch run test:unit test/components/joiners/` passes (78), `hatch run test:types` (mypy) is clean, and `hatch run fmt` reports no changes.

### Notes for the reviewer

Minimal, isolated change to one component plus tests and a release note. The docstring already documented the negative-infinity behavior, so the fix brings the code in line with the documented contract rather than changing it.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
