### PR TITLE
chore: deprecate OpenTelemetry tracer + update docs

### DIFF
--- a/docs-website/docs/development/tracing.mdx
+++ b/docs-website/docs/development/tracing.mdx
@@ -113,7 +113,9 @@ To use your custom tracing backend with Haystack, follow these steps:
           self._tracer = tracer
 
       @contextlib.contextmanager
-      def trace(self, operation_name: str, tags: Optional[Dict[str, Any]] = None) -> Iterator[Span]:
+      def trace(
+          self, operation_name: str, tags: Optional[Dict[str, Any]] = None, parent_span: Optional[Span] = None
+      ) -> Iterator[Span]:
           with self._tracer.start_as_current_span(operation_name) as span:
               span = OpenTelemetrySpan(span)
               if tags:

--- a/docs-website/docs/development/tracing.mdx
+++ b/docs-website/docs/development/tracing.mdx
@@ -19,72 +19,13 @@ Instrumented applications typically send traces to a trace collector or a tracin
 
 ### OpenTelemetry
 
-To use OpenTelemetry as your tracing backend, follow these steps:
+The `OpenTelemetryConnector` component lets you trace your Haystack pipelines with [OpenTelemetry](https://opentelemetry.io/).
 
-1. Install the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/python/):
+Simply install the integration with `pip install opentelemetry-haystack`, then add the connector to your pipeline.
 
-   ```shell
-   pip install opentelemetry-sdk
-   pip install opentelemetry-exporter-otlp
-   ```
-2. To add traces to even deeper levels of your pipelines, we recommend you check out [OpenTelemetry integrations](https://opentelemetry.io/ecosystem/registry/?s=python), such as:
-   - [`urllib3` instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-urllib3) for tracing HTTP requests in your pipeline,
-   - [OpenAI instrumentation](https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-openai) for tracing OpenAI requests.
-3. There are two options for how to hook Haystack to the OpenTelemetry SDK.
-
-   - Run your Haystack applications using OpenTelemetry’s [automated instrumentation](https://opentelemetry.io/docs/languages/python/getting-started/#instrumentation). Haystack will automatically detect the configured tracing backend and use it to send traces.
-
-     First, install the `OpenTelemetry` CLI:
-
-     ```shell
-     pip install opentelemetry-distro
-     ```
-
-     Then, run your Haystack application using the OpenTelemetry SDK:
-
-     ```shell
-     opentelemetry-instrument \
-         --traces_exporter console \
-         --metrics_exporter console \
-         --logs_exporter console \
-         --service_name my-haystack-app \
-         <command to run your Haystack pipeline>
-     ```
-
-   — or —
-
-   - Configure the tracing backend in your Python code:
-
-     ```python
-     from haystack import tracing
-
-     from opentelemetry import trace
-     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-     from opentelemetry.sdk.trace import TracerProvider
-     from opentelemetry.sdk.trace.export import BatchSpanProcessor
-     from opentelemetry.sdk.resources import Resource
-     from opentelemetry.semconv.resource import ResourceAttributes
-
-     # Service name is required for most backends
-     resource = Resource(attributes={
-         ResourceAttributes.SERVICE_NAME: "haystack"  # Correct constant
-     })
-
-     tracer_provider = TracerProvider(resource=resource)
-     processor = BatchSpanProcessor(OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces"))
-     tracer_provider.add_span_processor(processor)
-     trace.set_tracer_provider(tracer_provider)
-
-     # Tell Haystack to auto-detect the configured tracer
-     import haystack.tracing
-     haystack.tracing.auto_enable_tracing()
-
-     # Explicitly tell Haystack to use your tracer
-     from haystack.tracing import OpenTelemetryTracer
-
-     tracer = tracer_provider.get_tracer("my_application")
-     tracing.enable_tracing(OpenTelemetryTracer(tracer))
-     ```
+:::info
+Check out the [integration page](https://haystack.deepset.ai/integrations/opentelemetry) for more details and example usage.
+:::
 
 ### Datadog
 

--- a/docs-website/docs/pipeline-components/connectors.mdx
+++ b/docs-website/docs/pipeline-components/connectors.mdx
@@ -22,4 +22,5 @@ These are Haystack integrations that connect your pipelines to services by exter
 | [LangfuseConnector](connectors/langfuseconnector.mdx)             | Enables tracing in Haystack pipelines using Langfuse.                                                     |
 | [OpenAPIConnector](connectors/openapiconnector.mdx)                 | Acts as an interface between the Haystack ecosystem and OpenAPI services, using explicit input arguments. |
 | [OpenAPIServiceConnector](connectors/openapiserviceconnector.mdx) | Acts as an interface between the Haystack ecosystem and OpenAPI services.                                 |
+| [OpenTelemetryConnector](connectors/opentelemetryconnector.mdx) | Enables tracing in Haystack pipelines using OpenTelemetry. |
 | [WeaveConnector](connectors/weaveconnector.mdx)                     | Connects you to Weights & Biases Weave framework for tracing and monitoring your pipeline components.     |

--- a/docs-website/docs/pipeline-components/connectors/opentelemetryconnector.mdx
+++ b/docs-website/docs/pipeline-components/connectors/opentelemetryconnector.mdx
@@ -1,0 +1,126 @@
+---
+title: "OpenTelemetryConnector"
+id: opentelemetryconnector
+slug: "/opentelemetryconnector"
+description: "Learn how to work with OpenTelemetry in Haystack."
+---
+
+# OpenTelemetryConnector
+
+Learn how to work with OpenTelemetry in Haystack.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | Anywhere, as it’s not connected to other components |
+| **Mandatory init variables** | None. The tracer is created at initialization time |
+| **Output variables** | `name`: The name of the tracing component |
+| **API reference** | [opentelemetry](/reference/integrations-opentelemetry) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/opentelemetry |
+| **Package name** | `opentelemetry-haystack` |
+
+</div>
+
+## Overview
+
+`OpenTelemetryConnector` integrates tracing capabilities into Haystack pipelines using [OpenTelemetry](https://opentelemetry.io/), through the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/python/). It captures detailed information about pipeline runs, like API calls, context data, prompts, and more, so you can see the complete trace of your pipeline execution in any OpenTelemetry-compatible backend.
+
+OpenTelemetry tracing is enabled as soon as the `OpenTelemetryConnector` is initialized, so you only need to add it to your pipeline – it does not need to be connected to other components or to run to take effect.
+
+You can optionally pass a `name` to identify this tracing component (it defaults to `opentelemetry`).
+
+### Prerequisites
+
+These are the things that you need before working with the `OpenTelemetryConnector`:
+
+1. A configured OpenTelemetry `TracerProvider` with an exporter (for example, an OTLP exporter that sends traces to a collector or a backend). Set up the provider before initializing the connector.
+2. Set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment variable to `true` – this will enable content tracing (inputs and outputs) in your pipelines.
+3. To add traces at even deeper levels, check out the available [OpenTelemetry instrumentations](https://opentelemetry.io/ecosystem/registry/?s=python), such as `opentelemetry-instrumentation-openai-v2` for tracing OpenAI requests.
+
+### Installation
+
+First, install the `opentelemetry-haystack` package to use the `OpenTelemetryConnector`:
+
+```shell
+pip install opentelemetry-haystack
+```
+
+<br />
+
+:::info[Usage Notice]
+
+To ensure proper tracing, always set environment variables before importing any Haystack components. This is crucial because Haystack initializes its internal tracing components during import. In the example below, we first set the environment variables and then import the relevant Haystack components.
+
+Alternatively, an even better practice is to set these environment variables in your shell before running the script. This approach keeps configuration separate from code and allows for easier management of different environments.
+:::
+
+## Usage
+
+In the example below, we are adding `OpenTelemetryConnector` to the pipeline as a _tracer_. Each pipeline run will produce a trace that includes the entire execution context, including prompts, completions, and metadata. You can then view the traces in your OpenTelemetry backend.
+
+```python
+import os
+
+os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.semconv.resource import ResourceAttributes
+
+# Configure the OpenTelemetry SDK. A service name is required for most backends.
+resource = Resource(attributes={ResourceAttributes.SERVICE_NAME: "haystack"})
+tracer_provider = TracerProvider(resource=resource)
+tracer_provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces")),
+)
+trace.set_tracer_provider(tracer_provider)
+
+from haystack import Pipeline
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.components.connectors.opentelemetry import (
+    OpenTelemetryConnector,
+)
+
+pipe = Pipeline()
+pipe.add_component("tracer", OpenTelemetryConnector("Chat example"))
+pipe.add_component("prompt_builder", ChatPromptBuilder())
+pipe.add_component("llm", OpenAIChatGenerator())
+pipe.connect("prompt_builder.prompt", "llm.messages")
+
+messages = [
+    ChatMessage.from_system(
+        "Always respond in German even if some input data is in other languages.",
+    ),
+    ChatMessage.from_user("Tell me about {{location}}"),
+]
+
+response = pipe.run(
+    data={
+        "prompt_builder": {
+            "template_variables": {"location": "Berlin"},
+            "template": messages,
+        },
+    },
+)
+print(response["llm"]["replies"][0])
+```
+
+### Configuring the tracing backend directly
+
+Instead of using the `OpenTelemetryConnector`, you can configure the OpenTelemetry tracing backend directly by enabling an `OpenTelemetryTracer`. Make sure to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment variable and configure your `TracerProvider` before importing any Haystack components.
+
+```python
+from opentelemetry import trace
+
+from haystack import tracing
+from haystack_integrations.tracing.opentelemetry import OpenTelemetryTracer
+
+tracing.enable_tracing(OpenTelemetryTracer(trace.get_tracer("my_application")))
+```

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -225,6 +225,7 @@ export default {
             'pipeline-components/connectors/langfuseconnector',
             'pipeline-components/connectors/openapiconnector',
             'pipeline-components/connectors/openapiserviceconnector',
+            'pipeline-components/connectors/opentelemetryconnector',
             'pipeline-components/connectors/weaveconnector',
             'pipeline-components/connectors/external-integrations-connectors',
           ],

--- a/docs-website/versioned_docs/version-2.30/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.30/development/tracing.mdx
@@ -113,7 +113,9 @@ To use your custom tracing backend with Haystack, follow these steps:
           self._tracer = tracer
 
       @contextlib.contextmanager
-      def trace(self, operation_name: str, tags: Optional[Dict[str, Any]] = None) -> Iterator[Span]:
+      def trace(
+          self, operation_name: str, tags: Optional[Dict[str, Any]] = None, parent_span: Optional[Span] = None
+      ) -> Iterator[Span]:
           with self._tracer.start_as_current_span(operation_name) as span:
               span = OpenTelemetrySpan(span)
               if tags:

--- a/docs-website/versioned_docs/version-2.30/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.30/development/tracing.mdx
@@ -19,72 +19,13 @@ Instrumented applications typically send traces to a trace collector or a tracin
 
 ### OpenTelemetry
 
-To use OpenTelemetry as your tracing backend, follow these steps:
+The `OpenTelemetryConnector` component lets you trace your Haystack pipelines with [OpenTelemetry](https://opentelemetry.io/).
 
-1. Install the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/python/):
+Simply install the integration with `pip install opentelemetry-haystack`, then add the connector to your pipeline.
 
-   ```shell
-   pip install opentelemetry-sdk
-   pip install opentelemetry-exporter-otlp
-   ```
-2. To add traces to even deeper levels of your pipelines, we recommend you check out [OpenTelemetry integrations](https://opentelemetry.io/ecosystem/registry/?s=python), such as:
-   - [`urllib3` instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-urllib3) for tracing HTTP requests in your pipeline,
-   - [OpenAI instrumentation](https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-openai) for tracing OpenAI requests.
-3. There are two options for how to hook Haystack to the OpenTelemetry SDK.
-
-   - Run your Haystack applications using OpenTelemetry’s [automated instrumentation](https://opentelemetry.io/docs/languages/python/getting-started/#instrumentation). Haystack will automatically detect the configured tracing backend and use it to send traces.
-
-     First, install the `OpenTelemetry` CLI:
-
-     ```shell
-     pip install opentelemetry-distro
-     ```
-
-     Then, run your Haystack application using the OpenTelemetry SDK:
-
-     ```shell
-     opentelemetry-instrument \
-         --traces_exporter console \
-         --metrics_exporter console \
-         --logs_exporter console \
-         --service_name my-haystack-app \
-         <command to run your Haystack pipeline>
-     ```
-
-   — or —
-
-   - Configure the tracing backend in your Python code:
-
-     ```python
-     from haystack import tracing
-
-     from opentelemetry import trace
-     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-     from opentelemetry.sdk.trace import TracerProvider
-     from opentelemetry.sdk.trace.export import BatchSpanProcessor
-     from opentelemetry.sdk.resources import Resource
-     from opentelemetry.semconv.resource import ResourceAttributes
-
-     # Service name is required for most backends
-     resource = Resource(attributes={
-         ResourceAttributes.SERVICE_NAME: "haystack"  # Correct constant
-     })
-
-     tracer_provider = TracerProvider(resource=resource)
-     processor = BatchSpanProcessor(OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces"))
-     tracer_provider.add_span_processor(processor)
-     trace.set_tracer_provider(tracer_provider)
-
-     # Tell Haystack to auto-detect the configured tracer
-     import haystack.tracing
-     haystack.tracing.auto_enable_tracing()
-
-     # Explicitly tell Haystack to use your tracer
-     from haystack.tracing import OpenTelemetryTracer
-
-     tracer = tracer_provider.get_tracer("my_application")
-     tracing.enable_tracing(OpenTelemetryTracer(tracer))
-     ```
+:::info
+Check out the [integration page](https://haystack.deepset.ai/integrations/opentelemetry) for more details and example usage.
+:::
 
 ### Datadog
 

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/connectors.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/connectors.mdx
@@ -22,4 +22,5 @@ These are Haystack integrations that connect your pipelines to services by exter
 | [LangfuseConnector](connectors/langfuseconnector.mdx)             | Enables tracing in Haystack pipelines using Langfuse.                                                     |
 | [OpenAPIConnector](connectors/openapiconnector.mdx)                 | Acts as an interface between the Haystack ecosystem and OpenAPI services, using explicit input arguments. |
 | [OpenAPIServiceConnector](connectors/openapiserviceconnector.mdx) | Acts as an interface between the Haystack ecosystem and OpenAPI services.                                 |
+| [OpenTelemetryConnector](connectors/opentelemetryconnector.mdx) | Enables tracing in Haystack pipelines using OpenTelemetry. |
 | [WeaveConnector](connectors/weaveconnector.mdx)                     | Connects you to Weights & Biases Weave framework for tracing and monitoring your pipeline components.     |

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/connectors/opentelemetryconnector.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/connectors/opentelemetryconnector.mdx
@@ -1,0 +1,126 @@
+---
+title: "OpenTelemetryConnector"
+id: opentelemetryconnector
+slug: "/opentelemetryconnector"
+description: "Learn how to work with OpenTelemetry in Haystack."
+---
+
+# OpenTelemetryConnector
+
+Learn how to work with OpenTelemetry in Haystack.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Most common position in a pipeline** | Anywhere, as it’s not connected to other components |
+| **Mandatory init variables** | None. The tracer is created at initialization time |
+| **Output variables** | `name`: The name of the tracing component |
+| **API reference** | [opentelemetry](/reference/integrations-opentelemetry) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/opentelemetry |
+| **Package name** | `opentelemetry-haystack` |
+
+</div>
+
+## Overview
+
+`OpenTelemetryConnector` integrates tracing capabilities into Haystack pipelines using [OpenTelemetry](https://opentelemetry.io/), through the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/python/). It captures detailed information about pipeline runs, like API calls, context data, prompts, and more, so you can see the complete trace of your pipeline execution in any OpenTelemetry-compatible backend.
+
+OpenTelemetry tracing is enabled as soon as the `OpenTelemetryConnector` is initialized, so you only need to add it to your pipeline – it does not need to be connected to other components or to run to take effect.
+
+You can optionally pass a `name` to identify this tracing component (it defaults to `opentelemetry`).
+
+### Prerequisites
+
+These are the things that you need before working with the `OpenTelemetryConnector`:
+
+1. A configured OpenTelemetry `TracerProvider` with an exporter (for example, an OTLP exporter that sends traces to a collector or a backend). Set up the provider before initializing the connector.
+2. Set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment variable to `true` – this will enable content tracing (inputs and outputs) in your pipelines.
+3. To add traces at even deeper levels, check out the available [OpenTelemetry instrumentations](https://opentelemetry.io/ecosystem/registry/?s=python), such as `opentelemetry-instrumentation-openai-v2` for tracing OpenAI requests.
+
+### Installation
+
+First, install the `opentelemetry-haystack` package to use the `OpenTelemetryConnector`:
+
+```shell
+pip install opentelemetry-haystack
+```
+
+<br />
+
+:::info[Usage Notice]
+
+To ensure proper tracing, always set environment variables before importing any Haystack components. This is crucial because Haystack initializes its internal tracing components during import. In the example below, we first set the environment variables and then import the relevant Haystack components.
+
+Alternatively, an even better practice is to set these environment variables in your shell before running the script. This approach keeps configuration separate from code and allows for easier management of different environments.
+:::
+
+## Usage
+
+In the example below, we are adding `OpenTelemetryConnector` to the pipeline as a _tracer_. Each pipeline run will produce a trace that includes the entire execution context, including prompts, completions, and metadata. You can then view the traces in your OpenTelemetry backend.
+
+```python
+import os
+
+os.environ["HAYSTACK_CONTENT_TRACING_ENABLED"] = "true"
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.semconv.resource import ResourceAttributes
+
+# Configure the OpenTelemetry SDK. A service name is required for most backends.
+resource = Resource(attributes={ResourceAttributes.SERVICE_NAME: "haystack"})
+tracer_provider = TracerProvider(resource=resource)
+tracer_provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces")),
+)
+trace.set_tracer_provider(tracer_provider)
+
+from haystack import Pipeline
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+
+from haystack_integrations.components.connectors.opentelemetry import (
+    OpenTelemetryConnector,
+)
+
+pipe = Pipeline()
+pipe.add_component("tracer", OpenTelemetryConnector("Chat example"))
+pipe.add_component("prompt_builder", ChatPromptBuilder())
+pipe.add_component("llm", OpenAIChatGenerator())
+pipe.connect("prompt_builder.prompt", "llm.messages")
+
+messages = [
+    ChatMessage.from_system(
+        "Always respond in German even if some input data is in other languages.",
+    ),
+    ChatMessage.from_user("Tell me about {{location}}"),
+]
+
+response = pipe.run(
+    data={
+        "prompt_builder": {
+            "template_variables": {"location": "Berlin"},
+            "template": messages,
+        },
+    },
+)
+print(response["llm"]["replies"][0])
+```
+
+### Configuring the tracing backend directly
+
+Instead of using the `OpenTelemetryConnector`, you can configure the OpenTelemetry tracing backend directly by enabling an `OpenTelemetryTracer`. Make sure to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment variable and configure your `TracerProvider` before importing any Haystack components.
+
+```python
+from opentelemetry import trace
+
+from haystack import tracing
+from haystack_integrations.tracing.opentelemetry import OpenTelemetryTracer
+
+tracing.enable_tracing(OpenTelemetryTracer(trace.get_tracer("my_application")))
+```

--- a/docs-website/versioned_sidebars/version-2.30-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.30-sidebars.json
@@ -221,6 +221,7 @@
             "pipeline-components/connectors/langfuseconnector",
             "pipeline-components/connectors/openapiconnector",
             "pipeline-components/connectors/openapiserviceconnector",
+            "pipeline-components/connectors/opentelemetryconnector",
             "pipeline-components/connectors/weaveconnector",
             "pipeline-components/connectors/external-integrations-connectors"
           ]

--- a/haystack/tracing/opentelemetry.py
+++ b/haystack/tracing/opentelemetry.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
+import warnings
 from collections.abc import Iterator
 from typing import Any
 
@@ -47,6 +48,17 @@ class OpenTelemetrySpan(Span):
 class OpenTelemetryTracer(Tracer):
     def __init__(self, tracer: "opentelemetry.trace.Tracer") -> None:
         """Creates an instance of OpenTelemetryTracer."""
+        warnings.warn(
+            "`OpenTelemetryTracer` will be removed from Haystack in version 3.0, as it is moving to "
+            "the `opentelemetry-haystack` package. To continue using it, install that package with "
+            "`pip install opentelemetry-haystack` and either add the `OpenTelemetryConnector` component to your "
+            "pipeline or update your import to "
+            "`from haystack_integrations.tracing.opentelemetry import OpenTelemetryTracer`. Note that OpenTelemetry "
+            "tracing in Haystack 3.0 is no longer auto-enabled when `opentelemetry-sdk` is installed; use the "
+            "`OpenTelemetryConnector` to enable it.",
+            FutureWarning,
+            stacklevel=2,
+        )
         opentelemetry_import.check()
         self._tracer = tracer
 

--- a/releasenotes/notes/deprecate-opentelemetry-tracer-2c7f4b9a1e6d8035.yaml
+++ b/releasenotes/notes/deprecate-opentelemetry-tracer-2c7f4b9a1e6d8035.yaml
@@ -1,0 +1,14 @@
+---
+deprecations:
+  - |
+    ``OpenTelemetryTracer`` is deprecated and will be removed from Haystack in version 3.0. It is moving to
+    the ``opentelemetry-haystack`` package. To continue using it, install the package with
+    ``pip install opentelemetry-haystack`` and add the ``OpenTelemetryConnector`` component to your pipeline to
+    enable tracing, or update your import as follows:
+
+    .. code-block:: python
+
+        from haystack_integrations.tracing.opentelemetry import OpenTelemetryTracer
+
+    Note that, starting with Haystack 3.0, OpenTelemetry tracing is no longer auto-enabled when
+    ``opentelemetry-sdk`` is installed. Use the ``OpenTelemetryConnector`` component to enable it.

--- a/test/tracing/test_opentelemetry.py
+++ b/test/tracing/test_opentelemetry.py
@@ -30,6 +30,10 @@ def opentelemetry_tracer(span_exporter: InMemorySpanExporter) -> opentelemetry.t
 
 
 class TestOpenTelemetryTracer:
+    def test_deprecation_warning(self, opentelemetry_tracer: opentelemetry.trace.Tracer) -> None:
+        with pytest.warns(FutureWarning, match="opentelemetry-haystack"):
+            OpenTelemetryTracer(opentelemetry_tracer)
+
     def test_opentelemetry_tracer(
         self, opentelemetry_tracer: opentelemetry.trace.Tracer, span_exporter: InMemorySpanExporter
     ) -> None:


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/383

### Proposed Changes:

Deprecate the use of `OpenTelemetryTracer` in Haystack core and point users to the new `opentelemetry-haystack` integration (see https://github.com/deepset-ai/haystack-core-integrations/pull/3487).

- Add a `FutureWarning` to `OpenTelemetryTracer.__init__` instructing users to install `opentelemetry-haystack` and use the new `OpenTelemetryConnector` component (or the new `from haystack_integrations.tracing.opentelemetry import OpenTelemetryTracer` import path).
- Update the Tracing docs to recommend the `OpenTelemetryConnector` and add a dedicated `OpenTelemetryConnector` docs page (current + 2.30 versioned docs, connectors table, and sidebars).
- Add a deprecation release note.
- Fixed custom-tracer example missing parent_span argument in separate commit

### How did you test it?

Added a new unit test asserting the `FutureWarning` is raised.

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.