### PR TITLE
ci: pass changed files through env in release-notes reST check

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -62,8 +62,12 @@ jobs:
       - name: Check reStructuredText code formatting
         if: steps.changed-files.outputs.any_changed == 'true' && !contains( github.event.pull_request.labels.*.name, 'ignore-for-release-notes')
         shell: python
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          files = "${{ steps.changed-files.outputs.all_changed_files }}".split()
+          import os
+
+          files = os.environ["CHANGED_FILES"].split()
           errors = []
 
           for filepath in files:


### PR DESCRIPTION
The Check reStructuredText code formatting step in release_notes.yml uses shell: python and builds its file list by interpolating the tj-actions/changed-files output directly into a Python source literal:

  files = "${{ steps.changed-files.outputs.all_changed_files }}".split()

At runtime the workflow expression is expanded by the Actions runner before Python starts, so the contents of that output become part of the Python source of the step. Because git allows filenames to contain a double-quote character as well as newlines and backslashes, a pull_request contributor can add a release-note file whose path breaks out of the string literal. GitHub renders the workflow using the head ref's copy of the file, so an attacker does not need write access to main to reach this code path.

The trigger is pull_request (not pull_request_target), so GITHUB_TOKEN is read-only for this repo and repository secrets are not attached to the job. The direct blast radius is limited to code execution in the release-notes job itself, but that job still runs on the deepset-owned runner pool and shares the ephemeral filesystem with the checked-out source tree, so injecting Python here is undesirable regardless.

The fix follows GitHub's documented secure workflows pattern: expose the changed-files output as an environment variable and read it from Python via os.environ, so the untrusted value never becomes part of the source string that the interpreter parses.

Same class of hardening as #11733 (persist-credentials: false) and #11777 (further dependency pinning + CodeQL), extended one step further into the workflow body.

### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
