### PR TITLE
fix: serialize nested chat generators via component_to_dict in FallbackChatGenerator 

### DIFF
--- a/haystack/components/generators/chat/fallback.py
+++ b/haystack/components/generators/chat/fallback.py
@@ -10,6 +10,7 @@ from typing import Any
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.chat.types import ChatGenerator
 from haystack.components.generators.utils import _normalize_messages
+from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage, StreamingCallbackT
 from haystack.tools import ToolsType
 from haystack.utils.deserialization import deserialize_component_inplace
@@ -62,9 +63,12 @@ class FallbackChatGenerator:
         self._is_warmed_up = False
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize the component, including nested chat generators when they support serialization."""
+        """Serialize the component, including nested chat generators."""
         return default_to_dict(
-            self, chat_generators=[gen.to_dict() for gen in self.chat_generators if hasattr(gen, "to_dict")]
+            self,
+            chat_generators=[
+                component_to_dict(gen, name=f"chat_generator_{idx}") for idx, gen in enumerate(self.chat_generators)
+            ],
         )
 
     @classmethod

--- a/releasenotes/notes/fix_fallback_chat_generator_serialization-9498ee2bbe2971be.yaml
+++ b/releasenotes/notes/fix_fallback_chat_generator_serialization-9498ee2bbe2971be.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed serialization of ``FallbackChatGenerator`` to use the standard ``component_to_dict`` serialization path. This ensures custom chat generator components without an explicit ``to_dict`` method are no longer silently omitted from the serialized ``chat_generators`` list.
+

--- a/test/components/generators/chat/test_fallback.py
+++ b/test/components/generators/chat/test_fallback.py
@@ -441,3 +441,63 @@ def test_warm_up_mixed_generators():
     # Verify the fallback still works correctly
     result = fallback.run([ChatMessage.from_user("test")])
     assert result["replies"][0].text == "A"
+
+
+@component
+class CustomGeneratorWithoutSerDe:
+    def __init__(self, text: str = "custom_ok"):
+        self.text = text
+
+    def run(
+        self,
+        messages: list[ChatMessage],
+        generation_kwargs: dict[str, Any] | None = None,
+        tools: ToolsType | None = None,
+        streaming_callback: StreamingCallbackT | None = None,
+    ) -> dict[str, Any]:
+        return {"replies": [ChatMessage.from_assistant(self.text)], "meta": {}}
+
+
+@component
+class NonSerializableGenerator:
+    def __init__(self, non_serializable_arg: Any):
+        self.non_serializable_arg = non_serializable_arg
+
+    def run(self, messages: list[ChatMessage]) -> dict[str, Any]:
+        return {"replies": []}
+
+
+def test_serialization_with_custom_generators_without_to_dict():
+    from haystack.core.errors import SerializationError
+
+    # 1. Test mixed chain serialization, order preservation, execution, and round-trip
+    gen0 = _DummySuccessGen(text="dummy_has_dict")
+    gen1 = CustomGeneratorWithoutSerDe(text="custom_no_dict_1")
+    gen2 = CustomGeneratorWithoutSerDe(text="custom_no_dict_2")
+
+    original = FallbackChatGenerator(chat_generators=[gen0, gen1, gen2])
+    data = original.to_dict()
+
+    # Ensure all three components are serialized and not silently omitted
+    assert len(data["init_parameters"]["chat_generators"]) == 3
+
+    # Reconstruct/Deserialize
+    restored = FallbackChatGenerator.from_dict(data)
+    assert isinstance(restored, FallbackChatGenerator)
+    assert len(restored.chat_generators) == 3
+
+    # Assert fallback order is exactly preserved
+    assert restored.chat_generators[0].text == "dummy_has_dict"
+    assert restored.chat_generators[1].text == "custom_no_dict_1"
+    assert restored.chat_generators[2].text == "custom_no_dict_2"
+    assert isinstance(restored.chat_generators[1], CustomGeneratorWithoutSerDe)
+    assert isinstance(restored.chat_generators[2], CustomGeneratorWithoutSerDe)
+
+    # Verify pipeline execution on the restored instance
+    res = restored.run([ChatMessage.from_user("hi")])
+    assert res["replies"][0].text == "dummy_has_dict"
+
+    # 2. Test failure path (fail loud) when a component is not serializable
+    non_serializable_fallback = FallbackChatGenerator(chat_generators=[NonSerializableGenerator(object())])
+    with pytest.raises(SerializationError, match="unsupported value of type"):
+        non_serializable_fallback.to_dict()

--- a/test/components/generators/chat/test_fallback.py
+++ b/test/components/generators/chat/test_fallback.py
@@ -11,6 +11,7 @@ import pytest
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.components.generators.chat.fallback import FallbackChatGenerator
+from haystack.core.errors import SerializationError
 from haystack.dataclasses import ChatMessage, StreamingCallbackT
 from haystack.tools import ToolsType
 
@@ -468,8 +469,6 @@ class NonSerializableGenerator:
 
 
 def test_serialization_with_custom_generators_without_to_dict():
-    from haystack.core.errors import SerializationError
-
     # 1. Test mixed chain serialization, order preservation, execution, and round-trip
     gen0 = _DummySuccessGen(text="dummy_has_dict")
     gen1 = CustomGeneratorWithoutSerDe(text="custom_no_dict_1")


### PR DESCRIPTION
## Summary

Fixes #11846.

## Proposed Changes

- Updated `FallbackChatGenerator.to_dict()` in `haystack/components/generators/chat/fallback.py` to use `component_to_dict()` instead of directly calling `.to_dict()` on nested chat generators.
- Added unit tests in `test_fallback.py` covering:
  - serialization/deserialization of mixed fallback chains (components with and without explicit `to_dict()` methods),
  - preservation of fallback ordering after a serialization round-trip,
  - successful round-trip execution after deserialization,
  - fail-loud behavior for non-serializable components.
- Added release notes describing the serialization fix.

## How did you test it?

```bash
hatch run test:unit test/components/generators/chat/test_fallback.py
```

Result:

```text
26 passed, 2 warnings
```

## Notes for the reviewer

### Root cause

`FallbackChatGenerator` serialized its nested chat generators using:

```python
chat_generators=[
    gen.to_dict()
    for gen in self.chat_generators
    if hasattr(gen, "to_dict")
]
```

This bypassed Haystack's standard serialization helper (`component_to_dict()`), which supports components that do not implement explicit `to_dict()`/`from_dict()` methods by falling back to constructor-based serialization. As a result, otherwise serializable components were silently omitted from the serialized representation.

### Reproducer

```python
from haystack import component
from haystack.components.generators.chat.fallback import FallbackChatGenerator
from haystack.dataclasses import ChatMessage


@component
class CustomGeneratorWithoutSerDe:
    def __init__(self, text: str = "custom_ok"):
        self.text = text

    def run(self, messages, **kwargs):
        return {"replies": [ChatMessage.from_assistant(self.text)]}


original = FallbackChatGenerator(
    chat_generators=[CustomGeneratorWithoutSerDe()]
)

data = original.to_dict()

# Before fix:
# data["init_parameters"]["chat_generators"] == []

# After fix:
# data["init_parameters"]["chat_generators"] contains the serialized component.
```

### Precedent

This change follows the same serialization pattern already used by `Agent.to_dict()`, which serializes nested components through `component_to_dict()`.

## Checklist

- [x] Read contributors guidelines and code of conduct
- [x] Updated related issue (#11846)
- [x] Added unit tests and updated docstrings
- [x] Used a conventional commit type in the PR title
- [x] Documented the code
- [x] Added a release note (`releasenotes/notes/fix_fallback_chat_generator_serialization-9498ee2bbe2971be.yaml`)
- [ ] Ran pre-commit hooks and fixed any issues