### PR TITLE
ci: dispatch haystack version bump to haystack-runtime instead of archived dc-pipeline-images

### DIFF
--- a/.github/utils/prepare_release_notification.sh
+++ b/.github/utils/prepare_release_notification.sh
@@ -4,7 +4,7 @@
 # Requires: VERSION, RUN_URL, HAS_FAILURE, GH_TOKEN, GITHUB_REPOSITORY
 # Optional: IS_RC, IS_FIRST_RC, MAJOR_MINOR, GITHUB_URL, PYPI_URL, DOCKER_URL,
 #           BUMP_VERSION_PR_URL, DC_PIPELINE_TEMPLATES_PR_URL, CUSTOM_NODES_PR_URL,
-#           DC_PIPELINE_IMAGES_PR_URL, GITHUB_WORKSPACE
+#           DC_PIPELINE_IMAGES_PR_URL (haystack-runtime bump PR), GITHUB_WORKSPACE
 # Output: slack_payload.json
 #
 # This script is used in the release.yml workflow to prepare the notification payload
@@ -64,7 +64,7 @@ if [[ "${IS_RC:-}" == "true" ]]; then
   PLATFORM_PRS=""
   [[ -n "${DC_PIPELINE_TEMPLATES_PR_URL:-}" ]] && PLATFORM_PRS+=$'\n'"- <${DC_PIPELINE_TEMPLATES_PR_URL}|dc-pipeline-templates>"
   [[ -n "${DC_CUSTOM_NODES_PR_URL:-}" ]] && PLATFORM_PRS+=$'\n'"- <${DC_CUSTOM_NODES_PR_URL}|deepset-cloud-custom-nodes>"
-  [[ -n "${DC_PIPELINE_IMAGES_PR_URL:-}" ]] && PLATFORM_PRS+=$'\n'"- <${DC_PIPELINE_IMAGES_PR_URL}|dc-pipeline-images>"
+  [[ -n "${DC_PIPELINE_IMAGES_PR_URL:-}" ]] && PLATFORM_PRS+=$'\n'"- <${DC_PIPELINE_IMAGES_PR_URL}|haystack-runtime>"
   if [[ -n "${PLATFORM_PRS}" ]]; then
     TXT+=$'\n\n'":factory: *Test PRs opened on Platform:*${PLATFORM_PRS}"
   fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
           body: |
             Bump haystack pin to `${{ env.VERSION }}` for platform testing.
 
-  bump-dc-pipeline-images:
+  bump-haystack-runtime:
     needs: ["parse-validate-version", "check-artifacts"]
     if: always() && needs.check-artifacts.result == 'success' && needs.parse-validate-version.outputs.is_rc == 'true'
     runs-on: ubuntu-slim
@@ -236,7 +236,7 @@ jobs:
           GH_TOKEN: ${{ secrets.HAYSTACK_BOT_TOKEN }}
         run: |
           gh workflow run update-package-version.yaml \
-            -R deepset-ai/dc-pipeline-images \
+            -R deepset-ai/haystack-runtime \
             -f haystack_version="${{ env.VERSION }}"
 
       - name: Wait for PR
@@ -246,7 +246,7 @@ jobs:
         run: |
           TRIGGER_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           for i in $(seq 1 30); do
-            PR_URL=$(gh pr list -R deepset-ai/dc-pipeline-images \
+            PR_URL=$(gh pr list -R deepset-ai/haystack-runtime \
               --head "bump/hs${{ env.VERSION }}" \
               --json url,createdAt \
               --jq ".[] | select(.createdAt >= \"$TRIGGER_TIME\") | .url")
@@ -268,7 +268,7 @@ jobs:
       - "check-artifacts"
       - "bump-dc-pipeline-templates"
       - "bump-deepset-cloud-custom-nodes"
-      - "bump-dc-pipeline-images"
+      - "bump-haystack-runtime"
     if: always()
     runs-on: ubuntu-slim
     steps:
@@ -290,7 +290,7 @@ jobs:
           BUMP_VERSION_PR_URL: ${{ needs.branch-off.outputs.bump_version_pr_url }}
           DC_PIPELINE_TEMPLATES_PR_URL: ${{ needs.bump-dc-pipeline-templates.outputs.pr_url }}
           DC_CUSTOM_NODES_PR_URL: ${{ needs.bump-deepset-cloud-custom-nodes.outputs.pr_url }}
-          DC_PIPELINE_IMAGES_PR_URL: ${{ needs.bump-dc-pipeline-images.outputs.pr_url }}
+          DC_PIPELINE_IMAGES_PR_URL: ${{ needs.bump-haystack-runtime.outputs.pr_url }}
         run: .github/utils/prepare_release_notification.sh
 
       - name: Send release notification to Slack


### PR DESCRIPTION
`dc-pipeline-images` was archived, so the `bump-dc-pipeline-images` job in `release.yml` has been silently doing nothing. Repoints it to `haystack-runtime`, which now directly pins `haystack-ai` and hosts the receiving `update-package-version.yaml` workflow.

Renames the job to `bump-haystack-runtime` and updates the Slack notification label accordingly.