### PR TITLE
test: fix Python 3.14 type serialization and ffmpeg-dependent skips

### DIFF
--- a/test/components/audio/test_whisper_local.py
+++ b/test/components/audio/test_whisper_local.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import shutil
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -16,6 +17,9 @@ from haystack.dataclasses import ByteStream, Document
 from haystack.utils.device import ComponentDevice, Device
 
 SAMPLES_PATH = Path(__file__).parent.parent.parent / "test_files"
+
+# LocalWhisperTranscriber loads non-wav audio via ffmpeg; skip live tests when it is not installed.
+_FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
 
 
 class TestLocalWhisperTranscriber:
@@ -178,6 +182,7 @@ class TestLocalWhisperTranscriber:
     @pytest.mark.integration
     @pytest.mark.slow
     @pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="ffmpeg not installed on Windows CI")
+    @pytest.mark.skipif(not _FFMPEG_AVAILABLE, reason="ffmpeg not installed")
     def test_whisper_local_transcriber(self, test_files_path):
         comp = LocalWhisperTranscriber(model="tiny", whisper_params={"language": "english"})
         output = comp.run(
@@ -208,6 +213,7 @@ class TestLocalWhisperTranscriber:
     @pytest.mark.integration
     @pytest.mark.slow
     @pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="ffmpeg not installed on Windows CI")
+    @pytest.mark.skipif(not _FFMPEG_AVAILABLE, reason="ffmpeg not installed")
     def test_whisper_local_transcriber_pipeline_and_url_source(self):
         pipe = Pipeline()
         pipe.add_component("fetcher", LinkContentFetcher())

--- a/test/utils/test_type_serialization.py
+++ b/test/utils/test_type_serialization.py
@@ -203,9 +203,14 @@ def test_output_type_serialization_typing_generic_with_nonetype():
     assert serialize_type(Tuple[int, type(None)]) == "typing.Tuple[int, None]"
     assert serialize_type(List[type(None)]) == "typing.List[None]"
     # A Union with more than two members that includes None must keep None as well.
-    assert serialize_type(Union[str, int, None]) == "typing.Union[str, int, None]"
-    # Optional must still be serialized without a redundant trailing None.
-    assert serialize_type(Optional[str]) == "typing.Optional[str]"
+    # On Python 3.14+, typing.Union is implemented as types.UnionType, so serialization uses PEP 604 syntax.
+    if sys.version_info >= (3, 14):
+        assert serialize_type(Union[str, int, None]) == "str | int | None"
+        assert serialize_type(Optional[str]) == "str | None"
+    else:
+        assert serialize_type(Union[str, int, None]) == "typing.Union[str, int, None]"
+        # Optional must still be serialized without a redundant trailing None.
+        assert serialize_type(Optional[str]) == "typing.Optional[str]"
 
 
 def test_output_type_round_trip_typing_generic_with_nonetype():


### PR DESCRIPTION
### Related Issues

- Local/dev readiness: ensure unit + integration suites pass on current Python (3.14) and environments without optional system tools.

### Proposed Changes:

This PR hardens the test suite so local development and CI remain green when running against newer Python versions and incomplete system dependencies.

**1. Python 3.14 `typing.Union` / `Optional` serialization expectations** (`test/utils/test_type_serialization.py`)
- On Python 3.14+, `typing.Union` is implemented as `types.UnionType`, so `serialize_type(Union[str, int, None])` naturally yields PEP 604 syntax (`str | int | None`) rather than `typing.Union[...]`.
- Likewise, `Optional[str]` serializes as `str | None` on 3.14+ instead of `typing.Optional[str]`.
- Tests now branch on `sys.version_info >= (3, 14)` so both pre-3.14 (`typing.Union` / `typing.Optional`) and 3.14+ (PEP 604) behaviors are asserted correctly.
- Round-trip tests (`serialize_type` → `deserialize_type`) continue to pass because deserialization accepts both forms.

**2. Guard whisper live integration tests when `ffmpeg` is missing** (`test/components/audio/test_whisper_local.py`)
- `LocalWhisperTranscriber` live/integration paths invoke `ffmpeg` for audio handling.
- Tests previously only skipped on Windows CI; on macOS/Linux without `ffmpeg` they failed with `FileNotFoundError: 'ffmpeg'`.
- Added an explicit `shutil.which("ffmpeg")` check and `@pytest.mark.skipif(not _FFMPEG_AVAILABLE, ...)` on the slow/integration live tests so local environments and CI agents without ffmpeg skip cleanly instead of erroring.

### How did you test it?

**Environment**
- Hatch test env (`hatch -e test`) with project installed in editable mode
- Python 3.14.2 on macOS (darwin arm64)
- Unit coverage via `pytest --cov=haystack`

**Unit tests**
```bash
hatch run test:unit -- test
```
- **5248 passed**, 4 skipped, 374 deselected (integration)
- **Coverage: 93%** total (`17950` statements, `1232` missed) — above the 85% target
- Fixed test `test_output_type_serialization_typing_generic_with_nonetype` verified on 3.14

**Integration tests (fast subset)**
```bash
hatch run test:integration-only-fast -- test
```
- **218 passed**, 96 skipped, 5312 deselected

**Targeted re-runs**
- `test_output_type_serialization_typing_generic_with_nonetype` — pass
- `test_output_type_round_trip_typing_generic_with_nonetype` — pass
- `test_whisper_local_transcriber` without ffmpeg — **skipped** (expected)
- Non-slow whisper unit tests — all pass

**Coverage notes**
- Unit suite already reports **93%** line coverage on `haystack/` (omit: `haystack/testing/*` per `pyproject.toml`).
- No production code changes were required; suite quality was sufficient above the 85% bar. Remaining misses are mostly optional/integration-only paths (e.g. live model backends, optional telemetry, SAS evaluator warm-up) that are covered by integration/e2e markers rather than unit mocks.

### Notes for the reviewer

- **No production (`haystack/`) changes** — test-only hardening.
- Python 3.14 is listed in package classifiers; this keeps the suite honest on that runtime.
- Whisper skips are additive: Windows CI still skips as before; any platform without `ffmpeg` now skips consistently.
- Maintainers may apply `ignore-for-release-notes` since this is tests-only; happy to add a reno note if preferred.
- This PR was generated/assisted with an AI assistant. Changes were reviewed, tests were run locally, and results are documented above.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
  - *(tests-only; maintainers can add `ignore-for-release-notes`)*
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
