### PR TITLE
feat: dedupe identical prepared texts within OpenAIDocumentEmbedder

### DIFF
--- a/haystack/components/embedders/openai_document_embedder.py
+++ b/haystack/components/embedders/openai_document_embedder.py
@@ -200,11 +200,41 @@ class OpenAIDocumentEmbedder:
 
         return texts_to_embed
 
+    @staticmethod
+    def _dedupe_batch(batch: tuple[tuple[str, str], ...]) -> tuple[list[str], dict[str, list[str]]]:
+        """
+        Deduplicate a batch of (doc_id, text) pairs by text content.
+
+        :param batch:
+            Tuple of (doc_id, text) tuples for one API batch.
+        :returns:
+            A tuple of:
+            - The unique texts to send to the embedding API, in deterministic order.
+            - A mapping from each unique text to the list of doc_ids that produced it.
+        """
+        text_to_doc_ids: dict[str, list[str]] = {}
+        unique_texts: list[str] = []
+        for doc_id, text in batch:
+            if text in text_to_doc_ids:
+                text_to_doc_ids[text].append(doc_id)
+            else:
+                text_to_doc_ids[text] = [doc_id]
+                unique_texts.append(text)
+        return unique_texts, text_to_doc_ids
+
     def _embed_batch(
         self, texts_to_embed: dict[str, str], batch_size: int
     ) -> tuple[dict[str, list[float]], dict[str, Any]]:
         """
         Embed a list of texts in batches.
+
+        Within each batch, byte-identical prepared texts are deduplicated before being sent to the
+        OpenAI API; the returned embedding is then assigned to every document that produced that
+        prepared text. Duplicate documents each receive an independent copy of the embedding list, so
+        downstream mutation of one document's embedding cannot leak into another. Deduplication only
+        operates within a single API batch and only matches full prepared strings produced by
+        ``_prepare_texts_to_embed`` (``prefix`` + ``meta_fields_to_embed`` + ``content`` + ``suffix``),
+        not shared fragments.
         """
 
         doc_ids_to_embeddings: dict[str, list[float]] = {}
@@ -212,7 +242,8 @@ class OpenAIDocumentEmbedder:
         for batch in tqdm(
             batched(texts_to_embed.items(), batch_size), disable=not self.progress_bar, desc="Calculating embeddings"
         ):
-            args: dict[str, Any] = {"model": self.model, "input": [b[1] for b in batch], "encoding_format": "float"}
+            unique_texts, text_to_doc_ids = self._dedupe_batch(batch)
+            args: dict[str, Any] = {"model": self.model, "input": unique_texts, "encoding_format": "float"}
 
             if self.dimensions is not None:
                 args["dimensions"] = self.dimensions
@@ -220,15 +251,20 @@ class OpenAIDocumentEmbedder:
             try:
                 response = self.client.embeddings.create(**args)
             except APIError as exc:
-                ids = ", ".join(b[0] for b in batch)
+                ids = ", ".join(doc_id for ids in text_to_doc_ids.values() for doc_id in ids)
                 msg = "Failed embedding of documents {ids} caused by {exc}"
                 logger.exception(msg, ids=ids, exc=exc)
                 if self.raise_on_failure:
                     raise exc
                 continue
 
-            embeddings = [el.embedding for el in response.data]
-            doc_ids_to_embeddings.update(dict(zip((b[0] for b in batch), embeddings, strict=True)))
+            for text, embedding_obj in zip(unique_texts, response.data, strict=True):
+                doc_ids = text_to_doc_ids[text]
+                # First doc_id keeps the original list; any further duplicates get a shallow copy so
+                # callers cannot leak in-place mutations between Documents that shared a prepared text.
+                doc_ids_to_embeddings[doc_ids[0]] = embedding_obj.embedding
+                for doc_id in doc_ids[1:]:
+                    doc_ids_to_embeddings[doc_id] = list(embedding_obj.embedding)
 
             if "model" not in meta:
                 meta["model"] = response.model
@@ -255,7 +291,8 @@ class OpenAIDocumentEmbedder:
             batches = async_tqdm(batches, desc="Calculating embeddings")
 
         for batch in batches:
-            args: dict[str, Any] = {"model": self.model, "input": [b[1] for b in batch]}
+            unique_texts, text_to_doc_ids = self._dedupe_batch(batch)
+            args: dict[str, Any] = {"model": self.model, "input": unique_texts}
 
             if self.dimensions is not None:
                 args["dimensions"] = self.dimensions
@@ -263,15 +300,18 @@ class OpenAIDocumentEmbedder:
             try:
                 response = await self.async_client.embeddings.create(**args)
             except APIError as exc:
-                ids = ", ".join(b[0] for b in batch)
+                ids = ", ".join(doc_id for ids in text_to_doc_ids.values() for doc_id in ids)
                 msg = "Failed embedding of documents {ids} caused by {exc}"
                 logger.exception(msg, ids=ids, exc=exc)
                 if self.raise_on_failure:
                     raise exc
                 continue
 
-            embeddings = [el.embedding for el in response.data]
-            doc_ids_to_embeddings.update(dict(zip((b[0] for b in batch), embeddings, strict=True)))
+            for text, embedding_obj in zip(unique_texts, response.data, strict=True):
+                doc_ids = text_to_doc_ids[text]
+                doc_ids_to_embeddings[doc_ids[0]] = embedding_obj.embedding
+                for doc_id in doc_ids[1:]:
+                    doc_ids_to_embeddings[doc_id] = list(embedding_obj.embedding)
 
             if "model" not in meta:
                 meta["model"] = response.model

--- a/releasenotes/notes/dedupe-openai-document-embedder-batches-856938be5630a335.yaml
+++ b/releasenotes/notes/dedupe-openai-document-embedder-batches-856938be5630a335.yaml
@@ -1,0 +1,13 @@
+---
+enhancements:
+  - |
+    `OpenAIDocumentEmbedder` (and its `AzureOpenAIDocumentEmbedder` subclass) now deduplicates
+    byte-identical prepared texts within each API batch before calling the OpenAI embeddings
+    endpoint. Documents that produced the same prepared string (the concatenation of ``prefix`` +
+    ``meta_fields_to_embed`` + ``content`` + ``suffix`` built by ``_prepare_texts_to_embed``) share
+    a single API call; each document still receives an independent copy of the embedding list, so
+    in-place mutation by downstream consumers does not leak between documents. This reduces token
+    usage when the same prepared text appears in multiple documents within a batch (re-indexing
+    duplicate rows, templated or synthetic content) without changing per-document output.
+    Deduplication is scoped to a single batch — duplicates that fall into different batches are
+    still embedded independently.

--- a/test/components/embedders/test_openai_document_embedder.py
+++ b/test/components/embedders/test_openai_document_embedder.py
@@ -264,6 +264,133 @@ class TestOpenAIDocumentEmbedder:
             with pytest.raises(APIError, match="Mocked error"):
                 embedder._embed_batch(texts_to_embed=fake_texts_to_embed, batch_size=2)
 
+    def test_dedupe_batch_preserves_order_and_groups_duplicates(self):
+        batch = (("a", "hello"), ("b", "world"), ("c", "hello"), ("d", "world"), ("e", "unique"))
+        unique_texts, text_to_doc_ids = OpenAIDocumentEmbedder._dedupe_batch(batch)
+        assert unique_texts == ["hello", "world", "unique"]
+        assert text_to_doc_ids == {"hello": ["a", "c"], "world": ["b", "d"], "unique": ["e"]}
+
+    def test_embed_batch_deduplicates_identical_texts(self):
+        embedder = OpenAIDocumentEmbedder(api_key=Secret.from_token("fake_api_key"))
+        # Three documents, two share the same text.
+        fake_texts_to_embed = {"id_1": "shared text", "id_2": "unique text", "id_3": "shared text"}
+
+        from openai.types.create_embedding_response import Usage
+
+        mock_response = Mock()
+        mock_response.data = [Mock(embedding=[0.1, 0.2]), Mock(embedding=[0.3, 0.4])]
+        mock_response.model = "text-embedding-ada-002"
+        mock_response.usage = Usage(prompt_tokens=5, total_tokens=5)
+
+        with patch.object(embedder.client.embeddings, "create", return_value=mock_response) as mock_create:
+            doc_ids_to_embeddings, meta = embedder._embed_batch(
+                texts_to_embed=fake_texts_to_embed, batch_size=10
+            )
+
+        # Only unique texts were sent to the API.
+        sent_input = mock_create.call_args.kwargs["input"]
+        assert sent_input == ["shared text", "unique text"]
+        assert mock_create.call_count == 1
+
+        # Both documents with the shared text get the same embedding.
+        assert doc_ids_to_embeddings["id_1"] == [0.1, 0.2]
+        assert doc_ids_to_embeddings["id_3"] == [0.1, 0.2]
+        assert doc_ids_to_embeddings["id_2"] == [0.3, 0.4]
+        assert meta["model"] == "text-embedding-ada-002"
+
+    @pytest.mark.asyncio
+    async def test_embed_batch_async_deduplicates_identical_texts(self):
+        from unittest.mock import AsyncMock
+
+        from openai.types.create_embedding_response import Usage
+
+        embedder = OpenAIDocumentEmbedder(api_key=Secret.from_token("fake_api_key"))
+        fake_texts_to_embed = {"id_1": "shared text", "id_2": "unique text", "id_3": "shared text"}
+
+        mock_response = Mock()
+        mock_response.data = [Mock(embedding=[0.1, 0.2]), Mock(embedding=[0.3, 0.4])]
+        mock_response.model = "text-embedding-ada-002"
+        mock_response.usage = Usage(prompt_tokens=5, total_tokens=5)
+
+        embedder.async_client.embeddings.create = AsyncMock(return_value=mock_response)
+        doc_ids_to_embeddings, meta = await embedder._embed_batch_async(
+            texts_to_embed=fake_texts_to_embed, batch_size=10
+        )
+
+        sent_input = embedder.async_client.embeddings.create.call_args.kwargs["input"]
+        assert sent_input == ["shared text", "unique text"]
+        assert embedder.async_client.embeddings.create.call_count == 1
+        assert doc_ids_to_embeddings["id_1"] == [0.1, 0.2]
+        assert doc_ids_to_embeddings["id_3"] == [0.1, 0.2]
+        assert doc_ids_to_embeddings["id_2"] == [0.3, 0.4]
+        assert meta["model"] == "text-embedding-ada-002"
+
+        with contextlib.suppress(RuntimeError):
+            await embedder.async_client.close()
+
+    def test_embed_batch_dedupe_does_not_alias_embeddings(self):
+        """Documents that shared a prepared text must NOT share the same embedding list object.
+
+        Otherwise a downstream consumer that mutates one Document's embedding in place (for example
+        an L2 normalizer or a dimension-truncation step) would silently corrupt every duplicate.
+        """
+        from openai.types.create_embedding_response import Usage
+
+        embedder = OpenAIDocumentEmbedder(api_key=Secret.from_token("fake_api_key"))
+        fake_texts_to_embed = {"id_1": "shared", "id_2": "shared", "id_3": "shared"}
+
+        mock_response = Mock()
+        mock_response.data = [Mock(embedding=[0.1, 0.2])]
+        mock_response.model = "text-embedding-ada-002"
+        mock_response.usage = Usage(prompt_tokens=1, total_tokens=1)
+
+        with patch.object(embedder.client.embeddings, "create", return_value=mock_response):
+            doc_ids_to_embeddings, _ = embedder._embed_batch(
+                texts_to_embed=fake_texts_to_embed, batch_size=10
+            )
+
+        assert doc_ids_to_embeddings["id_1"] == [0.1, 0.2]
+        assert doc_ids_to_embeddings["id_2"] == [0.1, 0.2]
+        assert doc_ids_to_embeddings["id_3"] == [0.1, 0.2]
+        # The three lists must be distinct objects so per-document mutation is isolated.
+        assert doc_ids_to_embeddings["id_1"] is not doc_ids_to_embeddings["id_2"]
+        assert doc_ids_to_embeddings["id_1"] is not doc_ids_to_embeddings["id_3"]
+        assert doc_ids_to_embeddings["id_2"] is not doc_ids_to_embeddings["id_3"]
+
+        doc_ids_to_embeddings["id_1"].append(99.0)
+        assert doc_ids_to_embeddings["id_2"] == [0.1, 0.2]
+        assert doc_ids_to_embeddings["id_3"] == [0.1, 0.2]
+
+    def test_embed_batch_no_duplicates_within_batch(self):
+        """Documents with the same text in *different* API batches are NOT deduplicated across batches."""
+        embedder = OpenAIDocumentEmbedder(api_key=Secret.from_token("fake_api_key"))
+        fake_texts_to_embed = {"id_1": "shared text", "id_2": "shared text"}
+
+        from openai.types.create_embedding_response import Usage
+
+        mock_response_a = Mock()
+        mock_response_a.data = [Mock(embedding=[0.1, 0.2])]
+        mock_response_a.model = "text-embedding-ada-002"
+        mock_response_a.usage = Usage(prompt_tokens=3, total_tokens=3)
+
+        mock_response_b = Mock()
+        mock_response_b.data = [Mock(embedding=[0.5, 0.6])]
+        mock_response_b.model = "text-embedding-ada-002"
+        mock_response_b.usage = Usage(prompt_tokens=3, total_tokens=3)
+
+        with patch.object(
+            embedder.client.embeddings, "create", side_effect=[mock_response_a, mock_response_b]
+        ) as mock_create:
+            doc_ids_to_embeddings, meta = embedder._embed_batch(
+                texts_to_embed=fake_texts_to_embed, batch_size=1
+            )
+
+        # batch_size=1 means each doc gets its own API call — dedupe only operates within a batch.
+        assert mock_create.call_count == 2
+        assert doc_ids_to_embeddings["id_1"] == [0.1, 0.2]
+        assert doc_ids_to_embeddings["id_2"] == [0.5, 0.6]
+        assert meta["usage"]["prompt_tokens"] == 6
+
     @pytest.mark.skipif(os.environ.get("OPENAI_API_KEY", "") == "", reason="OPENAI_API_KEY is not set")
     @pytest.mark.integration
     def test_run(self):


### PR DESCRIPTION
OpenAIDocumentEmbedder._embed_batch and _embed_batch_async previously sent every (doc_id, prepared_text) pair in a batch to the OpenAI embeddings API as-is. When two or more documents in the same batch produced byte-identical prepared text (the concatenation of prefix + meta_fields_to_embed + content
+ suffix built by _prepare_texts_to_embed), the API was billed for the same embedding multiple times.

This change adds a small _dedupe_batch helper that collapses identical prepared texts within a single batch before the API call. Each unique text is embedded once. Each document that produced that text receives an independent copy of the embedding list, so a downstream consumer that mutates one document's embedding in place (e.g. L2 normalization or dimension truncation) cannot leak that mutation into another document. AzureOpenAIDocumentEmbedder inherits the behavior.

Notes on scope:
- Dedupe is per-batch. A duplicate split across two API batches by batch_size is still embedded independently.
- Dedupe matches the full prepared string, not shared fragments (e.g. a common header inside otherwise-different bodies will not dedupe).
- When no duplicates exist the behavior is byte-identical; building the dedupe map is O(batch_size), negligible against an HTTP round trip.

Tests cover the dedupe map, sync and async embed paths, the no-cross-batch- dedupe contract, and a regression test asserting that duplicate documents receive independent embedding list objects.

### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
