### PR TITLE
feat(retries): align OpenAI / Azure OpenAI default max_retries

### DIFF
--- a/haystack/components/embedders/azure_document_embedder.py
+++ b/haystack/components/embedders/azure_document_embedder.py
@@ -101,7 +101,7 @@ class AzureOpenAIDocumentEmbedder(OpenAIDocumentEmbedder):
             If not set, defaults to either the
             `OPENAI_TIMEOUT` environment variable, or 30 seconds.
         :param max_retries: Maximum number of retries to contact AzureOpenAI after an internal error.
-            If not set, defaults to either the `OPENAI_MAX_RETRIES` environment variable or to 5 retries.
+            If not set, defaults to either the `OPENAI_MAX_RETRIES` environment variable or to 2 retries.
         :param default_headers: Default headers to send to the AzureOpenAI client.
         :param azure_ad_token_provider: A function that returns an Azure Active Directory token, will be invoked on
             every request.
@@ -138,7 +138,7 @@ class AzureOpenAIDocumentEmbedder(OpenAIDocumentEmbedder):
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
         self.timeout = timeout if timeout is not None else float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
-        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "2"))
         self.default_headers = default_headers or {}
         self.azure_ad_token_provider = azure_ad_token_provider
         self.http_client_kwargs = http_client_kwargs

--- a/haystack/components/embedders/azure_text_embedder.py
+++ b/haystack/components/embedders/azure_text_embedder.py
@@ -82,7 +82,7 @@ class AzureOpenAITextEmbedder(OpenAITextEmbedder):
             If not set, defaults to either the
             `OPENAI_TIMEOUT` environment variable, or 30 seconds.
         :param max_retries: Maximum number of retries to contact AzureOpenAI after an internal error.
-            If not set, defaults to either the `OPENAI_MAX_RETRIES` environment variable, or to 5 retries.
+            If not set, defaults to either the `OPENAI_MAX_RETRIES` environment variable, or to 2 retries.
         :param prefix:
             A string to add at the beginning of each text.
         :param suffix:
@@ -118,7 +118,7 @@ class AzureOpenAITextEmbedder(OpenAITextEmbedder):
         self.dimensions = dimensions
         self.organization = organization
         self.timeout = timeout if timeout is not None else float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
-        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "2"))
         self.prefix = prefix
         self.suffix = suffix
         self.default_headers = default_headers or {}

--- a/haystack/components/embedders/openai_document_embedder.py
+++ b/haystack/components/embedders/openai_document_embedder.py
@@ -98,7 +98,7 @@ class OpenAIDocumentEmbedder:
             `OPENAI_TIMEOUT` environment variable, or 30 seconds.
         :param max_retries:
             Maximum number of retries to contact OpenAI after an internal error.
-            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or 5 retries.
+            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or 2 retries.
         :param http_client_kwargs:
             A dictionary of keyword arguments to configure a custom `httpx.Client`or `httpx.AsyncClient`.
             For more information, see the [HTTPX documentation](https://www.python-httpx.org/api/#client).
@@ -125,7 +125,7 @@ class OpenAIDocumentEmbedder:
         if timeout is None:
             timeout = float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
         if max_retries is None:
-            max_retries = int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+            max_retries = int(os.environ.get("OPENAI_MAX_RETRIES", "2"))
 
         client_kwargs: dict[str, Any] = {
             "api_key": api_key.resolve_value(),

--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -81,7 +81,7 @@ class OpenAITextEmbedder:
             `OPENAI_TIMEOUT` environment variable, or 30 seconds.
         :param max_retries:
             Maximum number of retries to contact OpenAI after an internal error.
-            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or set to 5.
+            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or set to 2.
         :param http_client_kwargs:
             A dictionary of keyword arguments to configure a custom `httpx.Client`or `httpx.AsyncClient`.
             For more information, see the [HTTPX documentation](https://www.python-httpx.org/api/#client).
@@ -100,7 +100,7 @@ class OpenAITextEmbedder:
         if timeout is None:
             timeout = float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
         if max_retries is None:
-            max_retries = int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+            max_retries = int(os.environ.get("OPENAI_MAX_RETRIES", "2"))
 
         client_kwargs: dict[str, Any] = {
             "api_key": api_key.resolve_value(),

--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -89,7 +89,7 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         :param timeout: Timeout for AzureOpenAI client. If not set, it is inferred from the
             `OPENAI_TIMEOUT` environment variable or set to 30.
         :param max_retries: Maximum retries to establish contact with AzureOpenAI if it returns an internal error.
-            If not set, it is inferred from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
+            If not set, it is inferred from the `OPENAI_MAX_RETRIES` environment variable or set to 2.
         :param http_client_kwargs:
             A dictionary of keyword arguments to configure a custom `httpx.Client`or `httpx.AsyncClient`.
             For more information, see the [HTTPX documentation](https://www.python-httpx.org/api/#client).
@@ -146,7 +146,7 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         self.organization = organization
         self.model: str = azure_deployment or "gpt-4.1-mini"
         self.timeout = timeout if timeout is not None else float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
-        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "2"))
         self.http_client_kwargs = http_client_kwargs
         self.default_headers = default_headers or {}
         self.azure_ad_token_provider = azure_ad_token_provider

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -151,7 +151,7 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         :param timeout: Timeout for OpenAI client calls. If not set, it defaults to either the
             `OPENAI_TIMEOUT` environment variable, or 30 seconds.
         :param max_retries: Maximum number of retries to contact OpenAI after an internal error.
-            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or set to 5.
+            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or set to 2.
         :param generation_kwargs: Other parameters to use for the model. These parameters are sent directly to
             the OpenAI endpoint. For details, see [OpenAI documentation](https://platform.openai.com/docs/api-reference/chat).
             Some of the supported parameters:
@@ -225,7 +225,7 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         self.organization = organization
         self.model = azure_deployment or "gpt-4.1-mini"
         self.timeout = timeout if timeout is not None else float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
-        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "2"))
         self.default_headers = default_headers or {}
         self.azure_ad_token_provider = azure_ad_token_provider
         self.http_client_kwargs = http_client_kwargs

--- a/haystack/components/generators/chat/azure_responses.py
+++ b/haystack/components/generators/chat/azure_responses.py
@@ -121,7 +121,7 @@ class AzureOpenAIResponsesChatGenerator(OpenAIResponsesChatGenerator):
         :param timeout: Timeout for OpenAI client calls. If not set, it defaults to either the
             `OPENAI_TIMEOUT` environment variable, or 30 seconds.
         :param max_retries: Maximum number of retries to contact OpenAI after an internal error.
-            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or set to 5.
+            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or set to 2.
         :param generation_kwargs: Other parameters to use for the model. These parameters are sent
            directly to the OpenAI endpoint.
            See OpenAI [documentation](https://platform.openai.com/docs/api-reference/responses) for

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -184,7 +184,7 @@ class OpenAIChatGenerator:
             `OPENAI_TIMEOUT` environment variable, or 30 seconds.
         :param max_retries:
             Maximum number of retries to contact OpenAI after an internal error.
-            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or set to 5.
+            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or set to 2.
         :param tools:
             A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
         :param tools_strict:
@@ -212,7 +212,7 @@ class OpenAIChatGenerator:
         if timeout is None:
             timeout = float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
         if max_retries is None:
-            max_retries = int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+            max_retries = int(os.environ.get("OPENAI_MAX_RETRIES", "2"))
 
         client_kwargs: dict[str, Any] = {
             "api_key": api_key.resolve_value(),

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -167,7 +167,7 @@ class OpenAIResponsesChatGenerator:
             `OPENAI_TIMEOUT` environment variable, or 30 seconds.
         :param max_retries:
             Maximum number of retries to contact OpenAI after an internal error.
-            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or set to 5.
+            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or set to 2.
         :param tools:
             The tools that the model can use to prepare calls. This parameter can accept either a
             mixed list of Haystack `Tool` objects and Haystack `Toolset`. Or you can pass a dictionary of
@@ -198,7 +198,7 @@ class OpenAIResponsesChatGenerator:
         if timeout is None:
             timeout = float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
         if max_retries is None:
-            max_retries = int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+            max_retries = int(os.environ.get("OPENAI_MAX_RETRIES", "2"))
 
         resolved_api_key = api_key.resolve_value() if isinstance(api_key, Secret) else api_key
         client_kwargs: dict[str, Any] = {

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -116,7 +116,7 @@ class OpenAIGenerator:
             or set to 30.
         :param max_retries:
             Maximum retries to establish contact with OpenAI if it returns an internal error, if not set it is inferred
-            from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
+            from the `OPENAI_MAX_RETRIES` environment variable or set to 2.
         :param http_client_kwargs:
             A dictionary of keyword arguments to configure a custom `httpx.Client`or `httpx.AsyncClient`.
             For more information, see the [HTTPX documentation](https://www.python-httpx.org/api/#client).
@@ -136,7 +136,7 @@ class OpenAIGenerator:
         if timeout is None:
             timeout = float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
         if max_retries is None:
-            max_retries = int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+            max_retries = int(os.environ.get("OPENAI_MAX_RETRIES", "2"))
 
         self.client = OpenAI(
             api_key=api_key.resolve_value(),

--- a/haystack/components/generators/openai_dalle.py
+++ b/haystack/components/generators/openai_dalle.py
@@ -63,7 +63,7 @@ class DALLEImageGenerator:
             or set to 30.
         :param max_retries:
             Maximum retries to establish contact with OpenAI if it returns an internal error. If not set, it is inferred
-            from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
+            from the `OPENAI_MAX_RETRIES` environment variable or set to 2.
         :param http_client_kwargs:
             A dictionary of keyword arguments to configure a custom `httpx.Client`or `httpx.AsyncClient`.
             For more information, see the [HTTPX documentation](https://www.python-httpx.org/api/#client).
@@ -81,7 +81,7 @@ class DALLEImageGenerator:
         self.organization = organization
 
         self.timeout = timeout if timeout is not None else float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
-        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "2"))
         self.http_client_kwargs = http_client_kwargs
 
         self.client: OpenAI | None = None

--- a/releasenotes/notes/lower-default-openai-max-retries-to-2-9e8f4d1b3a7c5e6d.yaml
+++ b/releasenotes/notes/lower-default-openai-max-retries-to-2-9e8f4d1b3a7c5e6d.yaml
@@ -1,0 +1,15 @@
+---
+upgrade:
+  - |
+    The default value of ``max_retries`` for OpenAI and Azure OpenAI
+    generators, embedders, and ``DALLEImageGenerator`` has been lowered
+    from ``5`` to ``2`` to align with the upstream ``openai-python`` SDK.
+
+    When neither ``max_retries`` nor ``OPENAI_MAX_RETRIES`` is configured,
+    this changes the retry budget from up to six total request attempts
+    to up to three. This can reduce time spent retrying transient failures,
+    but workloads that depended on the previous retry behavior should
+    explicitly configure ``max_retries=5``.
+
+    Existing explicit constructor values and ``OPENAI_MAX_RETRIES``
+    environment-variable settings continue to take precedence.

--- a/test/components/embedders/test_azure_document_embedder.py
+++ b/test/components/embedders/test_azure_document_embedder.py
@@ -72,7 +72,7 @@ class TestAzureOpenAIDocumentEmbedder:
                 "progress_bar": True,
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
-                "max_retries": 5,
+                "max_retries": 2,
                 "timeout": 30.0,
                 "default_headers": {},
                 "azure_ad_token_provider": None,
@@ -141,7 +141,7 @@ class TestAzureOpenAIDocumentEmbedder:
                 "progress_bar": True,
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
-                "max_retries": 5,
+                "max_retries": 2,
                 "timeout": 30.0,
                 "default_headers": {},
                 "azure_ad_token_provider": None,
@@ -153,7 +153,7 @@ class TestAzureOpenAIDocumentEmbedder:
         assert component.azure_deployment == "text-embedding-ada-002"
         assert component.azure_endpoint == "https://example-resource.azure.openai.com/"
         assert component.api_version == "2023-05-15"
-        assert component.max_retries == 5
+        assert component.max_retries == 2
         assert component.timeout == 30.0
         assert component.prefix == ""
         assert component.suffix == ""

--- a/test/components/embedders/test_azure_text_embedder.py
+++ b/test/components/embedders/test_azure_text_embedder.py
@@ -56,7 +56,7 @@ class TestAzureOpenAITextEmbedder:
                 "organization": None,
                 "azure_endpoint": "https://example-resource.azure.openai.com/",
                 "api_version": "2023-05-15",
-                "max_retries": 5,
+                "max_retries": 2,
                 "timeout": 30.0,
                 "prefix": "",
                 "suffix": "",
@@ -114,7 +114,7 @@ class TestAzureOpenAITextEmbedder:
                 "organization": None,
                 "azure_endpoint": "https://example-resource.azure.openai.com/",
                 "api_version": "2023-05-15",
-                "max_retries": 5,
+                "max_retries": 2,
                 "timeout": 30.0,
                 "prefix": "",
                 "suffix": "",
@@ -127,7 +127,7 @@ class TestAzureOpenAITextEmbedder:
         assert component.model == "text-embedding-ada-002"
         assert component.azure_endpoint == "https://example-resource.azure.openai.com/"
         assert component.api_version == "2023-05-15"
-        assert component.max_retries == 5
+        assert component.max_retries == 2
         assert component.timeout == 30.0
         assert component.prefix == ""
         assert component.suffix == ""

--- a/test/components/embedders/test_openai_document_embedder.py
+++ b/test/components/embedders/test_openai_document_embedder.py
@@ -27,7 +27,7 @@ class TestOpenAIDocumentEmbedder:
         assert embedder.progress_bar is True
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
-        assert embedder.client.max_retries == 5
+        assert embedder.client.max_retries == 2
         assert embedder.client.timeout == 30.0
 
     def test_init_with_parameters(self, monkeypatch):

--- a/test/components/embedders/test_openai_text_embedder.py
+++ b/test/components/embedders/test_openai_text_embedder.py
@@ -24,7 +24,7 @@ class TestOpenAITextEmbedder:
         assert embedder.prefix == ""
         assert embedder.suffix == ""
         assert embedder.client.timeout == 30
-        assert embedder.client.max_retries == 5
+        assert embedder.client.max_retries == 2
 
     def test_init_with_parameters(self, monkeypatch):
         monkeypatch.setenv("OPENAI_TIMEOUT", "100")

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -114,7 +114,7 @@ class TestAzureOpenAIChatGenerator:
         assert component.tools == tools
         assert component.tools_strict
         assert component.azure_ad_token_provider is not None
-        assert component.max_retries == 5
+        assert component.max_retries == 2
 
     def test_init_with_0_max_retries(self, tools):
         """Tests that the max_retries init param is set correctly if equal 0"""
@@ -215,7 +215,7 @@ class TestAzureOpenAIChatGenerator:
                 "streaming_callback": None,
                 "generation_kwargs": {},
                 "timeout": 30.0,
-                "max_retries": 5,
+                "max_retries": 2,
                 "default_headers": {},
                 "tools": None,
                 "tools_strict": False,
@@ -247,7 +247,7 @@ class TestAzureOpenAIChatGenerator:
                 "streaming_callback": None,
                 "generation_kwargs": {},
                 "timeout": 30.0,
-                "max_retries": 5,
+                "max_retries": 2,
                 "default_headers": {},
                 "tools": None,
                 "tools_strict": False,
@@ -331,7 +331,7 @@ class TestAzureOpenAIChatGenerator:
                 "streaming_callback": None,
                 "generation_kwargs": {},
                 "timeout": 30.0,
-                "max_retries": 5,
+                "max_retries": 2,
                 "default_headers": {},
                 "tools": [
                     {
@@ -361,7 +361,7 @@ class TestAzureOpenAIChatGenerator:
         assert generator.streaming_callback is None
         assert generator.generation_kwargs == {}
         assert generator.timeout == 30.0
-        assert generator.max_retries == 5
+        assert generator.max_retries == 2
         assert generator.default_headers == {}
         assert generator.tools == [
             Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
@@ -390,7 +390,7 @@ class TestAzureOpenAIChatGenerator:
                         "streaming_callback": None,
                         "generation_kwargs": {},
                         "timeout": 30.0,
-                        "max_retries": 5,
+                        "max_retries": 2,
                         "api_key": {"type": "env_var", "env_vars": ["AZURE_OPENAI_API_KEY"], "strict": False},
                         "azure_ad_token": {"type": "env_var", "env_vars": ["AZURE_OPENAI_AD_TOKEN"], "strict": False},
                         "default_headers": {},

--- a/test/components/generators/chat/test_azure_responses.py
+++ b/test/components/generators/chat/test_azure_responses.py
@@ -269,7 +269,7 @@ class TestSerDe:
                 "streaming_callback": None,
                 "generation_kwargs": {},
                 "timeout": 30.0,
-                "max_retries": 5,
+                "max_retries": 2,
                 "tools": [
                     {
                         "type": "haystack.tools.tool.Tool",
@@ -296,7 +296,7 @@ class TestSerDe:
         assert generator.streaming_callback is None
         assert generator.generation_kwargs == {}
         assert generator.timeout == 30.0
-        assert generator.max_retries == 5
+        assert generator.max_retries == 2
         assert generator.tools == [
             Tool(name="name", description="description", parameters={"x": {"type": "string"}}, function=print)
         ]

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -202,7 +202,7 @@ class TestOpenAIChatGenerator:
         assert component.streaming_callback is None
         assert not component.generation_kwargs
         assert component.client.timeout == 30
-        assert component.client.max_retries == 5
+        assert component.client.max_retries == 2
         assert component.tools is None
         assert not component.tools_strict
         assert component.http_client_kwargs is None

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -117,7 +117,7 @@ class TestInitialization:
         assert component.streaming_callback is None
         assert not component.generation_kwargs
         assert component.client.timeout == 30
-        assert component.client.max_retries == 5
+        assert component.client.max_retries == 2
         assert component.tools is None
         assert not component.tools_strict
         assert component.http_client_kwargs is None

--- a/test/components/generators/test_azure.py
+++ b/test/components/generators/test_azure.py
@@ -44,7 +44,7 @@ class TestAzureOpenAIGenerator:
         assert component.timeout == 30.0
         assert component.generation_kwargs == {"max_completion_tokens": 10, "some_test_param": "test-params"}
         assert component.azure_ad_token_provider is not None
-        assert component.max_retries == 5
+        assert component.max_retries == 2
 
     def test_init_with_0_max_retries(self):
         """Tests that the max_retries init param is set correctly if equal 0"""
@@ -65,6 +65,15 @@ class TestAzureOpenAIGenerator:
         assert component.azure_ad_token_provider is not None
         assert component.max_retries == 0
 
+    def test_init_uses_max_retries_from_env(self, monkeypatch):
+        """OPENAI_MAX_RETRIES env var should override the default when no constructor value is passed."""
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        monkeypatch.setenv("OPENAI_MAX_RETRIES", "7")
+
+        component = AzureOpenAIGenerator(azure_endpoint="some-non-existing-endpoint")
+
+        assert component.max_retries == 7
+
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
         component = AzureOpenAIGenerator(azure_endpoint="some-non-existing-endpoint")
@@ -81,7 +90,7 @@ class TestAzureOpenAIGenerator:
                 "organization": None,
                 "system_prompt": None,
                 "timeout": 30.0,
-                "max_retries": 5,
+                "max_retries": 2,
                 "http_client_kwargs": None,
                 "generation_kwargs": {},
                 "default_headers": {},
@@ -138,7 +147,7 @@ class TestAzureOpenAIGenerator:
                 "organization": None,
                 "system_prompt": None,
                 "timeout": 30.0,
-                "max_retries": 5,
+                "max_retries": 2,
                 "http_client_kwargs": None,
                 "generation_kwargs": {},
                 "default_headers": {},

--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -25,7 +25,7 @@ class TestOpenAIGenerator:
         assert component.streaming_callback is None
         assert not component.generation_kwargs
         assert component.client.timeout == 30
-        assert component.client.max_retries == 5
+        assert component.client.max_retries == 2
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -49,6 +49,15 @@ class TestOpenAIGenerator:
         assert component.generation_kwargs == {"max_completion_tokens": 10, "some_test_param": "test-params"}
         assert component.client.timeout == 40.0
         assert component.client.max_retries == 1
+
+    def test_init_uses_max_retries_from_env(self, monkeypatch):
+        """OPENAI_MAX_RETRIES env var should override the default when no constructor value is passed."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        monkeypatch.setenv("OPENAI_MAX_RETRIES", "7")
+
+        component = OpenAIGenerator()
+
+        assert component.client.max_retries == 7
 
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")

--- a/test/components/generators/test_openai_dalle.py
+++ b/test/components/generators/test_openai_dalle.py
@@ -34,7 +34,7 @@ class TestDALLEImageGenerator:
         assert component.api_base_url is None
         assert component.organization is None
         assert pytest.approx(component.timeout) == 30.0
-        assert component.max_retries == 5
+        assert component.max_retries == 2
         assert component.http_client_kwargs is None
 
     def test_init_with_params(self, monkeypatch):
@@ -79,7 +79,7 @@ class TestDALLEImageGenerator:
         component.warm_up()
         assert component.client.api_key == "test-api-key"
         assert component.client.timeout == 30
-        assert component.client.max_retries == 5
+        assert component.client.max_retries == 2
 
     def test_to_dict(self):
         generator = DALLEImageGenerator()
@@ -153,7 +153,7 @@ class TestDALLEImageGenerator:
         assert generator.api_base_url is None
         assert generator.organization is None
         assert pytest.approx(generator.timeout) == 30.0
-        assert generator.max_retries == 5
+        assert generator.max_retries == 2
         assert generator.http_client_kwargs is None
 
     def test_run(self, mock_image_response):


### PR DESCRIPTION
Haystack currently overrides openai-python's default retry budget from 5 to 2 across its OpenAI and Azure OpenAI components. This patch aligns Haystack's unconfigured behavior with the upstream SDK while preserving both explicit max_retries values and OPENAI_MAX_RETRIES overrides.

When neither max_retries nor OPENAI_MAX_RETRIES is configured, this changes the retry budget from up to six total request attempts to up to three for transient failures (5xx, 408, 409, 429, timeouts, connection errors).

Components affected (OpenAI + Azure OpenAI):
  - OpenAIGenerator, OpenAIChatGenerator, OpenAIResponsesChatGenerator
  - AzureOpenAIGenerator, AzureOpenAIChatGenerator, AzureOpenAIResponsesChatGenerator
  - OpenAITextEmbedder, OpenAIDocumentEmbedder, AzureOpenAITextEmbedder, AzureOpenAIDocumentEmbedder
  - DALLEImageGenerator

Workloads that depended on the previous behavior can restore it by setting max_retries=5 explicitly or OPENAI_MAX_RETRIES=5 in the environment. Existing explicit values continue to take precedence.

New tests:
  - test_init_uses_max_retries_from_env on OpenAIGenerator and AzureOpenAIGenerator, verifying the OPENAI_MAX_RETRIES env-var override is honored when no constructor value is passed.

Happy to defer if maintainers disagree.

### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
