### PR TITLE
feat: add asynchronous support to LLMRanker with run_async method

### DIFF
--- a/haystack/components/rankers/llm_ranker.py
+++ b/haystack/components/rankers/llm_ranker.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-
+import asyncio
 from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict, logging
@@ -248,6 +248,78 @@ class LLMRanker:
 
         try:
             result = self._chat_generator.run(messages=[ChatMessage.from_user(prompt["prompt"])])
+        except Exception as exc:
+            if self.raise_on_failure:
+                raise
+            logger.warning(
+                "LLMRanker failed during chat generation. Returning fallback order. Error: {error}", error=exc
+            )
+            return {"documents": fallback_documents}
+
+        try:
+            reply_text = self._get_reply_text(result)
+            ranked_documents = self._rank_documents_from_reply(reply_text=reply_text, documents=deduplicated_documents)
+        except (TypeError, ValueError) as exc:
+            if self.raise_on_failure:
+                raise
+            logger.warning(
+                "LLMRanker failed while processing the chat response. Returning fallback order. Error: {error}",
+                error=exc,
+            )
+            return {"documents": fallback_documents}
+
+        return {"documents": ranked_documents[:top_k]}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self, query: str, documents: list[Document], top_k: int | None = None
+    ) -> dict[str, list[Document]]:
+        """
+        Rank documents Asynchronously for a query using an LLM.
+
+        Before ranking, duplicate documents are removed.
+
+        :param query:
+            The query used for reranking.
+        :param documents:
+            Candidate documents to rerank.
+        :param top_k:
+            The maximum number of documents to return. Overrides the instance's `top_k` if provided.
+        :returns:
+            A dictionary with the ranked documents under the `documents` key.
+        """
+        if top_k is not None and top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {top_k}")
+
+        if not documents:
+            return {"documents": []}
+
+        top_k = self.top_k if top_k is None else top_k
+        deduplicated_documents = _deduplicate_documents(documents)
+        fallback_documents = deduplicated_documents
+
+        if not query.strip():
+            logger.warning("Empty query provided to LLMRanker. Returning documents without reranking.")
+            return {"documents": fallback_documents}
+
+        if not self._is_warmed_up:
+            self.warm_up()
+
+        prompt = self._prompt_builder.run(query=query.strip(), documents=deduplicated_documents)
+
+        messages = [ChatMessage.from_user(prompt["prompt"])]
+        generator_has_async = hasattr(self._chat_generator, "run_async")
+        try:
+            if generator_has_async:
+                result = await self._chat_generator.run_async(messages=messages)
+            else:
+                logger.debug(
+                    "{generator_type} does not implement 'run_async'."
+                    " Running the synchronous 'run' method in a thread to avoid blocking the event loop.",
+                    generator_type=type(self._chat_generator).__name__,
+                )
+
+                result = await asyncio.to_thread(self._chat_generator.run, messages=messages)
         except Exception as exc:
             if self.raise_on_failure:
                 raise

--- a/releasenotes/notes/llm-ranker-run-async-9207e3a7f0a86c2d.yaml
+++ b/releasenotes/notes/llm-ranker-run-async-9207e3a7f0a86c2d.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added native asynchronous support (``run_async``) to ``LLMRanker``. This allows reranking
+    to run concurrently inside async applications like FastMCP or FastAPI without blocking the
+    main event loop, while automatically falling back to a thread worker for chat generators
+    that don't implement ``run_async``

--- a/test/components/rankers/test_llm_ranker.py
+++ b/test/components/rankers/test_llm_ranker.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from jinja2 import TemplateSyntaxError
@@ -311,6 +311,278 @@ def test_init_prompt_rejects_additional_variables(mock_chat_generator):
         )
 
 
+@pytest.mark.asyncio
+async def test_run_async_invalid_runtime_top_k(mock_chat_generator):
+    ranker = LLMRanker(chat_generator=mock_chat_generator)
+
+    with pytest.raises(ValueError, match="top_k must be > 0"):
+        await ranker.run_async(query="test", documents=[Document(content="doc")], top_k=0)
+
+
+@pytest.mark.asyncio
+async def test_run_async_empty_documents(mock_chat_generator):
+    ranker = LLMRanker(chat_generator=mock_chat_generator)
+    result = await ranker.run_async(query="test", documents=[])
+
+    assert result == {"documents": []}
+
+
+@pytest.mark.asyncio
+async def test_run_async_whitespace_query_returns_fallback(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=1)
+
+    result = await ranker.run_async(query="   ", documents=documents)
+
+    assert result == {"documents": documents}
+    mock_chat_generator.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_async_successful_ranking(mock_chat_generator):
+    documents = [
+        Document(id="1", content="first"),
+        Document(id="2", content="second"),
+        Document(id="3", content="third"),
+    ]
+    mock_chat_generator.run_async = AsyncMock(
+        return_value={
+            "replies": [ChatMessage.from_assistant('{"documents": [{"index": 2}, {"index": 1}, {"index": 3}]}')]
+        }
+    )
+    ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=2)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert [document.id for document in result["documents"]] == ["2", "1"]
+
+
+@pytest.mark.asyncio
+async def test_run_async_returns_only_documents_listed_by_the_llm(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    mock_chat_generator.run_async = AsyncMock(
+        return_value={"replies": [ChatMessage.from_assistant('{"documents": [{"index": 2}]}')]}
+    )
+    ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=2)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert [document.id for document in result["documents"]] == ["2"]
+
+
+@pytest.mark.asyncio
+async def test_run_async_runtime_top_k_overrides_instance_top_k(mock_chat_generator):
+    documents = [
+        Document(id="doc_1", content="first"),
+        Document(id="doc_2", content="second"),
+        Document(id="doc_3", content="third"),
+    ]
+    mock_chat_generator.run_async = AsyncMock(
+        return_value={
+            "replies": [ChatMessage.from_assistant('{"documents": [{"index": 3}, {"index": 2}, {"index": 1}]}')]
+        }
+    )
+    ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=3)
+
+    result = await ranker.run_async(query="test query", documents=documents, top_k=1)
+
+    assert [document.id for document in result["documents"]] == ["doc_3"]
+
+
+@pytest.mark.asyncio
+async def test_run_async_ignores_out_of_range_indices(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    mock_chat_generator.run_async = AsyncMock(
+        return_value={
+            "replies": [ChatMessage.from_assistant('{"documents": [{"index": 99}, {"index": 2}, {"index": 1}]}')]
+        }
+    )
+    ranker = LLMRanker(chat_generator=mock_chat_generator)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert [document.id for document in result["documents"]] == ["2", "1"]
+
+
+@pytest.mark.asyncio
+async def test_run_async_empty_ranking_result_returns_empty_documents(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    mock_chat_generator.run_async = AsyncMock(
+        return_value={"replies": [ChatMessage.from_assistant('{"documents": []}')]}
+    )
+    ranker = LLMRanker(chat_generator=mock_chat_generator)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert result == {"documents": []}
+
+
+@pytest.mark.asyncio
+async def test_run_async_invalid_json_falls_back(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    mock_chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("not-json")]})
+    ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=1, raise_on_failure=False)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert result == {"documents": documents}
+
+
+@pytest.mark.asyncio
+async def test_run_async_invalid_json_raises(mock_chat_generator):
+    documents = [Document(id="1", content="first")]
+    mock_chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("not-json")]})
+    ranker = LLMRanker(chat_generator=mock_chat_generator, raise_on_failure=True)
+
+    with pytest.raises(ValueError):
+        await ranker.run_async(query="test query", documents=documents)
+
+
+@pytest.mark.asyncio
+async def test_run_async_generator_exception_falls_back(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    mock_chat_generator.run_async = AsyncMock(side_effect=RuntimeError("generator failed"))
+    ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=1)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert result == {"documents": documents}
+
+
+@pytest.mark.asyncio
+async def test_run_async_generator_exception_raises(mock_chat_generator):
+    documents = [Document(id="1", content="first")]
+    mock_chat_generator.run_async = AsyncMock(side_effect=RuntimeError("generator failed"))
+    ranker = LLMRanker(chat_generator=mock_chat_generator, raise_on_failure=True)
+
+    with pytest.raises(RuntimeError, match="generator failed"):
+        await ranker.run_async(query="test query", documents=documents)
+
+
+@pytest.mark.asyncio
+async def test_run_async_no_replies_falls_back(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    mock_chat_generator.run_async = AsyncMock(return_value={"replies": []})
+    ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=1)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert result == {"documents": documents}
+
+
+@pytest.mark.asyncio
+async def test_run_async_reply_without_text_falls_back(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    mock_chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant(tool_calls=[])]})
+    ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=1)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert result == {"documents": documents}
+
+
+@pytest.mark.asyncio
+async def test_run_async_no_valid_document_indices_falls_back(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    mock_chat_generator.run_async = AsyncMock(
+        return_value={"replies": [ChatMessage.from_assistant('{"documents": [{"index": 0}, {"index": 3}]}')]}
+    )
+    ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=1)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert result == {"documents": documents}
+
+
+@pytest.mark.asyncio
+async def test_run_async_deduplicates_documents_before_ranking(mock_chat_generator):
+    documents = [
+        Document(id="duplicate", content="keep me", score=0.9),
+        Document(id="duplicate", content="drop me", score=0.1),
+        Document(id="unique", content="unique", score=0.2),
+    ]
+    mock_chat_generator.run_async = AsyncMock(
+        return_value={"replies": [ChatMessage.from_assistant('{"documents": [{"index": 2}, {"index": 1}]}')]}
+    )
+    ranker = LLMRanker(chat_generator=mock_chat_generator)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert [document.content for document in result["documents"]] == ["unique", "keep me"]
+
+
+@pytest.mark.asyncio
+async def test_run_async_preserves_duplicate_indices(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    mock_chat_generator.run_async = AsyncMock(
+        return_value={
+            "replies": [ChatMessage.from_assistant('{"documents": [{"index": 2}, {"index": 2}, {"index": 1}]}')]
+        }
+    )
+    ranker = LLMRanker(chat_generator=mock_chat_generator)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert [document.id for document in result["documents"]] == ["2", "2", "1"]
+
+
+@pytest.mark.asyncio
+async def test_run_async_numeric_string_index_is_accepted(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    mock_chat_generator.run_async = AsyncMock(
+        return_value={"replies": [ChatMessage.from_assistant('{"documents": [{"index": "2"}]}')]}
+    )
+    ranker = LLMRanker(chat_generator=mock_chat_generator)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert result == {"documents": [documents[1]]}
+
+
+@pytest.mark.asyncio
+async def test_run_async_invalid_index_type_falls_back(mock_chat_generator):
+    documents = [Document(id="1", content="first"), Document(id="2", content="second")]
+    mock_chat_generator.run_async = AsyncMock(
+        return_value={"replies": [ChatMessage.from_assistant('{"documents": [{"index": "invalid"}]}')]}
+    )
+    ranker = LLMRanker(chat_generator=mock_chat_generator)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert result == {"documents": documents}
+
+
+@pytest.mark.asyncio
+async def test_run_async_uses_generator_run_async_when_available(mock_chat_generator):
+    documents = [Document(id="1", content="first")]
+    mock_chat_generator.run_async = AsyncMock(
+        return_value={"replies": [ChatMessage.from_assistant('{"documents": [{"index": 1}]}')]}
+    )
+    ranker = LLMRanker(chat_generator=mock_chat_generator)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert [document.id for document in result["documents"]] == ["1"]
+    mock_chat_generator.run_async.assert_called_once()
+    mock_chat_generator.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_async_falls_back_to_thread_when_no_run_async(mock_chat_generator):
+    documents = [Document(id="1", content="first")]
+
+    class SyncOnlyGenerator:
+        def run(self, messages):
+            return {"replies": [ChatMessage.from_assistant('{"documents": [{"index": 1}]}')]}
+
+    sync_only_generator = SyncOnlyGenerator()
+    ranker = LLMRanker(chat_generator=sync_only_generator)
+
+    result = await ranker.run_async(query="test query", documents=documents)
+
+    assert [document.id for document in result["documents"]] == ["1"]
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY", None),
@@ -345,5 +617,45 @@ def test_live_run_ranks_rust_for_programming_language_query():
     ranker = LLMRanker(top_k=1)
 
     result = ranker.run(query="Which document is about a programming language?", documents=documents)
+
+    assert [document.id for document in result["documents"]] == ["doc-rust"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY", None),
+    reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+)
+async def test_live_run_async_ranks_berlin_first_for_germany_query():
+    documents = [
+        Document(id="doc-berlin", content="Berlin is the capital of Germany."),
+        Document(id="doc-paris", content="Paris is the capital of France."),
+        Document(id="doc-rust", content="Rust is a systems programming language focused on safety."),
+    ]
+    ranker = LLMRanker(top_k=2)
+
+    result = await ranker.run_async(query="What is the capital of Germany?", documents=documents)
+
+    assert result["documents"]
+    assert result["documents"][0].id == "doc-berlin"
+    assert len(result["documents"]) <= 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY", None),
+    reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+)
+async def test_live_run_async_ranks_rust_for_programming_language_query():
+    documents = [
+        Document(id="doc-berlin", content="Berlin is the capital of Germany."),
+        Document(id="doc-paris", content="Paris is the capital of France."),
+        Document(id="doc-rust", content="Rust is a systems programming language focused on safety."),
+    ]
+    ranker = LLMRanker(top_k=1)
+
+    result = await ranker.run_async(query="Which document is about a programming language?", documents=documents)
 
     assert [document.id for document in result["documents"]] == ["doc-rust"]


### PR DESCRIPTION
### Related Issues

- fixes feat: Add asynchronous support (run_async) to LLMRanker #11840 

### Proposed Changes:

Added native asynchronous support (`run_async`) to `LLMRanker`. This allows reranking pipelines to run concurrently inside asynchronous environments (like FastMCP or FastAPI) without stalling the main event loop during LLM network requests.

How it works:

- **Runtime check for async support:** Verifies whether the assigned chat generator natively supports async execution via `hasattr(self._chat_generator, "run_async")`. If it only supports synchronous execution, it automatically drops down to a safe thread-pool fallback via `asyncio.to_thread` instead of blocking the event loop.
- **Identical logic to `run`:** Deduplication, empty-query/empty-document guards, and the ranking/parsing post-processing (`_get_reply_text`, `_rank_documents_from_reply`) are unchanged and shared between the sync and async paths - only the chat generation call itself differs.
- **Monitored failure tracking:** Strictly matches the existing sync error-handling configuration (`raise_on_failure`), falling back to the original document order when ranking or generation fails and the flag is `False`, or re-raising when it's `True`.

### How did you test it?

Added a complete async test suite (`test_run_async_*`) mirroring the existing sync test coverage in `test_llm_ranker.py`. The tests cover:

- **run_async version for existing run sync tests:** Implemented the corresponding test_run_async versions for test_run ones.
- **Dual-path execution:** Confirming `run_async` is used when the chat generator supports it, and that it is *not* used (with `asyncio.to_thread` calling sync `run` instead) when the generator lacks `run_async`.
- **Live integration tests:** Added async equivalents of the existing live integration tests against the real OpenAI API, confirming end-to-end ranking behavior.

Ran `hatch run test:unit test/components/rankers/test_llm_ranker.py` with a 100% clean pass, `hatch run ruff format` / `hatch run ruff check --fix`.

### Notes for the reviewer

The implementation structure mirrors the synchronous `run` method identically to keep the component maintenance straightforward.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `feat: add run_async support to LLMRanker`
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.