### PR TITLE
fix: raise `DeserializationError` for unimportable classes

### DIFF
--- a/haystack/utils/base_serialization.py
+++ b/haystack/utils/base_serialization.py
@@ -269,9 +269,10 @@ def _deserialize_value(value: dict[str, Any]) -> Any:
     payload = value["data"]
 
     # Custom class where value_type is a qualified class name
+    # ValueError covers type names without a module prefix, which import_class_by_name cannot split
     try:
         cls = import_class_by_name(value_type)
-    except ImportError as e:
+    except (ImportError, ValueError) as e:
         raise DeserializationError(f"Class '{value_type}' not correctly imported") from e
 
     # try from_dict (e.g. Haystack dataclasses and Components)

--- a/haystack/utils/base_serialization.py
+++ b/haystack/utils/base_serialization.py
@@ -269,7 +269,10 @@ def _deserialize_value(value: dict[str, Any]) -> Any:
     payload = value["data"]
 
     # Custom class where value_type is a qualified class name
-    cls = import_class_by_name(value_type)
+    try:
+        cls = import_class_by_name(value_type)
+    except ImportError as e:
+        raise DeserializationError(f"Class '{value_type}' not correctly imported") from e
 
     # try from_dict (e.g. Haystack dataclasses and Components)
     if hasattr(cls, "from_dict") and callable(cls.from_dict):

--- a/releasenotes/notes/fix-deseri-import-class-5d22bc73b2089ecb.yaml
+++ b/releasenotes/notes/fix-deseri-import-class-5d22bc73b2089ecb.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed ``_deserialize_value_with_schema`` raising ``ImportError`` instead of ``DeserializationError``
+    when a snapshot references a class that can no longer be imported.

--- a/test/utils/test_base_serialization.py
+++ b/test/utils/test_base_serialization.py
@@ -423,6 +423,15 @@ def test_deserialize_value_with_wrong_value():
         )
 
 
+def test_deserialize_value_with_schema_class_not_importable():
+    with pytest.raises(
+        DeserializationError, match="Class 'test_base_serialization.NonExistentClass' not correctly imported"
+    ):
+        _deserialize_value_with_schema(
+            {"serialization_schema": {"type": "test_base_serialization.NonExistentClass"}, "serialized_data": {}}
+        )
+
+
 def test_serialize_and_deserialize_pydantic_model():
     model_instance = CustomModel(id=1, name="Test")
     serialized = _serialize_value_with_schema(model_instance)

--- a/test/utils/test_base_serialization.py
+++ b/test/utils/test_base_serialization.py
@@ -432,6 +432,11 @@ def test_deserialize_value_with_schema_class_not_importable():
         )
 
 
+def test_deserialize_value_with_schema_class_name_without_module():
+    with pytest.raises(DeserializationError, match="Class 'NonExistentClass' not correctly imported"):
+        _deserialize_value_with_schema({"serialization_schema": {"type": "NonExistentClass"}, "serialized_data": {}})
+
+
 def test_serialize_and_deserialize_pydantic_model():
     model_instance = CustomModel(id=1, name="Test")
     serialized = _serialize_value_with_schema(model_instance)


### PR DESCRIPTION
### Proposed Changes:

`_deserialize_value` raised a raw `ImportError` when a serialized snapshot referenced a class that no longer exists. Now it raises `DeserializationError`, consistent with the rest of the function.

### How did you test it?

- Added `test_deserialize_value_with_schema_class_not_importable`. 

### Notes for the reviewer

- This is a follow-up to https://github.com/deepset-ai/haystack/pull/11889  from the same file kept separate since that one was a risk-free deletion and this one is an actual behavior change

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
