### PR TITLE
fix: PythonCodeSplitter secondary-split pieces missing qualified name context

### DIFF
--- a/haystack/components/preprocessors/python_code_splitter.py
+++ b/haystack/components/preprocessors/python_code_splitter.py
@@ -556,7 +556,8 @@ class PythonCodeSplitter:
             meta["secondary_split"] = True
             meta["secondary_split_index"] = idx
             meta["secondary_split_total"] = len(intermediate)
-            results.append(Document(content=piece.content or "", meta=meta))
+            content = piece.content or "" if idx == 0 else f"# {qualified_name}\n{piece.content or ''}"
+            results.append(Document(content=content, meta=meta))
         return results
 
     @component.output_types(documents=list[Document])

--- a/haystack/components/preprocessors/python_code_splitter.py
+++ b/haystack/components/preprocessors/python_code_splitter.py
@@ -556,6 +556,9 @@ class PythonCodeSplitter:
             meta["secondary_split"] = True
             meta["secondary_split_index"] = idx
             meta["secondary_split_total"] = len(intermediate)
+
+            # Prepend the unit's qualified name as a comment to non-first pieces,
+            # since only the first piece naturally retains the def/class signature line.
             content = piece.content or "" if idx == 0 else f"# {qualified_name}\n{piece.content or ''}"
             results.append(Document(content=content, meta=meta))
         return results

--- a/haystack/components/preprocessors/python_code_splitter.py
+++ b/haystack/components/preprocessors/python_code_splitter.py
@@ -556,11 +556,9 @@ class PythonCodeSplitter:
             meta["secondary_split"] = True
             meta["secondary_split_index"] = idx
             meta["secondary_split_total"] = len(intermediate)
+            meta["qualified_name"] = qualified_name
+            results.append(Document(content=piece.content or "", meta=meta))
 
-            # Prepend the unit's qualified name as a comment to non-first pieces,
-            # since only the first piece naturally retains the def/class signature line.
-            content = piece.content or "" if idx == 0 else f"# {qualified_name}\n{piece.content or ''}"
-            results.append(Document(content=content, meta=meta))
         return results
 
     @component.output_types(documents=list[Document])

--- a/releasenotes/notes/python-code-splitter-secondary-split-context-8449dc47dcce0928.yaml
+++ b/releasenotes/notes/python-code-splitter-secondary-split-context-8449dc47dcce0928.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed ``PythonCodeSplitter`` secondary-split pieces losing all identifying
+    context after the first piece when a function, method, or class body is
+    oversized and falls back to line-based splitting. Every piece after the
+    first is now prefixed with the unit's qualified name (e.g. ``# ClassName.method_name``)
+    so that retrieval can still associate the chunk with its source function.

--- a/releasenotes/notes/python-code-splitter-secondary-split-context-8449dc47dcce0928.yaml
+++ b/releasenotes/notes/python-code-splitter-secondary-split-context-8449dc47dcce0928.yaml
@@ -1,8 +1,9 @@
 ---
 fixes:
   - |
-    Fixed ``PythonCodeSplitter`` secondary-split pieces losing all identifying
-    context after the first piece when a function, method, or class body is
-    oversized and falls back to line-based splitting. Every piece after the
-    first is now prefixed with the unit's qualified name (e.g. ``# ClassName.method_name``)
-    so that retrieval can still associate the chunk with its source function.
+    Fixed ``PythonCodeSplitter`` losing identifying context for oversized
+    functions, methods, or classes. When a unit is too large and falls back
+    to line-based secondary splitting, only the first resulting piece
+    naturally retains the source ``def``/``class`` line; every piece now
+    includes a ``qualified_name`` field in ``meta`` identifying the function,
+    method, or class it came from.

--- a/test/components/preprocessors/test_python_code_splitter.py
+++ b/test/components/preprocessors/test_python_code_splitter.py
@@ -872,3 +872,26 @@ class TestEdgeCases:
         doc = Document(content="class Broken(\n    pass\n")
         with pytest.raises(SyntaxError):
             splitter.run(documents=[doc])
+
+
+class TestSecondarySplitQualifiedName:
+    def test_first_piece_has_no_prefix(self, oversized_function_source):
+        splitter = PythonCodeSplitter(min_effective_lines=2, max_effective_lines=5, oversized_factor=3)
+        result = splitter.run(documents=[Document(content=oversized_function_source)])
+        secondary = sorted(
+            (c for c in result["documents"] if c.meta.get("secondary_split")),
+            key=lambda c: c.meta["secondary_split_index"],
+        )
+        assert secondary
+        assert not (secondary[0].content or "").startswith("# giant")
+
+    def test_non_first_pieces_are_prefixed_with_qualified_name(self, oversized_function_source):
+        splitter = PythonCodeSplitter(min_effective_lines=2, max_effective_lines=5, oversized_factor=3)
+        result = splitter.run(documents=[Document(content=oversized_function_source)])
+        secondary = sorted(
+            (c for c in result["documents"] if c.meta.get("secondary_split")),
+            key=lambda c: c.meta["secondary_split_index"],
+        )
+        assert len(secondary) >= 2
+        for piece in secondary[1:]:
+            assert (piece.content or "").startswith("# giant")

--- a/test/components/preprocessors/test_python_code_splitter.py
+++ b/test/components/preprocessors/test_python_code_splitter.py
@@ -836,6 +836,12 @@ class TestOversizedFallback:
         assert chunks_with_short and chunks_with_long
         assert chunks_with_short[0] is not chunks_with_long[0]
 
+    def test_qualified_name_in_meta_for_all_pieces(self, oversized_function_source):
+        splitter = PythonCodeSplitter(min_effective_lines=2, max_effective_lines=5, oversized_factor=3)
+        result = splitter.run(documents=[Document(content=oversized_function_source)])
+        for piece in result["documents"]:
+            assert piece.meta.get("qualified_name") == "giant"
+
 
 class TestEdgeCases:
     def test_module_with_only_docstring(self):
@@ -872,26 +878,3 @@ class TestEdgeCases:
         doc = Document(content="class Broken(\n    pass\n")
         with pytest.raises(SyntaxError):
             splitter.run(documents=[doc])
-
-
-class TestSecondarySplitQualifiedName:
-    def test_first_piece_has_no_prefix(self, oversized_function_source):
-        splitter = PythonCodeSplitter(min_effective_lines=2, max_effective_lines=5, oversized_factor=3)
-        result = splitter.run(documents=[Document(content=oversized_function_source)])
-        secondary = sorted(
-            (c for c in result["documents"] if c.meta.get("secondary_split")),
-            key=lambda c: c.meta["secondary_split_index"],
-        )
-        assert secondary
-        assert not (secondary[0].content or "").startswith("# giant")
-
-    def test_non_first_pieces_are_prefixed_with_qualified_name(self, oversized_function_source):
-        splitter = PythonCodeSplitter(min_effective_lines=2, max_effective_lines=5, oversized_factor=3)
-        result = splitter.run(documents=[Document(content=oversized_function_source)])
-        secondary = sorted(
-            (c for c in result["documents"] if c.meta.get("secondary_split")),
-            key=lambda c: c.meta["secondary_split_index"],
-        )
-        assert len(secondary) >= 2
-        for piece in secondary[1:]:
-            assert (piece.content or "").startswith("# giant")


### PR DESCRIPTION
### Related Issues
- fixes #11874

### Proposed Changes:
`PythonCodeSplitter._secondary_split()` falls back to a plain line-based split for oversized functions/methods/classes. Only the first resulting piece naturally contains the `def`/`class` signature line, so every piece after that has no identifying text at all, which hurts retrieval ranking for those pieces.

Fixed by reusing the `qualified_name` value already computed in `_secondary_split()` (currently only used in the `logger.warning(...)` call) and prepending it as a `# qualified_name` comment line to every piece after the first.

### How did you test it?
Manually verified locally with a reproduction script: created a `Document` with a single function exceeding the oversized threshold, ran it through `PythonCodeSplitter().run(...)`, and confirmed:
- Piece 0 still starts with the original `def function_name(...):` line (unchanged).
- Pieces 1+ now start with `# function_name` before the body content (previously had no identifying text at all).

### Notes for the reviewer
Open to feedback on the prepended format (comment style, placement) before I finalize with tests and a release note.

### Checklist
- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [ ] I have added a release note file, following the contributors guidelines.
- [x] I have run pre-commit hooks and fixed any issue.