### PR TITLE
fix: allow multiple connections to PromptBuilder.documents

### DIFF
--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -6,11 +6,15 @@ from typing import Any, Literal
 
 from jinja2.sandbox import SandboxedEnvironment
 
-from haystack import component, default_to_dict, logging
+from haystack import Document, component, default_to_dict, logging
 from haystack.utils import Jinja2TimeExtension
 from haystack.utils.jinja2_extensions import _extract_template_variables_and_assignments
 
 logger = logging.getLogger(__name__)
+
+_PROMPT_VARIABLE_INPUT_TYPES: dict[str, type] = {
+    "documents": list[Document],
+}
 
 
 @component
@@ -195,10 +199,12 @@ class PromptBuilder:
 
         # setup inputs
         for var in self.variables:
+            input_type = _PROMPT_VARIABLE_INPUT_TYPES.get(var, Any)
             if self.required_variables == "*" or var in self.required_variables:
-                component.set_input_type(self, var, Any)
+                component.set_input_type(self, var, input_type)
             else:
-                component.set_input_type(self, var, Any, "")
+                default = [] if var == "documents" else ""
+                component.set_input_type(self, var, input_type, default)
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -12,9 +12,7 @@ from haystack.utils.jinja2_extensions import _extract_template_variables_and_ass
 
 logger = logging.getLogger(__name__)
 
-_PROMPT_VARIABLE_INPUT_TYPES: dict[str, type] = {
-    "documents": list[Document],
-}
+_PROMPT_VARIABLE_INPUT_TYPES: dict[str, type] = {"documents": list[Document]}
 
 
 @component

--- a/releasenotes/notes/fix-prompt-builder-multiple-documents-10721b4c8d2e1f0a9.yaml
+++ b/releasenotes/notes/fix-prompt-builder-multiple-documents-10721b4c8d2e1f0a9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed ``PromptBuilder`` rejecting a second connection to ``documents`` when wiring multiple retrievers
+    into a pipeline. The ``documents`` template variable is now typed as ``list[Document]`` so the pipeline
+    can aggregate multiple document lists before rendering the prompt.

--- a/test/components/builders/test_prompt_builder.py
+++ b/test/components/builders/test_prompt_builder.py
@@ -12,8 +12,10 @@ from jinja2 import TemplateSyntaxError
 
 from haystack import component
 from haystack.components.builders.prompt_builder import PromptBuilder
+from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.core.pipeline.pipeline import Pipeline
 from haystack.dataclasses.document import Document
+from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 
 class TestPromptBuilder:
@@ -245,6 +247,27 @@ class TestPromptBuilder:
                 "prompt": "Here is the document: Hello world, I live in Berlin \n Query: Where does the speaker live?"
             }
         }
+
+    def test_multiple_retriever_connections_to_documents(self):
+        template = "{% for doc in documents %}{{ doc.content }} {% endfor %}"
+        prompt_builder = PromptBuilder(template=template, variables=["documents"])
+
+        store_1 = InMemoryDocumentStore()
+        store_2 = InMemoryDocumentStore()
+        store_1.write_documents([Document(content="Paris")])
+        store_2.write_documents([Document(content="Berlin")])
+
+        pipe = Pipeline()
+        pipe.add_component("retriever_1", InMemoryBM25Retriever(document_store=store_1))
+        pipe.add_component("retriever_2", InMemoryBM25Retriever(document_store=store_2))
+        pipe.add_component("prompt_builder", prompt_builder)
+        pipe.connect("retriever_1.documents", "prompt_builder.documents")
+        pipe.connect("retriever_2.documents", "prompt_builder.documents")
+
+        result = pipe.run({"retriever_1": {"query": "Paris"}, "retriever_2": {"query": "Berlin"}})
+
+        assert "Paris" in result["prompt_builder"]["prompt"]
+        assert "Berlin" in result["prompt_builder"]["prompt"]
 
     def test_example_in_pipeline_simple(self):
         default_template = "This is the default prompt:\n Query: {{query}}"


### PR DESCRIPTION
### Related Issues

- fixes #10721

### Proposed Changes:

`PromptBuilder` registered template variables with type `Any`, so `_make_socket_auto_variadic()` could not treat `documents` as a list socket and blocked a second retriever connection.

Following @anakin87's suggestion on the issue, `documents` is now typed as `list[Document]`. The pipeline aggregates multiple connected document lists before rendering the template. Optional `documents` defaults to `[]` instead of `""`.

### How did you test it?

- Added `test_multiple_retriever_connections_to_documents` in `test/components/builders/test_prompt_builder.py`
- `pytest test/components/builders/test_prompt_builder.py` — 33 passed
- `ruff check` and `ruff format --check` on changed files

### Notes for the reviewer

Minimal change scoped to `PromptBuilder` only (not `ChatPromptBuilder`). No changes to `_make_socket_auto_variadic`.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

This PR was partially AI-assisted; I reviewed and tested all changes locally.