### PR TITLE
fix: support negative indices in _ToolsetWrapper.__getitem__

### DIFF
--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -426,12 +426,8 @@ class _ToolsetWrapper(Toolset):
         return sum(1 for _ in self)
 
     def __getitem__(self, index: int) -> Tool:
-        """Get a tool by index across all toolsets."""
-        # Leverage iteration instead of manual index tracking
-        for i, tool in enumerate(self):
-            if i == index:
-                return tool
-        raise IndexError("ToolsetWrapper index out of range")
+        """Get a tool by index across all toolsets, supporting negative indices like a list."""
+        return list(self)[index]
 
     def __add__(self, other: Toolset | Tool | list[Tool]) -> "_ToolsetWrapper":
         """Add another toolset or tool to this wrapper."""

--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -359,9 +359,6 @@ class _ToolsetWrapper(Toolset):
                 if self._selected_tool_names is None or tool.name in self._selected_tool_names:
                     yield tool
 
-    # `__len__` and `__getitem__` are deliberately not overridden: Toolset's implementations go through
-    # `__iter__` above, so they already flatten all wrapped toolsets and index like a list of Tools.
-
     def get_selectable_tools(self) -> list[Tool]:
         """Return every selectable tool across all wrapped toolsets, ignoring any active filter."""
         return [tool for toolset in self.toolsets for tool in toolset.get_selectable_tools()]

--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -359,6 +359,9 @@ class _ToolsetWrapper(Toolset):
                 if self._selected_tool_names is None or tool.name in self._selected_tool_names:
                     yield tool
 
+    # `__len__` and `__getitem__` are deliberately not overridden: Toolset's implementations go through
+    # `__iter__` above, so they already flatten all wrapped toolsets and index like a list of Tools.
+
     def get_selectable_tools(self) -> list[Tool]:
         """Return every selectable tool across all wrapped toolsets, ignoring any active filter."""
         return [tool for toolset in self.toolsets for tool in toolset.get_selectable_tools()]
@@ -420,14 +423,6 @@ class _ToolsetWrapper(Toolset):
             toolsets.append(toolset_class.from_dict(toolset_data))
 
         return cls(toolsets=toolsets)
-
-    def __len__(self) -> int:
-        """Return total number of tools across all toolsets (respecting any active name filter)."""
-        return sum(1 for _ in self)
-
-    def __getitem__(self, index: int) -> Tool:
-        """Get a tool by index across all toolsets, supporting negative indices like a list."""
-        return list(self)[index]
 
     def __add__(self, other: Toolset | Tool | list[Tool]) -> "_ToolsetWrapper":
         """Add another toolset or tool to this wrapper."""

--- a/releasenotes/notes/fix-toolset-wrapper-negative-index-e96e9d5e25c3e743.yaml
+++ b/releasenotes/notes/fix-toolset-wrapper-negative-index-e96e9d5e25c3e743.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed `_ToolsetWrapper.__getitem__` (used when combining `Toolset`s with `+`) raising `IndexError` for negative
+    indices, unlike a plain `Toolset`. Indexing a combined toolset now behaves consistently with a list of `Tool`s,
+    as documented.

--- a/releasenotes/notes/fix-toolset-wrapper-negative-index-e96e9d5e25c3e743.yaml
+++ b/releasenotes/notes/fix-toolset-wrapper-negative-index-e96e9d5e25c3e743.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Fixed `_ToolsetWrapper.__getitem__` (used when combining `Toolset`s with `+`) raising `IndexError` for negative
-    indices, unlike a plain `Toolset`. Indexing a combined toolset now behaves consistently with a list of `Tool`s,
-    as documented.
+    Fixed ``_ToolsetWrapper.__getitem__`` (used when combining ``Toolset``\ s with ``+``) raising ``IndexError`` for
+    negative indices, unlike a plain ``Toolset``. Indexing a combined toolset now behaves consistently with a list of
+    ``Tool``\ s, as documented.

--- a/test/tools/test_toolset_wrapper.py
+++ b/test/tools/test_toolset_wrapper.py
@@ -107,6 +107,21 @@ class TestToolsetWrapper:
         assert add_tool in result
         assert multiply_tool in result
 
+    def test_wrapper_getitem_supports_negative_indices(self, add_tool, multiply_tool):
+        """Test that _ToolsetWrapper.__getitem__ behaves like a list, including negative indices."""
+        toolset1 = Toolset([add_tool])
+        toolset2 = Toolset([multiply_tool])
+
+        result = toolset1 + toolset2
+
+        assert result[0] is add_tool
+        assert result[1] is multiply_tool
+        assert result[-1] is multiply_tool
+        assert result[-2] is add_tool
+
+        with pytest.raises(IndexError):
+            _ = result[2]
+
     def test_wrapper_with_agent(self, add_tool, multiply_tool, monkeypatch):
         """Test that _ToolsetWrapper works with Agent."""
         monkeypatch.setenv("OPENAI_API_KEY", "test")

--- a/test/tools/test_toolset_wrapper.py
+++ b/test/tools/test_toolset_wrapper.py
@@ -229,6 +229,12 @@ class TestToolsetWrapperToolSelection:
         assert [tool.name for tool in wrapper] == ["add", "subtract"]
         assert len(wrapper) == 2
 
+    def test_filter_restricts_getitem(self, add_tool, multiply_tool, subtract_tool):
+        wrapper = Toolset([add_tool, multiply_tool]) + Toolset([subtract_tool])
+        wrapper._selected_tool_names = {"add", "subtract"}
+        assert wrapper[0].name == "add"
+        assert wrapper[-1].name == "subtract"
+
     def test_spawn_isolates_own_and_child_state(self, add_tool, multiply_tool):
         ts1 = Toolset([add_tool])
         ts2 = Toolset([multiply_tool])


### PR DESCRIPTION
### Related Issues

- fixes #11759

### Proposed Changes:

`Toolset` is documented as implementing the collection interface (`__iter__`, `__contains__`, `__len__`, `__getitem__`) so it "behaves like a list of Tools." `Toolset.__getitem__` delegates to a real list, so negative indices work. But `_ToolsetWrapper` (returned when combining `Toolset`s with `+`) only did a forward `enumerate` scan in `__getitem__`, so `combined[-1]` always raised `IndexError`, breaking that documented contract as soon as two toolsets are combined.

This PR changes `_ToolsetWrapper.__getitem__` to materialize `list(self)` (reusing the existing `__iter__`, which already flattens all wrapped toolsets) and index into that, so it behaves exactly like a list, including negative indices and the standard out-of-range `IndexError`.

### How did you test it?

Added a regression test covering positive indices, negative indices, and the out-of-range case on a wrapper created by combining two `Toolset`s. Ran the full `test/tools/test_toolset_wrapper.py` and `test/tools/test_toolset.py` suites (23 passed), `ruff check`/`ruff format`, and `mypy` — all clean.

### Notes for the reviewer

None.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
