### PR TITLE
ci: rename DC_PIPELINE_IMAGES_PR_URL to HAYSTACK_RUNTIME_PR_URL

### DIFF
--- a/.github/utils/prepare_release_notification.sh
+++ b/.github/utils/prepare_release_notification.sh
@@ -3,8 +3,8 @@
 #
 # Requires: VERSION, RUN_URL, HAS_FAILURE, GH_TOKEN, GITHUB_REPOSITORY
 # Optional: IS_RC, IS_FIRST_RC, MAJOR_MINOR, GITHUB_URL, PYPI_URL, DOCKER_URL,
-#           BUMP_VERSION_PR_URL, DC_PIPELINE_TEMPLATES_PR_URL, CUSTOM_NODES_PR_URL,
-#           DC_PIPELINE_IMAGES_PR_URL (haystack-runtime bump PR), GITHUB_WORKSPACE
+#           BUMP_VERSION_PR_URL, DC_PIPELINE_TEMPLATES_PR_URL, DC_CUSTOM_NODES_PR_URL,
+#           HAYSTACK_RUNTIME_PR_URL, GITHUB_WORKSPACE
 # Output: slack_payload.json
 #
 # This script is used in the release.yml workflow to prepare the notification payload
@@ -64,7 +64,7 @@ if [[ "${IS_RC:-}" == "true" ]]; then
   PLATFORM_PRS=""
   [[ -n "${DC_PIPELINE_TEMPLATES_PR_URL:-}" ]] && PLATFORM_PRS+=$'\n'"- <${DC_PIPELINE_TEMPLATES_PR_URL}|dc-pipeline-templates>"
   [[ -n "${DC_CUSTOM_NODES_PR_URL:-}" ]] && PLATFORM_PRS+=$'\n'"- <${DC_CUSTOM_NODES_PR_URL}|deepset-cloud-custom-nodes>"
-  [[ -n "${DC_PIPELINE_IMAGES_PR_URL:-}" ]] && PLATFORM_PRS+=$'\n'"- <${DC_PIPELINE_IMAGES_PR_URL}|haystack-runtime>"
+  [[ -n "${HAYSTACK_RUNTIME_PR_URL:-}" ]] && PLATFORM_PRS+=$'\n'"- <${HAYSTACK_RUNTIME_PR_URL}|haystack-runtime>"
   if [[ -n "${PLATFORM_PRS}" ]]; then
     TXT+=$'\n\n'":factory: *Test PRs opened on Platform:*${PLATFORM_PRS}"
   fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
           BUMP_VERSION_PR_URL: ${{ needs.branch-off.outputs.bump_version_pr_url }}
           DC_PIPELINE_TEMPLATES_PR_URL: ${{ needs.bump-dc-pipeline-templates.outputs.pr_url }}
           DC_CUSTOM_NODES_PR_URL: ${{ needs.bump-deepset-cloud-custom-nodes.outputs.pr_url }}
-          DC_PIPELINE_IMAGES_PR_URL: ${{ needs.bump-haystack-runtime.outputs.pr_url }}
+          HAYSTACK_RUNTIME_PR_URL: ${{ needs.bump-haystack-runtime.outputs.pr_url }}
         run: .github/utils/prepare_release_notification.sh
 
       - name: Send release notification to Slack


### PR DESCRIPTION
### Proposed Changes?

Renames the release-notification variable `DC_PIPELINE_IMAGES_PR_URL` → `HAYSTACK_RUNTIME_PR_URL` in `release.yml` and `prepare_release_notification.sh`.

The name was a leftover from before #11719, which repointed this step from the now-archived `dc-pipeline-images` repo to `haystack-runtime` but kept the old variable name — making it misleading (the value already carries the haystack-runtime bump PR URL, and the Slack link is already labeled `haystack-runtime`).

Also fixes an adjacent doc-comment typo: the optional inputs list said `CUSTOM_NODES_PR_URL` but the script actually reads `DC_CUSTOM_NODES_PR_URL`.

Purely cosmetic — **no behavior change**. Verified locally by running `prepare_release_notification.sh` with mocked env: the new variable renders the `haystack-runtime` link and the old name no longer produces one.

Part of the haystack-runtime release-automation cleanup (deepset-ai/haystack-private#388).

### How did you test it?

Ran `prepare_release_notification.sh` locally with representative RC env vars and asserted the rendered Slack payload

### Checklist

- [x] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- CI-only change (workflow + release util script) — no release note required.