### PR TITLE
fix: validate Agent messages input type with actionable error

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -520,6 +520,12 @@ class Agent:
         system_prompt = system_prompt or self.system_prompt
         messages = messages or []
 
+        if not isinstance(messages, list):
+            raise TypeError(
+                f"Agent component expects list[ChatMessage] for 'messages', got {type(messages).__name__}. "
+                "Check that the 'messages' input is correctly wired in the pipeline."
+            )
+
         if user_prompt is not None:
             if self._user_chat_prompt_builder is None:
                 raise ValueError(

--- a/releasenotes/notes/agent-messages-type-validation-de6a494e1512c23d.yaml
+++ b/releasenotes/notes/agent-messages-type-validation-de6a494e1512c23d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Agent component now raises a clear TypeError when the `messages` input is not a list
+    (e.g. a string wired from an upstream component), instead of failing with the opaque
+    "can only concatenate list (not 'str') to list" error.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -968,6 +968,12 @@ class TestAgent:
         result = agent.run([])
         assert result["messages"] == []
 
+    def test_run_messages_string_raises_type_error(self):
+        chat_generator = MockChatGeneratorWithoutRunAsync()
+        agent = Agent(chat_generator=chat_generator, tools=[], system_prompt="You are helpful.")
+        with pytest.raises(TypeError, match="Agent component expects list\\[ChatMessage\\] for 'messages', got str"):
+            agent.run("this is a string not a list")
+
     def test_run_only_system_prompt(self, caplog):
         chat_generator = MockChatGeneratorWithoutRunAsync()
         agent = Agent(chat_generator=chat_generator, tools=[], system_prompt="This is a system prompt.")


### PR DESCRIPTION
## Summary
- `Agent._initialize_fresh_execution` now raises `TypeError` with a clear, actionable message when `messages` is not a list
- Previously, passing a string (e.g. from a misrouted pipeline connection) produced the opaque `can only concatenate list (not "str") to list` error deep in the method
- Added unit test covering the `str` input case

## Test plan
- [ ] `hatch run test:unit test/components/agents/test_agent.py -k "test_run_messages_string_raises_type_error"` passes

Fixes [PIP-491](https://linear.app/deepset/issue/PIP-491)

🤖 Generated with [Claude Code](https://claude.com/claude-code)