### PR TITLE
fix: raise FilterError on unknown metadata filter operators

### DIFF
--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -173,6 +173,9 @@ def _logic_condition(condition: dict[str, Any], document: Document | ByteStream)
         msg = f"'conditions' key missing in {condition}"
         raise FilterError(msg)
     operator: str = condition["operator"]
+    if operator not in LOGICAL_OPERATORS:
+        msg = f"Unknown logical operator '{operator}'. Valid operators are: {sorted(LOGICAL_OPERATORS)}"
+        raise FilterError(msg)
     conditions: list[dict[str, Any]] = condition["conditions"]
     return LOGICAL_OPERATORS[operator](document=document, conditions=conditions)
 
@@ -214,5 +217,8 @@ def _comparison_condition(condition: dict[str, Any], document: Document | ByteSt
     else:
         document_value = getattr(document, field)
     operator: str = condition["operator"]
+    if operator not in COMPARISON_OPERATORS:
+        msg = f"Unknown comparison operator '{operator}'. Valid operators are: {sorted(COMPARISON_OPERATORS)}"
+        raise FilterError(msg)
     filter_value: Any = condition["value"]
     return COMPARISON_OPERATORS[operator](filter_value=filter_value, value=document_value)

--- a/releasenotes/notes/filter-unknown-operator-error-8df4039c0db976ff.yaml
+++ b/releasenotes/notes/filter-unknown-operator-error-8df4039c0db976ff.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Metadata filters that use an unsupported operator now raise a clear ``FilterError``
+    that lists the valid operators, instead of a cryptic ``KeyError``. For example, a
+    typo such as ``{"field": "meta.year", "operator": "gt", "value": 2000}`` (instead of
+    ``">"``) previously surfaced as ``KeyError: 'gt'``. This applies to both comparison
+    operators and logical operators (``AND``, ``OR``, ``NOT``).

--- a/test/utils/test_filters.py
+++ b/test/utils/test_filters.py
@@ -572,6 +572,17 @@ document_matches_filter_raises_error_data = [
         {"operator": "XOR", "conditions": [{"field": "meta.page", "operator": "==", "value": 10}]},
         id="Unknown logical operator",
     ),
+    pytest.param(
+        {
+            "operator": "AND",
+            "conditions": [{"operator": "XOR", "conditions": [{"field": "meta.page", "operator": "==", "value": 10}]}],
+        },
+        id="Unknown nested logical operator",
+    ),
+    pytest.param(
+        {"operator": "and", "conditions": [{"field": "meta.page", "operator": "==", "value": 10}]},
+        id="Lowercase logical operator",
+    ),
 ]
 
 
@@ -580,3 +591,38 @@ def test_document_matches_filter_raises_error(filters):
     with pytest.raises(FilterError):
         document = Document(meta={"page": 10})
         document_matches_filter(filters, document)
+
+
+@pytest.mark.parametrize(
+    "filters,expected_message",
+    [
+        pytest.param(
+            {"field": "meta.page", "operator": "gt", "value": 10},
+            "Unknown comparison operator 'gt'",
+            id="Unknown comparison operator",
+        ),
+        pytest.param(
+            {"operator": "XOR", "conditions": [{"field": "meta.page", "operator": "==", "value": 10}]},
+            "Unknown logical operator 'XOR'",
+            id="Unknown logical operator",
+        ),
+        pytest.param(
+            {
+                "operator": "AND",
+                "conditions": [
+                    {"operator": "XOR", "conditions": [{"field": "meta.page", "operator": "==", "value": 10}]}
+                ],
+            },
+            "Unknown logical operator 'XOR'",
+            id="Unknown nested logical operator",
+        ),
+        pytest.param(
+            {"operator": "and", "conditions": [{"field": "meta.page", "operator": "==", "value": 10}]},
+            "Unknown logical operator 'and'",
+            id="Lowercase logical operator",
+        ),
+    ],
+)
+def test_document_matches_filter_unknown_operator_error_message(filters, expected_message):
+    with pytest.raises(FilterError, match=expected_message):
+        document_matches_filter(filters, Document(meta={"page": 10}))

--- a/test/utils/test_filters.py
+++ b/test/utils/test_filters.py
@@ -566,6 +566,12 @@ document_matches_filter_raises_error_data = [
     pytest.param({"operator": "==", "value": "test"}, id="Missing condition field key"),
     pytest.param({"field": "meta.name", "value": "test"}, id="Missing condition operator key"),
     pytest.param({"field": "meta.name", "operator": "=="}, id="Missing condition value key"),
+    # Unknown operators
+    pytest.param({"field": "meta.page", "operator": "gt", "value": 10}, id="Unknown comparison operator"),
+    pytest.param(
+        {"operator": "XOR", "conditions": [{"field": "meta.page", "operator": "==", "value": 10}]},
+        id="Unknown logical operator",
+    ),
 ]
 
 


### PR DESCRIPTION
## Related Issues

Fixes #11794

## Proposed Changes

Metadata filters that use an unsupported operator previously raised a bare `KeyError` with no context. Because `haystack/utils/filters.py` is the shared filter engine used by `InMemoryDocumentStore` and every external document store, this cryptic error surfaced across all stores.

This PR validates the operator in both `_comparison_condition` and `_logic_condition` and raises a `FilterError` listing the valid operators — consistent with how other malformed-filter cases (missing keys, wrong value types) are already handled.

**Before**
```python
document_matches_filter({"field": "meta.year", "operator": "gt", "value": 2000}, doc)
# KeyError: 'gt'
```

**After**
```text
FilterError: Unknown comparison operator 'gt'. Valid operators are: ['!=', '<', '<=', '==', '>', '>=', 'in', 'not in']
```

## How did you test it?

Added two cases to the existing `document_matches_filter_raises_error` parametrization (unknown comparison operator and unknown logical operator). All filter unit tests pass; `mypy` is clean.

## Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
