### PR TITLE
fix: confirmation strategies no longer bake stale tool args

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -1154,8 +1154,6 @@ class Agent:
                 state=exe_context.state,
                 confirmation_strategy_context=exe_context.confirmation_strategy_context,
                 tools=current_tools,
-                streaming_callback=exe_context.tool_execution_inputs["streaming_callback"],
-                enable_streaming_passthrough=exe_context.tool_execution_inputs["enable_streaming_callback_passthrough"],
             )
             exe_context.state.set(key="messages", value=new_chat_history, handler_override=replace_values)
 
@@ -1223,8 +1221,6 @@ class Agent:
                 messages_with_tool_calls=pending_tool_call_messages,
                 tools=current_tools,
                 state=exe_context.state,
-                streaming_callback=exe_context.tool_execution_inputs["streaming_callback"],
-                enable_streaming_passthrough=exe_context.tool_execution_inputs["enable_streaming_callback_passthrough"],
                 confirmation_strategy_context=exe_context.confirmation_strategy_context,
             )
             exe_context.state.set(key="messages", value=new_chat_history, handler_override=replace_values)

--- a/haystack/human_in_the_loop/strategies.py
+++ b/haystack/human_in_the_loop/strategies.py
@@ -6,9 +6,8 @@ from dataclasses import replace
 from typing import Any
 
 from haystack.components.agents.state.state import State
-from haystack.components.agents.tool_calling import _prepare_tool_args
 from haystack.core.serialization import default_from_dict, default_to_dict
-from haystack.dataclasses import ChatMessage, StreamingCallbackT, ToolCall
+from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.human_in_the_loop import ToolExecutionDecision
 from haystack.human_in_the_loop.types import ConfirmationPolicy, ConfirmationStrategy, ConfirmationUI
 from haystack.tools import Tool
@@ -242,8 +241,6 @@ def _process_confirmation_strategies(
     messages_with_tool_calls: list[ChatMessage],
     tools: list[Tool],
     state: State,
-    streaming_callback: StreamingCallbackT | None = None,
-    enable_streaming_passthrough: bool = False,
     confirmation_strategy_context: dict[str, Any] | None = None,
 ) -> tuple[list[ChatMessage], list[ChatMessage]]:
     """
@@ -252,9 +249,7 @@ def _process_confirmation_strategies(
     :param confirmation_strategies: Mapping of tool names to their corresponding confirmation strategies
     :param messages_with_tool_calls: Chat messages containing tool calls
     :param tools: The available tools, used to resolve each tool call by name
-    :param state: The current runtime state, used to prepare tool arguments and read the chat history
-    :param streaming_callback: Optional streaming callback to pass through to tools that accept it
-    :param enable_streaming_passthrough: Whether to inject the streaming callback into tool arguments
+    :param state: The current runtime state, used to read the chat history
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
     :returns:
         Tuple of modified messages with confirmed tool calls and updated chat history
@@ -268,9 +263,6 @@ def _process_confirmation_strategies(
         confirmation_strategies=confirmation_strategies,
         messages_with_tool_calls=messages_with_tool_calls,
         tools=tools,
-        state=state,
-        streaming_callback=streaming_callback,
-        enable_streaming_passthrough=enable_streaming_passthrough,
         confirmation_strategy_context=confirmation_strategy_context,
     )
 
@@ -295,8 +287,6 @@ async def _process_confirmation_strategies_async(
     messages_with_tool_calls: list[ChatMessage],
     tools: list[Tool],
     state: State,
-    streaming_callback: StreamingCallbackT | None = None,
-    enable_streaming_passthrough: bool = False,
     confirmation_strategy_context: dict[str, Any] | None = None,
 ) -> tuple[list[ChatMessage], list[ChatMessage]]:
     """
@@ -307,9 +297,7 @@ async def _process_confirmation_strategies_async(
     :param confirmation_strategies: Mapping of tool names to their corresponding confirmation strategies
     :param messages_with_tool_calls: Chat messages containing tool calls
     :param tools: The available tools, used to resolve each tool call by name
-    :param state: The current runtime state, used to prepare tool arguments and read the chat history
-    :param streaming_callback: Optional streaming callback to pass through to tools that accept it
-    :param enable_streaming_passthrough: Whether to inject the streaming callback into tool arguments
+    :param state: The current runtime state, used to read the chat history
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
     :returns:
         Tuple of modified messages with confirmed tool calls and updated chat history
@@ -323,9 +311,6 @@ async def _process_confirmation_strategies_async(
         confirmation_strategies=confirmation_strategies,
         messages_with_tool_calls=messages_with_tool_calls,
         tools=tools,
-        state=state,
-        streaming_callback=streaming_callback,
-        enable_streaming_passthrough=enable_streaming_passthrough,
         confirmation_strategy_context=confirmation_strategy_context,
     )
 
@@ -348,9 +333,6 @@ def _run_confirmation_strategies(
     confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy],
     messages_with_tool_calls: list[ChatMessage],
     tools: list[Tool],
-    state: State,
-    streaming_callback: StreamingCallbackT | None = None,
-    enable_streaming_passthrough: bool = False,
     confirmation_strategy_context: dict[str, Any] | None = None,
 ) -> list[ToolExecutionDecision]:
     """
@@ -359,9 +341,6 @@ def _run_confirmation_strategies(
     :param confirmation_strategies: Mapping of tool names to their corresponding confirmation strategies
     :param messages_with_tool_calls: Messages containing tool calls to process
     :param tools: The available tools, used to resolve each tool call by name
-    :param state: The current runtime state, used to prepare tool arguments
-    :param streaming_callback: Optional streaming callback to pass through to tools that accept it
-    :param enable_streaming_passthrough: Whether to inject the streaming callback into tool arguments
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
     :returns:
         A list of ToolExecutionDecision objects representing the decisions made for each tool call.
@@ -381,14 +360,10 @@ def _run_confirmation_strategies(
                 teds.append(_passthrough_tool_call(tool_call))
                 continue
 
-            # Prepare final tool args
-            final_args = _prepare_tool_args(
-                tool=tool_to_invoke,
-                tool_call_arguments=tool_call.arguments,
-                state=state,
-                streaming_callback=streaming_callback,
-                enable_streaming_passthrough=enable_streaming_passthrough,
-            )
+            # Confirm the model-requested arguments. State injection (inputs_from_state and State-typed parameters)
+            # is deliberately left to tool execution, which prepares args per batch so a tool observes State writes
+            # from tools that ran earlier in the same step. Baking injected args here would freeze stale values.
+            final_args = dict(tool_call.arguments)
 
             # Get tool execution decisions from confirmation strategies
             # If no confirmation strategy is defined for this tool, proceed with execution
@@ -418,9 +393,6 @@ async def _run_confirmation_strategies_async(
     confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy],
     messages_with_tool_calls: list[ChatMessage],
     tools: list[Tool],
-    state: State,
-    streaming_callback: StreamingCallbackT | None = None,
-    enable_streaming_passthrough: bool = False,
     confirmation_strategy_context: dict[str, Any] | None = None,
 ) -> list[ToolExecutionDecision]:
     """
@@ -432,9 +404,6 @@ async def _run_confirmation_strategies_async(
         String keys map individual tools, tuple keys map multiple tools to the same strategy.
     :param messages_with_tool_calls: Messages containing tool calls to process
     :param tools: The available tools, used to resolve each tool call by name
-    :param state: The current runtime state, used to prepare tool arguments
-    :param streaming_callback: Optional streaming callback to pass through to tools that accept it
-    :param enable_streaming_passthrough: Whether to inject the streaming callback into tool arguments
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
     :returns:
         A list of ToolExecutionDecision objects representing the decisions made for each tool call.
@@ -454,14 +423,10 @@ async def _run_confirmation_strategies_async(
                 teds.append(_passthrough_tool_call(tool_call))
                 continue
 
-            # Prepare final tool args
-            final_args = _prepare_tool_args(
-                tool=tool_to_invoke,
-                tool_call_arguments=tool_call.arguments,
-                state=state,
-                streaming_callback=streaming_callback,
-                enable_streaming_passthrough=enable_streaming_passthrough,
-            )
+            # Confirm the model-requested arguments. State injection (inputs_from_state and State-typed parameters)
+            # is deliberately left to tool execution, which prepares args per batch so a tool observes State writes
+            # from tools that ran earlier in the same step. Baking injected args here would freeze stale values.
+            final_args = dict(tool_call.arguments)
 
             # Get tool execution decisions from confirmation strategies
             # If no confirmation strategy is defined for this tool, proceed with execution

--- a/haystack/human_in_the_loop/strategies.py
+++ b/haystack/human_in_the_loop/strategies.py
@@ -360,9 +360,7 @@ def _run_confirmation_strategies(
                 teds.append(_passthrough_tool_call(tool_call))
                 continue
 
-            # Confirm the model-requested arguments. State injection (inputs_from_state and State-typed parameters)
-            # is deliberately left to tool execution, which prepares args per batch so a tool observes State writes
-            # from tools that ran earlier in the same step. Baking injected args here would freeze stale values.
+            # Confirm the model-requested arguments
             final_args = dict(tool_call.arguments)
 
             # Get tool execution decisions from confirmation strategies
@@ -423,9 +421,7 @@ async def _run_confirmation_strategies_async(
                 teds.append(_passthrough_tool_call(tool_call))
                 continue
 
-            # Confirm the model-requested arguments. State injection (inputs_from_state and State-typed parameters)
-            # is deliberately left to tool execution, which prepares args per batch so a tool observes State writes
-            # from tools that ran earlier in the same step. Baking injected args here would freeze stale values.
+            # Confirm the model-requested arguments
             final_args = dict(tool_call.arguments)
 
             # Get tool execution decisions from confirmation strategies

--- a/releasenotes/notes/fix-hitl-stale-tool-args-d268541b0c442a53.yaml
+++ b/releasenotes/notes/fix-hitl-stale-tool-args-d268541b0c442a53.yaml
@@ -10,8 +10,8 @@ upgrade:
 fixes:
   - |
     Fixed a bug where configuring an ``Agent`` confirmation strategy could make a tool run with stale arguments.
-    Confirmation prepared and baked each tool's final arguments up front (injecting ``inputs_from_state`` values from
-    the state at the start of the step), which defeated the per-batch argument preparation in tool execution: a tool
-    that reads a state key written by another tool in the same step would run with the pre-step value instead of the
-    freshly produced one. Confirmation now operates on the model-requested arguments and leaves state injection to
-    tool execution, so dependent tools again receive the correct values.
+    HITL confirmation prepared and baked each tool's final arguments up front (injecting ``inputs_from_state`` values
+    from the state at the start of the tool calling step), which defeated the per-batch argument preparation in tool
+    execution: a tool that reads a state key written by another tool in the same step would run with the pre-step
+    value instead of the freshly produced one. HITL confirmation now operates on the model-requested arguments and
+    leaves state injection to tool execution, so dependent tools again receive the correct values.

--- a/releasenotes/notes/fix-hitl-stale-tool-args-d268541b0c442a53.yaml
+++ b/releasenotes/notes/fix-hitl-stale-tool-args-d268541b0c442a53.yaml
@@ -1,0 +1,17 @@
+---
+upgrade:
+  - |
+    Confirmation strategies now receive the model-requested tool arguments in ``tool_params`` rather than the
+    fully-prepared arguments. Values injected from ``State`` via a tool's ``inputs_from_state`` mapping (and the
+    ``State`` object injected into ``State``-typed parameters) are no longer included in what is presented for
+    confirmation — that injection now happens only at tool execution time. If your ``ConfirmationUI`` or
+    ``ConfirmationPolicy`` displayed or inspected those state-injected values, it will now see only the arguments the
+    model provided.
+fixes:
+  - |
+    Fixed a bug where configuring an ``Agent`` confirmation strategy could make a tool run with stale arguments.
+    Confirmation prepared and baked each tool's final arguments up front (injecting ``inputs_from_state`` values from
+    the state at the start of the step), which defeated the per-batch argument preparation in tool execution: a tool
+    that reads a state key written by another tool in the same step would run with the pre-step value instead of the
+    freshly produced one. Confirmation now operates on the model-requested arguments and leaves state injection to
+    tool execution, so dependent tools again receive the correct values.

--- a/test/components/agents/test_agent_hitl.py
+++ b/test/components/agents/test_agent_hitl.py
@@ -3,13 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import Any
+from typing import Annotated, Any
+from unittest.mock import MagicMock
 
 import pytest
 
+from haystack import component
 from haystack.components.agents import Agent
 from haystack.components.generators.chat import OpenAIChatGenerator
-from haystack.dataclasses import ChatMessage
+from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.human_in_the_loop import (
     AlwaysAskPolicy,
     BlockingConfirmationStrategy,
@@ -18,7 +20,7 @@ from haystack.human_in_the_loop import (
     SimpleConsoleUI,
 )
 from haystack.human_in_the_loop.types import ConfirmationStrategy, ConfirmationUI
-from haystack.tools import Tool, create_tool_from_function
+from haystack.tools import Tool, Toolset, create_tool_from_function
 
 
 class MockUserInterface(ConfirmationUI):
@@ -202,3 +204,77 @@ class TestAgent:
         assert result["token_usage"]["prompt_tokens"] > 0
         assert result["token_usage"]["completion_tokens"] > 0
         assert result["token_usage"]["total_tokens"] > 0
+
+
+@component
+class MockChatGenerator:
+    @component.output_types(replies=list[ChatMessage])
+    def run(self, messages: list[ChatMessage], tools: list[Tool] | Toolset | None = None, **kwargs) -> dict[str, Any]:
+        return {"replies": [ChatMessage.from_assistant("Hello")]}
+
+
+def _producer() -> dict[str, str]:
+    return {"value": "PRODUCED"}
+
+
+def _consumer(value: Annotated[str, "the shared value"]) -> str:
+    return f"consumed:{value}"
+
+
+# `producer` overwrites the `shared` state key; `consumer` reads it via inputs_from_state. Called together in one
+# step, the batched executor must run producer first so consumer sees the fresh value.
+producer_tool = Tool(
+    name="producer",
+    description="Produce a value into state.",
+    parameters={"type": "object", "properties": {}, "required": []},
+    function=_producer,
+    outputs_to_state={"shared": {"source": "value"}},
+)
+consumer_tool = Tool(
+    name="consumer",
+    description="Consume the shared value.",
+    parameters={"type": "object", "properties": {"value": {"type": "string"}}, "required": ["value"]},
+    function=_consumer,
+    inputs_from_state={"shared": "value"},
+)
+
+
+class TestConfirmationStrategyToolArgPrep:
+    def test_confirmed_dependent_tool_runs_with_fresh_state(self):
+        """
+        When a confirmation strategy is configured, a tool that reads State a same-step tool writes must still run
+        with the freshly-produced value, not the stale step-start value.
+        """
+        agent = Agent(
+            chat_generator=MockChatGenerator(),
+            tools=[producer_tool, consumer_tool],
+            state_schema={"shared": {"type": str}},
+            confirmation_strategies={
+                "consumer": BlockingConfirmationStrategy(
+                    confirmation_policy=NeverAskPolicy(), confirmation_ui=SimpleConsoleUI()
+                )
+            },
+        )
+        agent.warm_up()
+        # Step 1: the model calls producer and consumer together (consumer relies on inputs_from_state for `value`).
+        # Step 2: a plain text reply ends the run.
+        agent.chat_generator.run = MagicMock(
+            side_effect=[
+                {
+                    "replies": [
+                        ChatMessage.from_assistant(tool_calls=[ToolCall("producer", {}), ToolCall("consumer", {})])
+                    ]
+                },
+                {"replies": [ChatMessage.from_assistant("done")]},
+            ]
+        )
+
+        # `shared` starts stale; producer overwrites it to "PRODUCED" before consumer runs.
+        result = agent.run(messages=[ChatMessage.from_user("go")], shared="OLD")
+
+        consumer_results = [
+            m.tool_call_result.result
+            for m in result["messages"]
+            if m.tool_call_result is not None and m.tool_call_result.origin.tool_name == "consumer"
+        ]
+        assert consumer_results == ["consumed:PRODUCED"]

--- a/test/human_in_the_loop/test_strategies.py
+++ b/test/human_in_the_loop/test_strategies.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import pytest
 
-from haystack.components.agents.agent import _ExecutionContext
 from haystack.components.agents.state.state import State
 from haystack.components.agents.tool_calling import ToolNotFoundException, _run_tool
 from haystack.dataclasses import ChatMessage, ToolCall
@@ -49,17 +48,6 @@ def tools() -> list[Tool]:
     )
 
     return [add_tool, mult_tool]
-
-
-@pytest.fixture
-def execution_context(tools: list[Tool]) -> _ExecutionContext:
-    return _ExecutionContext(
-        state=State(schema={"messages": {"type": list[ChatMessage]}}),
-        tools=tools,
-        chat_generator_inputs={},
-        tool_execution_inputs={},
-        counter=0,
-    )
 
 
 class TestBlockingConfirmationStrategy:
@@ -164,20 +152,19 @@ class TestBlockingConfirmationStrategy:
 
 
 class TestRunConfirmationStrategies:
-    def test_run_confirmation_strategies_no_strategy(self, tools, execution_context):
+    def test_run_confirmation_strategies_no_strategy(self, tools):
         teds = _run_confirmation_strategies(
             confirmation_strategies={},
             messages_with_tool_calls=[
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"param1": "value1"})])
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert teds == [
             ToolExecutionDecision(tool_name=tools[0].name, execute=True, final_tool_params={"param1": "value1"})
         ]
 
-    def test_run_confirmation_strategies_with_strategy(self, tools, execution_context):
+    def test_run_confirmation_strategies_with_strategy(self, tools):
         teds = _run_confirmation_strategies(
             confirmation_strategies={
                 tools[0].name: BlockingConfirmationStrategy(
@@ -188,13 +175,12 @@ class TestRunConfirmationStrategies:
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"param1": "value1"})])
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert teds == [
             ToolExecutionDecision(tool_name=tools[0].name, execute=True, final_tool_params={"param1": "value1"})
         ]
 
-    def test_run_confirmation_strategies_with_multi_tool_tuple_key(self, tools, execution_context):
+    def test_run_confirmation_strategies_with_multi_tool_tuple_key(self, tools):
         add_tool, mult_tool = tools[0], tools[1]
 
         strategy = BlockingConfirmationStrategy(confirmation_policy=NeverAskPolicy(), confirmation_ui=SimpleConsoleUI())
@@ -207,7 +193,6 @@ class TestRunConfirmationStrategies:
                 )
             ],
             tools=tools,
-            state=execution_context.state,
         )
 
         assert len(teds) == 2
@@ -216,7 +201,7 @@ class TestRunConfirmationStrategies:
         assert teds[1].tool_name == mult_tool.name
         assert teds[1].execute is True
 
-    def test_run_confirmation_strategies_unknown_tool_passes_through(self, tools, execution_context):
+    def test_run_confirmation_strategies_unknown_tool_passes_through(self, tools):
         # The model hallucinated a tool name that isn't in the available tools. Confirmation is skipped and the
         # call passes through unchanged so the tool-calling code can report it (ToolNotFoundException).
         teds = _run_confirmation_strategies(
@@ -231,7 +216,6 @@ class TestRunConfirmationStrategies:
                 )
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert teds == [
             ToolExecutionDecision(
@@ -542,15 +526,6 @@ class ConfirmationStrategyContextCapturingStrategy:
 class TestRunContext:
     def test_confirmation_strategy_context_passed_to_strategy(self, tools):
         confirmation_strategy_context = {"event_queue": "mock_queue", "redis_client": "mock_redis"}
-        execution_context = _ExecutionContext(
-            state=State(schema={"messages": {"type": list[ChatMessage]}}),
-            tools=tools,
-            chat_generator_inputs={},
-            tool_execution_inputs={},
-            counter=0,
-            confirmation_strategy_context=confirmation_strategy_context,
-        )
-
         capturing_strategy = ConfirmationStrategyContextCapturingStrategy()
         teds = _run_confirmation_strategies(
             confirmation_strategies={tools[0].name: capturing_strategy},
@@ -558,7 +533,6 @@ class TestRunContext:
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"a": 1, "b": 2})])
             ],
             tools=tools,
-            state=execution_context.state,
             confirmation_strategy_context=confirmation_strategy_context,
         )
 
@@ -571,15 +545,6 @@ class TestRunContext:
     @pytest.mark.asyncio
     async def test_confirmation_strategy_context_passed_to_strategy_async(self, tools):
         confirmation_strategy_context = {"websocket": "mock_websocket", "request_id": "12345"}
-        execution_context = _ExecutionContext(
-            state=State(schema={"messages": {"type": list[ChatMessage]}}),
-            tools=tools,
-            chat_generator_inputs={},
-            tool_execution_inputs={},
-            counter=0,
-            confirmation_strategy_context=confirmation_strategy_context,
-        )
-
         capturing_strategy = ConfirmationStrategyContextCapturingStrategy()
         teds = await _run_confirmation_strategies_async(
             confirmation_strategies={tools[0].name: capturing_strategy},
@@ -587,7 +552,6 @@ class TestRunContext:
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"a": 1, "b": 2})])
             ],
             tools=tools,
-            state=execution_context.state,
             confirmation_strategy_context=confirmation_strategy_context,
         )
 
@@ -688,7 +652,7 @@ class TestAsyncConfirmationStrategies:
         assert decision.feedback is not None and "rejected asynchronously" in decision.feedback
 
     @pytest.mark.asyncio
-    async def test_async_strategy_used_by_run_confirmation_strategies_async(self, tools, execution_context):
+    async def test_async_strategy_used_by_run_confirmation_strategies_async(self, tools):
         strategy = TrueAsyncConfirmationStrategy(delay=0.01, decision="confirm")
 
         teds = await _run_confirmation_strategies_async(
@@ -697,7 +661,6 @@ class TestAsyncConfirmationStrategies:
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"a": 1, "b": 2})])
             ],
             tools=tools,
-            state=execution_context.state,
         )
 
         # Verify that only the async method was called
@@ -726,14 +689,13 @@ class TestAsyncConfirmationStrategies:
         assert decision.final_tool_params == {"param1": "value1"}
 
     @pytest.mark.asyncio
-    async def test_run_confirmation_strategies_async_no_strategy(self, tools, execution_context):
+    async def test_run_confirmation_strategies_async_no_strategy(self, tools):
         teds = await _run_confirmation_strategies_async(
             confirmation_strategies={},
             messages_with_tool_calls=[
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"a": 1, "b": 2})])
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert len(teds) == 1
         assert teds[0].tool_name == tools[0].name
@@ -741,7 +703,7 @@ class TestAsyncConfirmationStrategies:
         assert teds[0].final_tool_params == {"a": 1, "b": 2}
 
     @pytest.mark.asyncio
-    async def test_run_confirmation_strategies_async_with_strategy(self, tools, execution_context):
+    async def test_run_confirmation_strategies_async_with_strategy(self, tools):
         teds = await _run_confirmation_strategies_async(
             confirmation_strategies={
                 tools[0].name: BlockingConfirmationStrategy(
@@ -752,14 +714,13 @@ class TestAsyncConfirmationStrategies:
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"a": 1, "b": 2})])
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert len(teds) == 1
         assert teds[0].tool_name == tools[0].name
         assert teds[0].execute is True
 
     @pytest.mark.asyncio
-    async def test_run_confirmation_strategies_async_unknown_tool_passes_through(self, tools, execution_context):
+    async def test_run_confirmation_strategies_async_unknown_tool_passes_through(self, tools):
         # The model hallucinated a tool name that isn't in the available tools. Confirmation is skipped and the
         # call passes through unchanged so the tool-calling code can report it (ToolNotFoundException).
         teds = await _run_confirmation_strategies_async(
@@ -774,7 +735,6 @@ class TestAsyncConfirmationStrategies:
                 )
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert teds == [
             ToolExecutionDecision(


### PR DESCRIPTION
### Related Issues

- step 1 of addressing https://github.com/deepset-ai/haystack-private/issues/445

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fixed a bug where configuring an ``Agent`` confirmation strategy could make a tool run with stale arguments. HITL confirmation prepared and baked each tool's final arguments up front (injecting ``inputs_from_state`` values from the state at the start of the tool calling step), which defeated the per-batch argument preparation in tool execution: a tool that reads a state key written by another tool in the same step would run with the pre-step value instead of the freshly produced one. HITL confirmation now operates on the model-requested arguments and leaves state injection to tool execution, so dependent tools again receive the correct values.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added new tests and updated existing ones.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

**Note:** This is still technically a breaking change in addition to being a bug fix since now we only show the LLM generated args to the users of HITL. I talked with @julian-risch offline and we agreed this was okay to do for now and that if a requirement came up later of needing to see the final args we can tackle that as a new feature.

I decided to omit the entry to MIGRATION.md for now and will add a full entry on the follow up PR that will fully resolve issue https://github.com/deepset-ai/haystack-private/issues/445

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
