### PR TITLE
fix: support quantization ranges for int8 single-text embeddings

### DIFF
--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -5,11 +5,14 @@
 import json
 from typing import Any, Literal
 
+import numpy as np
+
 from haystack.lazy_imports import LazyImport
 from haystack.utils.auth import Secret
 
 with LazyImport(message="Run 'pip install \"sentence-transformers>=5.0.0\"'") as sentence_transformers_import:
     from sentence_transformers import SentenceTransformer
+    from sentence_transformers.util import quantize_embeddings
 
 with LazyImport(message="Run 'pip install \"pillow\"'") as pillow_import:
     from PIL.Image import Image
@@ -111,4 +114,12 @@ class _SentenceTransformersEmbeddingBackend:
         )
 
     def embed(self, data: list[str] | list["Image"], **kwargs: Any) -> list[list[float]]:
+        quantization_ranges = kwargs.pop("quantization_ranges", None)
+        precision = kwargs.get("precision", "float32")
+        if quantization_ranges is not None and precision in ("int8", "uint8"):
+            # scalar quantization calibrates min/max ranges from the batch itself, which is degenerate for
+            # small batches (a single text produces meaningless embeddings), so we quantize with explicit ranges
+            kwargs["precision"] = "float32"
+            embeddings = self.model.encode(data, **kwargs)
+            return quantize_embeddings(embeddings, precision=precision, ranges=np.asarray(quantization_ranges)).tolist()
         return self.model.encode(data, **kwargs).tolist()

--- a/haystack/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_text_embedder.py
@@ -5,13 +5,15 @@
 import warnings
 from typing import Any, Literal
 
-from haystack import component, default_from_dict, default_to_dict
+from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.embedders.backends.sentence_transformers_backend import (
     _SentenceTransformersEmbeddingBackend,
     _SentenceTransformersEmbeddingBackendFactory,
 )
 from haystack.utils import ComponentDevice, Secret
 from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
+
+logger = logging.getLogger(__name__)
 
 
 @component
@@ -56,6 +58,7 @@ class SentenceTransformersTextEmbedder:
         encode_kwargs: dict[str, Any] | None = None,
         backend: Literal["torch", "onnx", "openvino"] = "torch",
         revision: str | None = None,
+        quantization_ranges: list[list[float]] | None = None,
     ) -> None:
         """
         Create a SentenceTransformersTextEmbedder component.
@@ -113,6 +116,12 @@ class SentenceTransformersTextEmbedder:
         :param revision:
             The specific model version to use. It can be a branch name, a tag name, or a commit id,
             for a stored model on Hugging Face.
+        :param quantization_ranges:
+            Calibration ranges to use for "int8" and "uint8" precision, as a matrix of shape
+            (2, embedding_dim) with the minimum values in the first row and the maximum values in the second.
+            Without ranges, scalar quantization calibrates the value range from the batch itself, which is
+            degenerate for a single text and produces meaningless embeddings. Compute the ranges from a
+            representative sample of embeddings, for example the document embeddings stored in your Document Store.
         """
         warnings.warn(
             "`SentenceTransformersTextEmbedder` will be removed from Haystack in version 3.0, as it is moving to "
@@ -143,6 +152,15 @@ class SentenceTransformersTextEmbedder:
         self.embedding_backend: _SentenceTransformersEmbeddingBackend | None = None
         self.precision = precision
         self.backend = backend
+        self.quantization_ranges = quantization_ranges
+
+        if precision in ("int8", "uint8") and quantization_ranges is None:
+            logger.warning(
+                "Using precision '{precision}' without `quantization_ranges` produces meaningless embeddings for "
+                "single texts, because the calibration range is computed from the batch itself. "
+                "Pass `quantization_ranges` computed from a representative sample of embeddings.",
+                precision=precision,
+            )
 
     def _get_telemetry_data(self) -> dict[str, Any]:
         """
@@ -177,6 +195,7 @@ class SentenceTransformersTextEmbedder:
             precision=self.precision,
             encode_kwargs=self.encode_kwargs,
             backend=self.backend,
+            quantization_ranges=self.quantization_ranges,
         )
         if serialization_dict["init_parameters"].get("model_kwargs") is not None:
             serialize_hf_model_kwargs(serialization_dict["init_parameters"]["model_kwargs"])
@@ -247,6 +266,7 @@ class SentenceTransformersTextEmbedder:
             show_progress_bar=self.progress_bar,
             normalize_embeddings=self.normalize_embeddings,
             precision=self.precision,
+            quantization_ranges=self.quantization_ranges,
             **(self.encode_kwargs if self.encode_kwargs else {}),
         )[0]
         return {"embedding": embedding}

--- a/releasenotes/notes/fix-int8-single-text-zero-embeddings-bbd4074c7ce977ee.yaml
+++ b/releasenotes/notes/fix-int8-single-text-zero-embeddings-bbd4074c7ce977ee.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    ``SentenceTransformersTextEmbedder`` produced meaningless embeddings (all zeros or all equal values)
+    when using ``precision="int8"`` or ``precision="uint8"``, because scalar quantization calibrated the
+    min/max range from the single-text batch itself. The embedder now accepts a ``quantization_ranges``
+    init parameter with explicit calibration ranges (shape ``(2, embedding_dim)``: minimum values in the
+    first row, maximum values in the second) that are forwarded to
+    ``sentence_transformers.util.quantize_embeddings``. A warning is logged when a quantized precision is
+    used without calibration ranges.

--- a/test/components/embedders/test_sentence_transformers_embedding_backend.py
+++ b/test/components/embedders/test_sentence_transformers_embedding_backend.py
@@ -4,6 +4,8 @@
 
 from unittest.mock import patch
 
+import numpy as np
+
 from haystack.components.embedders.backends.sentence_transformers_backend import (
     _SentenceTransformersEmbeddingBackendFactory,
 )
@@ -64,3 +66,34 @@ def test_embedding_function_with_kwargs(mock_sentence_transformer):
     embedding_backend.embed(data=data, normalize_embeddings=True)
 
     embedding_backend.model.encode.assert_called_once_with(data, normalize_embeddings=True)
+
+
+@patch("haystack.components.embedders.backends.sentence_transformers_backend.quantize_embeddings")
+@patch("haystack.components.embedders.backends.sentence_transformers_backend.SentenceTransformer")
+def test_embedding_function_with_quantization_ranges(mock_sentence_transformer, mock_quantize_embeddings):
+    embedding_backend = _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(model="quantized_model")
+    embedding_backend.model.encode.return_value = np.array([[0.1, 0.2]])
+    mock_quantize_embeddings.return_value = np.array([[12, 34]], dtype=np.int8)
+
+    data = ["sentence"]
+    ranges = [[-1.0, -1.0], [1.0, 1.0]]
+    result = embedding_backend.embed(data=data, precision="int8", quantization_ranges=ranges)
+
+    embedding_backend.model.encode.assert_called_once_with(data, precision="float32")
+    assert mock_quantize_embeddings.call_count == 1
+    _, called_kwargs = mock_quantize_embeddings.call_args
+    assert called_kwargs["precision"] == "int8"
+    assert np.array_equal(called_kwargs["ranges"], np.asarray(ranges))
+    assert result == [[12, 34]]
+
+
+@patch("haystack.components.embedders.backends.sentence_transformers_backend.quantize_embeddings")
+@patch("haystack.components.embedders.backends.sentence_transformers_backend.SentenceTransformer")
+def test_embedding_function_without_quantization_ranges(mock_sentence_transformer, mock_quantize_embeddings):
+    embedding_backend = _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(model="quantized_model_2")
+
+    data = ["sentence"]
+    embedding_backend.embed(data=data, precision="int8", quantization_ranges=None)
+
+    embedding_backend.model.encode.assert_called_once_with(data, precision="int8")
+    mock_quantize_embeddings.assert_not_called()

--- a/test/components/embedders/test_sentence_transformers_text_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_text_embedder.py
@@ -28,6 +28,7 @@ class TestSentenceTransformersTextEmbedder:
         assert embedder.local_files_only is False
         assert embedder.truncate_dim is None
         assert embedder.precision == "float32"
+        assert embedder.quantization_ranges is None
 
     def test_init_with_parameters(self):
         embedder = SentenceTransformersTextEmbedder(
@@ -44,6 +45,7 @@ class TestSentenceTransformersTextEmbedder:
             local_files_only=True,
             truncate_dim=256,
             precision="int8",
+            quantization_ranges=[[-1.0, -1.0], [1.0, 1.0]],
         )
         assert embedder.model == "model"
         assert embedder.device == ComponentDevice.from_str("cuda:0")
@@ -58,6 +60,7 @@ class TestSentenceTransformersTextEmbedder:
         assert embedder.local_files_only is True
         assert embedder.truncate_dim == 256
         assert embedder.precision == "int8"
+        assert embedder.quantization_ranges == [[-1.0, -1.0], [1.0, 1.0]]
 
     def test_to_dict(self):
         component = SentenceTransformersTextEmbedder(model="model", device=ComponentDevice.from_str("cpu"))
@@ -83,6 +86,7 @@ class TestSentenceTransformersTextEmbedder:
                 "config_kwargs": None,
                 "precision": "float32",
                 "backend": "torch",
+                "quantization_ranges": None,
             },
         }
 
@@ -104,6 +108,7 @@ class TestSentenceTransformersTextEmbedder:
             config_kwargs={"use_memory_efficient_attention": False},
             precision="int8",
             encode_kwargs={"task": "clustering"},
+            quantization_ranges=[[-1.0, -1.0], [1.0, 1.0]],
         )
         data = component.to_dict()
         assert data == {
@@ -127,6 +132,7 @@ class TestSentenceTransformersTextEmbedder:
                 "precision": "int8",
                 "encode_kwargs": {"task": "clustering"},
                 "backend": "torch",
+                "quantization_ranges": [[-1.0, -1.0], [1.0, 1.0]],
             },
         }
 
@@ -298,8 +304,29 @@ class TestSentenceTransformersTextEmbedder:
             show_progress_bar=True,
             normalize_embeddings=False,
             precision="float32",
+            quantization_ranges=None,
             task="retrieval.query",
         )
+
+    def test_run_with_quantization_ranges(self):
+        ranges = [[-1.0, -1.0], [1.0, 1.0]]
+        embedder = SentenceTransformersTextEmbedder(model="model", precision="int8", quantization_ranges=ranges)
+        embedder.embedding_backend = MagicMock()
+        text = "a nice text to embed"
+        embedder.run(text=text)
+        embedder.embedding_backend.embed.assert_called_once_with(
+            [text],
+            batch_size=32,
+            show_progress_bar=True,
+            normalize_embeddings=False,
+            precision="int8",
+            quantization_ranges=ranges,
+        )
+
+    def test_init_quantized_precision_without_ranges_warns(self, caplog):
+        with caplog.at_level("WARNING"):
+            SentenceTransformersTextEmbedder(model="model", precision="int8")
+        assert "quantization_ranges" in caplog.text
 
     @patch(
         "haystack.components.embedders.sentence_transformers_text_embedder._SentenceTransformersEmbeddingBackendFactory"
@@ -419,3 +446,22 @@ class TestSentenceTransformersTextEmbedder:
 
         assert len(embedding_def) == 128
         assert all(isinstance(el, int) for el in embedding_def)
+
+    @pytest.mark.integration
+    @pytest.mark.slow
+    def test_run_quantization_with_ranges(self, del_hf_env_vars):
+        """
+        Without explicit ranges, int8 quantization of a single text calibrates min/max from the batch itself,
+        producing a degenerate embedding. With ranges, the embedding must contain distinct values.
+        """
+        checkpoint = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
+        text = "a nice text to embed"
+
+        ranges = [[-1.0] * 128, [1.0] * 128]
+        embedder = SentenceTransformersTextEmbedder(model=checkpoint, precision="int8", quantization_ranges=ranges)
+        result = embedder.run(text=text)
+        embedding = result["embedding"]
+
+        assert len(embedding) == 128
+        assert all(isinstance(el, int) for el in embedding)
+        assert len(set(embedding)) > 1


### PR DESCRIPTION
### Related Issues

- fixes deepset-ai/haystack#9100

### Proposed Changes:

`SentenceTransformersTextEmbedder` with `precision="int8"`/`"uint8"` returns meaningless embeddings (all zeros or all equal values) and a downstream cosine division-by-zero in retrievers. Root cause: `SentenceTransformer.encode` calls `quantize_embeddings(embeddings, precision)` without `ranges`, so the min/max calibration is computed from the batch itself — degenerate for a single query text (min == max → step 0 → NaN → cast to int8).

- `SentenceTransformersTextEmbedder` gains a `quantization_ranges` init parameter (shape `(2, embedding_dim)`: min values in the first row, max in the second), serialized in `to_dict`/`from_dict`.
- `_SentenceTransformersEmbeddingBackend.embed` handles a `quantization_ranges` kwarg: for `int8`/`uint8` it encodes at `float32` and quantizes via `sentence_transformers.util.quantize_embeddings(..., ranges=...)`. Behavior without ranges is unchanged.
- A warning is logged when a quantized precision is used without calibration ranges.
- Release note added.

### How did you test it?

- Reproduced the bug: single text encoded with `precision="int8"` yields a degenerate embedding without ranges, correct distinct values with ranges.
- New unit tests: backend quantization path (with/without ranges), component kwarg forwarding, warning, serialization round-trip.
- New integration test `test_run_quantization_with_ranges` with `sentence-transformers-testing/stsb-bert-tiny-safetensors` asserting the embedding contains distinct int values.
- `hatch run test:unit test/components/embedders/` → 167 passed; `hatch run test:types` → clean; `hatch run fmt` → clean; pre-commit hooks pass.

### Notes for the reviewer

- Only `ranges` is exposed; `quantize_embeddings` also accepts `calibration_embeddings`, which could be added later if users prefer passing raw embeddings from their Document Store.
- Scope kept to the text embedder (single-text batches are where the calibration degenerates); `SentenceTransformersDocumentEmbedder` behavior is unchanged, though the backend support would allow extending it there too.
- This PR was generated with AI assistance (per the contributing guide's AI disclosure requirement).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.