### PR TITLE
fix: resolve AsyncPipeline.run RuntimeError

### DIFF
--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -703,7 +703,19 @@ class AsyncPipeline(PipelineBase):
                 )
             )
         else:
-            # Running loop present: do not create the coroutine and do not call asyncio.run()
-            raise RuntimeError(
-                "Cannot call run() from within an async context. Use 'await pipeline.run_async(...)' instead."
-            )
+            # Running loop present: use ThreadPoolExecutor to run the async pipeline
+            # without interfering with the current loop, while preserving contextvars.
+            from concurrent.futures import ThreadPoolExecutor
+
+            ctx = contextvars.copy_context()
+
+            def run_with_ctx():
+                return ctx.run(
+                    asyncio.run,
+                    self.run_async(
+                        data=data, include_outputs_from=include_outputs_from, concurrency_limit=concurrency_limit
+                    ),
+                )
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                return executor.submit(run_with_ctx).result()

--- a/test/core/pipeline/test_async_pipeline.py
+++ b/test/core/pipeline/test_async_pipeline.py
@@ -38,14 +38,15 @@ def test_run_in_sync_context(waiting_component):
     assert result == {"wait": {"waited_for": 0.001}}
 
 
-def test_run_in_async_context_raises_runtime_error():
+def test_run_in_async_context_succeeds(waiting_component):
     pp = AsyncPipeline()
+    pp.add_component("wait", waiting_component())
 
     async def call_run():
-        pp.run({})
+        return pp.run({"wait_for": 0.001})
 
-    with pytest.raises(RuntimeError, match="Cannot call run\\(\\) from within an async context"):
-        asyncio.run(call_run())
+    result = asyncio.run(call_run())
+    assert result == {"wait": {"waited_for": 0.001}}
 
 
 def test_component_with_empty_dict_as_output_appears_in_results():


### PR DESCRIPTION
fix #8951 

1. Replaced `RuntimeError` with a Background Thread Loop
2. Preserved Telemetry and Tracing via `contextvars`
3. Updated Unit Tests