### PR TITLE
ci: pin more dependencies and configure CodeQL checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,12 @@ updates:
       default-days: 1
 
   # Tracks the digest-pinned `COPY --from` image (ghcr.io/astral-sh/uv) in
-  # docker/Dockerfile.base. Note: the python:3.12-slim base/builder images are
-  # passed via build args from docker/docker-bake.hcl and the `docker run` image
-  # strings in workflows are not parsed by Dependabot; bump those manually.
+  # docker/Dockerfile.base. Note: the python:3.12-slim base/builder digests are
+  # carried both as the build_image/base_image ARG defaults in Dockerfile.base
+  # and in docker/docker-bake.hcl (which overrides them at build time).
+  # Dependabot does NOT parse images that reach FROM via an ARG, nor the
+  # `docker run` image strings in workflows, so bump those by hand and keep the
+  # Dockerfile.base ARG defaults and docker-bake.hcl digests in sync.
   - package-ecosystem: 'docker'
     directory: '/docker'
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,71 @@
+# CodeQL (SAST)
+#
+# Advanced setup for GitHub code scanning, committed as a workflow file so it is
+# reliably credited by the OpenSSF Scorecard SAST check:
+#   - scorecard's CodeQL-config probe only fires when a workflow references
+#     `github/codeql-action/analyze` (GitHub's "default setup" has no such file),
+#   - running `on: pull_request` produces a CodeQL check on every PR's commits,
+#     which scorecard's "runs on all commits" probe looks for.
+# See https://github.com/ossf/scorecard/issues/3817 for why default setup is not
+# enough on its own.
+#
+# IMPORTANT: GitHub does not allow advanced setup and "default setup" at the same
+# time. Disable CodeQL default setup under
+# Settings -> Code security -> Code scanning -> CodeQL analysis -> Default setup
+# before merging this workflow, otherwise the analyze step fails.
+#
+# Action versions are pinned by commit SHA (required by the pinned-dependencies
+# check) and kept fresh by Dependabot's `github-actions` updater.
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly baseline scan of the default branch.
+    - cron: "27 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload code-scanning results to the Security tab.
+      security-events: write
+      # Required by codeql-action to read the workflow/CI config.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Haystack is a Python project; Python is interpreted, so no build is
+          # needed. Add `javascript-typescript` here if the docs-website JS code
+          # should also be scanned.
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@9887d98ae49f1f598651b556d8c8f02f3ea065cb # v3.27.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@9887d98ae49f1f598651b556d8c8f02f3ea065cb # v3.27.0
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,22 +1,3 @@
-# CodeQL (SAST)
-#
-# Advanced setup for GitHub code scanning, committed as a workflow file so it is
-# reliably credited by the OpenSSF Scorecard SAST check:
-#   - scorecard's CodeQL-config probe only fires when a workflow references
-#     `github/codeql-action/analyze` (GitHub's "default setup" has no such file),
-#   - running `on: pull_request` produces a CodeQL check on every PR's commits,
-#     which scorecard's "runs on all commits" probe looks for.
-# See https://github.com/ossf/scorecard/issues/3817 for why default setup is not
-# enough on its own.
-#
-# IMPORTANT: GitHub does not allow advanced setup and "default setup" at the same
-# time. Disable CodeQL default setup under
-# Settings -> Code security -> Code scanning -> CodeQL analysis -> Default setup
-# before merging this workflow, otherwise the analyze step fails.
-#
-# Action versions are pinned by commit SHA (required by the pinned-dependencies
-# check) and kept fresh by Dependabot's `github-actions` updater.
-
 name: CodeQL
 
 on:
@@ -24,9 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    # Weekly baseline scan of the default branch.
-    - cron: "27 4 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,10 +10,17 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded run for the same ref (e.g. a force-push to a PR) so we
+# don't burn CI minutes analyzing commits that are already stale.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    timeout-minutes: 360
     permissions:
       # Required to upload code-scanning results to the Security tab.
       security-events: write
@@ -38,12 +45,12 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9887d98ae49f1f598651b556d8c8f02f3ea065cb # v3.27.0
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9887d98ae49f1f598651b556d8c8f02f3ea065cb # v3.27.0
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docs_search_sync.yml
+++ b/.github/workflows/docs_search_sync.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Docusaurus and build docs-website
         working-directory: docs-website
         run: |
-          npm install --ignore-scripts
+          npm ci --ignore-scripts
           npm rebuild sharp
           npm run build
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -61,6 +61,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@9887d98ae49f1f598651b556d8c8f02f3ea065cb # v3.27.0
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/workflows_linting.yml
+++ b/.github/workflows/workflows_linting.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: ">=1.24.0"
 
       - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
       - name: Run actionlint
         env:

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,7 +1,10 @@
-ARG build_image
-ARG base_image
+# Pinned digest defaults so the base images are resolvable by hash even when
+# the args are not passed (e.g. by supply-chain scanners or a plain `docker build`).
+# docker/docker-bake.hcl overrides these at build time; keep the digests in sync.
+ARG build_image=python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
+ARG base_image=python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
 
-FROM $build_image AS build-image
+FROM ${build_image} AS build-image
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG haystack_version
@@ -25,7 +28,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN uv pip install --no-cache-dir -U setuptools && \
     uv pip install --no-cache-dir .
 
-FROM $base_image AS final
+FROM ${base_image} AS final
 
 COPY --from=build-image /opt/venv /opt/venv
 


### PR DESCRIPTION
### Related Issues

- Follow-up to #11723 with further security improvements based on OpenSSF findings.

### Proposed Changes:

- **Pinned-Dependencies** — pin the base images in `docker/Dockerfile.base` by digest via `${...}` args (containerImage 1/3 → 3/3), pin `actionlint` to `v1.7.12` (go 0/1 → 1/1), and use `npm ci` in `docs_search_sync.yml` (npm 0/1 → 1/1).
- **SAST** — add a committed CodeQL workflow instead of GitHub Web UI config of CodeQL so the check is reliably credited on PRs before merging not after

### How did you test it?

### Notes for the reviewer

- I disabled **CodeQL setup** in GitHub Web UI again because GitHub does not seem to allow web UI default + advanced setup via workflow file together.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I've used a conventional commit type for my PR title (`ci:`).
- [x] I have documented my code.
- [x] I have run pre-commit hooks and fixed any issue.
- [ ] ~Release note~ — N/A (CI-only, not user-facing).
- [ ] ~Unit tests~ — N/A (CI configuration only).
