### PR TITLE
chore: remove deprecation warning util function

### DIFF
--- a/haystack/components/generators/utils.py
+++ b/haystack/components/generators/utils.py
@@ -3,22 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import warnings
 from typing import Any
 
 from haystack import logging
 from haystack.dataclasses import ChatMessage, ReasoningContent, StreamingChunk, ToolCall
 
 logger = logging.getLogger(__name__)
-
-
-def _generators_deprecation_warning(generator_name: str, chatgenerator_name: str) -> None:
-    warnings.warn(
-        f"The `{generator_name}` component is deprecated and will be removed in Haystack 3.0. "
-        f"Use `{chatgenerator_name}` instead, which now also supports string inputs.",
-        FutureWarning,
-        stacklevel=2,
-    )
 
 
 def print_streaming_chunk(chunk: StreamingChunk) -> None:


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/396

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Removes util function that warns users of the generators being deprecated in Haystack 3.0 in the v3 branch since its not being used in the v3 branch. All generators have already been removed. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
