### PR TITLE
fix: redact token from TokenSecret repr to prevent API key leaks

### DIFF
--- a/haystack/utils/auth.py
+++ b/haystack/utils/auth.py
@@ -162,6 +162,10 @@ class TokenSecret(Secret):
             "Cannot deserialize token-based secret. Use an alternative secret type like environment variables."
         )
 
+    def __repr__(self) -> str:
+        # Hide the token so it can't leak through print/log/traceback formatting.
+        return f"TokenSecret(_token=<redacted>, _type={self._type!r})"
+
     def resolve_value(self) -> Any | None:
         """Return the token."""
         return self._token

--- a/releasenotes/notes/redact-tokensecret-repr-34c7549247f4b6e4.yaml
+++ b/releasenotes/notes/redact-tokensecret-repr-34c7549247f4b6e4.yaml
@@ -1,0 +1,8 @@
+---
+security:
+  - |
+    The ``repr()`` of a ``Secret`` built via ``Secret.from_token(...)`` no longer
+    includes the raw token. Previously the dataclass-generated repr printed the
+    token verbatim, so any path that formats a component's locals — exception
+    tracebacks, ``print()``, Jupyter echo, log aggregators — could leak the API
+    key. The token is now rendered as ``<redacted>``.

--- a/test/utils/test_auth.py
+++ b/test/utils/test_auth.py
@@ -36,6 +36,11 @@ def test_token_secret():
     with pytest.raises(FrozenInstanceError):
         secret._type = SecretType.ENV_VAR
 
+    secret = Secret.from_token("sk-supersecret-1234567890ABCDEF")
+    assert "sk-supersecret-1234567890ABCDEF" not in repr(secret)
+    assert "sk-supersecret-1234567890ABCDEF" not in str(secret)
+    assert "<redacted>" in repr(secret)
+
 
 def test_env_var_secret():
     secret = Secret.from_env_var("TEST_ENV_VAR1")


### PR DESCRIPTION
### Related Issues

- fixes #11808

### Proposed Changes:

TokenSecret is a @dataclass(frozen=True) with no custom __repr__, so Python auto-generates one that prints every field, including the raw _token. Any path that formats locals: print(), exception tracebacks, Sentry/structlog breadcrumbs, Jupyter cell echo, pprint, leaks the user's API key.

Added an explicit __repr__ on TokenSecret that renders _token as <redacted>. Since str() falls back to __repr__, both paths are covered. __eq__/__hash__ are untouched (still dataclass-generated), so equality semantics don't change. EnvVarSecret is left alone, it stores env-var names, not values.

### How did you test it?

- Extended test_token_secret with three asserts: the raw token never appears in repr() or str(), and the <redacted> placeholder is present. This pins the contract so a future refactor can't silently reintroduce the leak.
- hatch run test:unit test/utils/test_auth.py: passes.
- hatch run test:unit test/ -k "token or secret or auth": 47 tests pass, none affected.
- hatch run test:types and hatch run fmt: clean.

### Notes for the reviewer

- I deliberately did not include the token length in the placeholder (some examples use <redacted, N chars>). Length leaks info for negligible debugging value.
- Out of scope: vars(secret), secret.__dict__, and dataclasses.asdict(secret) still expose _token. Closing those requires removing _token from the instance dict entirely (closure/descriptor), much larger change with pickle/copy implications. This PR closes the dominant leak path (everything that goes through repr) without touching the data model.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
