### PR TITLE
fix: Fix HITL code raising a KeyError when tool name is hallucinated

### DIFF
--- a/haystack/human_in_the_loop/strategies.py
+++ b/haystack/human_in_the_loop/strategies.py
@@ -220,6 +220,22 @@ def _get_confirmation_strategy(
     return None
 
 
+def _passthrough_tool_call(tool_call: ToolCall) -> ToolExecutionDecision:
+    """
+    Build a decision that executes a tool call as-is, bypassing confirmation.
+
+    Used for tool calls that don't resolve to a known tool (e.g. the model hallucinated the name). Instead of
+    raising here, the call is passed through unchanged so the tool-calling code resolves it and reports the
+    unknown tool uniformly (`ToolNotFoundException`, respecting `raise_on_failure`).
+
+    :param tool_call: The unresolved tool call to pass through.
+    :returns: A decision that executes the tool call with its original arguments.
+    """
+    return ToolExecutionDecision(
+        tool_call_id=tool_call.id, tool_name=tool_call.tool_name, execute=True, final_tool_params=tool_call.arguments
+    )
+
+
 def _process_confirmation_strategies(
     *,
     confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy],
@@ -359,7 +375,11 @@ def _run_confirmation_strategies(
 
         for tool_call in message.tool_calls:
             tool_name = tool_call.tool_name
-            tool_to_invoke = tools_with_names[tool_name]
+            tool_to_invoke = tools_with_names.get(tool_name)
+            if tool_to_invoke is None:
+                # Unknown tool (e.g. the model hallucinated the name): skip confirmation and pass it through.
+                teds.append(_passthrough_tool_call(tool_call))
+                continue
 
             # Prepare final tool args
             final_args = _prepare_tool_args(
@@ -428,7 +448,11 @@ async def _run_confirmation_strategies_async(
 
         for tool_call in message.tool_calls:
             tool_name = tool_call.tool_name
-            tool_to_invoke = tools_with_names[tool_name]
+            tool_to_invoke = tools_with_names.get(tool_name)
+            if tool_to_invoke is None:
+                # Unknown tool (e.g. the model hallucinated the name): skip confirmation and pass it through.
+                teds.append(_passthrough_tool_call(tool_call))
+                continue
 
             # Prepare final tool args
             final_args = _prepare_tool_args(

--- a/releasenotes/notes/fix-hitl-unknown-tool-keyerror-247291fb3df68428.yaml
+++ b/releasenotes/notes/fix-hitl-unknown-tool-keyerror-247291fb3df68428.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a ``KeyError`` raised by the human-in-the-loop confirmation strategies when a chat model hallucinated a
+    tool call whose name is not in the agent's tools. Such tool calls now bypass confirmation and pass through
+    unchanged, so the tool-calling code reports the unknown tool uniformly via ``ToolNotFoundException`` (respecting
+    ``raise_on_failure``) instead of crashing.

--- a/test/human_in_the_loop/test_strategies.py
+++ b/test/human_in_the_loop/test_strategies.py
@@ -214,6 +214,29 @@ class TestRunConfirmationStrategies:
         assert teds[1].tool_name == mult_tool.name
         assert teds[1].execute is True
 
+    def test_run_confirmation_strategies_unknown_tool_passes_through(self, tools, execution_context):
+        # The model hallucinated a tool name that isn't in the available tools. Confirmation is skipped and the
+        # call passes through unchanged so the tool-calling code can report it (ToolNotFoundException).
+        teds = _run_confirmation_strategies(
+            confirmation_strategies={
+                tools[0].name: BlockingConfirmationStrategy(
+                    confirmation_policy=AlwaysAskPolicy(), confirmation_ui=SimpleConsoleUI()
+                )
+            },
+            messages_with_tool_calls=[
+                ChatMessage.from_assistant(
+                    tool_calls=[ToolCall(id="tc-1", tool_name="hallucinated_tool", arguments={"a": 1})]
+                )
+            ],
+            tools=tools,
+            state=execution_context.state,
+        )
+        assert teds == [
+            ToolExecutionDecision(
+                tool_call_id="tc-1", tool_name="hallucinated_tool", execute=True, final_tool_params={"a": 1}
+            )
+        ]
+
 
 class TestApplyToolExecutionDecisions:
     @pytest.fixture
@@ -697,3 +720,27 @@ class TestAsyncConfirmationStrategies:
         assert len(teds) == 1
         assert teds[0].tool_name == tools[0].name
         assert teds[0].execute is True
+
+    @pytest.mark.asyncio
+    async def test_run_confirmation_strategies_async_unknown_tool_passes_through(self, tools, execution_context):
+        # The model hallucinated a tool name that isn't in the available tools. Confirmation is skipped and the
+        # call passes through unchanged so the tool-calling code can report it (ToolNotFoundException).
+        teds = await _run_confirmation_strategies_async(
+            confirmation_strategies={
+                tools[0].name: BlockingConfirmationStrategy(
+                    confirmation_policy=AlwaysAskPolicy(), confirmation_ui=SimpleConsoleUI()
+                )
+            },
+            messages_with_tool_calls=[
+                ChatMessage.from_assistant(
+                    tool_calls=[ToolCall(id="tc-1", tool_name="hallucinated_tool", arguments={"a": 1})]
+                )
+            ],
+            tools=tools,
+            state=execution_context.state,
+        )
+        assert teds == [
+            ToolExecutionDecision(
+                tool_call_id="tc-1", tool_name="hallucinated_tool", execute=True, final_tool_params={"a": 1}
+            )
+        ]

--- a/test/human_in_the_loop/test_strategies.py
+++ b/test/human_in_the_loop/test_strategies.py
@@ -9,6 +9,7 @@ import pytest
 
 from haystack.components.agents.agent import _ExecutionContext
 from haystack.components.agents.state.state import State
+from haystack.components.agents.tool_calling import ToolNotFoundException, _run_tool
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.human_in_the_loop import (
     AlwaysAskPolicy,
@@ -21,6 +22,7 @@ from haystack.human_in_the_loop import (
 )
 from haystack.human_in_the_loop.strategies import (
     _apply_tool_execution_decisions,
+    _process_confirmation_strategies,
     _run_confirmation_strategies,
     _run_confirmation_strategies_async,
     _update_chat_history,
@@ -236,6 +238,41 @@ class TestRunConfirmationStrategies:
                 tool_call_id="tc-1", tool_name="hallucinated_tool", execute=True, final_tool_params={"a": 1}
             )
         ]
+
+
+class TestUnknownToolEndToEnd:
+    def test_hallucinated_tool_survives_confirmation_and_is_reported_as_not_found(self, tools):
+        # A confirmation strategy is configured, and the model emits a tool call for a tool that doesn't exist.
+        # The hallucinated call must pass through confirmation unchanged and then be reported by the tool-calling
+        # code as not found, exactly as it would be without any confirmation strategy configured.
+        state = State(schema={"messages": {"type": list[ChatMessage]}})
+        tool_call = ToolCall(id="tc-1", tool_name="hallucinated_tool", arguments={"a": 1})
+        assistant_message = ChatMessage.from_assistant(tool_calls=[tool_call])
+        state.set("messages", [ChatMessage.from_user("do something"), assistant_message])
+
+        modified_messages, _ = _process_confirmation_strategies(
+            confirmation_strategies={
+                tools[0].name: BlockingConfirmationStrategy(
+                    confirmation_policy=AlwaysAskPolicy(), confirmation_ui=SimpleConsoleUI()
+                )
+            },
+            messages_with_tool_calls=[assistant_message],
+            tools=tools,
+            state=state,
+        )
+
+        # The hallucinated call survives the confirmation layer unchanged (it is not dropped).
+        surviving_calls = [tc for message in modified_messages for tc in (message.tool_calls or [])]
+        assert surviving_calls == [tool_call]
+
+        # raise_on_failure=True: the tool-calling code raises ToolNotFoundException.
+        with pytest.raises(ToolNotFoundException):
+            _run_tool(messages=modified_messages, state=state, tools=tools)
+
+        # raise_on_failure=False: it returns an error tool message instead of crashing.
+        tool_messages, _ = _run_tool(messages=modified_messages, state=state, tools=tools, raise_on_failure=False)
+        assert tool_messages[0].tool_call_results[0].error
+        assert "not found" in tool_messages[0].tool_call_results[0].result
 
 
 class TestApplyToolExecutionDecisions:


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/11754

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fixed a ``KeyError`` raised by the human-in-the-loop confirmation strategies when a chat model hallucinated a tool call whose name is not in the agent's tools. Such tool calls now bypass confirmation and pass through unchanged, so the tool-calling code reports the unknown tool uniformly via ``ToolNotFoundException`` (respecting ``raise_on_failure``) instead of crashing.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

new tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
