### PR TITLE
refactor!: Require explicit `inputs_from_state` for a Tool to read from State

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -457,6 +457,75 @@ pipeline.run(data={"retriever": {"query": query}, "agent": {"messages": [], "que
 If the prompt itself must still be assembled per run, build `ChatMessage` objects before the `Agent` (e.g. with a `ChatPromptBuilder`) and pass them through the `messages` input.
 For a runtime system prompt, construct an `Agent` without `system_prompt` or `user_prompt` and include a system message at the start of `messages`.
 
+#### Tools must declare `inputs_from_state` to read from `State` by name
+
+**What changed:** A tool now reads a value from the Agent's `State` by name only when it declares an explicit `inputs_from_state` mapping. Previously, a tool without `inputs_from_state` had every parameter implicitly treated as a potential `State` key: any parameter whose name matched a `State` key (and that the LLM did not supply) was silently filled from `State`. This implicit name-matching has been removed. It applies to every tool type, since `ComponentTool`, `PipelineTool`, `MCPTool`, and others all derive from the base `Tool` class.
+
+**Why:** The implicit matching was hidden — nothing in a tool's definition signaled that it read from `State`, so a tool could start consuming `State` purely because of an incidental parameter-name collision. With many tools and a large state schema this made accidental overlaps likely, and renaming a parameter or adding a `State` key could silently change what a tool received. Requiring an explicit mapping makes a tool's `State` dependencies visible and intentional. Auto-injection of the full `State` object into a parameter annotated as `State` is unaffected — that is explicit at the signature level.
+
+**How to migrate:** Add an explicit `inputs_from_state` mapping (`{state_key: parameter_name}`) to any tool that should read from `State` by name.
+
+Before (v2.x), whenever the model called `weather_tool` *without* supplying a `location` argument, the parameter was filled from the `location` state key automatically, because the parameter name matched a key in the Agent's `state_schema`. (If the model did supply `location`, the LLM-provided value always took precedence and `State` was not consulted.)
+```python
+from haystack.components.agents import Agent
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.tools import Tool
+
+weather_tool = Tool(
+    name="weather_tool",
+    description="Provides weather information for a given location.",
+    parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
+    function=weather_function,
+)
+
+agent = Agent(
+    chat_generator=OpenAIChatGenerator(model="gpt-5.4-nano"),
+    tools=[weather_tool],
+    # `location` lives in State, so it was silently injected into the tool's same-named parameter
+    # on any call where the model didn't already provide a `location` argument.
+    state_schema={"location": {"type": str}},
+)
+```
+
+After (v3.0), declare the mapping explicitly so the read from `State` is visible in the tool definition:
+```python
+from haystack.components.agents import Agent
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.tools import Tool
+
+weather_tool = Tool(
+    name="weather_tool",
+    description="Provides weather information for a given location.",
+    parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
+    function=weather_function,
+    inputs_from_state={"location": "location"},
+)
+
+agent = Agent(
+    chat_generator=OpenAIChatGenerator(model="gpt-5.4-nano"),
+    tools=[weather_tool],
+    state_schema={"location": {"type": str}},
+)
+```
+
+Tools that take the full `State` object via a `State`-annotated parameter need no change:
+```python
+from typing import Annotated
+
+from haystack.components.agents import State
+from haystack.tools import Tool
+
+def weather_function(location: Annotated[str, "The name of the city"], state: State) -> str:
+    ...
+
+weather_tool = Tool(
+    name="weather_tool",
+    description="Provides weather information for a given location.",
+    parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
+    function=weather_function,  # `state` is still injected automatically
+)
+```
+
 #### Reserved `state_schema` keys for built-in run metadata
 
 **What changed:** `Agent` now auto-populates three new outputs — `step_count`, `token_usage`, and `tool_call_counts` — and reserves those names in its `state_schema`. Passing any of them as a `state_schema` key now raises `ValueError`.

--- a/haystack/components/agents/tool_calling.py
+++ b/haystack/components/agents/tool_calling.py
@@ -69,10 +69,8 @@ def _merge_tool_outputs_into_state(tool: Tool, result: Any, state: State) -> Non
     """
     if not isinstance(result, dict):
         return
-    if not hasattr(tool, "outputs_to_state") or not isinstance(tool.outputs_to_state, dict):
-        return
 
-    for state_key, config in tool.outputs_to_state.items():
+    for state_key, config in (tool.outputs_to_state or {}).items():
         source_key = config.get("source", None)
         if source_key and source_key not in result:
             continue
@@ -243,30 +241,12 @@ def _get_func_params(tool: Tool) -> dict[str, Any]:
     return {name: param.annotation for name, param in inspect.signature(target).parameters.items()}  # type: ignore[arg-type]
 
 
-def _state_param_mappings(tool: Tool, func_params: dict[str, Any]) -> dict[str, str]:
-    """
-    Resolve the `{state_key: param_name}` mapping a tool uses to pull inputs from State.
-
-    Tools may declare this explicitly via `inputs_from_state`; otherwise every parameter is treated as a potential state
-     key by name. This is the single source of truth shared by `_inject_state_args` (which reads the actual values) and
-     `_state_io_for_call` (which derives the read set for scheduling).
-
-    :param tool: The tool whose state-input mapping to resolve.
-    :param func_params: The tool's parameter names mapped to their annotations (from `_get_func_params`).
-    :returns: A mapping of state key to the tool parameter it feeds.
-    """
-    inputs_from_state = getattr(tool, "inputs_from_state", None)
-    if isinstance(inputs_from_state, dict):
-        return inputs_from_state
-    return {name: name for name in func_params}
-
-
 def _inject_state_args(tool: Tool, llm_args: dict[str, Any], state: State) -> dict[str, Any]:
     """
     Merge LLM-provided arguments with state-sourced arguments.
 
-    LLM args take precedence. State values are pulled in via `inputs_from_state` mappings or parameter-name matching,
-    then the live State object is injected for any param annotated as State.
+    LLM args take precedence. State values are pulled in only for the keys a tool explicitly declares via its
+    `inputs_from_state` mapping, then the live State object is injected for any param annotated as State.
 
     :param tool: The tool being invoked, used to determine parameter mappings and State injection.
     :param llm_args: The arguments provided by the LLM, which take precedence over state values.
@@ -277,10 +257,12 @@ def _inject_state_args(tool: Tool, llm_args: dict[str, Any], state: State) -> di
     final_args = dict(llm_args)
     func_params = _get_func_params(tool)
 
-    for state_key, param_name in _state_param_mappings(tool, func_params).items():
+    # A tool reads from State by name only via an explicit `inputs_from_state` mapping
+    for state_key, param_name in (tool.inputs_from_state or {}).items():
         if param_name not in final_args and state.has(state_key):
             final_args[param_name] = state.get(state_key)
 
+    # We also inject the full State object for any parameter annotated as State
     for param_name, param_type in func_params.items():
         if _unwrap_optional(param_type) is State:
             final_args[param_name] = state
@@ -391,8 +373,8 @@ def _state_io_for_call(tool: Tool, llm_args: dict[str, Any]) -> tuple[_StateKeys
 
     Mirrors the resolution logic in `_inject_state_args`:
     - A tool with a `State`-annotated parameter can read/write any key, so both sets are the `_ALL_STATE_KEYS` wildcard.
-    - Otherwise reads come from `inputs_from_state` (or parameter-name matching when it is not set), excluding any
-      parameter the LLM already supplied (LLM args take precedence and short-circuit the state lookup).
+    - Otherwise reads come from the tool's explicit `inputs_from_state` mapping, excluding any parameter the LLM already
+      supplied (LLM args take precedence and short-circuit the state lookup).
     - Writes are the keys in `outputs_to_state`.
 
     :returns: A `(reads, writes)` tuple of state-key sets (or the `_ALL_STATE_KEYS` wildcard).
@@ -403,11 +385,10 @@ def _state_io_for_call(tool: Tool, llm_args: dict[str, Any]) -> tuple[_StateKeys
         return _ALL_STATE_KEYS, _ALL_STATE_KEYS
 
     # Calculate reads
-    param_mappings = _state_param_mappings(tool, func_params)
+    param_mappings = tool.inputs_from_state or {}
     reads = {state_key for state_key, param_name in param_mappings.items() if param_name not in llm_args}
     # Calculate writes
-    outputs_to_state = getattr(tool, "outputs_to_state", None)
-    writes = set(outputs_to_state.keys()) if isinstance(outputs_to_state, dict) else set()
+    writes = set((tool.outputs_to_state or {}).keys())
 
     return reads, writes
 

--- a/releasenotes/notes/require-explicit-inputs-from-state-7a3c1f9e8b2d4c60.yaml
+++ b/releasenotes/notes/require-explicit-inputs-from-state-7a3c1f9e8b2d4c60.yaml
@@ -1,0 +1,16 @@
+---
+upgrade:
+  - |
+    Tools now read a value from the ``Agent``'s ``State`` by name **only** when they declare an explicit
+    ``inputs_from_state`` mapping. Previously, when a tool had no ``inputs_from_state``, the ``Agent`` would implicitly
+    inject a ``State`` value into any tool parameter whose name happened to match a ``State`` key, on any call where the
+    model did not already supply that argument (LLM-provided arguments always took precedence). This implicit
+    name-matching has been removed. The change applies to every tool type, since ``ComponentTool``, ``PipelineTool``,
+    ``MCPTool``, and others all derive from the base ``Tool`` class.
+
+    This is a breaking change. If you relied on a tool parameter being filled from a same-named ``State`` key, add an
+    explicit mapping, for example ``inputs_from_state={"documents": "documents"}`` to feed the ``documents`` state key
+    into the tool's ``documents`` parameter.
+
+    Auto-injection of the full ``State`` object into a parameter annotated as ``State`` is unchanged and continues to
+    work without any mapping.

--- a/test/components/agents/test_tool_calling.py
+++ b/test/components/agents/test_tool_calling.py
@@ -151,7 +151,8 @@ class TestCore:
         with pytest.raises(ValueError):
             _validate_and_prepare_tools([weather_tool, weather_tool])
 
-    def test_inject_state_args_no_tool_inputs(self):
+    def test_inject_state_args_no_tool_inputs_does_not_match_by_name(self):
+        # Without an explicit `inputs_from_state`, a matching State key name must NOT be injected.
         weather_tool = Tool(
             name="weather_tool",
             description="Provides weather information for a given location.",
@@ -160,16 +161,17 @@ class TestCore:
         )
         state = State(schema={"location": {"type": str}}, data={"location": "Berlin"})
         args = _inject_state_args(tool=weather_tool, llm_args={}, state=state)
-        assert args == {"location": "Berlin"}
+        assert args == {}
 
-    def test_inject_state_args_no_tool_inputs_component_tool(self):
+    def test_inject_state_args_no_tool_inputs_component_tool_does_not_match_by_name(self):
+        # Without an explicit `inputs_from_state`, a matching State key name must NOT be injected.
         comp = PromptBuilder(template="Hello, {{name}}!")
         prompt_tool = ComponentTool(
             component=comp, name="prompt_tool", description="Creates a personalized greeting prompt."
         )
         state = State(schema={"name": {"type": str}}, data={"name": "James"})
         args = _inject_state_args(tool=prompt_tool, llm_args={}, state=state)
-        assert args == {"name": "James"}
+        assert args == {}
 
     def test_inject_state_args_with_tool_inputs(self):
         weather_tool = Tool(


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/418

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

- Tools now read a value from the ``Agent``'s ``State`` by name **only** when they declare an explicit ``inputs_from_state`` mapping. Previously, when a tool had no ``inputs_from_state``, the ``Agent`` would implicitly inject a ``State`` value into any tool parameter whose name happened to match a ``State`` key, on any call where the model did not already supply that argument (LLM-provided arguments always took precedence). This implicit name-matching has been removed and applies to every tool type, since ``ComponentTool``, ``PipelineTool``, ``MCPTool``, and others all derive from the base ``Tool`` class.

- Auto-injection of the full ``State`` object into a parameter annotated as ``State`` is unchanged and continues to work without any mapping.

- Added an upgrade section in the reno and an entry to the MIGRATION.md

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Updated existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
