### PR TITLE
fix: `OpenAIResponsesChatGenerator` filter streaming event fields from reasoning extra before call to Responses API

### DIFF
--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -684,6 +684,15 @@ def _convert_response_chunk_to_streaming_chunk(  # noqa: PLR0911
         # event falls through to the generic default and reasoning=None, so encrypted_content
         # is never available for multi-turn conversations.
         if chunk.item.type == "reasoning":
+            if chunk.item.content:
+                logger.warning(
+                    "OpenAI returned a non-empty 'content' field on a reasoning item ({_id}). "
+                    "This field is currently undocumented and was never observed in practice. "
+                    "The content is preserved in ReasoningContent.extra['content'] but is NOT "
+                    "reflected in ReasoningContent.reasoning_text. Please report this at "
+                    "https://github.com/deepset-ai/haystack/issues so we can update the mapping.",
+                    _id=chunk.item.id,
+                )
             reasoning = ReasoningContent(reasoning_text="", extra=chunk.item.to_dict())
             return StreamingChunk(
                 content="",

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -927,7 +927,13 @@ def _convert_chat_message_to_responses_api_format(message: ChatMessage) -> list[
     if reasonings:
         formatted_reasonings = []
         for reasoning in reasonings:
-            reasoning_item = {"summary": [], **(reasoning.extra)}
+            # Streaming events (e.g. response.reasoning_summary_text.delta) store event-level
+            # fields like item_id, output_index, summary_index, event_id, sequence_number into
+            # reasoning.extra. Those are not valid reasoning input item fields and the API
+            # rejects them with "Unknown parameter" when sent back in subsequent turns.
+            _valid_reasoning_fields = {"id", "type", "encrypted_content", "status"}
+            filtered_extra = {k: v for k, v in reasoning.extra.items() if k in _valid_reasoning_fields}
+            reasoning_item = {"summary": [], **filtered_extra}
             if reasoning.reasoning_text:
                 reasoning_item["summary"] = [{"text": reasoning.reasoning_text, "type": "summary_text"}]
             formatted_reasonings.append(reasoning_item)

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -931,7 +931,9 @@ def _convert_chat_message_to_responses_api_format(message: ChatMessage) -> list[
             # fields like item_id, output_index, summary_index, event_id, sequence_number into
             # reasoning.extra. Those are not valid reasoning input item fields and the API
             # rejects them with "Unknown parameter" when sent back in subsequent turns.
-            _valid_reasoning_fields = {"id", "type", "encrypted_content", "status"}
+            # Valid fields per ResponseReasoningItem schema: id, type, summary (handled separately),
+            # content, encrypted_content, status.
+            _valid_reasoning_fields = {"id", "type", "encrypted_content", "status", "content"}
             filtered_extra = {k: v for k, v in reasoning.extra.items() if k in _valid_reasoning_fields}
             reasoning_item = {"summary": [], **filtered_extra}
             if reasoning.reasoning_text:

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -590,6 +590,15 @@ def _convert_response_to_chat_message(responses: Response | ParsedResponse) -> C
             extra = output.to_dict()
             # we dont need the summary in the extra
             extra.pop("summary")
+            if output.content:
+                logger.warning(
+                    "OpenAI returned a non-empty 'content' field on a reasoning item ({_id}). "
+                    "This field is currently undocumented and was never observed in practice. "
+                    "The content is preserved in ReasoningContent.extra['content'] but is NOT "
+                    "reflected in ReasoningContent.reasoning_text. Please report this at "
+                    "https://github.com/deepset-ai/haystack/issues so we can update the mapping.",
+                    _id=output.id,
+                )
             reasoning_text = "\n".join([summary.text for summary in summaries if summaries])
             reasoning = ReasoningContent(reasoning_text=reasoning_text, extra=extra)
 

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -593,10 +593,8 @@ def _convert_response_to_chat_message(responses: Response | ParsedResponse) -> C
             if output.content:
                 logger.warning(
                     "OpenAI returned a non-empty 'content' field on a reasoning item ({_id}). "
-                    "This field is currently undocumented and was never observed in practice. "
                     "The content is preserved in ReasoningContent.extra['content'] but is NOT "
-                    "reflected in ReasoningContent.reasoning_text. Please report this at "
-                    "https://github.com/deepset-ai/haystack/issues so we can update the mapping.",
+                    "reflected in ReasoningContent.reasoning_text.",
                     _id=output.id,
                 )
             reasoning_text = "\n".join([summary.text for summary in summaries if summaries])

--- a/test/components/generators/chat/test_openai_responses_conversion.py
+++ b/test/components/generators/chat/test_openai_responses_conversion.py
@@ -1368,6 +1368,37 @@ class TestResponseToChatMessage:
             {"content": "I need to use the functions.weather tool.", "role": "assistant"},
         ]
 
+    def test_convert_assistant_message_reasoning_strips_invalid_streaming_fields(self):
+        chat_message = ChatMessage(
+            _role=ChatRole.ASSISTANT,
+            _content=[
+                ReasoningContent(
+                    reasoning_text="Let me think.",
+                    extra={
+                        "id": "rs_abc",
+                        "type": "reasoning",
+                        "encrypted_content": "enc123",
+                        "status": "completed",
+                        "item_id": "some_item",
+                        "output_index": 0,
+                        "summary_index": 1,
+                        "event_id": "ev_xyz",
+                        "sequence_number": 42,
+                    },
+                )
+            ],
+        )
+        result = _convert_chat_message_to_responses_api_format(chat_message)
+        assert result == [
+            {
+                "id": "rs_abc",
+                "type": "reasoning",
+                "encrypted_content": "enc123",
+                "status": "completed",
+                "summary": [{"text": "Let me think.", "type": "summary_text"}],
+            }
+        ]
+
     def test_convert_tool_message(self):
         tool_call_result = ChatMessage(
             _role=ChatRole.TOOL,


### PR DESCRIPTION
### Proposed Changes:

- In Previous PR #11669: streaming `response.reasoning_summary_text.delta` events spread event-level fields (`item_id`, `output_index`, `summary_index`, etc.) into `ReasoningContent.extra`. When sent back in next calls the API rejected them with `Unknown parameter: 'input[N].item_id'`.

- Fix filters `reasoning.extra` to only valid reasoning input item fields (`id`, `type`, `encrypted_content`, `status`) before serialising.

### How did you test it?

- Integration test `test_live_run_with_agent_streaming_and_reasoning` — was failing Windows without the fix, passes with it.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
