### PR TITLE
feat: Add breakpoint and snapshot support in same sync pipeline run

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -287,10 +287,14 @@ class Pipeline(PipelineBase):
             output is included.
 
         :param break_point:
-            A set of breakpoints that can be used to debug the pipeline execution.
+            A breakpoint that pauses execution before the specified component runs by raising a
+            `BreakpointException` carrying a `PipelineSnapshot` of the current pipeline state.
 
         :param pipeline_snapshot:
-            A dictionary containing a snapshot of a previously saved pipeline execution.
+            A snapshot of a previously interrupted pipeline execution to resume from. Can be combined with
+            `break_point` to step through a pipeline: resume from the snapshot and pause again at the next
+            breakpoint. The `break_point` must target a different component or visit count than the one the
+            snapshot was created at, otherwise it would trigger again before any progress is made.
 
         :param snapshot_callback:
             Optional callback function that is invoked when a pipeline snapshot is created.
@@ -319,10 +323,16 @@ class Pipeline(PipelineBase):
         """
         pipeline_running(self)  # telemetry
 
-        if break_point and pipeline_snapshot:
+        if (
+            break_point
+            and pipeline_snapshot
+            and break_point.component_name == pipeline_snapshot.break_point.component_name
+            and break_point.visit_count == pipeline_snapshot.break_point.visit_count
+        ):
             msg = (
-                "pipeline_breakpoint and pipeline_snapshot cannot be provided at the same time. "
-                "The pipeline run will be aborted."
+                "The provided break_point targets the same component and visit count as the break_point of the "
+                "pipeline_snapshot. It would trigger again before the resumed component runs, so the pipeline "
+                "could not make any progress. Provide a break_point with a different component or visit count."
             )
             raise PipelineInvalidPipelineSnapshotError(message=msg)
 

--- a/releasenotes/notes/allow-break-point-with-pipeline-snapshot-686cbbecc7ca0ae3.yaml
+++ b/releasenotes/notes/allow-break-point-with-pipeline-snapshot-686cbbecc7ca0ae3.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    ``Pipeline.run`` now accepts ``break_point`` and ``pipeline_snapshot`` at the same time. This enables a
+    stepped debugging experience: run until a breakpoint, then resume from the resulting snapshot with a new
+    breakpoint on the next component, pausing again for inspection at each step. The only rejected combination
+    is a ``break_point`` targeting the same component and visit count as the snapshot's break point, since it
+    would trigger again before the resumed component runs and the pipeline could not make any progress.

--- a/test/core/pipeline/test_breakpoint.py
+++ b/test/core/pipeline/test_breakpoint.py
@@ -8,7 +8,7 @@ import logging
 import pytest
 
 from haystack import component
-from haystack.core.errors import BreakpointException
+from haystack.core.errors import BreakpointException, PipelineInvalidPipelineSnapshotError
 from haystack.core.pipeline import Pipeline
 from haystack.core.pipeline.breakpoint import (
     HAYSTACK_PIPELINE_SNAPSHOT_SAVE_ENABLED,
@@ -133,6 +133,69 @@ def test_breakpoint_saves_intermediate_outputs(tmp_path, monkeypatch):
         assert isinstance(loaded_snapshot.break_point, Breakpoint)
         assert loaded_snapshot.break_point.component_name == "comp2"
         assert loaded_snapshot.break_point.visit_count == 0
+
+
+@component
+class _AppendingComponent:
+    @component.output_types(result=str)
+    def run(self, input_value: str) -> dict[str, str]:
+        return {"result": f"{input_value}_processed"}
+
+
+def _three_component_pipeline() -> Pipeline:
+    pipeline = Pipeline()
+    pipeline.add_component("comp1", _AppendingComponent())
+    pipeline.add_component("comp2", _AppendingComponent())
+    pipeline.add_component("comp3", _AppendingComponent())
+    pipeline.connect("comp1", "comp2")
+    pipeline.connect("comp2", "comp3")
+    return pipeline
+
+
+def test_break_point_with_pipeline_snapshot_steps_through_pipeline():
+    pipeline = _three_component_pipeline()
+
+    # run until the breakpoint on comp2
+    with pytest.raises(BreakpointException) as exc_info:
+        pipeline.run(data={"comp1": {"input_value": "test"}}, break_point=Breakpoint(component_name="comp2"))
+    first_snapshot = exc_info.value.pipeline_snapshot
+    assert first_snapshot is not None
+    assert first_snapshot.pipeline_state.component_visits == {"comp1": 1, "comp2": 0, "comp3": 0}
+
+    # step: resume from the snapshot and pause again at comp3
+    with pytest.raises(BreakpointException) as exc_info:
+        pipeline.run(data={}, pipeline_snapshot=first_snapshot, break_point=Breakpoint(component_name="comp3"))
+    second_snapshot = exc_info.value.pipeline_snapshot
+    assert second_snapshot is not None
+    assert second_snapshot.pipeline_state.component_visits == {"comp1": 1, "comp2": 1, "comp3": 0}
+
+    # resume from the second snapshot and run to completion
+    result = pipeline.run(data={}, pipeline_snapshot=second_snapshot)
+    assert result["comp3"]["result"] == "test_processed_processed_processed"
+
+
+def test_break_point_on_earlier_component_than_pipeline_snapshot_never_triggers():
+    pipeline = _three_component_pipeline()
+
+    with pytest.raises(BreakpointException) as exc_info:
+        pipeline.run(data={"comp1": {"input_value": "test"}}, break_point=Breakpoint(component_name="comp2"))
+    snapshot = exc_info.value.pipeline_snapshot
+
+    # comp1 already ran before the snapshot was taken, so a breakpoint on it never triggers
+    # and the resumed run completes normally
+    result = pipeline.run(data={}, pipeline_snapshot=snapshot, break_point=Breakpoint(component_name="comp1"))
+    assert result["comp3"]["result"] == "test_processed_processed_processed"
+
+
+def test_break_point_matching_pipeline_snapshot_break_point_raises():
+    pipeline = _three_component_pipeline()
+
+    with pytest.raises(BreakpointException) as exc_info:
+        pipeline.run(data={"comp1": {"input_value": "test"}}, break_point=Breakpoint(component_name="comp2"))
+    snapshot = exc_info.value.pipeline_snapshot
+
+    with pytest.raises(PipelineInvalidPipelineSnapshotError, match="different component or visit count"):
+        pipeline.run(data={}, pipeline_snapshot=snapshot, break_point=Breakpoint(component_name="comp2", visit_count=0))
 
 
 class TestCreatePipelineSnapshot:


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/447

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add support for running a pipeline with a snapshot and breakpoint in the same run. It was basically already supported just guarded by a check on our end. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added tests to make sure running with both runs as expected. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

cc @marc-mrt 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
