### PR TITLE
fix: handle unknown tool names in human_in_the_loop confirmation strategies

### DIFF
--- a/haystack/human_in_the_loop/strategies.py
+++ b/haystack/human_in_the_loop/strategies.py
@@ -373,7 +373,22 @@ def _run_confirmation_strategies(
 
         for tool_call in message.tool_calls:
             tool_name = tool_call.tool_name
-            tool_to_invoke = tools_with_names[tool_name]
+            tool_to_invoke = tools_with_names.get(tool_name)
+
+            # If the tool name doesn't match any known tool (e.g. the model hallucinated it), skip confirmation
+            # entirely and let the original tool call pass through unmodified. ToolInvoker already has proper
+            # handling for unknown tools (ToolNotFoundException, respecting raise_on_failure); we don't want to
+            # duplicate or pre-empt that here.
+            if tool_to_invoke is None:
+                teds.append(
+                    ToolExecutionDecision(
+                        tool_call_id=tool_call.id,
+                        tool_name=tool_name,
+                        execute=True,
+                        final_tool_params=tool_call.arguments,
+                    )
+                )
+                continue
 
             # Prepare final tool args
             final_args = _prepare_tool_args(
@@ -444,7 +459,22 @@ async def _run_confirmation_strategies_async(
 
         for tool_call in message.tool_calls:
             tool_name = tool_call.tool_name
-            tool_to_invoke = tools_with_names[tool_name]
+            tool_to_invoke = tools_with_names.get(tool_name)
+
+            # If the tool name doesn't match any known tool (e.g. the model hallucinated it), skip confirmation
+            # entirely and let the original tool call pass through unmodified. ToolInvoker already has proper
+            # handling for unknown tools (ToolNotFoundException, respecting raise_on_failure); we don't want to
+            # duplicate or pre-empt that here.
+            if tool_to_invoke is None:
+                teds.append(
+                    ToolExecutionDecision(
+                        tool_call_id=tool_call.id,
+                        tool_name=tool_name,
+                        execute=True,
+                        final_tool_params=tool_call.arguments,
+                    )
+                )
+                continue
 
             # Prepare final tool args
             final_args = _prepare_tool_args(

--- a/releasenotes/notes/fix-hitl-unknown-tool-keyerror-247291fb3df68428.yaml
+++ b/releasenotes/notes/fix-hitl-unknown-tool-keyerror-247291fb3df68428.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed `human_in_the_loop` confirmation strategies (`_run_confirmation_strategies` and
+    `_run_confirmation_strategies_async`) raising an unhandled `KeyError` when a tool call references a tool name
+    that isn't in the `tools` list (e.g. the chat model hallucinated it). The call now passes through unmodified to
+    `ToolInvoker`, which already raises a clean `ToolNotFoundException` (respecting `raise_on_failure`) for this
+    case.

--- a/releasenotes/notes/fix-hitl-unknown-tool-keyerror-247291fb3df68428.yaml
+++ b/releasenotes/notes/fix-hitl-unknown-tool-keyerror-247291fb3df68428.yaml
@@ -1,8 +1,8 @@
 ---
 fixes:
   - |
-    Fixed `human_in_the_loop` confirmation strategies (`_run_confirmation_strategies` and
-    `_run_confirmation_strategies_async`) raising an unhandled `KeyError` when a tool call references a tool name
-    that isn't in the `tools` list (e.g. the chat model hallucinated it). The call now passes through unmodified to
-    `ToolInvoker`, which already raises a clean `ToolNotFoundException` (respecting `raise_on_failure`) for this
+    Fixed ``human_in_the_loop`` confirmation strategies (``_run_confirmation_strategies`` and
+    ``_run_confirmation_strategies_async``) raising an unhandled ``KeyError`` when a tool call references a tool name
+    that isn't in the ``tools`` list (e.g. the chat model hallucinated it). The call now passes through unmodified to
+    ``ToolInvoker``, which already raises a clean ``ToolNotFoundException`` (respecting ``raise_on_failure``) for this
     case.

--- a/test/human_in_the_loop/test_strategies.py
+++ b/test/human_in_the_loop/test_strategies.py
@@ -239,6 +239,28 @@ class TestRunConfirmationStrategies:
         assert teds[1].tool_name == mult_tool.name
         assert teds[1].execute is True
 
+    def test_run_confirmation_strategies_with_unknown_tool_name(self, tools, execution_context):
+        # The chat model hallucinated a tool call for a tool that isn't in `tools`. This must not raise a KeyError,
+        # even though a confirmation strategy is configured (for a different, known tool).
+        teds = _run_confirmation_strategies(
+            confirmation_strategies={
+                tools[0].name: BlockingConfirmationStrategy(
+                    confirmation_policy=AlwaysAskPolicy(), confirmation_ui=SimpleConsoleUI()
+                )
+            },
+            messages_with_tool_calls=[
+                ChatMessage.from_assistant(
+                    tool_calls=[ToolCall(tool_name="does_not_exist", arguments={"a": 1}, id="1")]
+                )
+            ],
+            execution_context=execution_context,
+        )
+        assert teds == [
+            ToolExecutionDecision(
+                tool_name="does_not_exist", execute=True, tool_call_id="1", final_tool_params={"a": 1}
+            )
+        ]
+
 
 class TestApplyToolExecutionDecisions:
     @pytest.fixture
@@ -700,6 +722,29 @@ class TestAsyncConfirmationStrategies:
         assert teds[0].tool_name == tools[0].name
         assert teds[0].execute is True
         assert teds[0].final_tool_params == {"a": 1, "b": 2}
+
+    @pytest.mark.asyncio
+    async def test_run_confirmation_strategies_async_with_unknown_tool_name(self, tools, execution_context):
+        # The chat model hallucinated a tool call for a tool that isn't in `tools`. This must not raise a KeyError,
+        # even though a confirmation strategy is configured (for a different, known tool).
+        teds = await _run_confirmation_strategies_async(
+            confirmation_strategies={
+                tools[0].name: BlockingConfirmationStrategy(
+                    confirmation_policy=AlwaysAskPolicy(), confirmation_ui=SimpleConsoleUI()
+                )
+            },
+            messages_with_tool_calls=[
+                ChatMessage.from_assistant(
+                    tool_calls=[ToolCall(tool_name="does_not_exist", arguments={"a": 1}, id="1")]
+                )
+            ],
+            execution_context=execution_context,
+        )
+        assert teds == [
+            ToolExecutionDecision(
+                tool_name="does_not_exist", execute=True, tool_call_id="1", final_tool_params={"a": 1}
+            )
+        ]
 
     @pytest.mark.asyncio
     async def test_run_confirmation_strategies_async_with_strategy(self, tools, execution_context):


### PR DESCRIPTION
### Related Issues

- fixes #11754

### Proposed Changes:

`human_in_the_loop` confirmation strategies (`_run_confirmation_strategies` and `_run_confirmation_strategies_async`) used a raw `tools_with_names[tool_name]` dict lookup. If the chat model hallucinated a tool call for a name that isn't in the `tools` list, this raised an unhandled `KeyError` — even though `ToolInvoker` already handles this exact scenario cleanly via `ToolNotFoundException` (and respects `raise_on_failure`).

This PR changes the lookup to `.get()` and, when the tool name is unknown, skips confirmation entirely and passes the original tool call through unmodified — the same pass-through pattern already used when no confirmation strategy is configured for a tool. The call then reaches `ToolInvoker`, which reports the unknown tool consistently regardless of whether confirmation strategies are configured.

### How did you test it?

Added regression tests (sync + async) covering a tool call with an unknown tool name while a confirmation strategy is configured for a different, known tool. Ran the full `human_in_the_loop` test suite (30 passed), `ruff check`/`ruff format`, and `mypy` — all clean.

### Notes for the reviewer

None.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
