### PR TITLE
chore: use --uploaded-prior-to guard for pip installs in docs script and fuzzing script

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -6,10 +6,7 @@
 # Builds the Atheris fuzz targets for ClusterFuzzLite / OSS-Fuzz.
 # `compile_python_fuzzer` is provided by the base-builder-python image.
 
-# Upgrade pip so that the --uploaded-prior-to supply-chain flag is available
 python3 -m pip install --upgrade pip
-# --uploaded-prior-to=P1D restricts dependency resolution to versions uploaded
-# more than a day ago, guarding against freshly-uploaded (potentially malicious) releases
 pip3 install . --uploaded-prior-to=P1D
 
 for harness in "$SRC"/haystack/test/fuzz/fuzz_*.py; do

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -6,7 +6,11 @@
 # Builds the Atheris fuzz targets for ClusterFuzzLite / OSS-Fuzz.
 # `compile_python_fuzzer` is provided by the base-builder-python image.
 
-pip3 install .
+# Upgrade pip so that the --uploaded-prior-to supply-chain flag is available
+python3 -m pip install --upgrade pip
+# --uploaded-prior-to=P1D restricts dependency resolution to versions uploaded
+# more than a day ago, guarding against freshly-uploaded (potentially malicious) releases
+pip3 install . --uploaded-prior-to=P1D
 
 for harness in "$SRC"/haystack/test/fuzz/fuzz_*.py; do
   name=$(basename "$harness" .py)

--- a/docs-website/scripts/setup-dev.sh
+++ b/docs-website/scripts/setup-dev.sh
@@ -22,11 +22,16 @@ if ! command -v python &> /dev/null; then
     exit 1
 fi
 
+# Upgrade pip so that the --uploaded-prior-to supply-chain flag is available
+echo "⬆️  Upgrading pip..."
+python -m pip install --upgrade pip
+
 # Check if base dependencies are installed
 echo "📦 Checking base dependencies..."
 python -c "import requests, toml" 2>/dev/null || {
     echo "⚠️  Installing base dependencies (requests, toml)..."
-    pip install requests toml
+    # --uploaded-prior-to=P1D avoids versions uploaded in the last day (supply-chain guard)
+    pip install requests toml --uploaded-prior-to=P1D
 }
 
 # Get Haystack version (default to main)
@@ -46,7 +51,7 @@ echo "📋 Generated requirements.txt with $(wc -l < requirements.txt) dependenc
 
 # Install dependencies
 echo "⚙️  Installing dependencies..."
-pip install -r requirements.txt
+pip install -r requirements.txt --uploaded-prior-to=P1D
 
 echo "✅ Setup complete! You can now run:"
 echo "   python scripts/test_python_snippets.py --verbose"

--- a/docs-website/scripts/setup-dev.sh
+++ b/docs-website/scripts/setup-dev.sh
@@ -22,7 +22,6 @@ if ! command -v python &> /dev/null; then
     exit 1
 fi
 
-# Upgrade pip so that the --uploaded-prior-to supply-chain flag is available
 echo "⬆️  Upgrading pip..."
 python -m pip install --upgrade pip
 
@@ -30,7 +29,6 @@ python -m pip install --upgrade pip
 echo "📦 Checking base dependencies..."
 python -c "import requests, toml" 2>/dev/null || {
     echo "⚠️  Installing base dependencies (requests, toml)..."
-    # --uploaded-prior-to=P1D avoids versions uploaded in the last day (supply-chain guard)
     pip install requests toml --uploaded-prior-to=P1D
 }
 


### PR DESCRIPTION
### Related Issues

- None. Flagged during automated code quality checks.

### Proposed Changes:

Add `--uploaded-prior-to=P1D` to the `pip install` commands that were still unpinned, and upgrade pip first so the flag is available on older pip versions:

- `docs-website/scripts/setup-dev.sh` — both `pip install` commands.
- `.clusterfuzzlite/build.sh` — `pip3 install .`.

### How did you test it?

### Notes for the reviewer

In `build.sh`, `pip3 install .` builds Haystack from the local checkout, so the flag intentionally doesn't affect the package itself but it guards the transitive dependencies resolved from PyPI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [n/a] I have updated the related issue with new insights and changes.
- [n/a] I have added unit tests and updated the docstrings. (Shell-only change, no unit-testable surface.)
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `security:` maps to `chore:`/`ci:` hardening.
- I have documented my code (inline comments explaining the flag).
- [n/a] I have added a release note file. (No user-facing runtime change.)
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.