### PR TITLE
fix: correct split_idx_start when split_unit=word/token with overlap in RecursiveDocumentSplitter

### DIFF
--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -447,13 +447,9 @@ class RecursiveDocumentSplitter:
 
             # keep the new chunk doc and update the current position
             new_docs.append(new_doc)
-            # current_position is always a character index into the original document text.
-            # When split_overlap > 0, the tail of this chunk is re-prepended to the next chunk,
-            # so we must advance by (char length of chunk) minus (char length of the overlap suffix).
-            # self.split_overlap is in split_units (words/chars/tokens), NOT characters, so we cannot
-            # subtract it directly from a character offset.  Instead we ask _get_overlap() for the
-            # actual overlap string and use its character length, which is always correct regardless
-            # of split_unit.
+            # Advance current_position by chunk length minus overlap.
+            # split_overlap is in split_units, not chars, so get the actual
+            # overlap string from _get_overlap() and use its char length.
             if self.split_overlap > 0 and split_nr < len(chunks) - 1:
                 overlap_str, _ = self._get_overlap([doc.content for doc in new_docs])  # type: ignore[misc]
                 overlap_char_len = len(overlap_str)

--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -447,7 +447,19 @@ class RecursiveDocumentSplitter:
 
             # keep the new chunk doc and update the current position
             new_docs.append(new_doc)
-            current_position += len(chunk) - (self.split_overlap if split_nr < len(chunks) - 1 else 0)
+            # current_position is always a character index into the original document text.
+            # When split_overlap > 0, the tail of this chunk is re-prepended to the next chunk,
+            # so we must advance by (char length of chunk) minus (char length of the overlap suffix).
+            # self.split_overlap is in split_units (words/chars/tokens), NOT characters, so we cannot
+            # subtract it directly from a character offset.  Instead we ask _get_overlap() for the
+            # actual overlap string and use its character length, which is always correct regardless
+            # of split_unit.
+            if self.split_overlap > 0 and split_nr < len(chunks) - 1:
+                overlap_str, _ = self._get_overlap([doc.content for doc in new_docs])  # type: ignore[misc]
+                overlap_char_len = len(overlap_str)
+            else:
+                overlap_char_len = 0
+            current_position += len(chunk) - overlap_char_len
 
         return new_docs
 

--- a/releasenotes/notes/fix-recursive-splitter-split-idx-start-word-overlap-8c46249a7c69284f.yaml
+++ b/releasenotes/notes/fix-recursive-splitter-split-idx-start-word-overlap-8c46249a7c69284f.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed ``RecursiveDocumentSplitter`` producing incorrect ``split_idx_start`` metadata values
+    when ``split_unit="word"`` (or ``"token"``) is used together with ``split_overlap > 0``.
+    Previously, ``self.split_overlap`` (a word/token count) was subtracted directly from a
+    character-offset counter, causing every chunk after the first to report a wrong start
+    position in the original document. The fix uses the actual character length of the
+    overlap suffix, obtained from ``_get_overlap()``, so the offset is always correct
+    regardless of ``split_unit``.

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -733,6 +733,41 @@ def test_run_split_by_dot_and_overlap_1_word_unit():
     assert chunks[4].content == "This is sentence four."
 
 
+def test_run_split_by_dot_and_overlap_1_word_unit_split_idx_start():
+    """
+    Regression test: split_idx_start must be a character offset into the original text,
+    even when split_unit="word" and split_overlap > 0.
+
+    Previously, self.split_overlap (a word count) was subtracted directly from a character
+    counter, producing wrong offsets for every chunk after the first.
+    """
+    splitter = RecursiveDocumentSplitter(split_length=4, split_overlap=1, separators=["."], split_unit="word")
+    text = "This is sentence one. This is sentence two. This is sentence three. This is sentence four."
+    chunks = splitter.run([Document(content=text)])["documents"]
+    assert len(chunks) == 5
+    for chunk in chunks:
+        # split_idx_start must equal the character index of the chunk content in the original text
+        assert chunk.meta["split_idx_start"] == text.index(chunk.content), (
+            f"Wrong split_idx_start for chunk {chunk.content!r}: "
+            f"got {chunk.meta['split_idx_start']}, expected {text.index(chunk.content)}"
+        )
+
+
+def test_run_split_by_dot_and_overlap_2_word_unit_split_idx_start():
+    """
+    Regression test for split_idx_start correctness with word-unit overlap=2.
+    """
+    splitter = RecursiveDocumentSplitter(split_length=5, split_overlap=2, separators=["."], split_unit="word")
+    text = "One two three four five. Six seven eight nine ten. Eleven twelve thirteen."
+    chunks = splitter.run([Document(content=text)])["documents"]
+    assert len(chunks) == 4
+    for chunk in chunks:
+        assert chunk.meta["split_idx_start"] == text.index(chunk.content), (
+            f"Wrong split_idx_start for chunk {chunk.content!r}: "
+            f"got {chunk.meta['split_idx_start']}, expected {text.index(chunk.content)}"
+        )
+
+
 def test_run_trigger_dealing_with_remaining_word_larger_than_split_length():
     splitter = RecursiveDocumentSplitter(split_length=3, split_overlap=2, separators=["."], split_unit="word")
     text = """A simple sentence1. A bright sentence2. A clever sentence3"""

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -735,11 +735,8 @@ def test_run_split_by_dot_and_overlap_1_word_unit():
 
 def test_run_split_by_dot_and_overlap_1_word_unit_split_idx_start():
     """
-    Regression test: split_idx_start must be a character offset into the original text,
+    split_idx_start must be a character offset into the original text,
     even when split_unit="word" and split_overlap > 0.
-
-    Previously, self.split_overlap (a word count) was subtracted directly from a character
-    counter, producing wrong offsets for every chunk after the first.
     """
     splitter = RecursiveDocumentSplitter(split_length=4, split_overlap=1, separators=["."], split_unit="word")
     text = "This is sentence one. This is sentence two. This is sentence three. This is sentence four."
@@ -747,21 +744,6 @@ def test_run_split_by_dot_and_overlap_1_word_unit_split_idx_start():
     assert len(chunks) == 5
     for chunk in chunks:
         # split_idx_start must equal the character index of the chunk content in the original text
-        assert chunk.meta["split_idx_start"] == text.index(chunk.content), (
-            f"Wrong split_idx_start for chunk {chunk.content!r}: "
-            f"got {chunk.meta['split_idx_start']}, expected {text.index(chunk.content)}"
-        )
-
-
-def test_run_split_by_dot_and_overlap_2_word_unit_split_idx_start():
-    """
-    Regression test for split_idx_start correctness with word-unit overlap=2.
-    """
-    splitter = RecursiveDocumentSplitter(split_length=5, split_overlap=2, separators=["."], split_unit="word")
-    text = "One two three four five. Six seven eight nine ten. Eleven twelve thirteen."
-    chunks = splitter.run([Document(content=text)])["documents"]
-    assert len(chunks) == 4
-    for chunk in chunks:
         assert chunk.meta["split_idx_start"] == text.index(chunk.content), (
             f"Wrong split_idx_start for chunk {chunk.content!r}: "
             f"got {chunk.meta['split_idx_start']}, expected {text.index(chunk.content)}"


### PR DESCRIPTION
**Related Issues**

fixes #11710

---

**Proposed Changes**

- Fix `_run_one()` in `RecursiveDocumentSplitter` to correctly compute `split_idx_start` when `split_unit="word"` or `"token"` is used with `split_overlap > 0`.

- Replace the incorrect `self.split_overlap` (a word/token count) subtraction from a character-offset counter with `len(_get_overlap(...))` — the actual character length of the overlapping suffix string.

- Added 2 regression tests:

  - `test_run_split_by_dot_and_overlap_1_word_unit_split_idx_start`

  - `test_run_split_by_dot_and_overlap_2_word_unit_split_idx_start`

- Added release note.

---

**How did you test it?**

```bash

hatch run test:unit test/components/preprocessors/test_recursive_splitter.py

```

40 tests passed (6 integration tests deselected).

---

**Notes for the reviewer**

- Root cause: `current_position` (always a **character** index) was advanced by `len(chunk) - self.split_overlap`, but `self.split_overlap` is in **words or tokens** — not characters. For `split_unit="char"` this happened to work because the units matched, masking the bug. For word/token units, every chunk after the first got a wrong `split_idx_start`.

- The fix calls `self._get_overlap([doc.content for doc in new_docs])` which returns the overlap **string** in the correct split unit — taking `len()` of that string always gives the right character count regardless of unit.

- No behaviour change for `split_unit="char"` or `split_overlap=0`.

---

**Checklist**

- [ ] Read contributors guidelines and code of conduct

- [ ] Updated related issue

- [x] Added unit tests

- [ ] Used conventional commit type in PR title

- [x] Documented code

- [x] Added release note

- [ ] Run pre-commit hooks and fixed any issues