### PR TITLE
feat!: Recast HITL as before tool hook

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -608,6 +608,60 @@ agent = Agent(
 )
 ```
 
+#### Human-in-the-Loop confirmation is now a `before_tool` hook
+
+**What changed:** The `confirmation_strategies` and `confirmation_strategy_context` parameters have been removed from `Agent.__init__`, `Agent.run`, and `Agent.run_async`. Human-in-the-Loop tool confirmation is now expressed through the general Agent hooks mechanism: wrap your confirmation strategies in a `ConfirmationHook` and register it under the `before_tool` hook point. Request-scoped resources that used to be passed via `confirmation_strategy_context` are now passed via the generic `hook_context` run argument (read by hooks with `state.get("hook_context")`).
+
+**Why:** Confirmation was a one-off, before-tool interception bolted onto the Agent. Hooks generalize that seam, so HITL becomes one application of a single, uniform extension point instead of a parallel concept with its own serialization and run plumbing.
+
+**How to migrate:**
+
+Before (v2.x):
+```python
+from haystack.components.agents import Agent
+from haystack.human_in_the_loop import BlockingConfirmationStrategy, AlwaysAskPolicy, RichConsoleUI
+
+agent = Agent(
+    chat_generator=...,
+    tools=[...],
+    confirmation_strategies={
+        "my_tool": BlockingConfirmationStrategy(
+            confirmation_policy=AlwaysAskPolicy(), confirmation_ui=RichConsoleUI()
+        )
+    },
+)
+agent.run(messages=[...], confirmation_strategy_context={"websocket": ws})
+```
+
+After (v3.0):
+```python
+from haystack.components.agents import Agent
+from haystack.human_in_the_loop import (
+    BlockingConfirmationStrategy,
+    AlwaysAskPolicy,
+    ConfirmationHook,
+    RichConsoleUI,
+)
+
+confirmation_hook = ConfirmationHook(
+    confirmation_strategies={
+        "my_tool": BlockingConfirmationStrategy(
+            confirmation_policy=AlwaysAskPolicy(), confirmation_ui=RichConsoleUI()
+        )
+    }
+)
+agent = Agent(chat_generator=..., tools=[...], hooks={"before_tool": [confirmation_hook]})
+agent.run(messages=[...], hook_context={"websocket": ws})
+```
+
+#### Confirmation strategies now see only the model-requested tool arguments
+
+**What changed:** Confirmation strategies now receive the arguments the model produced for a tool call in `tool_params`, rather than the fully-prepared arguments. Values injected from `State` via a tool's `inputs_from_state` mapping (and the `State` object passed to `State`-typed parameters) are no longer included in what is presented for confirmation — that injection now happens only at tool execution time.
+
+**Why:** Preparing and baking each tool's arguments up front defeated the per-batch argument preparation in tool execution, so a tool that read a state key written by another tool in the same step could run with stale values. Confirmation now operates on the model-requested arguments and leaves state injection to execution. See the release note for the failure mode details.
+
+**How to migrate:** If your `ConfirmationUI` or `ConfirmationPolicy` displayed or inspected state-injected argument values, update it to expect only the arguments the model provided. No change is needed if you only relied on the model-requested arguments.
+
 ### LLM
 
 #### Runtime `user_prompt` and `system_prompt` removed from `LLM.run` / `LLM.run_async`

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -584,7 +584,7 @@ weather_tool = Tool(
 
 #### Reserved `state_schema` keys
 
-**What changed:** `Agent` now reserves several names in its `state_schema`: the auto-populated run-metadata outputs `step_count`, `token_usage`, and `tool_call_counts`, and the hook loop-control key `continue_run` (set by an `on_exit` hook to keep the Agent running). Passing any of them as a `state_schema` key now raises `ValueError`.
+**What changed:** `Agent` now reserves several names in its `state_schema`: the auto-populated run-metadata outputs `step_count`, `token_usage`, and `tool_call_counts`, and the hook-facing keys `continue_run` (set by an `on_exit` hook to keep the Agent running), `tools` (the tools available in the current step, for hooks to inspect), and `hook_context` (the per-run resources passed to `Agent.run`). Passing any of them as a `state_schema` key now raises `ValueError`.
 
 **Why:** These keys are managed by `Agent` itself; allowing users to redefine them would let a user-defined entry shadow the value the Agent reads or writes.
 

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -32,12 +32,6 @@ from haystack.hooks.utils import (
     warm_up_hooks,
     warm_up_hooks_async,
 )
-from haystack.human_in_the_loop.strategies import (
-    _deserialize_confirmation_strategies,
-    _process_confirmation_strategies,
-    _process_confirmation_strategies_async,
-)
-from haystack.human_in_the_loop.types import ConfirmationStrategy
 from haystack.tools import (
     Tool,
     Toolset,
@@ -67,10 +61,16 @@ _INTERNAL_STATE_KEYS: dict[str, dict[str, Any]] = {
     "tool_call_counts": {"type": dict[str, int], "handler": replace_values},
 }
 
-# State keys hooks use to control the run loop. Like internal keys they are reserved and cannot be redefined by users,
-# but unlike internal keys they are transient loop-control signals and are NOT exposed as Agent inputs or outputs.
-# `continue_run`: set by an `on_exit` hook to keep the Agent running instead of stopping (re-read each exit attempt).
-_CONTROL_STATE_KEYS: dict[str, dict[str, Any]] = {"continue_run": {"type": bool, "handler": replace_values}}
+# State keys the Agent manages for hooks. Like internal keys they are reserved and cannot be redefined by users, but
+# unlike internal keys they are NOT exposed as Agent inputs or outputs (they are run-control / hook-facing state):
+# - `continue_run`: set by an `on_exit` hook to keep the Agent running instead of stopping (re-read each exit attempt).
+# - `tools`: the flattened tools available in the current step, so a hook can inspect them (e.g. HITL confirmation).
+# - `hook_context`: per-run request-scoped resources passed to `run`/`run_async` for hooks to read.
+_RESERVED_STATE_KEYS: dict[str, dict[str, Any]] = {
+    "continue_run": {"type": bool, "handler": replace_values},
+    "tools": {"type": list, "handler": replace_values},
+    "hook_context": {"type": dict[str, Any], "handler": replace_values},
+}
 
 
 def _accumulate_usage(current: Any, new: Any) -> Any:
@@ -143,8 +143,8 @@ def _get_run_method_params(instance: "Agent") -> set[str]:
 
 
 def _public_outputs(state: State) -> dict[str, Any]:
-    """Return the State data excluding transient loop-control keys (the Agent's user-facing outputs)."""
-    return {key: value for key, value in state.data.items() if key not in _CONTROL_STATE_KEYS}
+    """Return the State data excluding the Agent-managed reserved keys (i.e. the Agent's user-facing outputs)."""
+    return {key: value for key, value in state.data.items() if key not in _RESERVED_STATE_KEYS}
 
 
 def _consume_continue_run(state: State) -> bool:
@@ -327,11 +327,6 @@ class _ExecutionContext:
     :param chat_generator_inputs: Runtime inputs to be passed to the chat generator (tools are injected per step).
     :param tool_execution_inputs: Runtime inputs to be passed to tool execution (tools are injected per step).
     :param counter: A counter to track the number of steps taken in the agent's run.
-    :param confirmation_strategy_context: Optional dictionary for passing request-scoped resources
-        to confirmation strategies. In web/server environments, this enables passing per-request
-        objects (e.g., WebSocket connections, async queues, or pub/sub clients) that strategies can use for
-        non-blocking user interaction. This is passed directly to strategies via the `confirmation_strategy_context`
-        parameter in their `run()` and `run_async()` methods.
     """
 
     state: State
@@ -339,7 +334,6 @@ class _ExecutionContext:
     chat_generator_inputs: dict
     tool_execution_inputs: dict
     counter: int = 0
-    confirmation_strategy_context: dict[str, Any] | None = None
 
 
 @component
@@ -511,7 +505,6 @@ class Agent:
         raise_on_tool_invocation_failure: bool = False,
         tool_concurrency_limit: int = 4,
         tool_streaming_callback_passthrough: bool = False,
-        confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy] | None = None,
         hooks: dict[HookPoint, list[Hook]] | None = None,
     ) -> None:
         """
@@ -546,7 +539,6 @@ class Agent:
         :param tool_concurrency_limit: Maximum number of tool calls to execute at the same time.
             Defaults to 4. Set to 1 to disable parallel tool execution.
         :param tool_streaming_callback_passthrough: If True, pass the streaming callback to tools that accept it.
-        :param confirmation_strategies: A dictionary mapping tool names to ConfirmationStrategy instances.
         :param hooks: A dictionary mapping a hook point to a list of hooks the Agent runs at that point. Each hook
             receives the live `State` and influences the run by mutating it in place; hooks for a hook point run in
             list order. Valid hook points are:
@@ -577,7 +569,7 @@ class Agent:
             exit_conditions = ["text"]
 
         if state_schema is not None:
-            reserved_keys = _INTERNAL_STATE_KEYS.keys() | _CONTROL_STATE_KEYS.keys()
+            reserved_keys = _INTERNAL_STATE_KEYS.keys() | _RESERVED_STATE_KEYS.keys()
             reserved_used = sorted(set(state_schema) & reserved_keys)
             if reserved_used:
                 raise ValueError(
@@ -621,7 +613,6 @@ class Agent:
         self.streaming_callback = streaming_callback
         self.tool_concurrency_limit = tool_concurrency_limit
         self.tool_streaming_callback_passthrough = tool_streaming_callback_passthrough
-        self._confirmation_strategies = confirmation_strategies or {}
         self.hooks = hooks
         self._tools_warmed_up = False
         self._hooks_warmed_up = False
@@ -632,7 +623,7 @@ class Agent:
         self.state_schema = dict(self._state_schema)
         if self.state_schema.get("messages") is None:
             self.state_schema["messages"] = {"type": list[ChatMessage], "handler": merge_lists}
-        for key, config in {**_INTERNAL_STATE_KEYS, **_CONTROL_STATE_KEYS}.items():
+        for key, config in {**_INTERNAL_STATE_KEYS, **_RESERVED_STATE_KEYS}.items():
             self.state_schema[key] = dict(config)
 
         # --- Component I/O ---
@@ -640,7 +631,7 @@ class Agent:
         output_types: dict[str, Any] = {"last_message": ChatMessage}
         for param, config in self.state_schema.items():
             # Control keys are transient loop-control signals, not exposed as inputs or outputs.
-            if param in _CONTROL_STATE_KEYS:
+            if param in _RESERVED_STATE_KEYS:
                 continue
             output_types[param] = config["type"]
             # Internal state keys are populated internally by the Agent itself and are not exposed as inputs
@@ -784,14 +775,6 @@ class Agent:
             raise_on_tool_invocation_failure=self.raise_on_tool_invocation_failure,
             tool_concurrency_limit=self.tool_concurrency_limit,
             tool_streaming_callback_passthrough=self.tool_streaming_callback_passthrough,
-            confirmation_strategies={
-                (list(key) if isinstance(key, tuple) else key): component_to_dict(
-                    obj=strategy, name="confirmation_strategy"
-                )
-                for key, strategy in self._confirmation_strategies.items()
-            }
-            if self._confirmation_strategies
-            else None,
             hooks=_serialize_hooks_dictionary(self.hooks) if self.hooks else None,
         )
 
@@ -814,11 +797,6 @@ class Agent:
             init_params["streaming_callback"] = deserialize_callable(init_params["streaming_callback"])
 
         deserialize_tools_or_toolset_inplace(init_params, key="tools")
-
-        if init_params.get("confirmation_strategies") is not None:
-            init_params["confirmation_strategies"] = _deserialize_confirmation_strategies(
-                init_params["confirmation_strategies"]
-            )
 
         if init_params.get("hooks") is not None:
             init_params["hooks"] = _deserialize_hooks_dictionary(init_params["hooks"])
@@ -855,7 +833,7 @@ class Agent:
         *,
         generation_kwargs: dict[str, Any] | None = None,
         tools: ToolsType | list[str] | None = None,
-        confirmation_strategy_context: dict[str, Any] | None = None,
+        hook_context: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> _ExecutionContext:
         """
@@ -868,8 +846,8 @@ class Agent:
             override the parameters passed during component initialization.
         :param tools: Optional list of Tool objects, a Toolset, or list of tool names to use for this run.
             When passing tool names, tools are selected from the Agent's originally configured tools.
-        :param confirmation_strategy_context: Optional dictionary for passing request-scoped resources
-            to confirmation strategies.
+        :param hook_context: Optional dictionary of request-scoped resources made available to hooks via
+            `state.get("hook_context")`.
         :param kwargs: Additional data to pass to the State used by the Agent.
         """
         messages = messages or []
@@ -911,6 +889,7 @@ class Agent:
         state.set("token_usage", {})
         state.set("tool_call_counts", {tool.name: 0 for tool in flat_tools})
         state.set("continue_run", False)
+        state.set("hook_context", hook_context or {})
 
         streaming_callback = select_streaming_callback(  # type: ignore[call-overload]
             init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=requires_async
@@ -933,7 +912,6 @@ class Agent:
             tools=selected_tools,
             chat_generator_inputs=generator_inputs,
             tool_execution_inputs=tool_execution_inputs,
-            confirmation_strategy_context=confirmation_strategy_context,
         )
 
     def _select_tools(self, tools: ToolsType | list[str] | None = None) -> ToolsType:
@@ -979,7 +957,7 @@ class Agent:
         *,
         generation_kwargs: dict[str, Any] | None = None,
         tools: ToolsType | list[str] | None = None,
-        confirmation_strategy_context: dict[str, Any] | None = None,
+        hook_context: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """
@@ -992,10 +970,10 @@ class Agent:
             override the parameters passed during component initialization.
         :param tools: Optional list of Tool objects, a Toolset, or list of tool names to use for this run.
             When passing tool names, tools are selected from the Agent's originally configured tools.
-        :param confirmation_strategy_context: Optional dictionary for passing request-scoped resources
-            to confirmation strategies. Useful in web/server environments to provide per-request
-            objects (e.g., WebSocket connections, async queues, Redis pub/sub clients) that strategies
-            can use for non-blocking user interaction.
+        :param hook_context: Optional dictionary of request-scoped resources made available to hooks via
+            `state.get("hook_context")`. Useful in web/server environments to provide per-request objects
+            (e.g., WebSocket connections, async queues, Redis pub/sub clients) that a hook can use, for
+            example a ConfirmationHook driving non-blocking user interaction.
         :param kwargs: Additional data to pass to the State schema used by the Agent.
             The keys must match the schema defined in the Agent's `state_schema`.
         :returns:
@@ -1019,7 +997,7 @@ class Agent:
             requires_async=False,
             generation_kwargs=generation_kwargs,
             tools=tools,
-            confirmation_strategy_context=confirmation_strategy_context,
+            hook_context=hook_context,
             **kwargs,
         )
 
@@ -1048,7 +1026,7 @@ class Agent:
         *,
         generation_kwargs: dict[str, Any] | None = None,
         tools: ToolsType | list[str] | None = None,
-        confirmation_strategy_context: dict[str, Any] | None = None,
+        hook_context: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """
@@ -1064,12 +1042,10 @@ class Agent:
         :param generation_kwargs: Additional keyword arguments for LLM. These parameters will
             override the parameters passed during component initialization.
         :param tools: Optional list of Tool objects, a Toolset, or list of tool names to use for this run.
-        :param kwargs: Additional data to pass to the State schema used by the Agent.
-            The keys must match the schema defined in the Agent's `state_schema`.
-        :param confirmation_strategy_context: Optional dictionary for passing request-scoped resources
-            to confirmation strategies. Useful in web/server environments to provide per-request
-            objects (e.g., WebSocket connections, async queues, Redis pub/sub clients) that strategies
-            can use for non-blocking user interaction.
+        :param hook_context: Optional dictionary of request-scoped resources made available to hooks via
+            `state.get("hook_context")`. Useful in web/server environments to provide per-request objects
+            (e.g., WebSocket connections, async queues, Redis pub/sub clients) that a hook can use, for
+            example a ConfirmationHook driving non-blocking user interaction.
         :param kwargs: Additional data to pass to the State schema used by the Agent.
             The keys must match the schema defined in the Agent's `state_schema`.
         :returns:
@@ -1093,7 +1069,7 @@ class Agent:
             requires_async=True,
             tools=tools,
             generation_kwargs=generation_kwargs,
-            confirmation_strategy_context=confirmation_strategy_context,
+            hook_context=hook_context,
             **kwargs,
         )
 
@@ -1124,6 +1100,8 @@ class Agent:
             # earlier steps. Validate names here so duplicates fail before starting the step.
             current_tools = flatten_tools_or_toolsets(exe_context.tools)
             _check_duplicate_tool_names(current_tools)
+            # Expose the current tools to hooks (e.g. ConfirmationHook) via State.
+            exe_context.state.set("tools", current_tools, handler_override=replace_values)
 
             _run_hooks(self.hooks, BEFORE_LLM, exe_context.state)
             chat_generator_inputs = {
@@ -1147,18 +1125,12 @@ class Agent:
                 return self._continue_after_exit_hooks(exe_context)
 
             _run_hooks(self.hooks, BEFORE_TOOL, exe_context.state)
+            # Re-read the pending tool calls from State so that any rewrites a before_tool hook made (e.g.
+            # ConfirmationHook rejecting or modifying calls) are honored by the executor.
             pending_tool_call_messages = _pending_tool_call_messages_from_state(exe_context.state)
-            modified_tool_call_messages, new_chat_history = _process_confirmation_strategies(
-                confirmation_strategies=self._confirmation_strategies,
-                messages_with_tool_calls=pending_tool_call_messages,
-                state=exe_context.state,
-                confirmation_strategy_context=exe_context.confirmation_strategy_context,
-                tools=current_tools,
-            )
-            exe_context.state.set(key="messages", value=new_chat_history, handler_override=replace_values)
 
             tool_execution_inputs = {
-                "messages": modified_tool_call_messages,
+                "messages": pending_tool_call_messages,
                 "state": exe_context.state,
                 **exe_context.tool_execution_inputs,
                 "tools": current_tools,
@@ -1175,7 +1147,7 @@ class Agent:
             exe_context.counter += 1
             exe_context.state.set("step_count", exe_context.counter)
             exit_triggered = self.exit_conditions != ["text"] and self._check_exit_conditions(
-                llm_messages=modified_tool_call_messages, tool_messages=tool_messages
+                llm_messages=pending_tool_call_messages, tool_messages=tool_messages
             )
             if exit_triggered:
                 return self._continue_after_exit_hooks(exe_context)
@@ -1190,6 +1162,8 @@ class Agent:
             # earlier steps. Validate names here so duplicates fail before starting the step.
             current_tools = flatten_tools_or_toolsets(exe_context.tools)
             _check_duplicate_tool_names(current_tools)
+            # Expose the current tools to hooks (e.g. ConfirmationHook) via State.
+            exe_context.state.set("tools", current_tools, handler_override=replace_values)
 
             await _run_hooks_async(self.hooks, BEFORE_LLM, exe_context.state)
             chat_generator_inputs = {
@@ -1215,18 +1189,12 @@ class Agent:
                 return await self._continue_after_exit_hooks_async(exe_context)
 
             await _run_hooks_async(self.hooks, BEFORE_TOOL, exe_context.state)
+            # Re-read the pending tool calls from State so that any rewrites a before_tool hook made (e.g.
+            # ConfirmationHook rejecting or modifying calls) are honored by the executor.
             pending_tool_call_messages = _pending_tool_call_messages_from_state(exe_context.state)
-            modified_tool_call_messages, new_chat_history = await _process_confirmation_strategies_async(
-                confirmation_strategies=self._confirmation_strategies,
-                messages_with_tool_calls=pending_tool_call_messages,
-                tools=current_tools,
-                state=exe_context.state,
-                confirmation_strategy_context=exe_context.confirmation_strategy_context,
-            )
-            exe_context.state.set(key="messages", value=new_chat_history, handler_override=replace_values)
 
             tool_execution_inputs = {
-                "messages": modified_tool_call_messages,
+                "messages": pending_tool_call_messages,
                 "state": exe_context.state,
                 **exe_context.tool_execution_inputs,
                 "tools": current_tools,
@@ -1243,7 +1211,7 @@ class Agent:
             exe_context.counter += 1
             exe_context.state.set("step_count", exe_context.counter)
             exit_triggered = self.exit_conditions != ["text"] and self._check_exit_conditions(
-                llm_messages=modified_tool_call_messages, tool_messages=tool_messages
+                llm_messages=pending_tool_call_messages, tool_messages=tool_messages
             )
             if exit_triggered:
                 return await self._continue_after_exit_hooks_async(exe_context)

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -147,6 +147,40 @@ def _public_outputs(state: State) -> dict[str, Any]:
     return {key: value for key, value in state.data.items() if key not in _INTERNAL_STATE_KEYS}
 
 
+def _validate_hooks(hooks: dict[HookPoint, list[Hook]]) -> None:
+    """
+    Validate a hooks mapping: known hook points, real Hook objects, and hook-point restrictions.
+
+    :param hooks: Mapping of hook point to the hooks registered under it.
+    :raises ValueError: If a hook point is unknown, or a hook is registered under a hook point it does not support.
+    :raises TypeError: If a registered hook has no callable `run(state)`.
+    """
+    for hook_point, hook_list in hooks.items():
+        if hook_point not in VALID_HOOK_POINTS:
+            raise ValueError(
+                f"Invalid hook point '{hook_point}'. Valid hook points are: {', '.join(VALID_HOOK_POINTS)}."
+            )
+        for h in hook_list:
+            if not callable(getattr(h, "run", None)):
+                if callable(h):
+                    raise TypeError(
+                        f"Hook registered for hook point '{hook_point}' is callable but is not a Hook object. "
+                        "If it is a function, wrap it with the @hook decorator."
+                    )
+                raise TypeError(
+                    f"Hook registered for hook point '{hook_point}' must have a callable 'run(state)', "
+                    f"got an object of type '{type(h).__name__}'."
+                )
+            # A hook may declare `allowed_hook_points` to restrict where it can run (e.g. ConfirmationHook only
+            # makes sense at "before_tool"). Hooks without it can be registered under any hook point.
+            allowed_points = getattr(h, "allowed_hook_points", None)
+            if allowed_points is not None and hook_point not in allowed_points:
+                raise ValueError(
+                    f"Hook of type '{type(h).__name__}' is registered under hook point '{hook_point}' but only "
+                    f"supports: {', '.join(allowed_points)}."
+                )
+
+
 def _consume_continue_run(state: State) -> bool:
     """Return the `continue_run` control flag and reset it so it does not carry over to the next exit attempt."""
     should_continue = state.data["continue_run"]
@@ -553,7 +587,8 @@ class Agent:
               exit condition, but not when it stops because `max_agent_steps` is reached.
         :raises TypeError: If the chat_generator does not support tools parameter in its run method.
         :raises ValueError: If any `user_prompt` variable overlaps with the `state_schema` or `run` method parameters,
-            or if a hook is registered under an unknown hook point.
+            if a hook is registered under an unknown hook point, or if a hook is registered under a hook point it does
+            not support (via its `allowed_hook_points`).
         """
         # --- Validation ---
         self._chat_generator_supports_tools: bool = "tools" in inspect.signature(chat_generator.run).parameters
@@ -582,22 +617,7 @@ class Agent:
             raise ValueError("tool_concurrency_limit must be greater than or equal to 1.")
 
         hooks = hooks or {}
-        for hook_point, hook_list in hooks.items():
-            if hook_point not in VALID_HOOK_POINTS:
-                raise ValueError(
-                    f"Invalid hook point '{hook_point}'. Valid hook points are: {', '.join(VALID_HOOK_POINTS)}."
-                )
-            for h in hook_list:
-                if not callable(getattr(h, "run", None)):
-                    if callable(h):
-                        raise TypeError(
-                            f"Hook registered for hook point '{hook_point}' is callable but is not a Hook object. "
-                            "If it is a function, wrap it with the @hook decorator."
-                        )
-                    raise TypeError(
-                        f"Hook registered for hook point '{hook_point}' must have a callable 'run(state)', "
-                        f"got an object of type '{type(h).__name__}'."
-                    )
+        _validate_hooks(hooks)
 
         # --- Attributes ---
         self.chat_generator = chat_generator

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -53,20 +53,20 @@ _JINJA2_CHAT_TEMPLATE_RE = re.compile(r"\{%\s*message\s")
 # Regex to extract the role from a Jinja2 message block, e.g. {% message role="user" %}
 _JINJA2_MESSAGE_ROLE_RE = re.compile(r'\{%\s*message\s+role\s*=\s*["\'](\w+)["\']')
 
-# State keys that the Agent populates automatically during a run.
-# Users may not define them in their own `state_schema`, and they are exposed only as Agent outputs.
-_INTERNAL_STATE_KEYS: dict[str, dict[str, Any]] = {
+# Run-metadata state keys the Agent populates automatically during a run. Users may not define them in their own
+# `state_schema`, and they are exposed as Agent outputs only (not inputs).
+_RUN_METADATA_STATE_KEYS: dict[str, dict[str, Any]] = {
     "step_count": {"type": int, "handler": replace_values},
     "token_usage": {"type": dict[str, Any], "handler": replace_values},
     "tool_call_counts": {"type": dict[str, int], "handler": replace_values},
 }
 
-# State keys the Agent manages for hooks. Like internal keys they are reserved and cannot be redefined by users, but
-# unlike internal keys they are NOT exposed as Agent inputs or outputs (they are run-control / hook-facing state):
+# Internal state keys the Agent manages for run control and hooks. Like run-metadata keys they are reserved and cannot
+# be redefined by users, but unlike them they are NOT exposed as Agent inputs or outputs (purely internal state):
 # - `continue_run`: set by an `on_exit` hook to keep the Agent running instead of stopping (re-read each exit attempt).
 # - `tools`: the flattened tools available in the current step, so a hook can inspect them (e.g. HITL confirmation).
 # - `hook_context`: per-run request-scoped resources passed to `run`/`run_async` for hooks to read.
-_RESERVED_STATE_KEYS: dict[str, dict[str, Any]] = {
+_INTERNAL_STATE_KEYS: dict[str, dict[str, Any]] = {
     "continue_run": {"type": bool, "handler": replace_values},
     "tools": {"type": list, "handler": replace_values},
     "hook_context": {"type": dict[str, Any], "handler": replace_values},
@@ -143,8 +143,8 @@ def _get_run_method_params(instance: "Agent") -> set[str]:
 
 
 def _public_outputs(state: State) -> dict[str, Any]:
-    """Return the State data excluding the Agent-managed reserved keys (i.e. the Agent's user-facing outputs)."""
-    return {key: value for key, value in state.data.items() if key not in _RESERVED_STATE_KEYS}
+    """Return the State data excluding the internal state keys (i.e. the Agent's user-facing outputs)."""
+    return {key: value for key, value in state.data.items() if key not in _INTERNAL_STATE_KEYS}
 
 
 def _consume_continue_run(state: State) -> bool:
@@ -569,7 +569,7 @@ class Agent:
             exit_conditions = ["text"]
 
         if state_schema is not None:
-            reserved_keys = _INTERNAL_STATE_KEYS.keys() | _RESERVED_STATE_KEYS.keys()
+            reserved_keys = _RUN_METADATA_STATE_KEYS.keys() | _INTERNAL_STATE_KEYS.keys()
             reserved_used = sorted(set(state_schema) & reserved_keys)
             if reserved_used:
                 raise ValueError(
@@ -623,19 +623,19 @@ class Agent:
         self.state_schema = dict(self._state_schema)
         if self.state_schema.get("messages") is None:
             self.state_schema["messages"] = {"type": list[ChatMessage], "handler": merge_lists}
-        for key, config in {**_INTERNAL_STATE_KEYS, **_RESERVED_STATE_KEYS}.items():
+        for key, config in {**_RUN_METADATA_STATE_KEYS, **_INTERNAL_STATE_KEYS}.items():
             self.state_schema[key] = dict(config)
 
         # --- Component I/O ---
         self._run_method_params = _get_run_method_params(self)
         output_types: dict[str, Any] = {"last_message": ChatMessage}
         for param, config in self.state_schema.items():
-            # Control keys are transient loop-control signals, not exposed as inputs or outputs.
-            if param in _RESERVED_STATE_KEYS:
+            # Internal keys are run-control / hook-facing state, not exposed as inputs or outputs.
+            if param in _INTERNAL_STATE_KEYS:
                 continue
             output_types[param] = config["type"]
-            # Internal state keys are populated internally by the Agent itself and are not exposed as inputs
-            if param not in self._run_method_params and param not in _INTERNAL_STATE_KEYS:
+            # Run-metadata keys are populated by the Agent itself and exposed as outputs only, not inputs.
+            if param not in self._run_method_params and param not in _RUN_METADATA_STATE_KEYS:
                 component.set_input_type(self, name=param, type=config["type"], default=None)
         component.set_output_types(self, **output_types)
 

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -1154,8 +1154,6 @@ class Agent:
                 state=exe_context.state,
                 confirmation_strategy_context=exe_context.confirmation_strategy_context,
                 tools=current_tools,
-                streaming_callback=exe_context.tool_execution_inputs["streaming_callback"],
-                enable_streaming_passthrough=exe_context.tool_execution_inputs["enable_streaming_callback_passthrough"],
             )
             exe_context.state.set(key="messages", value=new_chat_history, handler_override=replace_values)
 
@@ -1223,8 +1221,6 @@ class Agent:
                 messages_with_tool_calls=pending_tool_call_messages,
                 tools=current_tools,
                 state=exe_context.state,
-                streaming_callback=exe_context.tool_execution_inputs["streaming_callback"],
-                enable_streaming_passthrough=exe_context.tool_execution_inputs["enable_streaming_callback_passthrough"],
                 confirmation_strategy_context=exe_context.confirmation_strategy_context,
             )
             exe_context.state.set(key="messages", value=new_chat_history, handler_override=replace_values)

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -105,7 +105,7 @@ def _record_llm_usage(state: State, llm_messages: list[ChatMessage]) -> None:
     :param llm_messages: The ChatMessage objects returned from the latest LLM call. Token usage is read from each
         message's `meta["usage"]` field, if present.
     """
-    current = state.get("token_usage")
+    current = state.data.get("token_usage")
     updated = False
     for msg in llm_messages:
         usage = msg.meta.get("usage")
@@ -124,7 +124,7 @@ def _record_tool_calls(state: State, tool_messages: list[ChatMessage]) -> None:
     :param tool_messages: The ChatMessage objects returned from the latest tool execution. Per-tool counts are
         incremented based on each message's `tool_call_result.origin.tool_name`.
     """
-    counts = state.get("tool_call_counts") or {}
+    counts = state.data.get("tool_call_counts") or {}
     updated = False
     for tm in tool_messages:
         if tm.tool_call_result is None:
@@ -149,7 +149,7 @@ def _public_outputs(state: State) -> dict[str, Any]:
 
 def _consume_continue_run(state: State) -> bool:
     """Return the `continue_run` control flag and reset it so it does not carry over to the next exit attempt."""
-    should_continue = state.get("continue_run")
+    should_continue = state.data["continue_run"]
     state.set("continue_run", False)
     return should_continue
 
@@ -847,7 +847,7 @@ class Agent:
         :param tools: Optional list of Tool objects, a Toolset, or list of tool names to use for this run.
             When passing tool names, tools are selected from the Agent's originally configured tools.
         :param hook_context: Optional dictionary of request-scoped resources made available to hooks via
-            `state.get("hook_context")`.
+            `state.data.get("hook_context")`.
         :param kwargs: Additional data to pass to the State used by the Agent.
         """
         messages = messages or []
@@ -971,7 +971,7 @@ class Agent:
         :param tools: Optional list of Tool objects, a Toolset, or list of tool names to use for this run.
             When passing tool names, tools are selected from the Agent's originally configured tools.
         :param hook_context: Optional dictionary of request-scoped resources made available to hooks via
-            `state.get("hook_context")`. Useful in web/server environments to provide per-request objects
+            `state.data.get("hook_context")`. Useful in web/server environments to provide per-request objects
             (e.g., WebSocket connections, async queues, Redis pub/sub clients) that a hook can use, for
             example a ConfirmationHook driving non-blocking user interaction.
         :param kwargs: Additional data to pass to the State schema used by the Agent.
@@ -1043,7 +1043,7 @@ class Agent:
             override the parameters passed during component initialization.
         :param tools: Optional list of Tool objects, a Toolset, or list of tool names to use for this run.
         :param hook_context: Optional dictionary of request-scoped resources made available to hooks via
-            `state.get("hook_context")`. Useful in web/server environments to provide per-request objects
+            `state.data.get("hook_context")`. Useful in web/server environments to provide per-request objects
             (e.g., WebSocket connections, async queues, Redis pub/sub clients) that a hook can use, for
             example a ConfirmationHook driving non-blocking user interaction.
         :param kwargs: Additional data to pass to the State schema used by the Agent.

--- a/haystack/human_in_the_loop/__init__.py
+++ b/haystack/human_in_the_loop/__init__.py
@@ -9,6 +9,7 @@ from lazy_imports import LazyImporter
 
 _import_structure = {
     "dataclasses": ["ConfirmationUIResult", "ToolExecutionDecision"],
+    "hooks": ["ConfirmationHook"],
     "policies": ["AlwaysAskPolicy", "AskOncePolicy", "NeverAskPolicy"],
     "strategies": ["BlockingConfirmationStrategy"],
     "user_interfaces": ["RichConsoleUI", "SimpleConsoleUI"],
@@ -17,6 +18,7 @@ _import_structure = {
 if TYPE_CHECKING:
     from .dataclasses import ConfirmationUIResult as ConfirmationUIResult
     from .dataclasses import ToolExecutionDecision as ToolExecutionDecision
+    from .hooks import ConfirmationHook as ConfirmationHook
     from .policies import AlwaysAskPolicy as AlwaysAskPolicy
     from .policies import AskOncePolicy as AskOncePolicy
     from .policies import NeverAskPolicy as NeverAskPolicy

--- a/haystack/human_in_the_loop/hooks.py
+++ b/haystack/human_in_the_loop/hooks.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack.components.agents.state.state import State
+from haystack.components.agents.state.state_utils import replace_values
+from haystack.core.serialization import default_from_dict, default_to_dict
+from haystack.human_in_the_loop.strategies import (
+    _deserialize_confirmation_strategies,
+    _process_confirmation_strategies,
+    _process_confirmation_strategies_async,
+    _serialize_confirmation_strategies,
+)
+from haystack.human_in_the_loop.types import ConfirmationStrategy
+
+
+class ConfirmationHook:
+    """
+    A `before_tool` Agent hook that applies Human-in-the-Loop confirmation strategies to pending tool calls.
+
+    Register it on an `Agent` to confirm, modify, or reject tool calls before they run:
+
+    ```python
+    from haystack.components.agents import Agent
+    from haystack.human_in_the_loop import (
+        BlockingConfirmationStrategy,
+        ConfirmationHook,
+        NeverAskPolicy,
+        SimpleConsoleUI,
+    )
+
+    hook = ConfirmationHook(
+        confirmation_strategies={
+            "my_tool": BlockingConfirmationStrategy(
+                confirmation_policy=NeverAskPolicy(), confirmation_ui=SimpleConsoleUI()
+            )
+        }
+    )
+    agent = Agent(chat_generator=..., tools=[...], hooks={"before_tool": [hook]})
+    ```
+
+    Request-scoped resources for the strategies (e.g. a WebSocket or queue) are passed per run via the Agent's
+    `hook_context` argument (`agent.run(messages=[...], hook_context={...})`) and read by the hook with
+    `state.get("hook_context")`.
+    """
+
+    def __init__(self, confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy]) -> None:
+        """
+        :param confirmation_strategies: Mapping of tool name (or a tuple of tool names) to its `ConfirmationStrategy`.
+        """
+        self.confirmation_strategies = confirmation_strategies
+
+    def run(self, state: State) -> None:
+        """
+        Confirm the pending tool calls, rewriting the `messages` in `state` to reflect modifications and rejections.
+
+        :param state: The Agent's live `State`. Reads the available tools (`state.get("tools")`) and the per-run
+            context (`state.get("hook_context")`), and the pending tool calls from the last message; writes the
+            updated conversation back to `messages`.
+        """
+        messages = state.data.get("messages") or []
+        if not messages or not messages[-1].tool_calls:
+            return
+        _, new_chat_history = _process_confirmation_strategies(
+            confirmation_strategies=self.confirmation_strategies,
+            messages_with_tool_calls=[messages[-1]],
+            tools=state.get("tools") or [],
+            state=state,
+            confirmation_strategy_context=state.get("hook_context"),
+        )
+        state.set("messages", new_chat_history, handler_override=replace_values)
+
+    async def run_async(self, state: State) -> None:
+        """Async version of `run`."""
+        messages = state.data.get("messages") or []
+        if not messages or not messages[-1].tool_calls:
+            return
+        _, new_chat_history = await _process_confirmation_strategies_async(
+            confirmation_strategies=self.confirmation_strategies,
+            messages_with_tool_calls=[messages[-1]],
+            tools=state.get("tools") or [],
+            state=state,
+            confirmation_strategy_context=state.get("hook_context"),
+        )
+        state.set("messages", new_chat_history, handler_override=replace_values)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the hook, including its confirmation strategies (tuple keys become JSON-array strings)."""
+        return default_to_dict(
+            self, confirmation_strategies=_serialize_confirmation_strategies(self.confirmation_strategies)
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ConfirmationHook":
+        """Deserialize the hook, reconstructing its confirmation strategies."""
+        init_params = data.get("init_parameters", {})
+        if init_params.get("confirmation_strategies") is not None:
+            init_params["confirmation_strategies"] = _deserialize_confirmation_strategies(
+                init_params["confirmation_strategies"]
+            )
+        return default_from_dict(cls, data)

--- a/haystack/human_in_the_loop/hooks.py
+++ b/haystack/human_in_the_loop/hooks.py
@@ -25,9 +25,11 @@ class ConfirmationHook:
     ```python
     from haystack.components.agents import Agent
     from haystack.human_in_the_loop import (
+        AlwaysAskPolicy,
         BlockingConfirmationStrategy,
         ConfirmationHook,
         NeverAskPolicy,
+        RichConsoleUI,
         SimpleConsoleUI,
     )
 
@@ -39,6 +41,23 @@ class ConfirmationHook:
         }
     )
     agent = Agent(chat_generator=..., tools=[...], hooks={"before_tool": [hook]})
+    ```
+
+    A key may be a single tool name, a tuple of tool names sharing one strategy, or the wildcard `"*"` which applies
+    to any tool without a more specific entry. More specific keys win, so you can set a default for all tools and
+    override individual ones:
+
+    ```python
+    hook = ConfirmationHook(
+        confirmation_strategies={
+            "delete_file": BlockingConfirmationStrategy(
+                confirmation_policy=AlwaysAskPolicy(), confirmation_ui=RichConsoleUI()
+            ),
+            "*": BlockingConfirmationStrategy(
+                confirmation_policy=NeverAskPolicy(), confirmation_ui=SimpleConsoleUI()
+            ),
+        }
+    )
     ```
 
     Request-scoped resources for the strategies (e.g. a WebSocket or queue) are passed per run via the Agent's
@@ -54,7 +73,10 @@ class ConfirmationHook:
 
     def __init__(self, confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy]) -> None:
         """
+        Initialize the hook with its per-tool confirmation strategies.
+
         :param confirmation_strategies: Mapping of tool name (or a tuple of tool names) to its `ConfirmationStrategy`.
+            The wildcard key `"*"` applies to any tool without a more specific entry.
         """
         self.confirmation_strategies = confirmation_strategies
 

--- a/haystack/human_in_the_loop/hooks.py
+++ b/haystack/human_in_the_loop/hooks.py
@@ -44,6 +44,12 @@ class ConfirmationHook:
     Request-scoped resources for the strategies (e.g. a WebSocket or queue) are passed per run via the Agent's
     `hook_context` argument (`agent.run(messages=[...], hook_context={...})`) and read by the hook with
     `state.get("hook_context")`.
+
+    Register this hook only under the `before_tool` hook point. It confirms the pending tool calls on the last
+    message, which exist only between the model requesting tools and those tools running. Under `before_llm` or
+    `on_exit` the last message never has pending tool calls, so the hook silently does nothing and tools run
+    unconfirmed. Use a single ConfirmationHook with one entry per tool (or per tuple of tools) in
+    `confirmation_strategies` rather than registering several hooks.
     """
 
     def __init__(self, confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy]) -> None:

--- a/haystack/human_in_the_loop/hooks.py
+++ b/haystack/human_in_the_loop/hooks.py
@@ -69,7 +69,7 @@ class ConfirmationHook:
         messages = state.data.get("messages") or []
         if not messages or not messages[-1].tool_calls:
             return
-        _, new_chat_history = _process_confirmation_strategies(
+        new_chat_history = _process_confirmation_strategies(
             confirmation_strategies=self.confirmation_strategies,
             messages_with_tool_calls=[messages[-1]],
             tools=state.get("tools") or [],
@@ -83,7 +83,7 @@ class ConfirmationHook:
         messages = state.data.get("messages") or []
         if not messages or not messages[-1].tool_calls:
             return
-        _, new_chat_history = await _process_confirmation_strategies_async(
+        new_chat_history = await _process_confirmation_strategies_async(
             confirmation_strategies=self.confirmation_strategies,
             messages_with_tool_calls=[messages[-1]],
             tools=state.get("tools") or [],

--- a/haystack/human_in_the_loop/hooks.py
+++ b/haystack/human_in_the_loop/hooks.py
@@ -62,14 +62,16 @@ class ConfirmationHook:
 
     Request-scoped resources for the strategies (e.g. a WebSocket or queue) are passed per run via the Agent's
     `hook_context` argument (`agent.run(messages=[...], hook_context={...})`) and read by the hook with
-    `state.get("hook_context")`.
+    `state.data.get("hook_context")`.
 
-    Register this hook only under the `before_tool` hook point. It confirms the pending tool calls on the last
-    message, which exist only between the model requesting tools and those tools running. Under `before_llm` or
-    `on_exit` the last message never has pending tool calls, so the hook silently does nothing and tools run
-    unconfirmed. Use a single ConfirmationHook with one entry per tool (or per tuple of tools) in
-    `confirmation_strategies` rather than registering several hooks.
+    This hook only makes sense at the `before_tool` hook point, where the pending tool calls exist (between the model
+    requesting tools and those tools running); the Agent enforces this and raises if it is registered elsewhere. Use a
+    single ConfirmationHook with one entry per tool (or per tuple of tools) in `confirmation_strategies` rather than
+    registering several hooks.
     """
+
+    # Restrict this hook to the "before_tool" point; the Agent validates this at construction.
+    allowed_hook_points = ("before_tool",)
 
     def __init__(self, confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy]) -> None:
         """

--- a/haystack/human_in_the_loop/hooks.py
+++ b/haystack/human_in_the_loop/hooks.py
@@ -84,9 +84,10 @@ class ConfirmationHook:
         """
         Confirm the pending tool calls, rewriting the `messages` in `state` to reflect modifications and rejections.
 
-        :param state: The Agent's live `State`. Reads the available tools (`state.get("tools")`) and the per-run
-            context (`state.get("hook_context")`), and the pending tool calls from the last message; writes the
-            updated conversation back to `messages`.
+        :param state: The Agent's live `State`. Reads the available tools (`state.data.get("tools")`) and the per-run
+            context (`state.data.get("hook_context")`), and the pending tool calls from the last message; writes the
+            updated conversation back to `messages`. Reads go through `state.data` rather than `state.get`, which
+            deep-copies and would break non-copyable resources (e.g. a WebSocket or client) in `hook_context`.
         """
         messages = state.data.get("messages") or []
         if not messages or not messages[-1].tool_calls:
@@ -94,9 +95,9 @@ class ConfirmationHook:
         new_chat_history = _process_confirmation_strategies(
             confirmation_strategies=self.confirmation_strategies,
             messages_with_tool_calls=[messages[-1]],
-            tools=state.get("tools") or [],
+            tools=state.data.get("tools") or [],
             state=state,
-            confirmation_strategy_context=state.get("hook_context"),
+            confirmation_strategy_context=state.data.get("hook_context"),
         )
         state.set("messages", new_chat_history, handler_override=replace_values)
 
@@ -108,9 +109,9 @@ class ConfirmationHook:
         new_chat_history = await _process_confirmation_strategies_async(
             confirmation_strategies=self.confirmation_strategies,
             messages_with_tool_calls=[messages[-1]],
-            tools=state.get("tools") or [],
+            tools=state.data.get("tools") or [],
             state=state,
-            confirmation_strategy_context=state.get("hook_context"),
+            confirmation_strategy_context=state.data.get("hook_context"),
         )
         state.set("messages", new_chat_history, handler_override=replace_values)
 

--- a/haystack/human_in_the_loop/strategies.py
+++ b/haystack/human_in_the_loop/strategies.py
@@ -243,9 +243,12 @@ def _process_confirmation_strategies(
     tools: list[Tool],
     state: State,
     confirmation_strategy_context: dict[str, Any] | None = None,
-) -> tuple[list[ChatMessage], list[ChatMessage]]:
+) -> list[ChatMessage]:
     """
-    Run the confirmation strategies and return modified tool call messages and updated chat history.
+    Run the confirmation strategies and return the updated chat history.
+
+    The returned history ends with the confirmed/modified tool calls (preceded by any rejection messages), so the
+    pending tool calls to execute are always those on its last message.
 
     :param confirmation_strategies: Mapping of tool names to their corresponding confirmation strategies
     :param messages_with_tool_calls: Chat messages containing tool calls
@@ -253,11 +256,11 @@ def _process_confirmation_strategies(
     :param state: The current runtime state, used to read the chat history
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
     :returns:
-        Tuple of modified messages with confirmed tool calls and updated chat history
+        The updated chat history.
     """
-    # If confirmations strategies is empty, return original messages and chat history
+    # If confirmations strategies is empty, return the chat history unchanged
     if not confirmation_strategies:
-        return messages_with_tool_calls, state.get("messages")
+        return state.get("messages")
 
     # Run confirmation strategies and get tool execution decisions
     teds = _run_confirmation_strategies(
@@ -273,13 +276,11 @@ def _process_confirmation_strategies(
     )
 
     # Update the chat history with rejection messages and new tool call messages
-    new_chat_history = _update_chat_history(
+    return _update_chat_history(
         chat_history=state.get("messages"),
         rejection_messages=rejection_messages,
         tool_call_and_explanation_messages=modified_tool_call_messages,
     )
-
-    return modified_tool_call_messages, new_chat_history
 
 
 async def _process_confirmation_strategies_async(
@@ -289,11 +290,14 @@ async def _process_confirmation_strategies_async(
     tools: list[Tool],
     state: State,
     confirmation_strategy_context: dict[str, Any] | None = None,
-) -> tuple[list[ChatMessage], list[ChatMessage]]:
+) -> list[ChatMessage]:
     """
     Async version of _process_confirmation_strategies.
 
-    Run the confirmation strategies and return modified tool call messages and updated chat history.
+    Run the confirmation strategies and return the updated chat history.
+
+    The returned history ends with the confirmed/modified tool calls (preceded by any rejection messages), so the
+    pending tool calls to execute are always those on its last message.
 
     :param confirmation_strategies: Mapping of tool names to their corresponding confirmation strategies
     :param messages_with_tool_calls: Chat messages containing tool calls
@@ -301,11 +305,11 @@ async def _process_confirmation_strategies_async(
     :param state: The current runtime state, used to read the chat history
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
     :returns:
-        Tuple of modified messages with confirmed tool calls and updated chat history
+        The updated chat history.
     """
-    # If confirmations strategies is empty, return original messages and chat history
+    # If confirmations strategies is empty, return the chat history unchanged
     if not confirmation_strategies:
-        return messages_with_tool_calls, state.get("messages")
+        return state.get("messages")
 
     # Run confirmation strategies and get tool execution decisions (async version)
     teds = await _run_confirmation_strategies_async(
@@ -321,13 +325,11 @@ async def _process_confirmation_strategies_async(
     )
 
     # Update the chat history with rejection messages and new tool call messages
-    new_chat_history = _update_chat_history(
+    return _update_chat_history(
         chat_history=state.get("messages"),
         rejection_messages=rejection_messages,
         tool_call_and_explanation_messages=modified_tool_call_messages,
     )
-
-    return modified_tool_call_messages, new_chat_history
 
 
 def _run_confirmation_strategies(

--- a/haystack/human_in_the_loop/strategies.py
+++ b/haystack/human_in_the_loop/strategies.py
@@ -6,9 +6,8 @@ from dataclasses import replace
 from typing import Any
 
 from haystack.components.agents.state.state import State
-from haystack.components.agents.tool_calling import _prepare_tool_args
 from haystack.core.serialization import default_from_dict, default_to_dict
-from haystack.dataclasses import ChatMessage, StreamingCallbackT, ToolCall
+from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.human_in_the_loop import ToolExecutionDecision
 from haystack.human_in_the_loop.types import ConfirmationPolicy, ConfirmationStrategy, ConfirmationUI
 from haystack.tools import Tool
@@ -242,8 +241,6 @@ def _process_confirmation_strategies(
     messages_with_tool_calls: list[ChatMessage],
     tools: list[Tool],
     state: State,
-    streaming_callback: StreamingCallbackT | None = None,
-    enable_streaming_passthrough: bool = False,
     confirmation_strategy_context: dict[str, Any] | None = None,
 ) -> tuple[list[ChatMessage], list[ChatMessage]]:
     """
@@ -252,9 +249,7 @@ def _process_confirmation_strategies(
     :param confirmation_strategies: Mapping of tool names to their corresponding confirmation strategies
     :param messages_with_tool_calls: Chat messages containing tool calls
     :param tools: The available tools, used to resolve each tool call by name
-    :param state: The current runtime state, used to prepare tool arguments and read the chat history
-    :param streaming_callback: Optional streaming callback to pass through to tools that accept it
-    :param enable_streaming_passthrough: Whether to inject the streaming callback into tool arguments
+    :param state: The current runtime state, used to read the chat history
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
     :returns:
         Tuple of modified messages with confirmed tool calls and updated chat history
@@ -268,9 +263,6 @@ def _process_confirmation_strategies(
         confirmation_strategies=confirmation_strategies,
         messages_with_tool_calls=messages_with_tool_calls,
         tools=tools,
-        state=state,
-        streaming_callback=streaming_callback,
-        enable_streaming_passthrough=enable_streaming_passthrough,
         confirmation_strategy_context=confirmation_strategy_context,
     )
 
@@ -295,8 +287,6 @@ async def _process_confirmation_strategies_async(
     messages_with_tool_calls: list[ChatMessage],
     tools: list[Tool],
     state: State,
-    streaming_callback: StreamingCallbackT | None = None,
-    enable_streaming_passthrough: bool = False,
     confirmation_strategy_context: dict[str, Any] | None = None,
 ) -> tuple[list[ChatMessage], list[ChatMessage]]:
     """
@@ -307,9 +297,7 @@ async def _process_confirmation_strategies_async(
     :param confirmation_strategies: Mapping of tool names to their corresponding confirmation strategies
     :param messages_with_tool_calls: Chat messages containing tool calls
     :param tools: The available tools, used to resolve each tool call by name
-    :param state: The current runtime state, used to prepare tool arguments and read the chat history
-    :param streaming_callback: Optional streaming callback to pass through to tools that accept it
-    :param enable_streaming_passthrough: Whether to inject the streaming callback into tool arguments
+    :param state: The current runtime state, used to read the chat history
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
     :returns:
         Tuple of modified messages with confirmed tool calls and updated chat history
@@ -323,9 +311,6 @@ async def _process_confirmation_strategies_async(
         confirmation_strategies=confirmation_strategies,
         messages_with_tool_calls=messages_with_tool_calls,
         tools=tools,
-        state=state,
-        streaming_callback=streaming_callback,
-        enable_streaming_passthrough=enable_streaming_passthrough,
         confirmation_strategy_context=confirmation_strategy_context,
     )
 
@@ -348,9 +333,6 @@ def _run_confirmation_strategies(
     confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy],
     messages_with_tool_calls: list[ChatMessage],
     tools: list[Tool],
-    state: State,
-    streaming_callback: StreamingCallbackT | None = None,
-    enable_streaming_passthrough: bool = False,
     confirmation_strategy_context: dict[str, Any] | None = None,
 ) -> list[ToolExecutionDecision]:
     """
@@ -359,9 +341,6 @@ def _run_confirmation_strategies(
     :param confirmation_strategies: Mapping of tool names to their corresponding confirmation strategies
     :param messages_with_tool_calls: Messages containing tool calls to process
     :param tools: The available tools, used to resolve each tool call by name
-    :param state: The current runtime state, used to prepare tool arguments
-    :param streaming_callback: Optional streaming callback to pass through to tools that accept it
-    :param enable_streaming_passthrough: Whether to inject the streaming callback into tool arguments
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
     :returns:
         A list of ToolExecutionDecision objects representing the decisions made for each tool call.
@@ -381,14 +360,10 @@ def _run_confirmation_strategies(
                 teds.append(_passthrough_tool_call(tool_call))
                 continue
 
-            # Prepare final tool args
-            final_args = _prepare_tool_args(
-                tool=tool_to_invoke,
-                tool_call_arguments=tool_call.arguments,
-                state=state,
-                streaming_callback=streaming_callback,
-                enable_streaming_passthrough=enable_streaming_passthrough,
-            )
+            # Confirm the model-requested arguments. State injection (inputs_from_state and State-typed parameters)
+            # is deliberately left to tool execution, which prepares args per batch so a tool observes State writes
+            # from tools that ran earlier in the same step. Baking injected args here would freeze stale values.
+            final_args = dict(tool_call.arguments)
 
             # Get tool execution decisions from confirmation strategies
             # If no confirmation strategy is defined for this tool, proceed with execution
@@ -418,9 +393,6 @@ async def _run_confirmation_strategies_async(
     confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy],
     messages_with_tool_calls: list[ChatMessage],
     tools: list[Tool],
-    state: State,
-    streaming_callback: StreamingCallbackT | None = None,
-    enable_streaming_passthrough: bool = False,
     confirmation_strategy_context: dict[str, Any] | None = None,
 ) -> list[ToolExecutionDecision]:
     """
@@ -432,9 +404,6 @@ async def _run_confirmation_strategies_async(
         String keys map individual tools, tuple keys map multiple tools to the same strategy.
     :param messages_with_tool_calls: Messages containing tool calls to process
     :param tools: The available tools, used to resolve each tool call by name
-    :param state: The current runtime state, used to prepare tool arguments
-    :param streaming_callback: Optional streaming callback to pass through to tools that accept it
-    :param enable_streaming_passthrough: Whether to inject the streaming callback into tool arguments
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
     :returns:
         A list of ToolExecutionDecision objects representing the decisions made for each tool call.
@@ -454,14 +423,10 @@ async def _run_confirmation_strategies_async(
                 teds.append(_passthrough_tool_call(tool_call))
                 continue
 
-            # Prepare final tool args
-            final_args = _prepare_tool_args(
-                tool=tool_to_invoke,
-                tool_call_arguments=tool_call.arguments,
-                state=state,
-                streaming_callback=streaming_callback,
-                enable_streaming_passthrough=enable_streaming_passthrough,
-            )
+            # Confirm the model-requested arguments. State injection (inputs_from_state and State-typed parameters)
+            # is deliberately left to tool execution, which prepares args per batch so a tool observes State writes
+            # from tools that ran earlier in the same step. Baking injected args here would freeze stale values.
+            final_args = dict(tool_call.arguments)
 
             # Get tool execution decisions from confirmation strategies
             # If no confirmation strategy is defined for this tool, proceed with execution

--- a/haystack/human_in_the_loop/strategies.py
+++ b/haystack/human_in_the_loop/strategies.py
@@ -206,7 +206,8 @@ def _get_confirmation_strategy(
     :param tool_name:
         The name of the tool to look up.
     :param confirmation_strategies:
-        Dictionary of confirmation strategies with string or tuple keys.
+        Dictionary of confirmation strategies with string or tuple keys. The `"*"` key, if present, is a wildcard
+        applied to any tool without a more specific entry.
     :returns:
         The confirmation strategy if found, None otherwise.
     """
@@ -217,7 +218,8 @@ def _get_confirmation_strategy(
         if isinstance(key, tuple) and tool_name in key:
             return strategy
 
-    return None
+    # Fall back to the wildcard entry that applies to any tool without a more specific match.
+    return confirmation_strategies.get("*")
 
 
 def _passthrough_tool_call(tool_call: ToolCall) -> ToolExecutionDecision:

--- a/haystack/human_in_the_loop/strategies.py
+++ b/haystack/human_in_the_loop/strategies.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from dataclasses import replace
 from typing import Any
 
 from haystack.components.agents.state.state import State
-from haystack.core.serialization import default_from_dict, default_to_dict
+from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.human_in_the_loop import ToolExecutionDecision
 from haystack.human_in_the_loop.types import ConfirmationPolicy, ConfirmationStrategy, ConfirmationUI
@@ -572,12 +573,32 @@ def _update_chat_history(
     return chat_history[: insertion_point + 1] + rejection_messages + tool_call_and_explanation_messages
 
 
+def _serialize_confirmation_strategies(
+    confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy],
+) -> dict[str, Any]:
+    """
+    Serialize a confirmation strategies dictionary to a plain, mapping-key-safe dictionary.
+
+    Mapping keys must be strings, so a tuple of tool names (one strategy shared across several tools) is encoded
+    as a JSON-array string (e.g. `("a", "b")` -> `'["a", "b"]'`); a single tool name is kept as-is.
+
+    :param confirmation_strategies: Mapping of tool name (or a tuple of tool names) to its strategy.
+    :returns: The same mapping with string keys and each strategy serialized to a dictionary.
+    """
+    return {
+        (json.dumps(list(key)) if isinstance(key, tuple) else key): component_to_dict(
+            obj=strategy, name="confirmation_strategy"
+        )
+        for key, strategy in confirmation_strategies.items()
+    }
+
+
 def _deserialize_confirmation_strategies(data: dict[str, Any]) -> dict[str | tuple[str, ...], ConfirmationStrategy]:
     """
     Deserialize a confirmation strategies dictionary from its serialized form.
 
-    Deserializes each strategy component in-place and converts any list keys back to tuples,
-    since JSON serializes tuple keys as lists.
+    Deserializes each strategy component in-place and converts keys that were encoded as JSON-array strings (tuples
+    of tool names) back to tuples; single tool-name string keys are kept as-is.
 
     :param data: Raw dictionary of serialized confirmation strategies, keyed by tool name(s).
     :returns: Deserialized confirmation strategies with proper key types.
@@ -585,4 +606,15 @@ def _deserialize_confirmation_strategies(data: dict[str, Any]) -> dict[str | tup
     for raw_key in list(data):
         deserialize_component_inplace(data, key=raw_key)
 
-    return {(tuple(raw_key) if isinstance(raw_key, list) else raw_key): strategy for raw_key, strategy in data.items()}
+    return {_decode_strategy_key(raw_key): strategy for raw_key, strategy in data.items()}
+
+
+def _decode_strategy_key(raw_key: str | list) -> str | tuple[str, ...]:
+    """Reverse of the key encoding in `_serialize_confirmation_strategies`."""
+    # Backwards-compatibility: an actual list (older in-memory forms) becomes a tuple.
+    if isinstance(raw_key, list):
+        return tuple(raw_key)
+    # A JSON-array string encodes a tuple of tool names; any other string is a single tool name.
+    if raw_key.startswith("["):
+        return tuple(json.loads(raw_key))
+    return raw_key

--- a/haystack/human_in_the_loop/strategies.py
+++ b/haystack/human_in_the_loop/strategies.py
@@ -262,7 +262,7 @@ def _process_confirmation_strategies(
     """
     # If confirmations strategies is empty, return the chat history unchanged
     if not confirmation_strategies:
-        return state.get("messages")
+        return state.data["messages"]
 
     # Run confirmation strategies and get tool execution decisions
     teds = _run_confirmation_strategies(
@@ -279,7 +279,7 @@ def _process_confirmation_strategies(
 
     # Update the chat history with rejection messages and new tool call messages
     return _update_chat_history(
-        chat_history=state.get("messages"),
+        chat_history=state.data["messages"],
         rejection_messages=rejection_messages,
         tool_call_and_explanation_messages=modified_tool_call_messages,
     )
@@ -311,7 +311,7 @@ async def _process_confirmation_strategies_async(
     """
     # If confirmations strategies is empty, return the chat history unchanged
     if not confirmation_strategies:
-        return state.get("messages")
+        return state.data["messages"]
 
     # Run confirmation strategies and get tool execution decisions (async version)
     teds = await _run_confirmation_strategies_async(
@@ -328,7 +328,7 @@ async def _process_confirmation_strategies_async(
 
     # Update the chat history with rejection messages and new tool call messages
     return _update_chat_history(
-        chat_history=state.get("messages"),
+        chat_history=state.data["messages"],
         rejection_messages=rejection_messages,
         tool_call_and_explanation_messages=modified_tool_call_messages,
     )

--- a/haystack/human_in_the_loop/strategies.py
+++ b/haystack/human_in_the_loop/strategies.py
@@ -360,9 +360,7 @@ def _run_confirmation_strategies(
                 teds.append(_passthrough_tool_call(tool_call))
                 continue
 
-            # Confirm the model-requested arguments. State injection (inputs_from_state and State-typed parameters)
-            # is deliberately left to tool execution, which prepares args per batch so a tool observes State writes
-            # from tools that ran earlier in the same step. Baking injected args here would freeze stale values.
+            # Confirm the model-requested arguments
             final_args = dict(tool_call.arguments)
 
             # Get tool execution decisions from confirmation strategies
@@ -423,9 +421,7 @@ async def _run_confirmation_strategies_async(
                 teds.append(_passthrough_tool_call(tool_call))
                 continue
 
-            # Confirm the model-requested arguments. State injection (inputs_from_state and State-typed parameters)
-            # is deliberately left to tool execution, which prepares args per batch so a tool observes State writes
-            # from tools that ran earlier in the same step. Baking injected args here would freeze stale values.
+            # Confirm the model-requested arguments
             final_args = dict(tool_call.arguments)
 
             # Get tool execution decisions from confirmation strategies

--- a/pydoc/human_in_the_loop_api.yml
+++ b/pydoc/human_in_the_loop_api.yml
@@ -1,6 +1,6 @@
 loaders:
   - search_path: [../haystack/human_in_the_loop]
-    modules: ["dataclasses", "policies", "strategies", "user_interfaces"]
+    modules: ["dataclasses", "hooks", "policies", "strategies", "user_interfaces"]
 processors:
   - type: filter
     documented_only: true

--- a/releasenotes/notes/fix-hitl-stale-tool-args-d268541b0c442a53.yaml
+++ b/releasenotes/notes/fix-hitl-stale-tool-args-d268541b0c442a53.yaml
@@ -10,8 +10,8 @@ upgrade:
 fixes:
   - |
     Fixed a bug where configuring an ``Agent`` confirmation strategy could make a tool run with stale arguments.
-    Confirmation prepared and baked each tool's final arguments up front (injecting ``inputs_from_state`` values from
-    the state at the start of the step), which defeated the per-batch argument preparation in tool execution: a tool
-    that reads a state key written by another tool in the same step would run with the pre-step value instead of the
-    freshly produced one. Confirmation now operates on the model-requested arguments and leaves state injection to
-    tool execution, so dependent tools again receive the correct values.
+    HITL confirmation prepared and baked each tool's final arguments up front (injecting ``inputs_from_state`` values
+    from the state at the start of the tool calling step), which defeated the per-batch argument preparation in tool
+    execution: a tool that reads a state key written by another tool in the same step would run with the pre-step
+    value instead of the freshly produced one. HITL confirmation now operates on the model-requested arguments and
+    leaves state injection to tool execution, so dependent tools again receive the correct values.

--- a/releasenotes/notes/fix-hitl-stale-tool-args-d268541b0c442a53.yaml
+++ b/releasenotes/notes/fix-hitl-stale-tool-args-d268541b0c442a53.yaml
@@ -1,0 +1,17 @@
+---
+upgrade:
+  - |
+    Confirmation strategies now receive the model-requested tool arguments in ``tool_params`` rather than the
+    fully-prepared arguments. Values injected from ``State`` via a tool's ``inputs_from_state`` mapping (and the
+    ``State`` object injected into ``State``-typed parameters) are no longer included in what is presented for
+    confirmation — that injection now happens only at tool execution time. If your ``ConfirmationUI`` or
+    ``ConfirmationPolicy`` displayed or inspected those state-injected values, it will now see only the arguments the
+    model provided.
+fixes:
+  - |
+    Fixed a bug where configuring an ``Agent`` confirmation strategy could make a tool run with stale arguments.
+    Confirmation prepared and baked each tool's final arguments up front (injecting ``inputs_from_state`` values from
+    the state at the start of the step), which defeated the per-batch argument preparation in tool execution: a tool
+    that reads a state key written by another tool in the same step would run with the pre-step value instead of the
+    freshly produced one. Confirmation now operates on the model-requested arguments and leaves state injection to
+    tool execution, so dependent tools again receive the correct values.

--- a/releasenotes/notes/recast-hitl-as-before-tool-hook-0ef6ba1502cf97ad.yaml
+++ b/releasenotes/notes/recast-hitl-as-before-tool-hook-0ef6ba1502cf97ad.yaml
@@ -31,4 +31,6 @@ features:
   - |
     Added ``ConfirmationHook``, a ``before_tool`` Agent hook that applies Human-in-the-Loop confirmation strategies
     to pending tool calls. It confirms, modifies, or rejects the tool calls the model requested before they run by
-    rewriting the conversation in the Agent's ``State``.
+    rewriting the conversation in the Agent's ``State``. Its ``confirmation_strategies`` mapping accepts a single
+    tool name, a tuple of tool names, or the wildcard ``"*"`` that applies to any tool without a more specific
+    entry, so you can set a default strategy for all tools and override individual ones.

--- a/releasenotes/notes/recast-hitl-as-before-tool-hook-0ef6ba1502cf97ad.yaml
+++ b/releasenotes/notes/recast-hitl-as-before-tool-hook-0ef6ba1502cf97ad.yaml
@@ -34,3 +34,9 @@ features:
     rewriting the conversation in the Agent's ``State``. Its ``confirmation_strategies`` mapping accepts a single
     tool name, a tuple of tool names, or the wildcard ``"*"`` that applies to any tool without a more specific
     entry, so you can set a default strategy for all tools and override individual ones.
+  - |
+    Agent hooks may now declare an ``allowed_hook_points`` attribute listing the hook points they support. The
+    ``Agent`` validates it at construction and raises a ``ValueError`` if such a hook is registered under an
+    unsupported hook point. For example, ``ConfirmationHook`` sets ``allowed_hook_points = ("before_tool",)``, so
+    registering it under ``before_llm`` or ``on_exit`` now fails fast instead of silently doing nothing. Hooks that
+    do not declare the attribute can still be registered under any hook point.

--- a/releasenotes/notes/recast-hitl-as-before-tool-hook-0ef6ba1502cf97ad.yaml
+++ b/releasenotes/notes/recast-hitl-as-before-tool-hook-0ef6ba1502cf97ad.yaml
@@ -1,0 +1,34 @@
+---
+upgrade:
+  - |
+    Human-in-the-Loop tool confirmation on ``Agent`` is now expressed as a ``before_tool`` hook instead of a
+    dedicated concept. The ``confirmation_strategies`` and ``confirmation_strategy_context`` parameters have been
+    removed from ``Agent.__init__``, ``Agent.run``, and ``Agent.run_async``. To migrate, wrap your confirmation
+    strategies in the new ``ConfirmationHook``, register it under the ``before_tool`` hook point, and pass any
+    request-scoped resources through the generic ``hook_context`` run argument instead of
+    ``confirmation_strategy_context``:
+
+    .. code-block:: python
+
+        from haystack.components.agents import Agent
+        from haystack.human_in_the_loop import (
+            AlwaysAskPolicy,
+            BlockingConfirmationStrategy,
+            ConfirmationHook,
+            RichConsoleUI,
+        )
+
+        confirmation_hook = ConfirmationHook(
+            confirmation_strategies={
+                "my_tool": BlockingConfirmationStrategy(
+                    confirmation_policy=AlwaysAskPolicy(), confirmation_ui=RichConsoleUI()
+                )
+            }
+        )
+        agent = Agent(chat_generator=..., tools=[...], hooks={"before_tool": [confirmation_hook]})
+        agent.run(messages=[...], hook_context={"websocket": ws})
+features:
+  - |
+    Added ``ConfirmationHook``, a ``before_tool`` Agent hook that applies Human-in-the-Loop confirmation strategies
+    to pending tool calls. It confirms, modifies, or rejects the tool calls the model requested before they run by
+    rewriting the conversation in the Agent's ``State``.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -296,7 +296,6 @@ class TestAgent:
                 "raise_on_tool_invocation_failure": False,
                 "tool_concurrency_limit": 5,
                 "tool_streaming_callback_passthrough": True,
-                "confirmation_strategies": None,
                 "hooks": None,
             },
         }
@@ -364,7 +363,6 @@ class TestAgent:
                 "streaming_callback": None,
                 "tool_concurrency_limit": 4,
                 "tool_streaming_callback_passthrough": False,
-                "confirmation_strategies": None,
                 "hooks": None,
             },
         }
@@ -469,6 +467,8 @@ class TestAgent:
             "token_usage": {"type": dict[str, Any], "handler": replace_values},
             "tool_call_counts": {"type": dict[str, int], "handler": replace_values},
             "continue_run": {"type": bool, "handler": replace_values},
+            "tools": {"type": list, "handler": replace_values},
+            "hook_context": {"type": dict[str, Any], "handler": replace_values},
         }
         assert agent.tool_concurrency_limit == 5
         assert agent.tool_streaming_callback_passthrough is True
@@ -577,6 +577,8 @@ class TestAgent:
             "token_usage": {"type": dict[str, Any], "handler": replace_values},
             "tool_call_counts": {"type": dict[str, int], "handler": replace_values},
             "continue_run": {"type": bool, "handler": replace_values},
+            "tools": {"type": list, "handler": replace_values},
+            "hook_context": {"type": dict[str, Any], "handler": replace_values},
         }
 
     def test_serde(self, weather_tool, component_tool, monkeypatch):
@@ -619,6 +621,8 @@ class TestAgent:
             "token_usage": {"type": dict[str, Any], "handler": replace_values},
             "tool_call_counts": {"type": dict[str, int], "handler": replace_values},
             "continue_run": {"type": bool, "handler": replace_values},
+            "tools": {"type": list, "handler": replace_values},
+            "hook_context": {"type": dict[str, Any], "handler": replace_values},
         }
         assert deserialized_agent.streaming_callback is sync_streaming_callback
 
@@ -1350,7 +1354,7 @@ class TestAgentTracing:
             "haystack.agent.max_steps": 100,
             "haystack.agent.tools": '[{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]',  # noqa: E501
             "haystack.agent.exit_conditions": '["text"]',
-            "haystack.agent.state_schema": '{"messages": {"type": "list[haystack.dataclasses.chat_message.ChatMessage]", "handler": "haystack.components.agents.state.state_utils.merge_lists"}, "step_count": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "token_usage": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tool_call_counts": {"type": "dict[str, int]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "continue_run": {"type": "bool", "handler": "haystack.components.agents.state.state_utils.replace_values"}}',  # noqa: E501
+            "haystack.agent.state_schema": '{"messages": {"type": "list[haystack.dataclasses.chat_message.ChatMessage]", "handler": "haystack.components.agents.state.state_utils.merge_lists"}, "step_count": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "token_usage": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tool_call_counts": {"type": "dict[str, int]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "continue_run": {"type": "bool", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tools": {"type": "list", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "hook_context": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}}',  # noqa: E501
             "haystack.agent.input": '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}], "streaming_callback": null}',  # noqa: E501
             "haystack.agent.output": '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}, {"role": "assistant", "meta": {}, "name": null, "content": [{"text": "Hello"}]}], "step_count": 1, "token_usage": {}, "tool_call_counts": {"weather_tool": 0}, "last_message": {"role": "assistant", "meta": {}, "name": null, "content": [{"text": "Hello"}]}}',  # noqa: E501
             "haystack.agent.steps_taken": 1,
@@ -1483,7 +1487,7 @@ class TestAgentTracing:
             "haystack.agent.max_steps": 100,
             "haystack.agent.tools": '[{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]',  # noqa: E501
             "haystack.agent.exit_conditions": '["text"]',
-            "haystack.agent.state_schema": '{"messages": {"type": "list[haystack.dataclasses.chat_message.ChatMessage]", "handler": "haystack.components.agents.state.state_utils.merge_lists"}, "step_count": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "token_usage": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tool_call_counts": {"type": "dict[str, int]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "continue_run": {"type": "bool", "handler": "haystack.components.agents.state.state_utils.replace_values"}}',  # noqa: E501
+            "haystack.agent.state_schema": '{"messages": {"type": "list[haystack.dataclasses.chat_message.ChatMessage]", "handler": "haystack.components.agents.state.state_utils.merge_lists"}, "step_count": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "token_usage": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tool_call_counts": {"type": "dict[str, int]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "continue_run": {"type": "bool", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tools": {"type": "list", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "hook_context": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}}',  # noqa: E501
             "haystack.agent.input": '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}], "streaming_callback": null}',  # noqa: E501
             "haystack.agent.output": '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}, {"role": "assistant", "meta": {}, "name": null, "content": [{"text": "Hello from run_async"}]}], "step_count": 1, "token_usage": {}, "tool_call_counts": {"weather_tool": 0}, "last_message": {"role": "assistant", "meta": {}, "name": null, "content": [{"text": "Hello from run_async"}]}}',  # noqa: E501
             "haystack.agent.steps_taken": 1,

--- a/test/components/agents/test_agent_hitl.py
+++ b/test/components/agents/test_agent_hitl.py
@@ -298,3 +298,75 @@ class TestConfirmationStrategyToolArgPrep:
             if m.tool_call_result is not None and m.tool_call_result.origin.tool_name == "consumer"
         ]
         assert consumer_results == ["consumed:PRODUCED"]
+
+
+def _echo(x: Annotated[int, "the value to echo"]) -> dict[str, int]:
+    return {"echoed": x}
+
+
+def _echo_tool(name: str) -> Tool:
+    return Tool(
+        name=name,
+        description=f"Echo tool {name}.",
+        parameters={"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]},
+        function=_echo,
+    )
+
+
+def _single_tool_hook(tool_name: str, ui_result: ConfirmationUIResult) -> ConfirmationHook:
+    return ConfirmationHook(
+        confirmation_strategies={
+            tool_name: BlockingConfirmationStrategy(
+                confirmation_policy=AlwaysAskPolicy(), confirmation_ui=MockUserInterface(ui_result)
+            )
+        }
+    )
+
+
+class TestMultipleConfirmationHooks:
+    def test_multiple_hooks_each_targeting_a_different_tool(self):
+        """
+        Three before_tool ConfirmationHooks, each owning a different tool of a three-call batch, compose correctly:
+        a tool a hook does not own passes through unchanged, so reject/modify decisions from all three hooks land on
+        the right calls in the final, re-read pending message.
+        """
+        foo, bar, baz = _echo_tool("foo"), _echo_tool("bar"), _echo_tool("baz")
+        hooks = {
+            "before_tool": [
+                _single_tool_hook("foo", ConfirmationUIResult(action="reject")),
+                _single_tool_hook("bar", ConfirmationUIResult(action="modify", new_tool_params={"x": 99})),
+                _single_tool_hook("baz", ConfirmationUIResult(action="modify", new_tool_params={"x": 77})),
+            ]
+        }
+        agent = Agent(chat_generator=MockChatGenerator(), tools=[foo, bar, baz], hooks=hooks)
+        agent.warm_up()
+        agent.chat_generator.run = MagicMock(
+            side_effect=[
+                {
+                    "replies": [
+                        ChatMessage.from_assistant(
+                            tool_calls=[ToolCall("foo", {"x": 1}), ToolCall("bar", {"x": 2}), ToolCall("baz", {"x": 3})]
+                        )
+                    ]
+                },
+                {"replies": [ChatMessage.from_assistant("done")]},
+            ]
+        )
+
+        result = agent.run(messages=[ChatMessage.from_user("go")])
+
+        results_by_tool = {
+            m.tool_call_result.origin.tool_name: m.tool_call_result
+            for m in result["messages"]
+            if m.tool_call_result is not None
+        }
+        # foo was rejected: it produced an error tool result and never executed.
+        assert results_by_tool["foo"].error is True
+        assert "rejected" in results_by_tool["foo"].result.lower()
+        # bar and baz ran with their modified arguments.
+        assert results_by_tool["bar"].error is False
+        assert results_by_tool["bar"].result == '{"echoed": 99}'
+        assert results_by_tool["baz"].error is False
+        assert results_by_tool["baz"].result == '{"echoed": 77}'
+        # Only the two confirmed tools actually executed.
+        assert result["tool_call_counts"] == {"foo": 0, "bar": 1, "baz": 1}

--- a/test/components/agents/test_agent_hitl.py
+++ b/test/components/agents/test_agent_hitl.py
@@ -61,6 +61,15 @@ def confirmation_hook(confirmation_strategies) -> ConfirmationHook:
 
 
 class TestAgent:
+    def test_confirmation_hook_accepted_on_before_tool(self, tools, confirmation_hook):
+        agent = Agent(chat_generator=MockChatGenerator(), tools=tools, hooks={"before_tool": [confirmation_hook]})
+        assert agent.hooks["before_tool"] == [confirmation_hook]
+
+    @pytest.mark.parametrize("bad_point", ["before_llm", "on_exit"])
+    def test_confirmation_hook_rejected_on_wrong_hook_point(self, tools, confirmation_hook, bad_point):
+        with pytest.raises(ValueError, match="only supports"):
+            Agent(chat_generator=MockChatGenerator(), tools=tools, hooks={bad_point: [confirmation_hook]})
+
     def test_to_dict(self, tools, confirmation_hook, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test")
         agent = Agent(chat_generator=OpenAIChatGenerator(), tools=tools, hooks={"before_tool": [confirmation_hook]})

--- a/test/components/agents/test_agent_hitl.py
+++ b/test/components/agents/test_agent_hitl.py
@@ -3,13 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import Any
+from typing import Annotated, Any
+from unittest.mock import MagicMock
 
 import pytest
 
+from haystack import component
 from haystack.components.agents import Agent
 from haystack.components.generators.chat import OpenAIChatGenerator
-from haystack.dataclasses import ChatMessage
+from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.human_in_the_loop import (
     AlwaysAskPolicy,
     BlockingConfirmationStrategy,
@@ -18,7 +20,7 @@ from haystack.human_in_the_loop import (
     SimpleConsoleUI,
 )
 from haystack.human_in_the_loop.types import ConfirmationStrategy, ConfirmationUI
-from haystack.tools import Tool, create_tool_from_function
+from haystack.tools import Tool, Toolset, create_tool_from_function
 
 
 class MockUserInterface(ConfirmationUI):
@@ -202,3 +204,77 @@ class TestAgent:
         assert result["token_usage"]["prompt_tokens"] > 0
         assert result["token_usage"]["completion_tokens"] > 0
         assert result["token_usage"]["total_tokens"] > 0
+
+
+@component
+class MockChatGenerator:
+    @component.output_types(replies=list[ChatMessage])
+    def run(self, messages: list[ChatMessage], tools: list[Tool] | Toolset | None = None, **kwargs) -> dict[str, Any]:
+        return {"replies": [ChatMessage.from_assistant("Hello")]}
+
+
+def _producer() -> dict[str, str]:
+    return {"value": "PRODUCED"}
+
+
+def _consumer(value: Annotated[str, "the shared value"]) -> str:
+    return f"consumed:{value}"
+
+
+# `producer` overwrites the `shared` state key; `consumer` reads it via inputs_from_state. Called together in one
+# step, the batched executor must run producer first so consumer sees the fresh value.
+producer_tool = Tool(
+    name="producer",
+    description="Produce a value into state.",
+    parameters={"type": "object", "properties": {}, "required": []},
+    function=_producer,
+    outputs_to_state={"shared": {"source": "value"}},
+)
+consumer_tool = Tool(
+    name="consumer",
+    description="Consume the shared value.",
+    parameters={"type": "object", "properties": {"value": {"type": "string"}}, "required": ["value"]},
+    function=_consumer,
+    inputs_from_state={"shared": "value"},
+)
+
+
+class TestConfirmationStrategyToolArgPrep:
+    def test_confirmed_dependent_tool_runs_with_fresh_state(self):
+        """
+        When a confirmation strategy is configured, a tool that reads State a same-step tool writes must still run
+        with the freshly-produced value, not the stale step-start value.
+        """
+        agent = Agent(
+            chat_generator=MockChatGenerator(),
+            tools=[producer_tool, consumer_tool],
+            state_schema={"shared": {"type": str}},
+            confirmation_strategies={
+                "consumer": BlockingConfirmationStrategy(
+                    confirmation_policy=NeverAskPolicy(), confirmation_ui=SimpleConsoleUI()
+                )
+            },
+        )
+        agent.warm_up()
+        # Step 1: the model calls producer and consumer together (consumer relies on inputs_from_state for `value`).
+        # Step 2: a plain text reply ends the run.
+        agent.chat_generator.run = MagicMock(
+            side_effect=[
+                {
+                    "replies": [
+                        ChatMessage.from_assistant(tool_calls=[ToolCall("producer", {}), ToolCall("consumer", {})])
+                    ]
+                },
+                {"replies": [ChatMessage.from_assistant("done")]},
+            ]
+        )
+
+        # `shared` starts stale; producer overwrites it to "PRODUCED" before consumer runs.
+        result = agent.run(messages=[ChatMessage.from_user("go")], shared="OLD")
+
+        consumer_results = [
+            m.tool_call_result.result
+            for m in result["messages"]
+            if m.tool_call_result is not None and m.tool_call_result.origin.tool_name == "consumer"
+        ]
+        assert consumer_results == ["consumed:PRODUCED"]

--- a/test/components/agents/test_agent_hitl.py
+++ b/test/components/agents/test_agent_hitl.py
@@ -15,6 +15,7 @@ from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.human_in_the_loop import (
     AlwaysAskPolicy,
     BlockingConfirmationStrategy,
+    ConfirmationHook,
     ConfirmationUIResult,
     NeverAskPolicy,
     SimpleConsoleUI,
@@ -54,12 +55,15 @@ def confirmation_strategies() -> dict[str, ConfirmationStrategy]:
     }
 
 
+@pytest.fixture
+def confirmation_hook(confirmation_strategies) -> ConfirmationHook:
+    return ConfirmationHook(confirmation_strategies=confirmation_strategies)
+
+
 class TestAgent:
-    def test_to_dict(self, tools, confirmation_strategies, monkeypatch):
+    def test_to_dict(self, tools, confirmation_hook, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test")
-        agent = Agent(
-            chat_generator=OpenAIChatGenerator(), tools=tools, confirmation_strategies=confirmation_strategies
-        )
+        agent = Agent(chat_generator=OpenAIChatGenerator(), tools=tools, hooks={"before_tool": [confirmation_hook]})
         agent_dict = agent.to_dict()
         assert agent_dict == {
             "type": "haystack.components.agents.agent.Agent",
@@ -109,34 +113,41 @@ class TestAgent:
                 "tool_streaming_callback_passthrough": False,
                 "required_variables": None,
                 "user_prompt": None,
-                "confirmation_strategies": {
-                    "addition_tool": {
-                        "type": "haystack.human_in_the_loop.strategies.BlockingConfirmationStrategy",
-                        "init_parameters": {
-                            "confirmation_policy": {
-                                "type": "haystack.human_in_the_loop.policies.NeverAskPolicy",
-                                "init_parameters": {},
+                "hooks": {
+                    "before_tool": [
+                        {
+                            "type": "haystack.human_in_the_loop.hooks.ConfirmationHook",
+                            "init_parameters": {
+                                "confirmation_strategies": {
+                                    "addition_tool": {
+                                        "type": "haystack.human_in_the_loop.strategies.BlockingConfirmationStrategy",
+                                        "init_parameters": {
+                                            "confirmation_policy": {
+                                                "type": "haystack.human_in_the_loop.policies.NeverAskPolicy",
+                                                "init_parameters": {},
+                                            },
+                                            "confirmation_ui": {
+                                                "type": "haystack.human_in_the_loop.user_interfaces.SimpleConsoleUI",
+                                                "init_parameters": {},
+                                            },
+                                            "reject_template": "Tool execution for '{tool_name}' was rejected by "
+                                            "the user.",
+                                            "modify_template": "The parameters for tool '{tool_name}' were updated "
+                                            "by the user to:\n{final_tool_params}",
+                                            "user_feedback_template": "With user feedback: {feedback}",
+                                        },
+                                    }
+                                }
                             },
-                            "confirmation_ui": {
-                                "type": "haystack.human_in_the_loop.user_interfaces.SimpleConsoleUI",
-                                "init_parameters": {},
-                            },
-                            "reject_template": "Tool execution for '{tool_name}' was rejected by the user.",
-                            "modify_template": "The parameters for tool '{tool_name}' were updated by the user to:"
-                            "\n{final_tool_params}",
-                            "user_feedback_template": "With user feedback: {feedback}",
-                        },
-                    }
+                        }
+                    ]
                 },
-                "hooks": None,
             },
         }
 
-    def test_from_dict(self, tools, confirmation_strategies, monkeypatch):
+    def test_from_dict(self, tools, confirmation_hook, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test")
-        agent = Agent(
-            chat_generator=OpenAIChatGenerator(), tools=tools, confirmation_strategies=confirmation_strategies
-        )
+        agent = Agent(chat_generator=OpenAIChatGenerator(), tools=tools, hooks={"before_tool": [confirmation_hook]})
         deserialized_agent = Agent.from_dict(agent.to_dict())
         assert deserialized_agent.to_dict() == agent.to_dict()
         assert isinstance(deserialized_agent.chat_generator, OpenAIChatGenerator)
@@ -144,18 +155,16 @@ class TestAgent:
         assert deserialized_agent.tools[0].name == "addition_tool"
         assert deserialized_agent.tool_concurrency_limit == agent.tool_concurrency_limit
         assert deserialized_agent.tool_streaming_callback_passthrough == agent.tool_streaming_callback_passthrough
-        assert isinstance(deserialized_agent._confirmation_strategies["addition_tool"], BlockingConfirmationStrategy)
-        assert isinstance(
-            deserialized_agent._confirmation_strategies["addition_tool"].confirmation_policy, NeverAskPolicy
-        )
-        assert isinstance(deserialized_agent._confirmation_strategies["addition_tool"].confirmation_ui, SimpleConsoleUI)
+        hook = deserialized_agent.hooks["before_tool"][0]
+        assert isinstance(hook, ConfirmationHook)
+        assert isinstance(hook.confirmation_strategies["addition_tool"], BlockingConfirmationStrategy)
+        assert isinstance(hook.confirmation_strategies["addition_tool"].confirmation_policy, NeverAskPolicy)
+        assert isinstance(hook.confirmation_strategies["addition_tool"].confirmation_ui, SimpleConsoleUI)
 
     @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
     @pytest.mark.integration
     def test_run_blocking_confirmation_strategy_modify(self, tools):
-        agent = Agent(
-            chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
-            tools=tools,
+        confirmation_hook = ConfirmationHook(
             confirmation_strategies={
                 "addition_tool": BlockingConfirmationStrategy(
                     confirmation_policy=AlwaysAskPolicy(),
@@ -163,7 +172,12 @@ class TestAgent:
                         ConfirmationUIResult(action="modify", new_tool_params={"a": 2, "b": 3})
                     ),
                 )
-            },
+            }
+        )
+        agent = Agent(
+            chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+            tools=tools,
+            hooks={"before_tool": [confirmation_hook]},
         )
         result = agent.run([ChatMessage.from_user("What is 2+2?")])
 
@@ -181,9 +195,7 @@ class TestAgent:
     @pytest.mark.integration
     @pytest.mark.asyncio
     async def test_run_async_blocking_confirmation_strategy_modify(self, tools):
-        agent = Agent(
-            chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
-            tools=tools,
+        confirmation_hook = ConfirmationHook(
             confirmation_strategies={
                 "addition_tool": BlockingConfirmationStrategy(
                     confirmation_policy=AlwaysAskPolicy(),
@@ -191,7 +203,12 @@ class TestAgent:
                         ConfirmationUIResult(action="modify", new_tool_params={"a": 2, "b": 3})
                     ),
                 )
-            },
+            }
+        )
+        agent = Agent(
+            chat_generator=OpenAIChatGenerator(model="gpt-4o-mini"),
+            tools=tools,
+            hooks={"before_tool": [confirmation_hook]},
         )
         result = await agent.run_async([ChatMessage.from_user("What is 2+2?")])
 
@@ -245,15 +262,18 @@ class TestConfirmationStrategyToolArgPrep:
         When a confirmation strategy is configured, a tool that reads State a same-step tool writes must still run
         with the freshly-produced value, not the stale step-start value.
         """
-        agent = Agent(
-            chat_generator=MockChatGenerator(),
-            tools=[producer_tool, consumer_tool],
-            state_schema={"shared": {"type": str}},
+        confirmation_hook = ConfirmationHook(
             confirmation_strategies={
                 "consumer": BlockingConfirmationStrategy(
                     confirmation_policy=NeverAskPolicy(), confirmation_ui=SimpleConsoleUI()
                 )
-            },
+            }
+        )
+        agent = Agent(
+            chat_generator=MockChatGenerator(),
+            tools=[producer_tool, consumer_tool],
+            state_schema={"shared": {"type": str}},
+            hooks={"before_tool": [confirmation_hook]},
         )
         agent.warm_up()
         # Step 1: the model calls producer and consumer together (consumer relies on inputs_from_state for `value`).

--- a/test/components/agents/test_agent_hitl.py
+++ b/test/components/agents/test_agent_hitl.py
@@ -355,18 +355,22 @@ class TestMultipleConfirmationHooks:
 
         result = agent.run(messages=[ChatMessage.from_user("go")])
 
-        results_by_tool = {
-            m.tool_call_result.origin.tool_name: m.tool_call_result
-            for m in result["messages"]
-            if m.tool_call_result is not None
-        }
-        # foo was rejected: it produced an error tool result and never executed.
-        assert results_by_tool["foo"].error is True
-        assert "rejected" in results_by_tool["foo"].result.lower()
-        # bar and baz ran with their modified arguments.
-        assert results_by_tool["bar"].error is False
-        assert results_by_tool["bar"].result == '{"echoed": 99}'
-        assert results_by_tool["baz"].error is False
-        assert results_by_tool["baz"].result == '{"echoed": 77}'
+        # The full transcript, in order: foo is rejected (its call + an error tool result appear before the
+        # surviving batch), bar and baz are modified (each with an explanation message) and then executed.
+        assert result["messages"] == [
+            ChatMessage.from_user("go"),
+            ChatMessage.from_assistant(tool_calls=[ToolCall("foo", {"x": 1})]),
+            ChatMessage.from_tool(
+                tool_result="Tool execution for 'foo' was rejected by the user.",
+                origin=ToolCall("foo", {"x": 1}),
+                error=True,
+            ),
+            ChatMessage.from_user("The parameters for tool 'bar' were updated by the user to:\n{'x': 99}"),
+            ChatMessage.from_user("The parameters for tool 'baz' were updated by the user to:\n{'x': 77}"),
+            ChatMessage.from_assistant(tool_calls=[ToolCall("bar", {"x": 99}), ToolCall("baz", {"x": 77})]),
+            ChatMessage.from_tool(tool_result='{"echoed": 99}', origin=ToolCall("bar", {"x": 99}), error=False),
+            ChatMessage.from_tool(tool_result='{"echoed": 77}', origin=ToolCall("baz", {"x": 77}), error=False),
+            ChatMessage.from_assistant("done"),
+        ]
         # Only the two confirmed tools actually executed.
         assert result["tool_call_counts"] == {"foo": 0, "bar": 1, "baz": 1}

--- a/test/human_in_the_loop/test_hooks.py
+++ b/test/human_in_the_loop/test_hooks.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import pytest
+
+from haystack.components.agents.state.state import State
+from haystack.components.agents.state.state_utils import merge_lists, replace_values
+from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.human_in_the_loop import (
+    AlwaysAskPolicy,
+    BlockingConfirmationStrategy,
+    ConfirmationHook,
+    ConfirmationUIResult,
+    NeverAskPolicy,
+    SimpleConsoleUI,
+)
+from haystack.human_in_the_loop.types import ConfirmationUI
+from haystack.tools import Tool, create_tool_from_function
+
+
+class MockUserInterface(ConfirmationUI):
+    def __init__(self, ui_result: ConfirmationUIResult) -> None:
+        self.ui_result = ui_result
+
+    def get_user_confirmation(
+        self, tool_name: str, tool_description: str, tool_params: dict[str, Any]
+    ) -> ConfirmationUIResult:
+        return self.ui_result
+
+
+def addition_tool(a: int, b: int) -> int:
+    return a + b
+
+
+@pytest.fixture
+def tools() -> list[Tool]:
+    return [
+        create_tool_from_function(
+            function=addition_tool, name="addition_tool", description="A tool that adds two integers together."
+        )
+    ]
+
+
+def _state_with(messages: list[ChatMessage], tools: list[Tool]) -> State:
+    schema = {
+        "messages": {"type": list[ChatMessage], "handler": merge_lists},
+        "tools": {"type": list, "handler": replace_values},
+    }
+    state = State(schema=schema, data={})
+    state.set("messages", messages, handler_override=replace_values)
+    state.set("tools", tools, handler_override=replace_values)
+    return state
+
+
+def _confirm_hook(ui_result: ConfirmationUIResult) -> ConfirmationHook:
+    return ConfirmationHook(
+        confirmation_strategies={
+            "addition_tool": BlockingConfirmationStrategy(
+                confirmation_policy=AlwaysAskPolicy(), confirmation_ui=MockUserInterface(ui_result)
+            )
+        }
+    )
+
+
+class TestConfirmationHook:
+    def test_no_tool_calls_is_noop(self, tools):
+        messages = [ChatMessage.from_user("hello"), ChatMessage.from_assistant("hi")]
+        state = _state_with(messages, tools)
+        hook = _confirm_hook(ConfirmationUIResult(action="reject"))
+
+        hook.run(state)
+
+        assert state.get("messages") == messages
+
+    def test_confirm_keeps_tool_call(self, tools):
+        tool_call = ToolCall("addition_tool", {"a": 1, "b": 2})
+        messages = [ChatMessage.from_user("add"), ChatMessage.from_assistant(tool_calls=[tool_call])]
+        state = _state_with(messages, tools)
+        # NeverAskPolicy auto-confirms, so the tool call is left untouched for the executor.
+        hook = ConfirmationHook(
+            confirmation_strategies={
+                "addition_tool": BlockingConfirmationStrategy(
+                    confirmation_policy=NeverAskPolicy(), confirmation_ui=SimpleConsoleUI()
+                )
+            }
+        )
+
+        hook.run(state)
+
+        assert state.get("messages")[-1].tool_calls == [tool_call]
+
+    def test_modify_updates_arguments(self, tools):
+        messages = [
+            ChatMessage.from_user("add"),
+            ChatMessage.from_assistant(tool_calls=[ToolCall("addition_tool", {"a": 1, "b": 2})]),
+        ]
+        state = _state_with(messages, tools)
+        hook = _confirm_hook(ConfirmationUIResult(action="modify", new_tool_params={"a": 10, "b": 20}))
+
+        hook.run(state)
+
+        pending = state.get("messages")[-1].tool_calls
+        assert len(pending) == 1
+        assert pending[0].arguments == {"a": 10, "b": 20}
+
+    def test_reject_drops_tool_call_and_appends_result(self, tools):
+        messages = [
+            ChatMessage.from_user("add"),
+            ChatMessage.from_assistant(tool_calls=[ToolCall("addition_tool", {"a": 1, "b": 2})]),
+        ]
+        state = _state_with(messages, tools)
+        hook = _confirm_hook(ConfirmationUIResult(action="reject"))
+
+        hook.run(state)
+
+        new_messages = state.get("messages")
+        # A rejection produces a tool-result message and removes the pending call so the executor skips it.
+        assert new_messages[-1].tool_call_result is not None
+        assert "rejected" in new_messages[-1].tool_call_result.result.lower()
+
+    def test_to_dict(self):
+        hook = ConfirmationHook(
+            confirmation_strategies={
+                "addition_tool": BlockingConfirmationStrategy(
+                    confirmation_policy=NeverAskPolicy(), confirmation_ui=SimpleConsoleUI()
+                )
+            }
+        )
+        assert hook.to_dict() == {
+            "type": "haystack.human_in_the_loop.hooks.ConfirmationHook",
+            "init_parameters": {
+                "confirmation_strategies": {
+                    "addition_tool": {
+                        "type": "haystack.human_in_the_loop.strategies.BlockingConfirmationStrategy",
+                        "init_parameters": {
+                            "confirmation_policy": {
+                                "type": "haystack.human_in_the_loop.policies.NeverAskPolicy",
+                                "init_parameters": {},
+                            },
+                            "confirmation_ui": {
+                                "type": "haystack.human_in_the_loop.user_interfaces.SimpleConsoleUI",
+                                "init_parameters": {},
+                            },
+                            "reject_template": "Tool execution for '{tool_name}' was rejected by the user.",
+                            "modify_template": "The parameters for tool '{tool_name}' were updated by the user to:"
+                            "\n{final_tool_params}",
+                            "user_feedback_template": "With user feedback: {feedback}",
+                        },
+                    }
+                }
+            },
+        }
+
+    def test_from_dict_round_trip(self):
+        hook = ConfirmationHook(
+            confirmation_strategies={
+                "addition_tool": BlockingConfirmationStrategy(
+                    confirmation_policy=NeverAskPolicy(), confirmation_ui=SimpleConsoleUI()
+                )
+            }
+        )
+        deserialized = ConfirmationHook.from_dict(hook.to_dict())
+        assert deserialized.to_dict() == hook.to_dict()
+        strategy = deserialized.confirmation_strategies["addition_tool"]
+        assert isinstance(strategy, BlockingConfirmationStrategy)
+        assert isinstance(strategy.confirmation_policy, NeverAskPolicy)
+        assert isinstance(strategy.confirmation_ui, SimpleConsoleUI)
+
+    def test_tuple_key_round_trips(self):
+        hook = ConfirmationHook(
+            confirmation_strategies={
+                ("addition_tool", "other_tool"): BlockingConfirmationStrategy(
+                    confirmation_policy=NeverAskPolicy(), confirmation_ui=SimpleConsoleUI()
+                )
+            }
+        )
+        deserialized = ConfirmationHook.from_dict(hook.to_dict())
+        assert ("addition_tool", "other_tool") in deserialized.confirmation_strategies
+
+
+class TestConfirmationHookAsync:
+    @pytest.mark.asyncio
+    async def test_reject_drops_tool_call_and_appends_result(self, tools):
+        messages = [
+            ChatMessage.from_user("add"),
+            ChatMessage.from_assistant(tool_calls=[ToolCall("addition_tool", {"a": 1, "b": 2})]),
+        ]
+        state = _state_with(messages, tools)
+        hook = _confirm_hook(ConfirmationUIResult(action="reject"))
+
+        await hook.run_async(state)
+
+        new_messages = state.get("messages")
+        assert new_messages[-1].tool_call_result is not None
+        assert "rejected" in new_messages[-1].tool_call_result.result.lower()

--- a/test/human_in_the_loop/test_hooks.py
+++ b/test/human_in_the_loop/test_hooks.py
@@ -55,14 +55,14 @@ def _state_with(messages: list[ChatMessage], tools: list[Tool]) -> State:
     return state
 
 
-def _confirm_hook(ui_result: ConfirmationUIResult) -> ConfirmationHook:
-    return ConfirmationHook(
-        confirmation_strategies={
-            "addition_tool": BlockingConfirmationStrategy(
-                confirmation_policy=AlwaysAskPolicy(), confirmation_ui=MockUserInterface(ui_result)
-            )
-        }
+def _confirm_strat(ui_result: ConfirmationUIResult) -> BlockingConfirmationStrategy:
+    return BlockingConfirmationStrategy(
+        confirmation_policy=AlwaysAskPolicy(), confirmation_ui=MockUserInterface(ui_result)
     )
+
+
+def _confirm_hook(ui_result: ConfirmationUIResult, tool_name: str = "addition_tool") -> ConfirmationHook:
+    return ConfirmationHook(confirmation_strategies={tool_name: _confirm_strat(ui_result)})
 
 
 class TestConfirmationHook:
@@ -179,6 +179,52 @@ class TestConfirmationHook:
         )
         deserialized = ConfirmationHook.from_dict(hook.to_dict())
         assert ("addition_tool", "other_tool") in deserialized.confirmation_strategies
+
+
+class TestConfirmationHookWildcard:
+    def test_wildcard_applies_to_any_tool(self, tools):
+        # No entry for "addition_tool"; the "*" wildcard covers it.
+        messages = [
+            ChatMessage.from_user("add"),
+            ChatMessage.from_assistant(tool_calls=[ToolCall(id="tc-1", tool_name="addition_tool", arguments={})]),
+        ]
+        state = _state_with(messages, tools)
+        _confirm_hook(ConfirmationUIResult(action="reject"), tool_name="*").run(state)
+
+        new_messages = state.get("messages")
+        assert new_messages[-1].tool_call_result is not None
+        assert "rejected" in new_messages[-1].tool_call_result.result.lower()
+
+    def test_specific_key_beats_wildcard(self):
+        add_tool = create_tool_from_function(
+            function=addition_tool, name="addition_tool", description="Adds two integers."
+        )
+        other_tool = create_tool_from_function(function=addition_tool, name="other_tool", description="Another tool.")
+        messages = [
+            ChatMessage.from_user("go"),
+            ChatMessage.from_assistant(
+                tool_calls=[
+                    ToolCall(id="tc-add", tool_name="addition_tool", arguments={"a": 1, "b": 2}),
+                    ToolCall(id="tc-other", tool_name="other_tool", arguments={"a": 3, "b": 4}),
+                ]
+            ),
+        ]
+        state = _state_with(messages, [add_tool, other_tool])
+        # addition_tool has its own (confirm) entry; other_tool falls through to the "*" (reject) wildcard.
+        hook = ConfirmationHook(
+            confirmation_strategies={
+                "addition_tool": _confirm_strat(ConfirmationUIResult(action="confirm")),
+                "*": _confirm_strat(ConfirmationUIResult(action="reject")),
+            }
+        )
+        hook.run(state)
+
+        new_messages = state.get("messages")
+        # addition_tool is confirmed, so it stays pending on the last message; other_tool is rejected.
+        assert [tc.tool_name for tc in new_messages[-1].tool_calls] == ["addition_tool"]
+        rejected = [m for m in new_messages if m.tool_call_result is not None]
+        assert [m.tool_call_result.origin.tool_name for m in rejected] == ["other_tool"]
+        assert rejected[0].tool_call_result.error is True
 
 
 class TestConfirmationHookAsync:

--- a/test/human_in_the_loop/test_hooks.py
+++ b/test/human_in_the_loop/test_hooks.py
@@ -70,9 +70,7 @@ class TestConfirmationHook:
         messages = [ChatMessage.from_user("hello"), ChatMessage.from_assistant("hi")]
         state = _state_with(messages, tools)
         hook = _confirm_hook(ConfirmationUIResult(action="reject"))
-
         hook.run(state)
-
         assert state.get("messages") == messages
 
     def test_confirm_keeps_tool_call(self, tools):
@@ -87,9 +85,7 @@ class TestConfirmationHook:
                 )
             }
         )
-
         hook.run(state)
-
         assert state.get("messages")[-1].tool_calls == [tool_call]
 
     def test_modify_updates_arguments(self, tools):
@@ -99,12 +95,14 @@ class TestConfirmationHook:
         ]
         state = _state_with(messages, tools)
         hook = _confirm_hook(ConfirmationUIResult(action="modify", new_tool_params={"a": 10, "b": 20}))
-
         hook.run(state)
-
-        pending = state.get("messages")[-1].tool_calls
-        assert len(pending) == 1
-        assert pending[0].arguments == {"a": 10, "b": 20}
+        # The original call is dropped; an explanation user message precedes the rebuilt call with the new arguments.
+        explanation = "The parameters for tool 'addition_tool' were updated by the user to:\n{'a': 10, 'b': 20}"
+        assert state.get("messages") == [
+            ChatMessage.from_user("add"),
+            ChatMessage.from_user(explanation),
+            ChatMessage.from_assistant(tool_calls=[ToolCall("addition_tool", {"a": 10, "b": 20})]),
+        ]
 
     def test_reject_drops_tool_call_and_appends_result(self, tools):
         messages = [
@@ -113,13 +111,17 @@ class TestConfirmationHook:
         ]
         state = _state_with(messages, tools)
         hook = _confirm_hook(ConfirmationUIResult(action="reject"))
-
         hook.run(state)
-
-        new_messages = state.get("messages")
-        # A rejection produces a tool-result message and removes the pending call so the executor skips it.
-        assert new_messages[-1].tool_call_result is not None
-        assert "rejected" in new_messages[-1].tool_call_result.result.lower()
+        # The call is answered by an error tool result, so it is resolved and the executor skips it (no pending call).
+        assert state.get("messages") == [
+            ChatMessage.from_user("add"),
+            ChatMessage.from_assistant(tool_calls=[ToolCall("addition_tool", {"a": 1, "b": 2})]),
+            ChatMessage.from_tool(
+                tool_result="Tool execution for 'addition_tool' was rejected by the user.",
+                origin=ToolCall("addition_tool", {"a": 1, "b": 2}),
+                error=True,
+            ),
+        ]
 
     def test_to_dict(self):
         hook = ConfirmationHook(
@@ -236,12 +238,17 @@ class TestConfirmationHookAsync:
         ]
         state = _state_with(messages, tools)
         hook = _confirm_hook(ConfirmationUIResult(action="reject"))
-
         await hook.run_async(state)
-
-        new_messages = state.get("messages")
-        assert new_messages[-1].tool_call_result is not None
-        assert "rejected" in new_messages[-1].tool_call_result.result.lower()
+        # run_async produces the same transcript as run: the call answered by an error tool result, no pending call.
+        assert state.get("messages") == [
+            ChatMessage.from_user("add"),
+            ChatMessage.from_assistant(tool_calls=[ToolCall("addition_tool", {"a": 1, "b": 2})]),
+            ChatMessage.from_tool(
+                tool_result="Tool execution for 'addition_tool' was rejected by the user.",
+                origin=ToolCall("addition_tool", {"a": 1, "b": 2}),
+                error=True,
+            ),
+        ]
 
 
 def _echo(x: int) -> dict[str, int]:
@@ -259,12 +266,7 @@ def _echo_tool(name: str) -> Tool:
 
 def _multi_tool_hook(decisions: dict[str, ConfirmationUIResult]) -> ConfirmationHook:
     return ConfirmationHook(
-        confirmation_strategies={
-            name: BlockingConfirmationStrategy(
-                confirmation_policy=AlwaysAskPolicy(), confirmation_ui=MockUserInterface(ui_result)
-            )
-            for name, ui_result in decisions.items()
-        }
+        confirmation_strategies={name: _confirm_strat(ui_result) for name, ui_result in decisions.items()}
     )
 
 

--- a/test/human_in_the_loop/test_hooks.py
+++ b/test/human_in_the_loop/test_hooks.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import threading
 from typing import Any
 
 import pytest
@@ -16,6 +17,7 @@ from haystack.human_in_the_loop import (
     ConfirmationUIResult,
     NeverAskPolicy,
     SimpleConsoleUI,
+    ToolExecutionDecision,
 )
 from haystack.human_in_the_loop.types import ConfirmationUI
 from haystack.tools import Tool, create_tool_from_function
@@ -122,6 +124,31 @@ class TestConfirmationHook:
                 error=True,
             ),
         ]
+
+    def test_hook_context_is_not_deepcopied(self, tools):
+        # A non-copyable resource in hook_context (e.g. a lock, WebSocket, or client) must reach the strategy
+        # unchanged. Reading via state.get would deepcopy and raise; the hook reads via state.data instead.
+        lock = threading.Lock()
+        received = {}
+
+        class CapturingStrategy:
+            def run(
+                self, *, tool_name, tool_description, tool_params, tool_call_id=None, confirmation_strategy_context=None
+            ):
+                received["context"] = confirmation_strategy_context
+                return ToolExecutionDecision(
+                    tool_name=tool_name, tool_call_id=tool_call_id, execute=True, final_tool_params=tool_params
+                )
+
+        messages = [
+            ChatMessage.from_user("add"),
+            ChatMessage.from_assistant(tool_calls=[ToolCall("addition_tool", {"a": 1, "b": 2})]),
+        ]
+        state = _state_with(messages, tools)
+        state.data["hook_context"] = {"resource": lock}
+        ConfirmationHook(confirmation_strategies={"addition_tool": CapturingStrategy()}).run(state)  # type: ignore[dict-item]
+        # Passed through by identity: the non-copyable resource is neither copied nor does the read raise.
+        assert received["context"]["resource"] is lock
 
     def test_to_dict(self):
         hook = ConfirmationHook(

--- a/test/human_in_the_loop/test_hooks.py
+++ b/test/human_in_the_loop/test_hooks.py
@@ -196,3 +196,88 @@ class TestConfirmationHookAsync:
         new_messages = state.get("messages")
         assert new_messages[-1].tool_call_result is not None
         assert "rejected" in new_messages[-1].tool_call_result.result.lower()
+
+
+def _echo(x: int) -> dict[str, int]:
+    return {"echoed": x}
+
+
+def _echo_tool(name: str) -> Tool:
+    return Tool(
+        name=name,
+        description=f"Echo tool {name}.",
+        parameters={"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]},
+        function=_echo,
+    )
+
+
+def _multi_tool_hook(decisions: dict[str, ConfirmationUIResult]) -> ConfirmationHook:
+    return ConfirmationHook(
+        confirmation_strategies={
+            name: BlockingConfirmationStrategy(
+                confirmation_policy=AlwaysAskPolicy(), confirmation_ui=MockUserInterface(ui_result)
+            )
+            for name, ui_result in decisions.items()
+        }
+    )
+
+
+def _assert_pending_calls_only_in_last_message(messages: list[ChatMessage]) -> None:
+    """
+    Assert the invariant the Agent loop relies on: after confirmation, every tool call that is still pending (an
+    assistant tool call with no matching tool result later in the history) lives in the last message. The loop reads
+    the calls to execute from the last message alone, so any leftover pending call elsewhere would silently never run.
+    """
+    resolved_ids = {m.tool_call_result.origin.id for m in messages if m.tool_call_result is not None}
+    for index, message in enumerate(messages):
+        pending = [tc for tc in (message.tool_calls or []) if tc.id not in resolved_ids]
+        if pending:
+            assert index == len(messages) - 1, f"pending calls in non-last message at index {index}: {pending}"
+
+
+class TestConfirmationHookPendingInvariant:
+    """The pending tool calls left after the hook runs must always sit in the last message of the chat history."""
+
+    def _run(self, decisions: dict[str, ConfirmationUIResult]) -> list[ChatMessage]:
+        names = list(decisions)
+        tools = [_echo_tool(name) for name in names]
+        tool_calls = [ToolCall(id=f"tc-{name}", tool_name=name, arguments={"x": i}) for i, name in enumerate(names)]
+        messages = [ChatMessage.from_user("go"), ChatMessage.from_assistant(tool_calls=tool_calls)]
+        state = _state_with(messages, tools)
+        _multi_tool_hook(decisions).run(state)
+        return state.get("messages")
+
+    def test_all_confirmed(self):
+        messages = self._run(
+            {"foo": ConfirmationUIResult(action="confirm"), "bar": ConfirmationUIResult(action="confirm")}
+        )
+        _assert_pending_calls_only_in_last_message(messages)
+        # Both calls survive, untouched, on the (single) last assistant message.
+        assert {tc.tool_name for tc in messages[-1].tool_calls} == {"foo", "bar"}
+
+    def test_all_rejected(self):
+        messages = self._run(
+            {"foo": ConfirmationUIResult(action="reject"), "bar": ConfirmationUIResult(action="reject")}
+        )
+        _assert_pending_calls_only_in_last_message(messages)
+        # Nothing left to run: the last message is a tool result, not a pending tool call.
+        assert not messages[-1].tool_calls
+
+    def test_mixed_reject_and_confirm(self):
+        messages = self._run(
+            {"foo": ConfirmationUIResult(action="reject"), "bar": ConfirmationUIResult(action="confirm")}
+        )
+        _assert_pending_calls_only_in_last_message(messages)
+        # The rejected call is resolved earlier; only the confirmed survivor remains pending, on the last message.
+        assert [tc.tool_name for tc in messages[-1].tool_calls] == ["bar"]
+
+    def test_mixed_reject_and_modify(self):
+        messages = self._run(
+            {
+                "foo": ConfirmationUIResult(action="reject"),
+                "bar": ConfirmationUIResult(action="modify", new_tool_params={"x": 99}),
+            }
+        )
+        _assert_pending_calls_only_in_last_message(messages)
+        assert [tc.tool_name for tc in messages[-1].tool_calls] == ["bar"]
+        assert messages[-1].tool_calls[0].arguments == {"x": 99}

--- a/test/human_in_the_loop/test_strategies.py
+++ b/test/human_in_the_loop/test_strategies.py
@@ -234,7 +234,7 @@ class TestUnknownToolEndToEnd:
         assistant_message = ChatMessage.from_assistant(tool_calls=[tool_call])
         state.set("messages", [ChatMessage.from_user("do something"), assistant_message])
 
-        modified_messages, _ = _process_confirmation_strategies(
+        new_chat_history = _process_confirmation_strategies(
             confirmation_strategies={
                 tools[0].name: BlockingConfirmationStrategy(
                     confirmation_policy=AlwaysAskPolicy(), confirmation_ui=SimpleConsoleUI()
@@ -245,16 +245,18 @@ class TestUnknownToolEndToEnd:
             state=state,
         )
 
-        # The hallucinated call survives the confirmation layer unchanged (it is not dropped).
-        surviving_calls = [tc for message in modified_messages for tc in (message.tool_calls or [])]
+        # The hallucinated call survives the confirmation layer unchanged (it is not dropped), as the pending call
+        # on the last message of the returned history.
+        pending_messages = [new_chat_history[-1]]
+        surviving_calls = [tc for message in pending_messages for tc in (message.tool_calls or [])]
         assert surviving_calls == [tool_call]
 
         # raise_on_failure=True: the tool-calling code raises ToolNotFoundException.
         with pytest.raises(ToolNotFoundException):
-            _run_tool(messages=modified_messages, state=state, tools=tools)
+            _run_tool(messages=pending_messages, state=state, tools=tools)
 
         # raise_on_failure=False: it returns an error tool message instead of crashing.
-        tool_messages, _ = _run_tool(messages=modified_messages, state=state, tools=tools, raise_on_failure=False)
+        tool_messages, _ = _run_tool(messages=pending_messages, state=state, tools=tools, raise_on_failure=False)
         assert tool_messages[0].tool_call_results[0].error
         assert "not found" in tool_messages[0].tool_call_results[0].result
 

--- a/test/human_in_the_loop/test_strategies.py
+++ b/test/human_in_the_loop/test_strategies.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import pytest
 
-from haystack.components.agents.agent import _ExecutionContext
 from haystack.components.agents.state.state import State
 from haystack.components.agents.tool_calling import ToolNotFoundException, _run_tool
 from haystack.dataclasses import ChatMessage, ToolCall
@@ -49,17 +48,6 @@ def tools() -> list[Tool]:
     )
 
     return [add_tool, mult_tool]
-
-
-@pytest.fixture
-def execution_context(tools: list[Tool]) -> _ExecutionContext:
-    return _ExecutionContext(
-        state=State(schema={"messages": {"type": list[ChatMessage]}}),
-        tools=tools,
-        chat_generator_inputs={},
-        tool_execution_inputs={},
-        counter=0,
-    )
 
 
 class TestBlockingConfirmationStrategy:
@@ -164,20 +152,19 @@ class TestBlockingConfirmationStrategy:
 
 
 class TestRunConfirmationStrategies:
-    def test_run_confirmation_strategies_no_strategy(self, tools, execution_context):
+    def test_run_confirmation_strategies_no_strategy(self, tools):
         teds = _run_confirmation_strategies(
             confirmation_strategies={},
             messages_with_tool_calls=[
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"param1": "value1"})])
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert teds == [
             ToolExecutionDecision(tool_name=tools[0].name, execute=True, final_tool_params={"param1": "value1"})
         ]
 
-    def test_run_confirmation_strategies_with_strategy(self, tools, execution_context):
+    def test_run_confirmation_strategies_with_strategy(self, tools):
         teds = _run_confirmation_strategies(
             confirmation_strategies={
                 tools[0].name: BlockingConfirmationStrategy(
@@ -188,13 +175,12 @@ class TestRunConfirmationStrategies:
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"param1": "value1"})])
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert teds == [
             ToolExecutionDecision(tool_name=tools[0].name, execute=True, final_tool_params={"param1": "value1"})
         ]
 
-    def test_run_confirmation_strategies_with_multi_tool_tuple_key(self, tools, execution_context):
+    def test_run_confirmation_strategies_with_multi_tool_tuple_key(self, tools):
         add_tool, mult_tool = tools[0], tools[1]
 
         strategy = BlockingConfirmationStrategy(confirmation_policy=NeverAskPolicy(), confirmation_ui=SimpleConsoleUI())
@@ -207,7 +193,6 @@ class TestRunConfirmationStrategies:
                 )
             ],
             tools=tools,
-            state=execution_context.state,
         )
 
         assert len(teds) == 2
@@ -216,7 +201,7 @@ class TestRunConfirmationStrategies:
         assert teds[1].tool_name == mult_tool.name
         assert teds[1].execute is True
 
-    def test_run_confirmation_strategies_unknown_tool_passes_through(self, tools, execution_context):
+    def test_run_confirmation_strategies_unknown_tool_passes_through(self, tools):
         # The model hallucinated a tool name that isn't in the available tools. Confirmation is skipped and the
         # call passes through unchanged so the tool-calling code can report it (ToolNotFoundException).
         teds = _run_confirmation_strategies(
@@ -231,7 +216,6 @@ class TestRunConfirmationStrategies:
                 )
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert teds == [
             ToolExecutionDecision(
@@ -542,15 +526,6 @@ class ConfirmationStrategyContextCapturingStrategy:
 class TestRunContext:
     def test_confirmation_strategy_context_passed_to_strategy(self, tools):
         confirmation_strategy_context = {"event_queue": "mock_queue", "redis_client": "mock_redis"}
-        execution_context = _ExecutionContext(
-            state=State(schema={"messages": {"type": list[ChatMessage]}}),
-            tools=tools,
-            chat_generator_inputs={},
-            tool_execution_inputs={},
-            counter=0,
-            confirmation_strategy_context=confirmation_strategy_context,
-        )
-
         capturing_strategy = ConfirmationStrategyContextCapturingStrategy()
         teds = _run_confirmation_strategies(
             confirmation_strategies={tools[0].name: capturing_strategy},
@@ -558,7 +533,6 @@ class TestRunContext:
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"a": 1, "b": 2})])
             ],
             tools=tools,
-            state=execution_context.state,
             confirmation_strategy_context=confirmation_strategy_context,
         )
 
@@ -571,15 +545,6 @@ class TestRunContext:
     @pytest.mark.asyncio
     async def test_confirmation_strategy_context_passed_to_strategy_async(self, tools):
         confirmation_strategy_context = {"websocket": "mock_websocket", "request_id": "12345"}
-        execution_context = _ExecutionContext(
-            state=State(schema={"messages": {"type": list[ChatMessage]}}),
-            tools=tools,
-            chat_generator_inputs={},
-            tool_execution_inputs={},
-            counter=0,
-            confirmation_strategy_context=confirmation_strategy_context,
-        )
-
         capturing_strategy = ConfirmationStrategyContextCapturingStrategy()
         teds = await _run_confirmation_strategies_async(
             confirmation_strategies={tools[0].name: capturing_strategy},
@@ -587,7 +552,6 @@ class TestRunContext:
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"a": 1, "b": 2})])
             ],
             tools=tools,
-            state=execution_context.state,
             confirmation_strategy_context=confirmation_strategy_context,
         )
 
@@ -688,7 +652,7 @@ class TestAsyncConfirmationStrategies:
         assert decision.feedback is not None and "rejected asynchronously" in decision.feedback
 
     @pytest.mark.asyncio
-    async def test_async_strategy_used_by_run_confirmation_strategies_async(self, tools, execution_context):
+    async def test_async_strategy_used_by_run_confirmation_strategies_async(self, tools):
         strategy = TrueAsyncConfirmationStrategy(delay=0.01, decision="confirm")
 
         teds = await _run_confirmation_strategies_async(
@@ -697,7 +661,6 @@ class TestAsyncConfirmationStrategies:
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"a": 1, "b": 2})])
             ],
             tools=tools,
-            state=execution_context.state,
         )
 
         # Verify that only the async method was called
@@ -726,14 +689,13 @@ class TestAsyncConfirmationStrategies:
         assert decision.final_tool_params == {"param1": "value1"}
 
     @pytest.mark.asyncio
-    async def test_run_confirmation_strategies_async_no_strategy(self, tools, execution_context):
+    async def test_run_confirmation_strategies_async_no_strategy(self, tools):
         teds = await _run_confirmation_strategies_async(
             confirmation_strategies={},
             messages_with_tool_calls=[
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"a": 1, "b": 2})])
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert len(teds) == 1
         assert teds[0].tool_name == tools[0].name
@@ -741,7 +703,7 @@ class TestAsyncConfirmationStrategies:
         assert teds[0].final_tool_params == {"a": 1, "b": 2}
 
     @pytest.mark.asyncio
-    async def test_run_confirmation_strategies_async_with_strategy(self, tools, execution_context):
+    async def test_run_confirmation_strategies_async_with_strategy(self, tools):
         teds = await _run_confirmation_strategies_async(
             confirmation_strategies={
                 tools[0].name: BlockingConfirmationStrategy(
@@ -752,14 +714,13 @@ class TestAsyncConfirmationStrategies:
                 ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"a": 1, "b": 2})])
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert len(teds) == 1
         assert teds[0].tool_name == tools[0].name
         assert teds[0].execute is True
 
     @pytest.mark.asyncio
-    async def test_run_confirmation_strategies_async_unknown_tool_passes_through(self, tools, execution_context):
+    async def test_run_confirmation_strategies_async_unknown_tool_passes_through(self, tools):
         # The model hallucinated a tool name that isn't in the available tools. Confirmation is skipped and the
         # call passes through unchanged so the tool-calling code can report it (ToolNotFoundException).
         teds = await _run_confirmation_strategies_async(
@@ -774,7 +735,6 @@ class TestAsyncConfirmationStrategies:
                 )
             ],
             tools=tools,
-            state=execution_context.state,
         )
         assert teds == [
             ToolExecutionDecision(


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/445

The goal of this is to reduce the need for dedicated parameters on the Agent's init method by utilizing the new Hooks feature as the preferred method for modifying the behavior of the Agent's loop.

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Added ``ConfirmationHook``, a ``before_tool`` Agent hook that applies Human-in-the-Loop confirmation strategies to pending tool calls. It confirms, modifies, or rejects the tool calls the model requested before they run by rewriting the conversation in the Agent's ``State``. Its ``confirmation_strategies`` mapping accepts a single tool name, a tuple of tool names, or the wildcard ``"*"`` that applies to any tool without a more specific entry, so you can set a default strategy for all tools and override individual ones.

**Breaking Changes:**
Human-in-the-Loop tool confirmation on ``Agent`` is now expressed as a ``before_tool`` hook instead of a dedicated concept. The ``confirmation_strategies`` and ``confirmation_strategy_context`` parameters have been
removed from ``Agent.__init__``, ``Agent.run``, and ``Agent.run_async``. To migrate, wrap your confirmation
strategies in the new ``ConfirmationHook``, register it under the ``before_tool`` hook point, and pass any request-scoped resources through the generic ``hook_context`` run argument instead of ``confirmation_strategy_context``:

```python
from haystack.components.agents import Agent
from haystack.human_in_the_loop import (
    AlwaysAskPolicy,
    BlockingConfirmationStrategy,
    ConfirmationHook,
    RichConsoleUI,
)

confirmation_hook = ConfirmationHook(
    confirmation_strategies={
        "my_tool": BlockingConfirmationStrategy(
            confirmation_policy=AlwaysAskPolicy(), confirmation_ui=RichConsoleUI()
        )
    }
)
agent = Agent(chat_generator=..., tools=[...], hooks={"before_tool": [confirmation_hook]})
agent.run(messages=[...], hook_context={"websocket": ws})
```

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added new tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

I did think about seeing if there was a way to reduce abstractions and verbosity such as replacing `ConfirmationStrategy` with a `ConfirmationHook` protocol, but I ruled this out since it did come with cons. 

  1. A `BlockingConfirmationHook` would only be able to hold one policy+UI  so if you wanted to set "always ask" for `delete_file` and "sometimes ask" for the remaining tools then you would need to set multiple hooks which increases verbosity. The current `{tool: strategy}` map (with tuple keys and `"*"` wildcard) handles per-tool differentiation, including mixing a blocking strategy for one tool and a custom non-blocking one for another, in a single hook.
  2. It downgrades the extension contract. Today a custom integration (e.g. the redis/openwebui non-blocking strategy) implements a small surface — `run(tool_name, description, params, ...) ->
  ToolExecutionDecision` — and Haystack handles the fiddly message surgery (rejection/modify message rewriting + history reconstruction). Making the hook the new protocol would force those authors to implement the full `run(state) -> None` making them redo that surgery themselves.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
