### PR TITLE
fix: fix async tool deserialization

### DIFF
--- a/haystack/utils/callable_serialization.py
+++ b/haystack/utils/callable_serialization.py
@@ -111,7 +111,7 @@ def deserialize_callable(callable_handle: str) -> Callable:
 
         # Handle the case where @tool decorator replaced the function with a Tool object
         if isinstance(attr_value, Tool):
-            attr_value = attr_value.function
+            attr_value = attr_value.function or attr_value.async_function
 
         # Handle the case where @hook decorator replaced the function with a FunctionHook object
         if isinstance(attr_value, FunctionHook):

--- a/releasenotes/notes/fix-deserialize-async-tool-callable-42995d2052814e59.yaml
+++ b/releasenotes/notes/fix-deserialize-async-tool-callable-42995d2052814e59.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed ``deserialize_callable`` failing for functions decorated with ``@tool`` when the
+    decorated function is asynchronous. Such tools store the callable in ``async_function``
+    with ``function`` set to ``None``, which previously caused deserialization to raise a
+    ``DeserializationError``. The underlying coroutine function is now resolved correctly.

--- a/test/utils/test_callable_serialization.py
+++ b/test/utils/test_callable_serialization.py
@@ -2,17 +2,32 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
+
 import httpx
 import pytest
 
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.core.errors import DeserializationError, SerializationError
 from haystack.testing.callable_serialization.random_callable import callable_to_deserialize
+from haystack.tools import tool
 from haystack.utils import deserialize_callable, serialize_callable
 
 
 def some_random_callable_for_testing(some_ignored_arg: str):
     pass
+
+
+@tool
+def sync_tool_for_testing(x: int) -> int:
+    """A sync tool."""
+    return x
+
+
+@tool
+async def async_tool_for_testing(x: int) -> int:
+    """An async tool."""
+    return x
 
 
 class TestClass:
@@ -94,6 +109,20 @@ def test_staticmethod_serialization_deserialization():
     result = serialize_callable(TestClass.static_method)
     fn = deserialize_callable(result)
     assert fn == TestClass.static_method
+
+
+def test_deserialization_of_tool_decorated_function():
+    # The @tool decorator replaces the module-level sync function with a Tool object;
+    # deserialization should return the underlying sync function.
+    fn = deserialize_callable("test_callable_serialization.sync_tool_for_testing")
+    assert fn(x=5) == 5
+
+
+def test_deserialization_of_tool_decorated_async_function():
+    # The @tool decorator replaces the module-level async function with a Tool object that has
+    # only `async_function` set; deserialization should return the underlying coroutine function.
+    fn = deserialize_callable("test_callable_serialization.async_tool_for_testing")
+    assert inspect.iscoroutinefunction(fn)
 
 
 def test_callable_deserialization_errors():


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fixed ``deserialize_callable`` failing for functions decorated with ``@tool`` when the decorated function is asynchronous. Such tools store the callable in ``async_function`` with ``function`` set to ``None``, which previously caused deserialization to raise a ``DeserializationError``. The underlying coroutine function is now resolved correctly.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

new tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
