### PR TITLE
fix: handle non-numeric sort_docs_by in MetaFieldGroupingRanker

### DIFF
--- a/haystack/components/rankers/meta_field_grouping_ranker.py
+++ b/haystack/components/rankers/meta_field_grouping_ranker.py
@@ -109,17 +109,16 @@ class MetaFieldGroupingRanker:
 
             document_groups[group_value][subgroup_value].append(doc)
 
-        # Resolve the sort field once. Falling back to "" keeps the lookup key a non-optional str for the
-        # type checker; an empty field simply means "no sorting" and is skipped by the check below.
+        # use a non-optional key for type checking; "" disables sorting.
         sort_field = self.sort_docs_by or ""
 
         ordered_docs = []
         for subgroups in document_groups.values():
             for docs in subgroups.values():
                 if sort_field:
-                    # Place documents that miss the sort field (value None) last. The (is_missing, value)
-                    # tuple keeps the comparison type-safe, so non-numeric fields (e.g. date strings) are
-                    # never compared against a sentinel value.
+                    # Sort by the field value, placing documents with a missing value last.
+                    # The (is_missing, value) tuple ensures that only actual field values are
+                    # compared, making the sort work for numbers, strings, and other types.
                     docs.sort(key=lambda d: (d.meta.get(sort_field) is None, d.meta.get(sort_field)))
                 ordered_docs.extend(docs)
 

--- a/haystack/components/rankers/meta_field_grouping_ranker.py
+++ b/haystack/components/rankers/meta_field_grouping_ranker.py
@@ -109,11 +109,18 @@ class MetaFieldGroupingRanker:
 
             document_groups[group_value][subgroup_value].append(doc)
 
+        # Resolve the sort field once. Falling back to "" keeps the lookup key a non-optional str for the
+        # type checker; an empty field simply means "no sorting" and is skipped by the check below.
+        sort_field = self.sort_docs_by or ""
+
         ordered_docs = []
         for subgroups in document_groups.values():
             for docs in subgroups.values():
-                if self.sort_docs_by:
-                    docs.sort(key=lambda d: d.meta.get(self.sort_docs_by or "", float("inf")))
+                if sort_field:
+                    # Place documents that miss the sort field (value None) last. The (is_missing, value)
+                    # tuple keeps the comparison type-safe, so non-numeric fields (e.g. date strings) are
+                    # never compared against a sentinel value.
+                    docs.sort(key=lambda d: (d.meta.get(sort_field) is None, d.meta.get(sort_field)))
                 ordered_docs.extend(docs)
 
         ordered_docs.extend(no_group_docs)

--- a/releasenotes/notes/fix-metafieldgroupingranker-non-numeric-sort-a3595a30603c12ba.yaml
+++ b/releasenotes/notes/fix-metafieldgroupingranker-non-numeric-sort-a3595a30603c12ba.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed ``MetaFieldGroupingRanker`` raising a ``TypeError`` when ``sort_docs_by`` points to a
+    non-numeric metadata field (for example ISO date strings) and some documents are missing that
+    field. Documents that miss the field are now placed at the end of their group, regardless of the
+    field's type.

--- a/test/components/rankers/test_meta_field_grouping_ranker.py
+++ b/test/components/rankers/test_meta_field_grouping_ranker.py
@@ -132,6 +132,42 @@ class TestMetaFieldGroupingRanker:
         assert result["documents"][1].meta["group"] == "42"
         assert result["documents"][2].content == "Document without group"
 
+    def test_run_sort_docs_by_non_numeric_field_with_missing_values(self) -> None:
+        """
+        Test that sorting by a non-numeric metadata field does not raise an error when some documents are missing
+        that field. Documents missing the sort field are placed at the end of their group.
+        """
+        docs = [
+            Document(content="newest", meta={"group": "42", "date": "2023-03-01"}),
+            Document(content="missing date", meta={"group": "42"}),
+            Document(content="oldest", meta={"group": "42", "date": "2023-01-01"}),
+        ]
+        ranker = MetaFieldGroupingRanker(group_by="group", sort_docs_by="date")
+        result = ranker.run(documents=docs)
+        assert "documents" in result
+        assert len(result["documents"]) == 3
+        assert result["documents"][0].content == "oldest"
+        assert result["documents"][1].content == "newest"
+        assert result["documents"][2].content == "missing date"
+
+    def test_run_sort_docs_by_field_present_but_none(self) -> None:
+        """
+        Test that sorting by a metadata field works when the field is present but set to None for some documents.
+        Documents with a None value are treated like missing values and placed at the end of their group.
+        """
+        docs = [
+            Document(content="present", meta={"group": "42", "date": "2023-01-01"}),
+            Document(content="none value", meta={"group": "42", "date": None}),
+            Document(content="missing", meta={"group": "42"}),
+        ]
+        ranker = MetaFieldGroupingRanker(group_by="group", sort_docs_by="date")
+        result = ranker.run(documents=docs)
+        assert "documents" in result
+        assert len(result["documents"]) == 3
+        assert result["documents"][0].content == "present"
+        assert result["documents"][1].content == "none value"
+        assert result["documents"][2].content == "missing"
+
     def test_run_metadata_with_different_data_types(self) -> None:
         """
         Test the behavior of the MetaFieldGroupingRanker component when the metadata values have different data types.


### PR DESCRIPTION
### Related Issues

- fixes #11725

### Proposed Changes:

`MetaFieldGroupingRanker.run()` raised `TypeError: '<' not supported between instances of 'float' and 'str'` when `sort_docs_by` pointed at a non-numeric metadata field (e.g. ISO date strings) and some documents were missing that field. The sort used `float("inf")` as the missing-value sentinel, which cannot be compared against non-numeric values.

This resolves the sort field once and uses a type-safe `(value is None, value)` sort key, so documents missing the field (or whose value is `None`) are placed at the end of their group regardless of the field's type. Behaviour for numeric fields is unchanged.

Repro (raises on `main`):

```python
from haystack.components.rankers import MetaFieldGroupingRanker
from haystack.dataclasses import Document

docs = [
    Document(content="newest", meta={"group": "42", "date": "2023-03-01"}),
    Document(content="missing date", meta={"group": "42"}),
    Document(content="oldest", meta={"group": "42", "date": "2023-01-01"}),
]
MetaFieldGroupingRanker(group_by="group", sort_docs_by="date").run(documents=docs)
# TypeError: '<' not supported between instances of 'float' and 'str'
```

### How did you test it?

Added two unit tests in `test/components/rankers/test_meta_field_grouping_ranker.py`:
- sorting by a non-numeric field with a missing key
- sorting by a field that is present but set to `None`

All existing ranker unit tests pass. `hatch run test:types` (mypy) and `hatch run fmt` are clean, and the pre-commit hooks pass.

### Notes for the reviewer

- Documents missing the sort field (or with a `None` value) are placed last, matching the previous numeric behaviour and the class's "documents without a group are placed at the end" convention. Sort stability is preserved.
- Out of scope: a single group mixing value *types* for the same key (e.g. `int` and `str`) remains inherently unsortable — that limitation is unchanged.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used a [conventional commit type](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title (`fix:`).
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

---

_Implemented with the help of an AI assistant; I have reviewed all changes and run the relevant tests and quality checks._
