### PR TITLE
feat: add `after_tool` hook needed for tool result offloading

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -23,7 +23,7 @@ from haystack.components.generators.chat.types import ChatGenerator
 from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
 from haystack.dataclasses import ChatMessage, ChatRole, StreamingCallbackT, select_streaming_callback
 from haystack.hooks.invocation import _run_hooks, _run_hooks_async
-from haystack.hooks.protocol import BEFORE_LLM, BEFORE_TOOL, ON_EXIT, VALID_HOOK_POINTS, Hook, HookPoint
+from haystack.hooks.protocol import AFTER_TOOL, BEFORE_LLM, BEFORE_TOOL, ON_EXIT, VALID_HOOK_POINTS, Hook, HookPoint
 from haystack.hooks.utils import (
     _deserialize_hooks_dictionary,
     _serialize_hooks_dictionary,
@@ -485,6 +485,9 @@ class Agent:
       re-reads the current last message from `state["messages"]`. If that message has tool calls, those calls are
       executed. If it has no tool calls, no tools run for that step, no tool-based exit condition is triggered, and the
       Agent loops back to the next LLM call unless `max_agent_steps` has been reached.
+    - `after_tool`: runs after tools execute, once their result messages are in `state["messages"]`, before the exit
+      check and the next LLM call. Use it to rewrite the freshly produced tool-result messages (e.g. offload, redact,
+      truncate, or summarize results). It does not run on the plain-text exit step, where no tools run.
     - `on_exit`: runs when the Agent is about to stop on an exit condition. An `on_exit` hook can keep the Agent
       running by setting `state.set("continue_run", True)`.
 
@@ -581,6 +584,10 @@ class Agent:
               the Agent re-reads the current last message from `state["messages"]`. If that message contains tool
               calls, those calls are executed. If it does not, no tools run for that step, no tool-based exit condition
               is triggered, and the Agent loops back to the next LLM call unless `max_agent_steps` has been reached.
+            - "after_tool": Runs after tools execute, once their result messages are in `state["messages"]`, before the
+              exit check and the next LLM call. Use it to rewrite the freshly produced tool-result messages (e.g.
+              offload, redact, truncate, or summarize results). It does not run on the plain-text exit step, where no
+              tools run.
             - "on_exit": Runs when the Agent is about to stop on an exit condition. An "on_exit" hook can keep the
               Agent running by setting the `continue_run` control flag (`state.set("continue_run", True)`), usually
               alongside a message telling the model what to do next. "on_exit" hooks run when the Agent stops on an
@@ -1163,6 +1170,9 @@ class Agent:
                 )
             exe_context.state.set("messages", tool_messages)
             _record_tool_calls(exe_context.state, tool_messages)
+            # `after_tool` hooks may rewrite the tool-result messages in `state["messages"]` (offload, redact,
+            # truncate, summarize) before the next LLM call sees them.
+            _run_hooks(self.hooks, AFTER_TOOL, exe_context.state)
 
             exe_context.counter += 1
             exe_context.state.set("step_count", exe_context.counter)
@@ -1227,6 +1237,9 @@ class Agent:
                 )
             exe_context.state.set("messages", tool_messages)
             _record_tool_calls(exe_context.state, tool_messages)
+            # `after_tool` hooks may rewrite the tool-result messages in `state["messages"]` (offload, redact,
+            # truncate, summarize) before the next LLM call sees them.
+            await _run_hooks_async(self.hooks, AFTER_TOOL, exe_context.state)
 
             exe_context.counter += 1
             exe_context.state.set("step_count", exe_context.counter)

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -1170,8 +1170,6 @@ class Agent:
                 )
             exe_context.state.set("messages", tool_messages)
             _record_tool_calls(exe_context.state, tool_messages)
-            # `after_tool` hooks may rewrite the tool-result messages in `state.data["messages"]` (offload, redact,
-            # truncate, summarize) before the next LLM call sees them.
             _run_hooks(self.hooks, AFTER_TOOL, exe_context.state)
 
             exe_context.counter += 1
@@ -1237,8 +1235,6 @@ class Agent:
                 )
             exe_context.state.set("messages", tool_messages)
             _record_tool_calls(exe_context.state, tool_messages)
-            # `after_tool` hooks may rewrite the tool-result messages in `state.data["messages"]` (offload, redact,
-            # truncate, summarize) before the next LLM call sees them.
             await _run_hooks_async(self.hooks, AFTER_TOOL, exe_context.state)
 
             exe_context.counter += 1

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -205,7 +205,7 @@ def _pending_tool_call_messages_from_state(state: State) -> list[ChatMessage]:
     """
     Return the pending tool-call message after `before_tool` hooks have run.
 
-    `before_tool` hooks may mutate `state["messages"]`. After they run, the Agent intentionally inspects only the
+    `before_tool` hooks may mutate `state.data["messages"]`. After they run, the Agent intentionally inspects only the
     current last message in the state. If that message has tool calls, those calls are executed. If it has no tool
     calls, no tools run for the step, no tool-based exit condition is triggered, and the Agent loops back to the next
     LLM call unless `max_agent_steps` has been reached.
@@ -482,12 +482,12 @@ class Agent:
 
     - `before_llm`: runs before each chat-generator call.
     - `before_tool`: runs after the model requests tool calls, before any tools run. After these hooks run, the Agent
-      re-reads the current last message from `state["messages"]`. If that message has tool calls, those calls are
+      re-reads the current last message from `state.data["messages"]`. If that message has tool calls, those calls are
       executed. If it has no tool calls, no tools run for that step, no tool-based exit condition is triggered, and the
       Agent loops back to the next LLM call unless `max_agent_steps` has been reached.
-    - `after_tool`: runs after tools execute, once their result messages are in `state["messages"]`, before the exit
-      check and the next LLM call. Use it to rewrite the freshly produced tool-result messages (e.g. offload, redact,
-      truncate, or summarize results). It does not run on the plain-text exit step, where no tools run.
+    - `after_tool`: runs after tools execute, once their result messages are in `state.data["messages"]`, before the
+      exit check and the next LLM call. Use it to rewrite the freshly produced tool-result messages (e.g. offload,
+      redact, truncate, or summarize results). It does not run on the plain-text exit step, where no tools run.
     - `on_exit`: runs when the Agent is about to stop on an exit condition. An `on_exit` hook can keep the Agent
       running by setting `state.set("continue_run", True)`.
 
@@ -581,13 +581,13 @@ class Agent:
             list order. Valid hook points are:
             - "before_llm": Runs before each chat-generator call.
             - "before_tool": Runs after the model requests tool calls, before any tools run. After these hooks run,
-              the Agent re-reads the current last message from `state["messages"]`. If that message contains tool
+              the Agent re-reads the current last message from `state.data["messages"]`. If that message contains tool
               calls, those calls are executed. If it does not, no tools run for that step, no tool-based exit condition
               is triggered, and the Agent loops back to the next LLM call unless `max_agent_steps` has been reached.
-            - "after_tool": Runs after tools execute, once their result messages are in `state["messages"]`, before the
-              exit check and the next LLM call. Use it to rewrite the freshly produced tool-result messages (e.g.
-              offload, redact, truncate, or summarize results). It does not run on the plain-text exit step, where no
-              tools run.
+            - "after_tool": Runs after tools execute, once their result messages are in `state.data["messages"]`,
+              before the exit check and the next LLM call. Use it to rewrite the freshly produced tool-result messages
+              (e.g. offload, redact, truncate, or summarize results). It does not run on the plain-text exit step,
+              where no tools run.
             - "on_exit": Runs when the Agent is about to stop on an exit condition. An "on_exit" hook can keep the
               Agent running by setting the `continue_run` control flag (`state.set("continue_run", True)`), usually
               alongside a message telling the model what to do next. "on_exit" hooks run when the Agent stops on an
@@ -1170,7 +1170,7 @@ class Agent:
                 )
             exe_context.state.set("messages", tool_messages)
             _record_tool_calls(exe_context.state, tool_messages)
-            # `after_tool` hooks may rewrite the tool-result messages in `state["messages"]` (offload, redact,
+            # `after_tool` hooks may rewrite the tool-result messages in `state.data["messages"]` (offload, redact,
             # truncate, summarize) before the next LLM call sees them.
             _run_hooks(self.hooks, AFTER_TOOL, exe_context.state)
 
@@ -1237,7 +1237,7 @@ class Agent:
                 )
             exe_context.state.set("messages", tool_messages)
             _record_tool_calls(exe_context.state, tool_messages)
-            # `after_tool` hooks may rewrite the tool-result messages in `state["messages"]` (offload, redact,
+            # `after_tool` hooks may rewrite the tool-result messages in `state.data["messages"]` (offload, redact,
             # truncate, summarize) before the next LLM call sees them.
             await _run_hooks_async(self.hooks, AFTER_TOOL, exe_context.state)
 

--- a/haystack/hooks/__init__.py
+++ b/haystack/hooks/__init__.py
@@ -8,13 +8,14 @@ from typing import TYPE_CHECKING
 from lazy_imports import LazyImporter
 
 _import_structure = {
-    "protocol": ["Hook", "HookPoint", "BEFORE_LLM", "BEFORE_TOOL", "ON_EXIT", "VALID_HOOK_POINTS"],
+    "protocol": ["Hook", "HookPoint", "BEFORE_LLM", "BEFORE_TOOL", "AFTER_TOOL", "ON_EXIT", "VALID_HOOK_POINTS"],
     "from_function": ["FunctionHook", "hook"],
 }
 
 if TYPE_CHECKING:
     from .from_function import FunctionHook as FunctionHook
     from .from_function import hook as hook
+    from .protocol import AFTER_TOOL as AFTER_TOOL
     from .protocol import BEFORE_LLM as BEFORE_LLM
     from .protocol import BEFORE_TOOL as BEFORE_TOOL
     from .protocol import ON_EXIT as ON_EXIT

--- a/haystack/hooks/protocol.py
+++ b/haystack/hooks/protocol.py
@@ -7,10 +7,11 @@ from typing import Any, Literal, Protocol, get_args
 from haystack.components.agents.state.state import State
 
 # Points in the Agent's run loop at which hooks can be registered.
-HookPoint = Literal["before_llm", "before_tool", "on_exit"]
+HookPoint = Literal["before_llm", "before_tool", "after_tool", "on_exit"]
 
 BEFORE_LLM: HookPoint = "before_llm"
 BEFORE_TOOL: HookPoint = "before_tool"
+AFTER_TOOL: HookPoint = "after_tool"
 ON_EXIT: HookPoint = "on_exit"
 VALID_HOOK_POINTS: tuple[HookPoint, ...] = get_args(HookPoint)
 

--- a/releasenotes/notes/add-after-tool-hook-d8d0779aaf65ce66.yaml
+++ b/releasenotes/notes/add-after-tool-hook-d8d0779aaf65ce66.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added an ``after_tool`` hook point to the ``Agent``. Hooks registered under ``after_tool`` run after tools execute,
+    once their result messages are in ``state["messages"]``, and before the exit check and the next LLM call. Use it to
+    rewrite the freshly produced tool-result messages, for example to offload, redact, truncate, or summarize results
+    before the next LLM call sees them. It does not run on the plain-text exit step, where no tools run. Register it
+    like any other hook: ``hooks={"after_tool": [my_hook]}``.

--- a/releasenotes/notes/add-after-tool-hook-d8d0779aaf65ce66.yaml
+++ b/releasenotes/notes/add-after-tool-hook-d8d0779aaf65ce66.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     Added an ``after_tool`` hook point to the ``Agent``. Hooks registered under ``after_tool`` run after tools execute,
-    once their result messages are in ``state["messages"]``, and before the exit check and the next LLM call. Use it to
+    once their result messages are in ``state.data["messages"]``, and before the exit check and the next LLM call. Use it to
     rewrite the freshly produced tool-result messages, for example to offload, redact, truncate, or summarize results
     before the next LLM call sees them. It does not run on the plain-text exit step, where no tools run. Register it
     like any other hook: ``hooks={"after_tool": [my_hook]}``.

--- a/test/components/agents/test_agent_hooks.py
+++ b/test/components/agents/test_agent_hooks.py
@@ -81,6 +81,24 @@ def replace_pending_call_with_non_tool_message(state: State) -> None:
 
 
 @hook
+def record_after_tool(state: State) -> None:
+    # Realistic after_tool use case: record that freshly produced tool results are available for rewriting.
+    state.set("trace", ["after_tool"])
+
+
+@hook
+def offload_tool_results(state: State) -> None:
+    # Realistic after_tool use case: replace freshly produced tool results with a compact pointer, preserving origin.
+    rewritten = [
+        ChatMessage.from_tool(tool_result="OFFLOADED", origin=m.tool_call_result.origin, error=m.tool_call_result.error)
+        if m.tool_call_result is not None
+        else m
+        for m in state.data["messages"]
+    ]
+    state.set("messages", rewritten, handler_override=replace_values)
+
+
+@hook
 def require_save(state: State) -> None:
     if state.get("tool_call_counts", {}).get("save", 0) == 0:
         state.set("messages", [ChatMessage.from_system("You must call save before finishing.")])
@@ -232,6 +250,74 @@ class TestBeforeToolHook:
         assert [m.text for m in result["messages"]][-2:] == ["Skipping tool execution.", "done"]
 
 
+class TestAfterToolHook:
+    def test_runs_after_tools_and_not_on_text_only_exit(self):
+        agent = _agent(
+            MockChatGenerator(),
+            tools=[save],
+            state_schema={"trace": {"type": list}},
+            hooks={"after_tool": [record_after_tool]},
+        )
+        agent.chat_generator.run = MagicMock(
+            side_effect=[
+                {"replies": [ChatMessage.from_assistant(tool_calls=[ToolCall("save", {"content": "x"})])]},
+                {"replies": [ChatMessage.from_assistant("done")]},
+            ]
+        )
+        result = agent.run(messages=[ChatMessage.from_user("hi")])
+        # Fires once for the single tool step; does not fire on the final text-only step (no tools ran there).
+        assert result["trace"] == ["after_tool"]
+
+    def test_does_not_run_when_no_tools_are_called(self):
+        agent = _agent(
+            MockChatGenerator(),
+            tools=[save],
+            state_schema={"trace": {"type": list}},
+            hooks={"after_tool": [record_after_tool]},
+        )
+        agent.chat_generator.run = MagicMock(return_value={"replies": [ChatMessage.from_assistant("done")]})
+        result = agent.run(messages=[ChatMessage.from_user("hi")])
+        assert result.get("trace", []) == []
+
+    def test_rewrites_tool_results_before_next_llm_call(self):
+        agent = _agent(MockChatGenerator(), tools=[save], hooks={"after_tool": [offload_tool_results]})
+        agent.chat_generator.run = MagicMock(
+            side_effect=[
+                {"replies": [ChatMessage.from_assistant(tool_calls=[ToolCall("save", {"content": "x"})])]},
+                {"replies": [ChatMessage.from_assistant("done")]},
+            ]
+        )
+        result = agent.run(messages=[ChatMessage.from_user("hi")])
+        # The rewritten result is what the next LLM call sees...
+        second_call_messages = agent.chat_generator.run.call_args_list[1].kwargs["messages"]
+        assert [m.tool_call_result.result for m in second_call_messages if m.tool_call_result is not None] == [
+            "OFFLOADED"
+        ]
+        # ...and what ends up in the final conversation.
+        assert [m.tool_call_result.result for m in result["messages"] if m.tool_call_result is not None] == [
+            "OFFLOADED"
+        ]
+
+    def test_rewriting_results_does_not_change_exit_matching(self):
+        # Exit conditions match on tool name + error, not result content, so offloading the result still exits.
+        agent = _agent(
+            MockChatGenerator(),
+            tools=[final_answer],
+            exit_conditions=["final_answer"],
+            hooks={"after_tool": [offload_tool_results]},
+        )
+        agent.chat_generator.run = MagicMock(
+            return_value={
+                "replies": [ChatMessage.from_assistant(tool_calls=[ToolCall("final_answer", {"answer": "42"})])]
+            }
+        )
+        result = agent.run(messages=[ChatMessage.from_user("hi")])
+        assert agent.chat_generator.run.call_count == 1
+        assert [m.tool_call_result.result for m in result["messages"] if m.tool_call_result is not None] == [
+            "OFFLOADED"
+        ]
+
+
 class TestOnExitHook:
     def test_mandatory_tool_forces_extra_step(self):
         agent = _agent(MockChatGenerator(), tools=[save], hooks={"on_exit": [require_save]})
@@ -340,6 +426,20 @@ class TestAgentHooksAsync:
         agent.chat_generator.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("done")]})
         await agent.run_async(messages=[ChatMessage.from_user("hi")])
         assert fired == [1]
+
+    @pytest.mark.asyncio
+    async def test_after_tool_hook_rewrites_results(self):
+        agent = _agent(MockChatGenerator(), tools=[save], hooks={"after_tool": [offload_tool_results]})
+        agent.chat_generator.run_async = AsyncMock(
+            side_effect=[
+                {"replies": [ChatMessage.from_assistant(tool_calls=[ToolCall("save", {"content": "x"})])]},
+                {"replies": [ChatMessage.from_assistant("done")]},
+            ]
+        )
+        result = await agent.run_async(messages=[ChatMessage.from_user("hi")])
+        assert [m.tool_call_result.result for m in result["messages"] if m.tool_call_result is not None] == [
+            "OFFLOADED"
+        ]
 
     @pytest.mark.asyncio
     async def test_async_on_exit_hook_forces_extra_step(self):

--- a/test/components/agents/test_agent_hooks.py
+++ b/test/components/agents/test_agent_hooks.py
@@ -82,7 +82,6 @@ def replace_pending_call_with_non_tool_message(state: State) -> None:
 
 @hook
 def record_after_tool(state: State) -> None:
-    # Realistic after_tool use case: record that freshly produced tool results are available for rewriting.
     state.set("trace", ["after_tool"])
 
 


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/405

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Added an ``after_tool`` hook point to the ``Agent``. Hooks registered under ``after_tool`` run after tools execute, once their result messages are in ``state.data["messages"]``, and before the exit check and the next LLM call. Use it to rewrite the freshly produced tool-result messages, for example to offload, redact, truncate, or summarize results before the next LLM call sees them. It does not run on the plain-text exit step, where no tools run. Register it
like any other hook: ``hooks={"after_tool": [my_hook]}``.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

First step towards adding tool result offloading as a feature. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
