### PR TITLE
fix: validate SearchableToolset result limits

### DIFF
--- a/haystack/tools/searchable_toolset.py
+++ b/haystack/tools/searchable_toolset.py
@@ -90,6 +90,9 @@ class SearchableToolset(Toolset):
                 f"Invalid catalog type: {type(catalog)}. Expected Tool, Toolset, or list of Tools and/or Toolsets."
             )
 
+        if top_k < 1:
+            raise ValueError(f"top_k must be greater than 0. Received: {top_k}")
+
         if search_tool_parameters_description is not None:
             invalid_keys = set(search_tool_parameters_description.keys()) - self._VALID_SEARCH_TOOL_PARAMS
             if invalid_keys:
@@ -196,6 +199,9 @@ class SearchableToolset(Toolset):
             tool names; they become available immediately.
             """
             num_results = k if k is not None else self._top_k
+
+            if num_results < 1:
+                return f"Number of results `k` must be greater than 0. Received: {num_results}."
 
             if not tool_keywords.strip():
                 return (

--- a/test/tools/test_searchable_toolset.py
+++ b/test/tools/test_searchable_toolset.py
@@ -113,6 +113,11 @@ class TestSearchableToolset:
                 )
             )
 
+    @pytest.mark.parametrize("top_k", [0, -1])
+    def test_init_with_non_positive_top_k(self, top_k):
+        with pytest.raises(ValueError, match="top_k must be greater than 0"):
+            SearchableToolset(catalog=[], top_k=top_k)
+
     def test_not_implemented_methods(self):
         toolset = SearchableToolset(catalog=[])
         with pytest.raises(NotImplementedError):
@@ -254,6 +259,18 @@ class TestSearchableToolsetBM25Mode:
 
         # Should find exactly 1 tool
         assert "Found and loaded 1 tool(s):" in result
+
+    @pytest.mark.parametrize("k", [0, -1])
+    def test_search_tools_rejects_non_positive_k(self, large_catalog, k):
+        """Test that search_tools rejects non-positive result limits."""
+        toolset = SearchableToolset(catalog=large_catalog, top_k=2)
+        toolset.warm_up()
+        assert toolset._bootstrap_tool is not None
+
+        result = toolset._bootstrap_tool.invoke(tool_keywords="add numbers together", k=k)
+
+        assert f"Number of results `k` must be greater than 0. Received: {k}." in result
+        assert len(toolset._discovered_tools) == 0
 
     def test_search_tools_no_results(self, large_catalog):
         """Test search_tools with no matching results."""


### PR DESCRIPTION
## Summary

- Validate `SearchableToolset(top_k=...)` so non-positive default result limits fail early.
- Guard the runtime `search_tools(..., k=...)` override against non-positive values.
- Add regression coverage for both constructor and runtime result-limit handling.

## Why

`SearchableToolset` passes the result limit through to BM25 retrieval. With non-positive limits, Python slicing can produce surprising behavior: `top_k=0` loads no tools, while negative values can load all but the last matching tool. Since this controls which tools become visible to an agent, the limit should be explicit and positive.

## Tests

- `.\.venv\Scripts\python.exe -m pytest test\tools\test_searchable_toolset.py -q`
- `.\.venv\Scripts\python.exe -m ruff check haystack\tools\searchable_toolset.py test\tools\test_searchable_toolset.py`
- `git diff --check HEAD~1 HEAD`