### PR TITLE
ci: route release version input through env, not shell interpolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,8 @@ jobs:
         id: parse-validate
         env:
           GH_TOKEN: ${{ github.token }}
-        run: .github/utils/parse_validate_version.sh "${{ inputs.version }}"
+          VERSION: ${{ inputs.version }}
+        run: .github/utils/parse_validate_version.sh "$VERSION"
 
   branch-off:
     needs: ["parse-validate-version"]


### PR DESCRIPTION
The parse-validate-version step in release.yml passes the workflow_dispatch version input to a bash script by interpolating the expression directly into the shell command:

  run: .github/utils/parse_validate_version.sh "${{ inputs.version }}"

At runtime the runner expands the expression before /bin/bash parses the line, so the raw contents of the input become part of the shell source of the step. If a triggering actor supplies a version string containing a backtick, dollar-parenthesis, or quote-escape sequence, that content is evaluated by the shell before it ever reaches the script.

The release workflow is guarded by an authorize job that requires the triggering actor to hold the maintain or admin role, so the practical risk today is limited: only trusted maintainers can reach this step. This change is defence in depth. It brings the step in line with the pattern used in the later bump-dc-pipeline-templates job (line 280 in the same file already sets VERSION via env), matches the guidance in GitHub's Security hardening for GitHub Actions documentation, and removes one more instance of the anti-pattern the ecosystem has been scrubbing since CVE-2025-30066.

Same class of hardening as #11733 (persist-credentials: false) and #11777 (dependency pinning + CodeQL).

### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
