### PR TITLE
fix: validate top_k in HuggingFaceTEIRanker

### DIFF
--- a/haystack/components/rankers/hugging_face_tei.py
+++ b/haystack/components/rankers/hugging_face_tei.py
@@ -97,6 +97,9 @@ class HuggingFaceTEIRanker:
             stacklevel=2,
         )
 
+        if top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {top_k}")
+
         self.url = url
         self.top_k = top_k
         self.timeout = timeout
@@ -207,6 +210,9 @@ class HuggingFaceTEIRanker:
         :raises TypeError:
             - If the API response is not in the expected list format.
         """
+        if top_k is not None and top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {top_k}")
+
         # Return empty if no documents provided
         if not documents:
             return {"documents": []}
@@ -269,6 +275,9 @@ class HuggingFaceTEIRanker:
         :raises TypeError:
             - If the API response is not in the expected list format.
         """
+        if top_k is not None and top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {top_k}")
+
         # Return empty if no documents provided
         if not documents:
             return {"documents": []}

--- a/releasenotes/notes/hugging-face-tei-validate-top-k-ec4e9f2781ce0f12.yaml
+++ b/releasenotes/notes/hugging-face-tei-validate-top-k-ec4e9f2781ce0f12.yaml
@@ -1,0 +1,9 @@
+fixes:
+  - |
+    Added validation to ``HuggingFaceTEIRanker`` to raise a clear ``ValueError``
+    when ``top_k`` is zero or negative, both at initialization and when
+    overridden at ``run()``/``run_async()`` time. Previously, an invalid
+    ``top_k`` value was silently accepted and could produce empty or
+    unexpected ranking results. This brings ``HuggingFaceTEIRanker`` in
+    line with the other ranker components in Haystack, which already
+    perform this validation.

--- a/test/components/rankers/test_hugging_face_tei.py
+++ b/test/components/rankers/test_hugging_face_tei.py
@@ -41,6 +41,16 @@ class TestHuggingFaceTEIRanker:
         assert ranker.max_retries == 5
         assert ranker.retry_status_codes == [500, 502, 503]
 
+    def test_init_with_zero_top_k_raises_error(self, del_hf_env_vars):
+        """Test that initializing with top_k=0 raises a ValueError"""
+        with pytest.raises(ValueError, match="top_k must be > 0, but got 0"):
+            HuggingFaceTEIRanker(url="https://api.my-tei-service.com", top_k=0)
+
+    def test_init_with_negative_top_k_raises_error(self, del_hf_env_vars):
+        """Test that initializing with a negative top_k raises a ValueError"""
+        with pytest.raises(ValueError, match="top_k must be > 0, but got -5"):
+            HuggingFaceTEIRanker(url="https://api.my-tei-service.com", top_k=-5)
+
     def test_to_dict(self, del_hf_env_vars):
         """Test serialization to dict with Secret token"""
         component = HuggingFaceTEIRanker(
@@ -206,6 +216,13 @@ class TestHuggingFaceTEIRanker:
         assert result["documents"][0].content == "Document 4"
         assert result["documents"][1].content == "Document 3"
 
+    def test_run_with_invalid_top_k_override_raises_error(self, del_hf_env_vars):
+        """Test that an invalid top_k override raises a ValueError in run()"""
+        ranker = HuggingFaceTEIRanker(url="https://api.my-tei-service.com")
+        docs = [Document(content="Document A")]
+        with pytest.raises(ValueError, match="top_k must be > 0, but got 0"):
+            ranker.run(query="test query", documents=docs, top_k=0)
+
     @patch("haystack.components.rankers.hugging_face_tei.request_with_retry")
     def test_run_deduplicates_documents(self, mock_request, del_hf_env_vars):
         """Test that duplicate documents are removed before sending to the API."""
@@ -307,6 +324,14 @@ class TestHuggingFaceTEIRanker:
         assert result["documents"][1].score == 0.85
         assert result["documents"][2].content == "Document A"
         assert result["documents"][2].score == 0.75
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_invalid_top_k_override_raises_error(self, del_hf_env_vars):
+        """Test that an invalid top_k override raises a ValueError in run_async()"""
+        ranker = HuggingFaceTEIRanker(url="https://api.my-tei-service.com")
+        docs = [Document(content="Document A")]
+        with pytest.raises(ValueError, match="top_k must be > 0, but got 0"):
+            await ranker.run_async(query="test query", documents=docs, top_k=0)
 
     @pytest.mark.asyncio
     @patch("haystack.components.rankers.hugging_face_tei.async_request_with_retry")


### PR DESCRIPTION
### Related Issues
- No related issue (discovered via code review and found a validation-parity gap across the rankers component family)

### Proposed Changes:
`HuggingFaceTEIRanker` had no validation on its `top_k` parameter, unlike five of its six sibling ranker components (`LLMRanker`, `LostInTheMiddleRanker`, `MetaFieldRanker`, `SentenceTransformersDiversityRanker`, `SentenceTransformersSimilarityRanker`, `TransformersSimilarityRanker`), all of which raise `ValueError(f"top_k must be > 0, but got {top_k}")` for invalid values.

Confirmed via reproduction that `HuggingFaceTEIRanker(url=..., top_k=0)` and `HuggingFaceTEIRanker(url=..., top_k=-5)` both construct without error, and the invalid value silently flows into ranking logic via `min(top_k or self.top_k, len(result))`.

This PR adds the same validation pattern at:
- `__init__` time (for the default `top_k`)
- `run()`'s optional `top_k` override
- `run_async()`'s optional `top_k` override

using the exact same validation logic and error message already used by the sibling components.

### How did you test it?
- Reproduced the gap manually before writing the fix
- Ran the full test suite locally: `PYTHONPATH="" hatch run test:unit test/components/rankers/test_hugging_face_tei.py` — 16 passed
- Ran type checks: `hatch run test:types` — no issues in 365 source files
- Ran formatter: `hatch run fmt` — all checks passed
- Confirmed via `git diff` that the change is purely additive (+9 lines, 0 removed), with zero unrelated formatting changes to the existing file

### Notes for the reviewer
Not a breaking change — no previously-valid `top_k` value is affected by this fix; only inputs that were already invalid (zero or negative) now fail clearly instead of silently producing broken behavior. Note that `HuggingFaceTEIRanker` is deprecated (moving to `huggingface-api-haystack` in 3.0), but its equally-deprecated siblings `SentenceTransformersDiversityRanker` and `SentenceTransformersSimilarityRanker` already maintain this same validation, so I kept it consistent here too.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.