### PR TITLE
fix: apply split_overlap in RecursiveDocumentSplitter fallback path

### DIFF
--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -353,7 +353,10 @@ class RecursiveDocumentSplitter:
                 return chunks
 
         # if no separator worked, fall back to word- or character-level chunking
-        return self._fall_back_to_fixed_chunking(text, self.split_units)
+        chunks = self._fall_back_to_fixed_chunking(text, self.split_units)
+        if self.split_overlap > 0:
+            chunks = self._apply_overlap(chunks)
+        return chunks
 
     def _fall_back_to_fixed_chunking(self, text: str, split_units: Literal["word", "char", "token"]) -> list[str]:
         """

--- a/releasenotes/notes/fix-recursive-splitter-fallback-overlap-8171ab24e89e6bb4.yaml
+++ b/releasenotes/notes/fix-recursive-splitter-fallback-overlap-8171ab24e89e6bb4.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixed ``RecursiveDocumentSplitter`` (introduced in v2.9.0) silently
+    Fixed ``RecursiveDocumentSplitter`` silently
     ignoring ``split_overlap`` when none of the configured ``separators``
     match the input text.  In that code path the component fell back to
     fixed-size chunking but returned the result directly without calling

--- a/releasenotes/notes/fix-recursive-splitter-fallback-overlap-8171ab24e89e6bb4.yaml
+++ b/releasenotes/notes/fix-recursive-splitter-fallback-overlap-8171ab24e89e6bb4.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Fixed ``RecursiveDocumentSplitter`` (introduced in v2.9.0) silently
+    ignoring ``split_overlap`` when none of the configured ``separators``
+    match the input text.  In that code path the component fell back to
+    fixed-size chunking but returned the result directly without calling
+    ``_apply_overlap``, so every chunk after the first was missing the
+    expected overlap prefix.  The fix applies ``_apply_overlap`` to the
+    fallback chunks before returning them, making behaviour consistent
+    with the separator-matched code path.  All three split units
+    (``"char"``, ``"word"``, and ``"token"``) are affected and are now
+    covered by regression tests.

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -1000,12 +1000,6 @@ def test_recursive_splitter_generates_unique_ids_and_correct_meta():
         assert chunk.meta["split_id"] == idx
 
 
-# ── Regression tests for fallback overlap bug ────────────────────────────────
-# When no separator in `separators` matches the text, _chunk_text falls back to
-# fixed chunking.  Before the fix, the final `return` on that path skipped the
-# `_apply_overlap` call, so `split_overlap` was silently ignored.
-
-
 def test_fallback_overlap_char_unit():
     """split_overlap must be applied even when no separator matches (char unit)."""
     splitter = RecursiveDocumentSplitter(split_length=5, split_overlap=2, separators=["\n\n"], split_unit="char")

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -998,3 +998,56 @@ def test_recursive_splitter_generates_unique_ids_and_correct_meta():
     for idx, chunk in enumerate(chunks):
         assert chunk.meta["parent_id"] == source_doc.id
         assert chunk.meta["split_id"] == idx
+
+
+# ── Regression tests for fallback overlap bug ────────────────────────────────
+# When no separator in `separators` matches the text, _chunk_text falls back to
+# fixed chunking.  Before the fix, the final `return` on that path skipped the
+# `_apply_overlap` call, so `split_overlap` was silently ignored.
+
+
+def test_fallback_overlap_char_unit():
+    """split_overlap must be applied even when no separator matches (char unit)."""
+    splitter = RecursiveDocumentSplitter(split_length=5, split_overlap=2, separators=["\n\n"], split_unit="char")
+    # No \n\n in text → all separators fail → final fixed-chunking fallback
+    text = "abcdefghij"
+    result = splitter.run([Document(content=text)])["documents"]
+
+    # With overlap=2 and length=5: "abcde", "defgh", "ghij"
+    assert len(result) == 3
+    assert result[0].content == "abcde"
+    assert result[1].content == "defgh"
+    assert result[2].content == "ghij"
+
+
+def test_fallback_overlap_word_unit():
+    """split_overlap must be applied even when no separator matches (word unit)."""
+    splitter = RecursiveDocumentSplitter(split_length=3, split_overlap=1, separators=["\n\n"], split_unit="word")
+    # No \n\n → final fixed-chunking fallback
+    text = "one two three four five six seven"
+    result = splitter.run([Document(content=text)])["documents"]
+
+    contents = [d.content for d in result]
+    # Each chunk must share 1 word with its neighbour
+    assert len(result) > 1
+    for i in range(len(result) - 1):
+        prev_words = result[i].content.split()
+        next_words = result[i + 1].content.split()
+        # The last word of chunk i must appear at the start of chunk i+1
+        assert prev_words[-1] == next_words[0], (
+            f"No overlap between chunk {i} ({contents[i]!r}) and chunk {i + 1} ({contents[i + 1]!r})"
+        )
+
+
+@pytest.mark.integration
+def test_fallback_overlap_token_unit():
+    """split_overlap must be applied even when no separator matches (token unit)."""
+    splitter = RecursiveDocumentSplitter(split_length=4, split_overlap=2, separators=["\n\n"], split_unit="token")
+    # No \n\n → final fixed-chunking fallback
+    text = "one two three four five six seven eight"
+    result = splitter.run([Document(content=text)])["documents"]
+
+    # Each chunk should be at most 4 tokens; overlap means more than 1 chunk
+    assert len(result) > 1
+    for chunk in result:
+        assert splitter._chunk_length(chunk.content) <= 4


### PR DESCRIPTION
**fix: `RecursiveDocumentSplitter` applies `split_overlap` in final fallback path**

**Related Issues**

Closes #11767

**Proposed Changes**

- Updated `_chunk_text()` to capture the result of `_fall_back_to_fixed_chunking()` and pass it through `_apply_overlap()` before returning, when `split_overlap > 0`.
- Added 3 regression tests covering all affected split units (`"char"`, `"word"`, `@pytest.mark.integration "token"`).
- Added release note noting the bug has been present since `v2.9.0` when `RecursiveDocumentSplitter` was introduced.

**How did you test it?**

```bash
hatch run test:unit test/components/preprocessors/test_recursive_splitter.py
```

41 passed, 7 deselected (integration), 2 warnings.

**Notes for the reviewer**

- **Root cause:** `_chunk_text()` has two code paths that produce chunks. The separator-matched path (inside the `for curr_separator` loop) correctly calls `_apply_overlap()` at line 349. The final fallback path (line 355–358, reached when *no* separator is found in the text) returned `_fall_back_to_fixed_chunking()` results directly, skipping `_apply_overlap()` entirely. The result: any user who sets `split_overlap > 0` and has documents that don't contain their chosen separators silently gets zero overlap.

- **Reproducer:**
    ```python
    splitter = RecursiveDocumentSplitter(
        split_length=5, split_overlap=2, separators=["\n\n"], split_unit="char"
    )
    # "abcdefghij" has no \n\n → triggers the broken path
    chunks = splitter.run([Document(content="abcdefghij")])["documents"]
    # Before fix → ['abcde', 'fghij']    (overlap silently dropped)
    # After fix  → ['abcde', 'defgh', 'ghij']
    ```

- The fix is a 3-line change; no API or behaviour change for any working code path.

**Checklist**

- [ ] Read contributors guidelines and code of conduct
- [x] Updated related issue
- [x] Added unit tests and updated docstrings
- [ ] Used conventional commit type in PR title
- [x] Documented code
- [x] Added release note (`releasenotes/notes/fix-recursive-splitter-fallback-overlap-8171ab24e89e6bb4.yaml`)
- [ ] Run pre-commit hooks and fixed any issues