### PR TITLE
feat: add MockTextEmbedder and MockDocumentEmbedder

### DIFF
--- a/haystack/components/embedders/__init__.py
+++ b/haystack/components/embedders/__init__.py
@@ -10,6 +10,8 @@ from lazy_imports import LazyImporter
 _import_structure = {
     "azure_document_embedder": ["AzureOpenAIDocumentEmbedder"],
     "azure_text_embedder": ["AzureOpenAITextEmbedder"],
+    "mock_document_embedder": ["MockDocumentEmbedder"],
+    "mock_text_embedder": ["MockTextEmbedder"],
     "openai_document_embedder": ["OpenAIDocumentEmbedder"],
     "openai_text_embedder": ["OpenAITextEmbedder"],
 }
@@ -17,6 +19,8 @@ _import_structure = {
 if TYPE_CHECKING:
     from .azure_document_embedder import AzureOpenAIDocumentEmbedder as AzureOpenAIDocumentEmbedder
     from .azure_text_embedder import AzureOpenAITextEmbedder as AzureOpenAITextEmbedder
+    from .mock_document_embedder import MockDocumentEmbedder as MockDocumentEmbedder
+    from .mock_text_embedder import MockTextEmbedder as MockTextEmbedder
     from .openai_document_embedder import OpenAIDocumentEmbedder as OpenAIDocumentEmbedder
     from .openai_text_embedder import OpenAITextEmbedder as OpenAITextEmbedder
 

--- a/haystack/components/embedders/mock_document_embedder.py
+++ b/haystack/components/embedders/mock_document_embedder.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from haystack import Document, component, default_from_dict, default_to_dict
+from haystack.components.embedders.mock_utils import (
+    EmbeddingFn,
+    _coerce_embedding,
+    _deterministic_embedding,
+    _estimate_usage,
+    _validate_embedding,
+)
+from haystack.utils import deserialize_callable, serialize_callable
+
+
+@component
+class MockDocumentEmbedder:
+    """
+    A Document Embedder that returns deterministic embeddings without calling any API.
+
+    It is a drop-in replacement for real Document Embedders (such as `OpenAIDocumentEmbedder`) in tests, smoke tests,
+    and quick prototypes. It implements the same interface (`run`, `run_async`, serialization) but never contacts an
+    external service, so it is fully deterministic and free to run.
+
+    The embedding is selected based on how the component is configured:
+
+    - **Deterministic (default)**: with no configuration, each document's embedding is derived from a hash of its
+      (prepared) text. The same text always yields the same embedding, and different texts yield different
+      embeddings, so the mock works in retrieval pipelines and is reproducible across runs and processes.
+    - **Fixed embedding**: pass an `embedding` vector. The same vector is assigned to every document.
+    - **Dynamic embedding**: pass an `embedding_fn` callable that receives the (prepared) text of a document and
+      returns the embedding. This is useful when the embedding should depend on the input in a custom way.
+
+    Like real Document Embedders, the metadata fields listed in `meta_fields_to_embed` are concatenated with the
+    document content before embedding, so the deterministic embedding reflects the embedded metadata.
+
+    ### Usage example
+
+    ```python
+    from haystack import Document
+    from haystack.components.embedders import MockDocumentEmbedder
+
+    embedder = MockDocumentEmbedder(dimension=8)
+    result = embedder.run([Document(content="I love pizza!")])
+    print(result["documents"][0].embedding)  # a deterministic list of 8 floats
+    ```
+    """
+
+    def __init__(
+        self,
+        embedding: list[float] | None = None,
+        *,
+        embedding_fn: EmbeddingFn | None = None,
+        dimension: int = 768,
+        model: str = "mock-model",
+        meta: dict[str, Any] | None = None,
+        prefix: str = "",
+        suffix: str = "",
+        meta_fields_to_embed: list[str] | None = None,
+        embedding_separator: str = "\n",
+        progress_bar: bool = False,
+    ) -> None:
+        """
+        Creates an instance of MockDocumentEmbedder.
+
+        :param embedding: An optional fixed embedding assigned to every document. Mutually exclusive with
+            `embedding_fn`. If neither is provided, a deterministic embedding is derived from each document's text.
+        :param embedding_fn: An optional callable that receives the prepared text of a document and returns the
+            embedding as a list of floats. Mutually exclusive with `embedding`. To support serialization, pass a
+            named function (lambdas and nested functions cannot be serialized).
+        :param dimension: The number of dimensions of the deterministic embedding. Ignored when `embedding` or
+            `embedding_fn` is provided, since their length is determined by the value or callable.
+        :param model: The model name reported in the metadata. Purely cosmetic; no model is loaded.
+        :param meta: Additional metadata merged into the output `meta`.
+        :param prefix: A string to add at the beginning of each text before embedding.
+        :param suffix: A string to add at the end of each text before embedding.
+        :param meta_fields_to_embed: List of metadata fields to embed along with the document text.
+        :param embedding_separator: Separator used to concatenate the metadata fields to the document text.
+        :param progress_bar: Accepted for interface compatibility with real Document Embedders and ignored.
+        :raises ValueError: If both `embedding` and `embedding_fn` are provided, or if `dimension` is not positive.
+        """
+        if embedding is not None and embedding_fn is not None:
+            raise ValueError("Pass either 'embedding' or 'embedding_fn', not both.")
+        if dimension <= 0:
+            raise ValueError("'dimension' must be a positive integer.")
+
+        self.embedding = _validate_embedding(embedding) if embedding is not None else None
+        self.embedding_fn = embedding_fn
+        self.dimension = dimension
+        self.model = model
+        self.meta = meta or {}
+        self.prefix = prefix
+        self.suffix = suffix
+        self.meta_fields_to_embed = meta_fields_to_embed or []
+        self.embedding_separator = embedding_separator
+        self.progress_bar = progress_bar
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the component to a dictionary."""
+        embedding_fn = serialize_callable(self.embedding_fn) if self.embedding_fn is not None else None
+        return default_to_dict(
+            self,
+            embedding=self.embedding,
+            embedding_fn=embedding_fn,
+            dimension=self.dimension,
+            model=self.model,
+            meta=self.meta,
+            prefix=self.prefix,
+            suffix=self.suffix,
+            meta_fields_to_embed=self.meta_fields_to_embed,
+            embedding_separator=self.embedding_separator,
+            progress_bar=self.progress_bar,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MockDocumentEmbedder:
+        """Deserialize the component from a dictionary."""
+        init_params = data.get("init_parameters", {})
+        embedding_fn = init_params.get("embedding_fn")
+        if embedding_fn:
+            init_params["embedding_fn"] = deserialize_callable(embedding_fn)
+        return default_from_dict(cls, data)
+
+    def _prepare_text_to_embed(self, document: Document) -> str:
+        """Concatenate the document content with the metadata fields to embed, mirroring real Document Embedders."""
+        meta_values_to_embed = [
+            str(document.meta[key])
+            for key in self.meta_fields_to_embed
+            if key in document.meta and document.meta[key] is not None
+        ]
+        return (
+            self.prefix + self.embedding_separator.join([*meta_values_to_embed, document.content or ""]) + self.suffix
+        )
+
+    def _embed(self, text: str) -> list[float]:
+        """Produce the embedding for the prepared text according to the configured mode."""
+        if self.embedding_fn is not None:
+            return _coerce_embedding(self.embedding_fn(text))
+        if self.embedding is not None:
+            return list(self.embedding)
+        return _deterministic_embedding(text, self.dimension)
+
+    @component.output_types(documents=list[Document], meta=dict[str, Any])
+    def run(self, documents: list[Document]) -> dict[str, Any]:
+        """
+        Return the input documents with deterministic embeddings added, without calling any API.
+
+        :param documents: A list of documents to embed.
+        :returns: A dictionary with the following keys:
+            - `documents`: A list of documents with embeddings.
+            - `meta`: Metadata about the (mock) model.
+        :raises TypeError: If `documents` is not a list of `Document` objects.
+        """
+        if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
+            raise TypeError(
+                "MockDocumentEmbedder expects a list of Documents as input. "
+                "In case you want to embed a string, please use the MockTextEmbedder."
+            )
+
+        texts_to_embed = [self._prepare_text_to_embed(document) for document in documents]
+        new_documents = [
+            replace(document, embedding=self._embed(text))
+            for document, text in zip(documents, texts_to_embed, strict=True)
+        ]
+
+        meta: dict[str, Any] = {"model": self.model, "usage": _estimate_usage(texts_to_embed)}
+        meta.update(self.meta)
+        return {"documents": new_documents, "meta": meta}
+
+    @component.output_types(documents=list[Document], meta=dict[str, Any])
+    async def run_async(self, documents: list[Document]) -> dict[str, Any]:
+        """
+        Asynchronously return the input documents with deterministic embeddings added, without calling any API.
+
+        :param documents: A list of documents to embed.
+        :returns: A dictionary with the following keys:
+            - `documents`: A list of documents with embeddings.
+            - `meta`: Metadata about the (mock) model.
+        :raises TypeError: If `documents` is not a list of `Document` objects.
+        """
+        return self.run(documents=documents)

--- a/haystack/components/embedders/mock_document_embedder.py
+++ b/haystack/components/embedders/mock_document_embedder.py
@@ -82,7 +82,9 @@ class MockDocumentEmbedder:
         :param meta_fields_to_embed: List of metadata fields to embed along with the document text.
         :param embedding_separator: Separator used to concatenate the metadata fields to the document text.
         :param progress_bar: Accepted for interface compatibility with real Document Embedders and ignored.
-        :raises ValueError: If both `embedding` and `embedding_fn` are provided, or if `dimension` is not positive.
+        :raises ValueError: If both `embedding` and `embedding_fn` are provided, if `dimension` is not positive, or
+            if `embedding` is an empty list.
+        :raises TypeError: If `embedding` is not a sequence of numbers.
         """
         if embedding is not None and embedding_fn is not None:
             raise ValueError("Pass either 'embedding' or 'embedding_fn', not both.")

--- a/haystack/components/embedders/mock_document_embedder.py
+++ b/haystack/components/embedders/mock_document_embedder.py
@@ -13,7 +13,6 @@ from haystack.components.embedders.mock_utils import (
     _coerce_embedding,
     _deterministic_embedding,
     _estimate_usage,
-    _validate_embedding,
 )
 from haystack.utils import deserialize_callable, serialize_callable
 
@@ -91,7 +90,7 @@ class MockDocumentEmbedder:
         if dimension <= 0:
             raise ValueError("'dimension' must be a positive integer.")
 
-        self.embedding = _validate_embedding(embedding) if embedding is not None else None
+        self.embedding = _coerce_embedding(embedding, name="'embedding'") if embedding is not None else None
         self.embedding_fn = embedding_fn
         self.dimension = dimension
         self.model = model
@@ -147,7 +146,7 @@ class MockDocumentEmbedder:
     def _embed(self, text: str) -> list[float]:
         """Produce the embedding for the prepared text according to the configured mode."""
         if self.embedding_fn is not None:
-            return _coerce_embedding(self.embedding_fn(text))
+            return _coerce_embedding(self.embedding_fn(text), name="the return value of 'embedding_fn'")
         if self.embedding is not None:
             return list(self.embedding)
         return _deterministic_embedding(text, self.dimension)

--- a/haystack/components/embedders/mock_document_embedder.py
+++ b/haystack/components/embedders/mock_document_embedder.py
@@ -163,8 +163,7 @@ class MockDocumentEmbedder:
             - `meta`: Metadata about the (mock) model.
         :raises TypeError: If `documents` is not a list of `Document` objects.
         """
-        if not self._is_warmed_up:
-            self.warm_up()
+        self.warm_up()
 
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             raise TypeError(

--- a/haystack/components/embedders/mock_document_embedder.py
+++ b/haystack/components/embedders/mock_document_embedder.py
@@ -101,6 +101,7 @@ class MockDocumentEmbedder:
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
         self.progress_bar = progress_bar
+        self._is_warmed_up = False
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the component to a dictionary."""
@@ -130,6 +131,7 @@ class MockDocumentEmbedder:
 
     def warm_up(self) -> None:
         """No-op warm up, provided for interface compatibility with real Embedders."""
+        self._is_warmed_up = True
 
     def _prepare_text_to_embed(self, document: Document) -> str:
         """Concatenate the document content with the metadata fields to embed, mirroring real Document Embedders."""
@@ -161,6 +163,9 @@ class MockDocumentEmbedder:
             - `meta`: Metadata about the (mock) model.
         :raises TypeError: If `documents` is not a list of `Document` objects.
         """
+        if not self._is_warmed_up:
+            self.warm_up()
+
         if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             raise TypeError(
                 "MockDocumentEmbedder expects a list of Documents as input. "

--- a/haystack/components/embedders/mock_document_embedder.py
+++ b/haystack/components/embedders/mock_document_embedder.py
@@ -128,6 +128,9 @@ class MockDocumentEmbedder:
             init_params["embedding_fn"] = deserialize_callable(embedding_fn)
         return default_from_dict(cls, data)
 
+    def warm_up(self) -> None:
+        """No-op warm up, provided for interface compatibility with real Embedders."""
+
     def _prepare_text_to_embed(self, document: Document) -> str:
         """Concatenate the document content with the metadata fields to embed, mirroring real Document Embedders."""
         meta_values_to_embed = [

--- a/haystack/components/embedders/mock_text_embedder.py
+++ b/haystack/components/embedders/mock_text_embedder.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from haystack import component, default_from_dict, default_to_dict
+from haystack.components.embedders.mock_utils import (
+    EmbeddingFn,
+    _coerce_embedding,
+    _deterministic_embedding,
+    _estimate_usage,
+    _validate_embedding,
+)
+from haystack.utils import deserialize_callable, serialize_callable
+
+
+@component
+class MockTextEmbedder:
+    """
+    A Text Embedder that returns deterministic embeddings without calling any API.
+
+    It is a drop-in replacement for real Text Embedders (such as `OpenAITextEmbedder`) in tests, smoke tests, and
+    quick prototypes. It implements the same interface (`run`, `run_async`, serialization) but never contacts an
+    external service, so it is fully deterministic and free to run.
+
+    The embedding is selected based on how the component is configured:
+
+    - **Deterministic (default)**: with no configuration, the embedding is derived from a hash of the input text.
+      The same text always yields the same embedding, and different texts yield different embeddings, so the mock
+      works in retrieval pipelines and is reproducible across runs and processes.
+    - **Fixed embedding**: pass an `embedding` vector. The same vector is returned for every input.
+    - **Dynamic embedding**: pass an `embedding_fn` callable that receives the (prepared) text and returns the
+      embedding. This is useful when the embedding should depend on the input in a custom way.
+
+    ### Usage example
+
+    ```python
+    from haystack.components.embedders import MockTextEmbedder
+
+    embedder = MockTextEmbedder(dimension=8)
+    result = embedder.run("I love pizza!")
+    print(result["embedding"])  # a deterministic list of 8 floats
+    ```
+    """
+
+    def __init__(
+        self,
+        embedding: list[float] | None = None,
+        *,
+        embedding_fn: EmbeddingFn | None = None,
+        dimension: int = 768,
+        model: str = "mock-model",
+        meta: dict[str, Any] | None = None,
+        prefix: str = "",
+        suffix: str = "",
+    ) -> None:
+        """
+        Creates an instance of MockTextEmbedder.
+
+        :param embedding: An optional fixed embedding returned for every input. Mutually exclusive with
+            `embedding_fn`. If neither is provided, a deterministic embedding is derived from the input text.
+        :param embedding_fn: An optional callable that receives the prepared text (after `prefix`/`suffix` are
+            applied) and returns the embedding as a list of floats. Mutually exclusive with `embedding`. To support
+            serialization, pass a named function (lambdas and nested functions cannot be serialized).
+        :param dimension: The number of dimensions of the deterministic embedding. Ignored when `embedding` or
+            `embedding_fn` is provided, since their length is determined by the value or callable.
+        :param model: The model name reported in the metadata. Purely cosmetic; no model is loaded.
+        :param meta: Additional metadata merged into the output `meta`.
+        :param prefix: A string to add at the beginning of the text before embedding.
+        :param suffix: A string to add at the end of the text before embedding.
+        :raises ValueError: If both `embedding` and `embedding_fn` are provided, or if `dimension` is not positive.
+        """
+        if embedding is not None and embedding_fn is not None:
+            raise ValueError("Pass either 'embedding' or 'embedding_fn', not both.")
+        if dimension <= 0:
+            raise ValueError("'dimension' must be a positive integer.")
+
+        self.embedding = _validate_embedding(embedding) if embedding is not None else None
+        self.embedding_fn = embedding_fn
+        self.dimension = dimension
+        self.model = model
+        self.meta = meta or {}
+        self.prefix = prefix
+        self.suffix = suffix
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the component to a dictionary."""
+        embedding_fn = serialize_callable(self.embedding_fn) if self.embedding_fn is not None else None
+        return default_to_dict(
+            self,
+            embedding=self.embedding,
+            embedding_fn=embedding_fn,
+            dimension=self.dimension,
+            model=self.model,
+            meta=self.meta,
+            prefix=self.prefix,
+            suffix=self.suffix,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MockTextEmbedder:
+        """Deserialize the component from a dictionary."""
+        init_params = data.get("init_parameters", {})
+        embedding_fn = init_params.get("embedding_fn")
+        if embedding_fn:
+            init_params["embedding_fn"] = deserialize_callable(embedding_fn)
+        return default_from_dict(cls, data)
+
+    def _embed(self, text: str) -> list[float]:
+        """Produce the embedding for the prepared text according to the configured mode."""
+        if self.embedding_fn is not None:
+            return _coerce_embedding(self.embedding_fn(text))
+        if self.embedding is not None:
+            return list(self.embedding)
+        return _deterministic_embedding(text, self.dimension)
+
+    @component.output_types(embedding=list[float], meta=dict[str, Any])
+    def run(self, text: str) -> dict[str, Any]:
+        """
+        Return a deterministic embedding for the input text without calling any API.
+
+        :param text: The text to embed.
+        :returns: A dictionary with the following keys:
+            - `embedding`: The embedding of the input text.
+            - `meta`: Metadata about the (mock) model.
+        :raises TypeError: If `text` is not a string.
+        """
+        if not isinstance(text, str):
+            raise TypeError(
+                "MockTextEmbedder expects a string as an input. "
+                "In case you want to embed a list of Documents, please use the MockDocumentEmbedder."
+            )
+
+        text_to_embed = self.prefix + text + self.suffix
+        meta: dict[str, Any] = {"model": self.model, "usage": _estimate_usage([text_to_embed])}
+        meta.update(self.meta)
+        return {"embedding": self._embed(text_to_embed), "meta": meta}
+
+    @component.output_types(embedding=list[float], meta=dict[str, Any])
+    async def run_async(self, text: str) -> dict[str, Any]:
+        """
+        Asynchronously return a deterministic embedding for the input text without calling any API.
+
+        :param text: The text to embed.
+        :returns: A dictionary with the following keys:
+            - `embedding`: The embedding of the input text.
+            - `meta`: Metadata about the (mock) model.
+        :raises TypeError: If `text` is not a string.
+        """
+        return self.run(text=text)

--- a/haystack/components/embedders/mock_text_embedder.py
+++ b/haystack/components/embedders/mock_text_embedder.py
@@ -71,7 +71,9 @@ class MockTextEmbedder:
         :param meta: Additional metadata merged into the output `meta`.
         :param prefix: A string to add at the beginning of the text before embedding.
         :param suffix: A string to add at the end of the text before embedding.
-        :raises ValueError: If both `embedding` and `embedding_fn` are provided, or if `dimension` is not positive.
+        :raises ValueError: If both `embedding` and `embedding_fn` are provided, if `dimension` is not positive, or
+            if `embedding` is an empty list.
+        :raises TypeError: If `embedding` is not a sequence of numbers.
         """
         if embedding is not None and embedding_fn is not None:
             raise ValueError("Pass either 'embedding' or 'embedding_fn', not both.")

--- a/haystack/components/embedders/mock_text_embedder.py
+++ b/haystack/components/embedders/mock_text_embedder.py
@@ -111,6 +111,9 @@ class MockTextEmbedder:
             init_params["embedding_fn"] = deserialize_callable(embedding_fn)
         return default_from_dict(cls, data)
 
+    def warm_up(self) -> None:
+        """No-op warm up, provided for interface compatibility with real Embedders."""
+
     def _embed(self, text: str) -> list[float]:
         """Produce the embedding for the prepared text according to the configured mode."""
         if self.embedding_fn is not None:

--- a/haystack/components/embedders/mock_text_embedder.py
+++ b/haystack/components/embedders/mock_text_embedder.py
@@ -135,8 +135,7 @@ class MockTextEmbedder:
             - `meta`: Metadata about the (mock) model.
         :raises TypeError: If `text` is not a string.
         """
-        if not self._is_warmed_up:
-            self.warm_up()
+        self.warm_up()
 
         if not isinstance(text, str):
             raise TypeError(

--- a/haystack/components/embedders/mock_text_embedder.py
+++ b/haystack/components/embedders/mock_text_embedder.py
@@ -87,6 +87,7 @@ class MockTextEmbedder:
         self.meta = meta or {}
         self.prefix = prefix
         self.suffix = suffix
+        self._is_warmed_up = False
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the component to a dictionary."""
@@ -113,6 +114,7 @@ class MockTextEmbedder:
 
     def warm_up(self) -> None:
         """No-op warm up, provided for interface compatibility with real Embedders."""
+        self._is_warmed_up = True
 
     def _embed(self, text: str) -> list[float]:
         """Produce the embedding for the prepared text according to the configured mode."""
@@ -133,6 +135,9 @@ class MockTextEmbedder:
             - `meta`: Metadata about the (mock) model.
         :raises TypeError: If `text` is not a string.
         """
+        if not self._is_warmed_up:
+            self.warm_up()
+
         if not isinstance(text, str):
             raise TypeError(
                 "MockTextEmbedder expects a string as an input. "

--- a/haystack/components/embedders/mock_text_embedder.py
+++ b/haystack/components/embedders/mock_text_embedder.py
@@ -12,7 +12,6 @@ from haystack.components.embedders.mock_utils import (
     _coerce_embedding,
     _deterministic_embedding,
     _estimate_usage,
-    _validate_embedding,
 )
 from haystack.utils import deserialize_callable, serialize_callable
 
@@ -80,7 +79,7 @@ class MockTextEmbedder:
         if dimension <= 0:
             raise ValueError("'dimension' must be a positive integer.")
 
-        self.embedding = _validate_embedding(embedding) if embedding is not None else None
+        self.embedding = _coerce_embedding(embedding, name="'embedding'") if embedding is not None else None
         self.embedding_fn = embedding_fn
         self.dimension = dimension
         self.model = model
@@ -119,7 +118,7 @@ class MockTextEmbedder:
     def _embed(self, text: str) -> list[float]:
         """Produce the embedding for the prepared text according to the configured mode."""
         if self.embedding_fn is not None:
-            return _coerce_embedding(self.embedding_fn(text))
+            return _coerce_embedding(self.embedding_fn(text), name="the return value of 'embedding_fn'")
         if self.embedding is not None:
             return list(self.embedding)
         return _deterministic_embedding(text, self.dimension)

--- a/haystack/components/embedders/mock_utils.py
+++ b/haystack/components/embedders/mock_utils.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import math
+import random
+from collections.abc import Callable
+
+# A callable that derives an embedding from the (prepared) text to embed. It receives the text and returns the
+# embedding as a list of floats.
+EmbeddingFn = Callable[[str], list[float]]
+
+
+def _l2_normalize(vector: list[float]) -> list[float]:
+    """Return the L2-normalized vector, so that mock embeddings behave like real (unit-length) ones."""
+    norm = math.sqrt(sum(value * value for value in vector))
+    if norm == 0.0:
+        return vector
+    return [value / norm for value in vector]
+
+
+def _deterministic_embedding(text: str, dimension: int) -> list[float]:
+    """
+    Generate a deterministic, unit-length embedding from the given text.
+
+    The same text always yields the same embedding, and different texts yield different embeddings, which makes mock
+    embeddings usable in retrieval pipelines and reproducible across runs and processes. The seed is derived from a
+    SHA-256 digest of the text (not the process-salted built-in `hash`) to guarantee cross-process stability.
+
+    :param text: The text to embed.
+    :param dimension: The number of dimensions of the resulting embedding.
+    :returns: A deterministic, L2-normalized embedding of length `dimension`.
+    """
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    seed = int.from_bytes(digest[:8], "big")
+    rng = random.Random(seed)
+    vector = [rng.uniform(-1.0, 1.0) for _ in range(dimension)]
+    return _l2_normalize(vector)
+
+
+def _coerce_embedding(result: object) -> list[float]:
+    """Validate and coerce the output of an `embedding_fn` into a list of floats."""
+    if not isinstance(result, (list, tuple)) or not all(isinstance(value, (int, float)) for value in result):
+        raise TypeError(f"'embedding_fn' must return a sequence of numbers, got {type(result)}.")
+    return [float(value) for value in result]
+
+
+def _validate_embedding(embedding: list[float]) -> list[float]:
+    """Validate that a user-provided fixed embedding is a non-empty sequence of numbers."""
+    if not isinstance(embedding, (list, tuple)) or not all(isinstance(value, (int, float)) for value in embedding):
+        raise TypeError(f"'embedding' must be a sequence of numbers, got {type(embedding)}.")
+    if len(embedding) == 0:
+        raise ValueError("'embedding' must not be empty.")
+    return [float(value) for value in embedding]
+
+
+def _estimate_usage(texts: list[str]) -> dict[str, int]:
+    """
+    Roughly estimate token usage as whitespace-separated word counts.
+
+    This is an approximation (not real tokenization) intended to give downstream code realistic-looking metadata.
+    """
+    prompt_tokens = sum(len(text.split()) for text in texts)
+    return {"prompt_tokens": prompt_tokens, "total_tokens": prompt_tokens}

--- a/haystack/components/embedders/mock_utils.py
+++ b/haystack/components/embedders/mock_utils.py
@@ -39,20 +39,18 @@ def _deterministic_embedding(text: str, dimension: int) -> list[float]:
     return _l2_normalize(vector)
 
 
-def _coerce_embedding(result: object) -> list[float]:
-    """Validate and coerce the output of an `embedding_fn` into a list of floats."""
-    if not isinstance(result, (list, tuple)) or not all(isinstance(value, (int, float)) for value in result):
-        raise TypeError(f"'embedding_fn' must return a sequence of numbers, got {type(result)}.")
-    return [float(value) for value in result]
+def _coerce_embedding(value: object, *, name: str) -> list[float]:
+    """
+    Validate that `value` is a non-empty sequence of numbers and coerce it into a list of floats.
 
-
-def _validate_embedding(embedding: list[float]) -> list[float]:
-    """Validate that a user-provided fixed embedding is a non-empty sequence of numbers."""
-    if not isinstance(embedding, (list, tuple)) or not all(isinstance(value, (int, float)) for value in embedding):
-        raise TypeError(f"'embedding' must be a sequence of numbers, got {type(embedding)}.")
-    if len(embedding) == 0:
-        raise ValueError("'embedding' must not be empty.")
-    return [float(value) for value in embedding]
+    :param value: The value to validate, e.g. a user-provided fixed embedding or the output of an `embedding_fn`.
+    :param name: How to refer to `value` in error messages, e.g. ``"'embedding'"``.
+    """
+    if not isinstance(value, (list, tuple)) or not all(isinstance(item, (int, float)) for item in value):
+        raise TypeError(f"{name} must be a sequence of numbers, got {type(value)}.")
+    if len(value) == 0:
+        raise ValueError(f"{name} must not be empty.")
+    return [float(item) for item in value]
 
 
 def _estimate_usage(texts: list[str]) -> dict[str, int]:

--- a/pydoc/embedders_api.yml
+++ b/pydoc/embedders_api.yml
@@ -4,6 +4,8 @@ loaders:
       [
         "azure_document_embedder",
         "azure_text_embedder",
+        "mock_document_embedder",
+        "mock_text_embedder",
         "openai_document_embedder",
         "openai_text_embedder",
       ]

--- a/releasenotes/notes/add-mock-embedders-ecbdfb55612d2267.yaml
+++ b/releasenotes/notes/add-mock-embedders-ecbdfb55612d2267.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Added ``MockTextEmbedder`` and ``MockDocumentEmbedder``, embedders that return deterministic embeddings without
+    calling any API. They are zero-cost drop-in replacements for real embedders in tests, smoke tests, and quick
+    prototypes. By default each embedding is derived from a stable hash of the (prepared) text, so the same text
+    always yields the same unit-length embedding and different texts yield different embeddings, making the mocks
+    usable in retrieval pipelines and reproducible across runs and processes. A fixed ``embedding`` vector or a
+    custom ``embedding_fn`` callable can be provided instead. Both implement the full embedder interface, including
+    ``run``, ``run_async``, and serialization.

--- a/test/components/embedders/test_mock_document_embedder.py
+++ b/test/components/embedders/test_mock_document_embedder.py
@@ -9,56 +9,41 @@ from haystack.components.embedders import MockDocumentEmbedder, MockTextEmbedder
 
 
 def _ones(text: str) -> list[float]:
-    """Module-level embedding function used to test `embedding_fn` serialization."""
+    """Module-level embedding function used to test `embedding_fn` and its serialization."""
     return [1.0, 1.0, 1.0]
 
 
 class TestMockDocumentEmbedder:
-    def test_init_defaults(self):
-        embedder = MockDocumentEmbedder()
-        assert embedder.embedding is None
-        assert embedder.embedding_fn is None
-        assert embedder.dimension == 768
-        assert embedder.model == "mock-model"
-        assert embedder.meta_fields_to_embed == []
-        assert embedder.embedding_separator == "\n"
+    @pytest.mark.parametrize(
+        ("args", "kwargs", "match"),
+        [
+            (([0.1],), {"embedding_fn": _ones}, "either 'embedding' or 'embedding_fn'"),
+            ((), {"dimension": -1}, "must be a positive integer"),
+        ],
+    )
+    def test_init_rejects_invalid_config(self, args, kwargs, match):
+        with pytest.raises(ValueError, match=match):
+            MockDocumentEmbedder(*args, **kwargs)
 
-    def test_init_rejects_embedding_and_embedding_fn(self):
-        with pytest.raises(ValueError, match="either 'embedding' or 'embedding_fn'"):
-            MockDocumentEmbedder([0.1], embedding_fn=_ones)
-
-    def test_init_rejects_non_positive_dimension(self):
-        with pytest.raises(ValueError, match="must be a positive integer"):
-            MockDocumentEmbedder(dimension=-1)
-
-    def test_deterministic_embeddings(self):
+    def test_embeds_documents(self):
         embedder = MockDocumentEmbedder(dimension=16)
-        documents = [Document(content="first"), Document(content="second")]
-        result = embedder.run(documents)
+        result = embedder.run([Document(content="first"), Document(content="second")])
         embeddings = [doc.embedding for doc in result["documents"]]
         assert all(len(embedding) == 16 for embedding in embeddings)
         assert embeddings[0] != embeddings[1]
 
-    def test_same_content_same_embedding(self):
-        embedder = MockDocumentEmbedder(dimension=8)
-        first = embedder.run([Document(content="pizza")])["documents"][0].embedding
-        second = embedder.run([Document(content="pizza")])["documents"][0].embedding
-        assert first == second
-
     def test_consistent_with_text_embedder(self):
-        # the same prepared text must yield the same embedding from both mock embedders
+        # the same prepared text yields the same embedding from both mock embedders (shared deterministic algorithm)
         text_embedding = MockTextEmbedder(dimension=8).run("pizza")["embedding"]
         doc_embedding = MockDocumentEmbedder(dimension=8).run([Document(content="pizza")])["documents"][0].embedding
         assert text_embedding == doc_embedding
 
     def test_fixed_embedding(self):
-        embedder = MockDocumentEmbedder([0.5, 0.5])
-        result = embedder.run([Document(content="a"), Document(content="b")])
+        result = MockDocumentEmbedder([0.5, 0.5]).run([Document(content="a"), Document(content="b")])
         assert all(doc.embedding == [0.5, 0.5] for doc in result["documents"])
 
     def test_embedding_fn(self):
-        embedder = MockDocumentEmbedder(embedding_fn=_ones)
-        result = embedder.run([Document(content="a")])
+        result = MockDocumentEmbedder(embedding_fn=_ones).run([Document(content="a")])
         assert result["documents"][0].embedding == [1.0, 1.0, 1.0]
 
     def test_meta_fields_to_embed_affect_embedding(self):
@@ -71,8 +56,7 @@ class TestMockDocumentEmbedder:
 
     def test_preserves_document_fields(self):
         document = Document(content="hello", meta={"title": "Greetings"})
-        result = MockDocumentEmbedder(dimension=8).run([document])
-        embedded = result["documents"][0]
+        embedded = MockDocumentEmbedder(dimension=8).run([document])["documents"][0]
         assert embedded.id == document.id
         assert embedded.content == "hello"
         assert embedded.meta == {"title": "Greetings"}
@@ -85,53 +69,41 @@ class TestMockDocumentEmbedder:
         assert result["documents"] == []
         assert result["meta"]["usage"] == {"prompt_tokens": 0, "total_tokens": 0}
 
-    def test_meta_defaults(self):
-        embedder = MockDocumentEmbedder(dimension=4)
-        meta = embedder.run([Document(content="a b"), Document(content="c")])["meta"]
+    def test_meta(self):
+        meta = MockDocumentEmbedder(dimension=4).run([Document(content="a b"), Document(content="c")])["meta"]
         assert meta["model"] == "mock-model"
         assert meta["usage"] == {"prompt_tokens": 3, "total_tokens": 3}
 
-    def test_run_rejects_non_documents(self):
+    @pytest.mark.parametrize("documents", ["not a list", [1, 2, 3]])
+    def test_run_rejects_non_documents(self, documents):
         with pytest.raises(TypeError, match="expects a list of Documents"):
-            MockDocumentEmbedder().run("not a list")
-
-        with pytest.raises(TypeError, match="expects a list of Documents"):
-            MockDocumentEmbedder().run([1, 2, 3])
+            MockDocumentEmbedder().run(documents)
 
     async def test_run_async(self):
         embedder = MockDocumentEmbedder(dimension=8)
         documents = [Document(content="hello")]
-        sync_result = embedder.run(documents)
-        async_result = await embedder.run_async(documents)
-        assert async_result["documents"][0].embedding == sync_result["documents"][0].embedding
+        async_embedding = (await embedder.run_async(documents))["documents"][0].embedding
+        assert async_embedding == embedder.run(documents)["documents"][0].embedding
 
-    def test_to_dict_from_dict_roundtrip(self):
-        embedder = MockDocumentEmbedder(
-            dimension=8, model="m", meta={"k": "v"}, meta_fields_to_embed=["title"], embedding_separator=" | "
-        )
-        data = embedder.to_dict()
-        assert data["type"] == "haystack.components.embedders.mock_document_embedder.MockDocumentEmbedder"
-        assert data["init_parameters"]["dimension"] == 8
-        assert data["init_parameters"]["meta_fields_to_embed"] == ["title"]
-        assert data["init_parameters"]["embedding_fn"] is None
-
-        restored = MockDocumentEmbedder.from_dict(data)
+    @pytest.mark.parametrize(
+        "embedder",
+        [
+            MockDocumentEmbedder(
+                dimension=8, model="m", meta={"k": "v"}, meta_fields_to_embed=["title"], embedding_separator=" | "
+            ),
+            MockDocumentEmbedder(embedding_fn=_ones),
+        ],
+        ids=["deterministic", "embedding_fn"],
+    )
+    def test_serialization_roundtrip(self, embedder):
+        restored = MockDocumentEmbedder.from_dict(embedder.to_dict())
+        assert isinstance(restored, MockDocumentEmbedder)
         document = Document(content="hello", meta={"title": "t"})
         assert restored.run([document])["documents"][0].embedding == embedder.run([document])["documents"][0].embedding
-
-    def test_to_dict_from_dict_with_embedding_fn(self):
-        embedder = MockDocumentEmbedder(embedding_fn=_ones)
-        data = embedder.to_dict()
-        assert data["init_parameters"]["embedding_fn"].endswith("test_mock_document_embedder._ones")
-        restored = MockDocumentEmbedder.from_dict(data)
-        assert restored.run([Document(content="a")])["documents"][0].embedding == [1.0, 1.0, 1.0]
 
     def test_in_pipeline(self):
         pipeline = Pipeline()
         pipeline.add_component("embedder", MockDocumentEmbedder(dimension=8))
-        result = pipeline.run({"embedder": {"documents": [Document(content="hello")]}})
-        assert len(result["embedder"]["documents"][0].embedding) == 8
-
         restored = Pipeline.from_dict(pipeline.to_dict())
-        restored_result = restored.run({"embedder": {"documents": [Document(content="hello")]}})
-        assert restored_result["embedder"]["documents"][0].embedding == result["embedder"]["documents"][0].embedding
+        result = restored.run({"embedder": {"documents": [Document(content="hello")]}})
+        assert len(result["embedder"]["documents"][0].embedding) == 8

--- a/test/components/embedders/test_mock_document_embedder.py
+++ b/test/components/embedders/test_mock_document_embedder.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack import Document, Pipeline
+from haystack.components.embedders import MockDocumentEmbedder, MockTextEmbedder
+
+
+def _ones(text: str) -> list[float]:
+    """Module-level embedding function used to test `embedding_fn` serialization."""
+    return [1.0, 1.0, 1.0]
+
+
+class TestMockDocumentEmbedder:
+    def test_init_defaults(self):
+        embedder = MockDocumentEmbedder()
+        assert embedder.embedding is None
+        assert embedder.embedding_fn is None
+        assert embedder.dimension == 768
+        assert embedder.model == "mock-model"
+        assert embedder.meta_fields_to_embed == []
+        assert embedder.embedding_separator == "\n"
+
+    def test_init_rejects_embedding_and_embedding_fn(self):
+        with pytest.raises(ValueError, match="either 'embedding' or 'embedding_fn'"):
+            MockDocumentEmbedder([0.1], embedding_fn=_ones)
+
+    def test_init_rejects_non_positive_dimension(self):
+        with pytest.raises(ValueError, match="must be a positive integer"):
+            MockDocumentEmbedder(dimension=-1)
+
+    def test_deterministic_embeddings(self):
+        embedder = MockDocumentEmbedder(dimension=16)
+        documents = [Document(content="first"), Document(content="second")]
+        result = embedder.run(documents)
+        embeddings = [doc.embedding for doc in result["documents"]]
+        assert all(len(embedding) == 16 for embedding in embeddings)
+        assert embeddings[0] != embeddings[1]
+
+    def test_same_content_same_embedding(self):
+        embedder = MockDocumentEmbedder(dimension=8)
+        first = embedder.run([Document(content="pizza")])["documents"][0].embedding
+        second = embedder.run([Document(content="pizza")])["documents"][0].embedding
+        assert first == second
+
+    def test_consistent_with_text_embedder(self):
+        # the same prepared text must yield the same embedding from both mock embedders
+        text_embedding = MockTextEmbedder(dimension=8).run("pizza")["embedding"]
+        doc_embedding = MockDocumentEmbedder(dimension=8).run([Document(content="pizza")])["documents"][0].embedding
+        assert text_embedding == doc_embedding
+
+    def test_fixed_embedding(self):
+        embedder = MockDocumentEmbedder([0.5, 0.5])
+        result = embedder.run([Document(content="a"), Document(content="b")])
+        assert all(doc.embedding == [0.5, 0.5] for doc in result["documents"])
+
+    def test_embedding_fn(self):
+        embedder = MockDocumentEmbedder(embedding_fn=_ones)
+        result = embedder.run([Document(content="a")])
+        assert result["documents"][0].embedding == [1.0, 1.0, 1.0]
+
+    def test_meta_fields_to_embed_affect_embedding(self):
+        document = Document(content="hello", meta={"title": "Greetings"})
+        without_meta = MockDocumentEmbedder(dimension=8).run([document])["documents"][0].embedding
+        with_meta = (
+            MockDocumentEmbedder(dimension=8, meta_fields_to_embed=["title"]).run([document])["documents"][0].embedding
+        )
+        assert without_meta != with_meta
+
+    def test_preserves_document_fields(self):
+        document = Document(content="hello", meta={"title": "Greetings"})
+        result = MockDocumentEmbedder(dimension=8).run([document])
+        embedded = result["documents"][0]
+        assert embedded.id == document.id
+        assert embedded.content == "hello"
+        assert embedded.meta == {"title": "Greetings"}
+        assert embedded.embedding is not None
+        # the original document is not mutated
+        assert document.embedding is None
+
+    def test_empty_documents(self):
+        result = MockDocumentEmbedder().run([])
+        assert result["documents"] == []
+        assert result["meta"]["usage"] == {"prompt_tokens": 0, "total_tokens": 0}
+
+    def test_meta_defaults(self):
+        embedder = MockDocumentEmbedder(dimension=4)
+        meta = embedder.run([Document(content="a b"), Document(content="c")])["meta"]
+        assert meta["model"] == "mock-model"
+        assert meta["usage"] == {"prompt_tokens": 3, "total_tokens": 3}
+
+    def test_run_rejects_non_documents(self):
+        with pytest.raises(TypeError, match="expects a list of Documents"):
+            MockDocumentEmbedder().run("not a list")
+
+        with pytest.raises(TypeError, match="expects a list of Documents"):
+            MockDocumentEmbedder().run([1, 2, 3])
+
+    async def test_run_async(self):
+        embedder = MockDocumentEmbedder(dimension=8)
+        documents = [Document(content="hello")]
+        sync_result = embedder.run(documents)
+        async_result = await embedder.run_async(documents)
+        assert async_result["documents"][0].embedding == sync_result["documents"][0].embedding
+
+    def test_to_dict_from_dict_roundtrip(self):
+        embedder = MockDocumentEmbedder(
+            dimension=8, model="m", meta={"k": "v"}, meta_fields_to_embed=["title"], embedding_separator=" | "
+        )
+        data = embedder.to_dict()
+        assert data["type"] == "haystack.components.embedders.mock_document_embedder.MockDocumentEmbedder"
+        assert data["init_parameters"]["dimension"] == 8
+        assert data["init_parameters"]["meta_fields_to_embed"] == ["title"]
+        assert data["init_parameters"]["embedding_fn"] is None
+
+        restored = MockDocumentEmbedder.from_dict(data)
+        document = Document(content="hello", meta={"title": "t"})
+        assert restored.run([document])["documents"][0].embedding == embedder.run([document])["documents"][0].embedding
+
+    def test_to_dict_from_dict_with_embedding_fn(self):
+        embedder = MockDocumentEmbedder(embedding_fn=_ones)
+        data = embedder.to_dict()
+        assert data["init_parameters"]["embedding_fn"].endswith("test_mock_document_embedder._ones")
+        restored = MockDocumentEmbedder.from_dict(data)
+        assert restored.run([Document(content="a")])["documents"][0].embedding == [1.0, 1.0, 1.0]
+
+    def test_in_pipeline(self):
+        pipeline = Pipeline()
+        pipeline.add_component("embedder", MockDocumentEmbedder(dimension=8))
+        result = pipeline.run({"embedder": {"documents": [Document(content="hello")]}})
+        assert len(result["embedder"]["documents"][0].embedding) == 8
+
+        restored = Pipeline.from_dict(pipeline.to_dict())
+        restored_result = restored.run({"embedder": {"documents": [Document(content="hello")]}})
+        assert restored_result["embedder"]["documents"][0].embedding == result["embedder"]["documents"][0].embedding

--- a/test/components/embedders/test_mock_document_embedder.py
+++ b/test/components/embedders/test_mock_document_embedder.py
@@ -85,6 +85,11 @@ class TestMockDocumentEmbedder:
         async_embedding = (await embedder.run_async(documents))["documents"][0].embedding
         assert async_embedding == embedder.run(documents)["documents"][0].embedding
 
+    def test_warm_up_is_noop(self):
+        embedder = MockDocumentEmbedder(dimension=8)
+        embedder.warm_up()  # callable and harmless
+        assert len(embedder.run([Document(content="hello")])["documents"][0].embedding) == 8
+
     @pytest.mark.parametrize(
         "embedder",
         [

--- a/test/components/embedders/test_mock_document_embedder.py
+++ b/test/components/embedders/test_mock_document_embedder.py
@@ -85,10 +85,15 @@ class TestMockDocumentEmbedder:
         async_embedding = (await embedder.run_async(documents))["documents"][0].embedding
         assert async_embedding == embedder.run(documents)["documents"][0].embedding
 
-    def test_warm_up_is_noop(self):
+    def test_warm_up_sets_flag_and_run_auto_warms(self):
         embedder = MockDocumentEmbedder(dimension=8)
-        embedder.warm_up()  # callable and harmless
-        assert len(embedder.run([Document(content="hello")])["documents"][0].embedding) == 8
+        assert embedder._is_warmed_up is False
+        embedder.warm_up()
+        assert embedder._is_warmed_up is True
+        # run auto-warms a fresh instance
+        fresh = MockDocumentEmbedder(dimension=8)
+        assert len(fresh.run([Document(content="hello")])["documents"][0].embedding) == 8
+        assert fresh._is_warmed_up is True
 
     @pytest.mark.parametrize(
         "embedder",

--- a/test/components/embedders/test_mock_text_embedder.py
+++ b/test/components/embedders/test_mock_text_embedder.py
@@ -8,59 +8,45 @@ import pytest
 
 from haystack import Pipeline
 from haystack.components.embedders import MockTextEmbedder
+from haystack.components.embedders.mock_utils import _l2_normalize
 
 
 def _ones(text: str) -> list[float]:
-    """Module-level embedding function used to test `embedding_fn` serialization."""
+    """Module-level embedding function used to test `embedding_fn` and its serialization."""
     return [1.0, 1.0, 1.0]
 
 
+def test_l2_normalize_handles_zero_vector():
+    # defensive guard in the shared deterministic-embedding helper: a zero vector is returned unchanged
+    assert _l2_normalize([0.0, 0.0]) == [0.0, 0.0]
+
+
 class TestMockTextEmbedder:
-    def test_init_defaults(self):
-        embedder = MockTextEmbedder()
-        assert embedder.embedding is None
-        assert embedder.embedding_fn is None
-        assert embedder.dimension == 768
-        assert embedder.model == "mock-model"
-        assert embedder.meta == {}
+    @pytest.mark.parametrize(
+        ("args", "kwargs", "exception", "match"),
+        [
+            (([0.1, 0.2],), {"embedding_fn": _ones}, ValueError, "either 'embedding' or 'embedding_fn'"),
+            ((), {"dimension": 0}, ValueError, "must be a positive integer"),
+            (([],), {}, ValueError, "must not be empty"),
+            ((["not", "numbers"],), {}, TypeError, "must be a sequence of numbers"),
+        ],
+    )
+    def test_init_rejects_invalid_config(self, args, kwargs, exception, match):
+        with pytest.raises(exception, match=match):
+            MockTextEmbedder(*args, **kwargs)
 
-    def test_init_rejects_embedding_and_embedding_fn(self):
-        with pytest.raises(ValueError, match="either 'embedding' or 'embedding_fn'"):
-            MockTextEmbedder([0.1, 0.2], embedding_fn=_ones)
-
-    def test_init_rejects_non_positive_dimension(self):
-        with pytest.raises(ValueError, match="must be a positive integer"):
-            MockTextEmbedder(dimension=0)
-
-    def test_init_rejects_empty_embedding(self):
-        with pytest.raises(ValueError, match="must not be empty"):
-            MockTextEmbedder([])
-
-    def test_init_rejects_invalid_embedding(self):
-        with pytest.raises(TypeError):
-            MockTextEmbedder(["not", "numbers"])
-
-    def test_deterministic_embedding_dimension(self):
-        embedder = MockTextEmbedder(dimension=16)
-        embedding = embedder.run("hello")["embedding"]
+    def test_deterministic_embedding(self):
+        embedding = MockTextEmbedder(dimension=16).run("hello")["embedding"]
         assert len(embedding) == 16
         assert all(isinstance(value, float) for value in embedding)
-
-    def test_deterministic_embedding_is_normalized(self):
-        embedder = MockTextEmbedder(dimension=32)
-        embedding = embedder.run("hello world")["embedding"]
+        # embeddings are L2-normalized, like real ones
         assert math.isclose(math.sqrt(sum(value * value for value in embedding)), 1.0, abs_tol=1e-9)
 
-    def test_same_text_same_embedding(self):
+    def test_deterministic_distinguishes_texts(self):
         embedder = MockTextEmbedder(dimension=8)
         assert embedder.run("pizza")["embedding"] == embedder.run("pizza")["embedding"]
-
-    def test_different_text_different_embedding(self):
-        embedder = MockTextEmbedder(dimension=8)
         assert embedder.run("pizza")["embedding"] != embedder.run("pasta")["embedding"]
-
-    def test_deterministic_across_instances(self):
-        # determinism does not depend on instance or process state (uses a stable hash, not the salted built-in hash)
+        # determinism holds across instances and processes (stable hash, not the salted built-in hash)
         assert (
             MockTextEmbedder(dimension=8).run("x")["embedding"] == MockTextEmbedder(dimension=8).run("x")["embedding"]
         )
@@ -71,8 +57,7 @@ class TestMockTextEmbedder:
         assert embedder.run("something else")["embedding"] == [0.1, 0.2, 0.3]
 
     def test_embedding_fn(self):
-        embedder = MockTextEmbedder(embedding_fn=_ones)
-        assert embedder.run("hello")["embedding"] == [1.0, 1.0, 1.0]
+        assert MockTextEmbedder(embedding_fn=_ones).run("hello")["embedding"] == [1.0, 1.0, 1.0]
 
     def test_embedding_fn_invalid_return_raises(self):
         embedder = MockTextEmbedder(embedding_fn=lambda text: "not a vector")
@@ -84,17 +69,14 @@ class TestMockTextEmbedder:
         prefixed = MockTextEmbedder(dimension=8, prefix="search: ").run("hello")["embedding"]
         assert plain != prefixed
 
-    def test_meta_defaults(self):
-        embedder = MockTextEmbedder(dimension=4)
-        meta = embedder.run("a b c")["meta"]
+    def test_meta(self):
+        meta = MockTextEmbedder(dimension=4).run("a b c")["meta"]
         assert meta["model"] == "mock-model"
         assert meta["usage"] == {"prompt_tokens": 3, "total_tokens": 3}
-
-    def test_meta_merging(self):
-        embedder = MockTextEmbedder(dimension=4, model="custom", meta={"extra": "value"})
-        meta = embedder.run("hello")["meta"]
-        assert meta["model"] == "custom"
-        assert meta["extra"] == "value"
+        # init model and meta are reflected and merged
+        custom = MockTextEmbedder(dimension=4, model="custom", meta={"extra": "value"}).run("hi")["meta"]
+        assert custom["model"] == "custom"
+        assert custom["extra"] == "value"
 
     def test_run_rejects_non_string(self):
         with pytest.raises(TypeError, match="expects a string"):
@@ -102,34 +84,25 @@ class TestMockTextEmbedder:
 
     async def test_run_async(self):
         embedder = MockTextEmbedder(dimension=8)
-        sync_result = embedder.run("hello")
-        async_result = await embedder.run_async("hello")
-        assert async_result["embedding"] == sync_result["embedding"]
+        assert (await embedder.run_async("hello"))["embedding"] == embedder.run("hello")["embedding"]
 
-    def test_to_dict_from_dict_roundtrip(self):
-        embedder = MockTextEmbedder(dimension=8, model="m", meta={"k": "v"}, prefix="p", suffix="s")
-        data = embedder.to_dict()
-        assert data["type"] == "haystack.components.embedders.mock_text_embedder.MockTextEmbedder"
-        assert data["init_parameters"]["dimension"] == 8
-        assert data["init_parameters"]["embedding_fn"] is None
-
-        restored = MockTextEmbedder.from_dict(data)
+    @pytest.mark.parametrize(
+        "embedder",
+        [
+            MockTextEmbedder(dimension=8, model="m", meta={"k": "v"}, prefix="p", suffix="s"),
+            MockTextEmbedder(embedding_fn=_ones),
+            MockTextEmbedder([0.1, 0.2, 0.3]),
+        ],
+        ids=["deterministic", "embedding_fn", "fixed"],
+    )
+    def test_serialization_roundtrip(self, embedder):
+        restored = MockTextEmbedder.from_dict(embedder.to_dict())
+        assert isinstance(restored, MockTextEmbedder)
         assert restored.run("hello")["embedding"] == embedder.run("hello")["embedding"]
-        assert restored.meta == {"k": "v"}
-
-    def test_to_dict_from_dict_with_embedding_fn(self):
-        embedder = MockTextEmbedder(embedding_fn=_ones)
-        data = embedder.to_dict()
-        assert data["init_parameters"]["embedding_fn"].endswith("test_mock_text_embedder._ones")
-        restored = MockTextEmbedder.from_dict(data)
-        assert restored.run("hello")["embedding"] == [1.0, 1.0, 1.0]
 
     def test_in_pipeline(self):
         pipeline = Pipeline()
         pipeline.add_component("embedder", MockTextEmbedder(dimension=8))
-        result = pipeline.run({"embedder": {"text": "hello"}})
-        assert len(result["embedder"]["embedding"]) == 8
-
         restored = Pipeline.from_dict(pipeline.to_dict())
-        restored_result = restored.run({"embedder": {"text": "hello"}})
-        assert restored_result["embedder"]["embedding"] == result["embedder"]["embedding"]
+        result = restored.run({"embedder": {"text": "hello"}})
+        assert len(result["embedder"]["embedding"]) == 8

--- a/test/components/embedders/test_mock_text_embedder.py
+++ b/test/components/embedders/test_mock_text_embedder.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import pytest
+
+from haystack import Pipeline
+from haystack.components.embedders import MockTextEmbedder
+
+
+def _ones(text: str) -> list[float]:
+    """Module-level embedding function used to test `embedding_fn` serialization."""
+    return [1.0, 1.0, 1.0]
+
+
+class TestMockTextEmbedder:
+    def test_init_defaults(self):
+        embedder = MockTextEmbedder()
+        assert embedder.embedding is None
+        assert embedder.embedding_fn is None
+        assert embedder.dimension == 768
+        assert embedder.model == "mock-model"
+        assert embedder.meta == {}
+
+    def test_init_rejects_embedding_and_embedding_fn(self):
+        with pytest.raises(ValueError, match="either 'embedding' or 'embedding_fn'"):
+            MockTextEmbedder([0.1, 0.2], embedding_fn=_ones)
+
+    def test_init_rejects_non_positive_dimension(self):
+        with pytest.raises(ValueError, match="must be a positive integer"):
+            MockTextEmbedder(dimension=0)
+
+    def test_init_rejects_empty_embedding(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            MockTextEmbedder([])
+
+    def test_init_rejects_invalid_embedding(self):
+        with pytest.raises(TypeError):
+            MockTextEmbedder(["not", "numbers"])
+
+    def test_deterministic_embedding_dimension(self):
+        embedder = MockTextEmbedder(dimension=16)
+        embedding = embedder.run("hello")["embedding"]
+        assert len(embedding) == 16
+        assert all(isinstance(value, float) for value in embedding)
+
+    def test_deterministic_embedding_is_normalized(self):
+        embedder = MockTextEmbedder(dimension=32)
+        embedding = embedder.run("hello world")["embedding"]
+        assert math.isclose(math.sqrt(sum(value * value for value in embedding)), 1.0, abs_tol=1e-9)
+
+    def test_same_text_same_embedding(self):
+        embedder = MockTextEmbedder(dimension=8)
+        assert embedder.run("pizza")["embedding"] == embedder.run("pizza")["embedding"]
+
+    def test_different_text_different_embedding(self):
+        embedder = MockTextEmbedder(dimension=8)
+        assert embedder.run("pizza")["embedding"] != embedder.run("pasta")["embedding"]
+
+    def test_deterministic_across_instances(self):
+        # determinism does not depend on instance or process state (uses a stable hash, not the salted built-in hash)
+        assert (
+            MockTextEmbedder(dimension=8).run("x")["embedding"] == MockTextEmbedder(dimension=8).run("x")["embedding"]
+        )
+
+    def test_fixed_embedding(self):
+        embedder = MockTextEmbedder([0.1, 0.2, 0.3])
+        assert embedder.run("anything")["embedding"] == [0.1, 0.2, 0.3]
+        assert embedder.run("something else")["embedding"] == [0.1, 0.2, 0.3]
+
+    def test_embedding_fn(self):
+        embedder = MockTextEmbedder(embedding_fn=_ones)
+        assert embedder.run("hello")["embedding"] == [1.0, 1.0, 1.0]
+
+    def test_embedding_fn_invalid_return_raises(self):
+        embedder = MockTextEmbedder(embedding_fn=lambda text: "not a vector")
+        with pytest.raises(TypeError, match="must return a sequence of numbers"):
+            embedder.run("hello")
+
+    def test_prefix_suffix_affect_embedding(self):
+        plain = MockTextEmbedder(dimension=8).run("hello")["embedding"]
+        prefixed = MockTextEmbedder(dimension=8, prefix="search: ").run("hello")["embedding"]
+        assert plain != prefixed
+
+    def test_meta_defaults(self):
+        embedder = MockTextEmbedder(dimension=4)
+        meta = embedder.run("a b c")["meta"]
+        assert meta["model"] == "mock-model"
+        assert meta["usage"] == {"prompt_tokens": 3, "total_tokens": 3}
+
+    def test_meta_merging(self):
+        embedder = MockTextEmbedder(dimension=4, model="custom", meta={"extra": "value"})
+        meta = embedder.run("hello")["meta"]
+        assert meta["model"] == "custom"
+        assert meta["extra"] == "value"
+
+    def test_run_rejects_non_string(self):
+        with pytest.raises(TypeError, match="expects a string"):
+            MockTextEmbedder().run(["not", "a", "string"])
+
+    async def test_run_async(self):
+        embedder = MockTextEmbedder(dimension=8)
+        sync_result = embedder.run("hello")
+        async_result = await embedder.run_async("hello")
+        assert async_result["embedding"] == sync_result["embedding"]
+
+    def test_to_dict_from_dict_roundtrip(self):
+        embedder = MockTextEmbedder(dimension=8, model="m", meta={"k": "v"}, prefix="p", suffix="s")
+        data = embedder.to_dict()
+        assert data["type"] == "haystack.components.embedders.mock_text_embedder.MockTextEmbedder"
+        assert data["init_parameters"]["dimension"] == 8
+        assert data["init_parameters"]["embedding_fn"] is None
+
+        restored = MockTextEmbedder.from_dict(data)
+        assert restored.run("hello")["embedding"] == embedder.run("hello")["embedding"]
+        assert restored.meta == {"k": "v"}
+
+    def test_to_dict_from_dict_with_embedding_fn(self):
+        embedder = MockTextEmbedder(embedding_fn=_ones)
+        data = embedder.to_dict()
+        assert data["init_parameters"]["embedding_fn"].endswith("test_mock_text_embedder._ones")
+        restored = MockTextEmbedder.from_dict(data)
+        assert restored.run("hello")["embedding"] == [1.0, 1.0, 1.0]
+
+    def test_in_pipeline(self):
+        pipeline = Pipeline()
+        pipeline.add_component("embedder", MockTextEmbedder(dimension=8))
+        result = pipeline.run({"embedder": {"text": "hello"}})
+        assert len(result["embedder"]["embedding"]) == 8
+
+        restored = Pipeline.from_dict(pipeline.to_dict())
+        restored_result = restored.run({"embedder": {"text": "hello"}})
+        assert restored_result["embedder"]["embedding"] == result["embedder"]["embedding"]

--- a/test/components/embedders/test_mock_text_embedder.py
+++ b/test/components/embedders/test_mock_text_embedder.py
@@ -86,6 +86,11 @@ class TestMockTextEmbedder:
         embedder = MockTextEmbedder(dimension=8)
         assert (await embedder.run_async("hello"))["embedding"] == embedder.run("hello")["embedding"]
 
+    def test_warm_up_is_noop(self):
+        embedder = MockTextEmbedder(dimension=8)
+        embedder.warm_up()  # callable and harmless
+        assert len(embedder.run("hello")["embedding"]) == 8
+
     @pytest.mark.parametrize(
         "embedder",
         [

--- a/test/components/embedders/test_mock_text_embedder.py
+++ b/test/components/embedders/test_mock_text_embedder.py
@@ -61,7 +61,7 @@ class TestMockTextEmbedder:
 
     def test_embedding_fn_invalid_return_raises(self):
         embedder = MockTextEmbedder(embedding_fn=lambda text: "not a vector")
-        with pytest.raises(TypeError, match="must return a sequence of numbers"):
+        with pytest.raises(TypeError, match="must be a sequence of numbers"):
             embedder.run("hello")
 
     def test_prefix_suffix_affect_embedding(self):

--- a/test/components/embedders/test_mock_text_embedder.py
+++ b/test/components/embedders/test_mock_text_embedder.py
@@ -86,10 +86,15 @@ class TestMockTextEmbedder:
         embedder = MockTextEmbedder(dimension=8)
         assert (await embedder.run_async("hello"))["embedding"] == embedder.run("hello")["embedding"]
 
-    def test_warm_up_is_noop(self):
+    def test_warm_up_sets_flag_and_run_auto_warms(self):
         embedder = MockTextEmbedder(dimension=8)
-        embedder.warm_up()  # callable and harmless
-        assert len(embedder.run("hello")["embedding"]) == 8
+        assert embedder._is_warmed_up is False
+        embedder.warm_up()
+        assert embedder._is_warmed_up is True
+        # run auto-warms a fresh instance
+        fresh = MockTextEmbedder(dimension=8)
+        assert len(fresh.run("hello")["embedding"]) == 8
+        assert fresh._is_warmed_up is True
 
     @pytest.mark.parametrize(
         "embedder",


### PR DESCRIPTION
### Related Issues

- Part of deepset-ai/haystack-private#376

### Proposed Changes:

Adds `MockTextEmbedder` and `MockDocumentEmbedder`, embedders that produce embeddings **without calling any API**. Drop-in replacements for real embedders (e.g. `OpenAITextEmbedder` in tests and prototypes.

Embedding selection modes (consistent across both components, and mirroring `MockChatGenerator`'s fixed / `*_fn` / default trio):
- **Deterministic (default)** – with no configuration, the embedding is derived from a stable SHA-256 hash of the prepared text. The same text always yields the same unit-length embedding. The mocks ranks documents differently in retrieval pipelines and results are reproducible across runs.
- **Fixed** – pass an `embedding` vector; returned/assigned for every input.
- **Dynamic** – pass `embedding_fn=callable(text) -> list[float]`.

Both components accept the parameters of real embedders (`prefix`, `suffix`; plus `meta_fields_to_embed` / `embedding_separator` for the document embedder). They report approximate token `usage` in `meta`, consistent with `MockChatGenerator`. They implement the full embedder interface: `run`, `run_async`, `to_dict` / `from_dict` (including `embedding_fn` named-callable serialization).

### How did you test it?

Added unit tests

### Notes for the reviewer

- I wasn't sure about whether to include warm_up but I see the benefit and also prefer the consistency with MockChatGenerator.
-  Added to https://github.com/deepset-ai/haystack-private/issues/381

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file.
- [x] I have run pre-commit hooks and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)