### PR TITLE
docs: detailing in docstrings the scope and context of each serialisation function

### DIFF
--- a/haystack/components/generators/utils.py
+++ b/haystack/components/generators/utils.py
@@ -170,7 +170,12 @@ def _convert_streaming_chunks_to_chat_message(chunks: list[StreamingChunk]) -> C
 
 
 def _serialize_object(obj: Any) -> Any:
-    """Convert an object to a serializable dict recursively"""
+    """
+    Convert an object to a serializable dict recursively.
+
+    Used for OpenAI SDK response objects, so it skips any attribute starting with "_" (SDK-internal
+    fields). `base_serialization`'s serializer doesn't skip those, so don't swap this out for it.
+    """
     if hasattr(obj, "model_dump"):
         return obj.model_dump()
     if hasattr(obj, "__dict__"):

--- a/haystack/core/serialization.py
+++ b/haystack/core/serialization.py
@@ -187,6 +187,10 @@ def default_to_dict(obj: Any, **init_parameters: Any) -> dict[str, Any]:
     Objects in `init_parameters` that have a `to_dict()` method are automatically
     serialized by calling that method.
 
+    This is the format used for saved pipeline files (`Pipeline.dump`/`Pipeline.load`). Don't merge
+    it with `base_serialization`'s serializer — that one uses a different envelope for a different
+    job (arbitrary runtime values, not Components) and changing either would break saved files.
+
     An example usage:
 
     ```python
@@ -251,7 +255,10 @@ def default_from_dict(cls: type[T], data: dict[str, Any]) -> T:
     """
     Utility function to deserialize a dictionary to an object.
 
-    This is mostly necessary for components but can be used by any object.
+    This is mostly necessary for components but can be used by any object. Reverses the
+    `{"type": ..., "init_parameters": ...}` envelope produced by `default_to_dict` — see that
+    function's docstring for why this envelope is not interchangeable with
+    `haystack.utils.base_serialization`'s.
 
     The function will raise a `DeserializationError` if the `type` field in `data` is
     missing or it doesn't match the type of `cls`.

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -247,6 +247,9 @@ def _serialize_content_part(part: ChatMessageContentT) -> dict[str, Any]:
     """
     Serialize a single content part of a ChatMessage.
 
+    Output looks like `{"text": "hello"}` or `{"image": {...}}` — short, hand-writable keys, not a
+    full class name. People write these by hand (e.g. in chat templates), so keep it this way.
+
     :param part:
         A ChatMessageContentT object.
     :returns:

--- a/haystack/tracing/utils.py
+++ b/haystack/tracing/utils.py
@@ -43,6 +43,10 @@ def _serializable_value(value: Any, use_placeholders: bool = True) -> Any:
     """
     Serializes a value into a format suitable for tracing.
 
+    One-way only: this is never deserialized, so it's allowed to lose data (e.g. replace large
+    objects with a placeholder). Don't swap it for `base_serialization`'s schema serializer, which
+    is built to round-trip exactly.
+
     :param value:
         The value to serialize.
     :param use_placeholders:

--- a/haystack/utils/base_serialization.py
+++ b/haystack/utils/base_serialization.py
@@ -77,6 +77,10 @@ def _serialize_value_with_schema(payload: Any) -> dict[str, Any]:  # noqa: PLR09
     - Lists, tuples, and sets. Lists with mixed types are not supported.
     - Primitive types (str, int, float, bool, None)
 
+    This is for runtime values (Agent/State data, pipeline inputs/outputs at a breakpoint), not
+    Component definitions — see `default_to_dict` in `core/serialization.py` for that other format.
+    Don't merge the two; they're not interchangeable.
+
     :param payload: The value to serialize (can be any type)
     :returns: The serialized dict representation of the given value. Contains two keys:
         - "serialization_schema": Contains type information for each field.


### PR DESCRIPTION
### Related Issues

- partly fixes https://github.com/deepset-ai/haystack-private/issues/450

### Proposed Changes:

Docstring-only additions, no behavior change. Added short "why" notes to 5 functions that looked like they could be merged or simplified, but can't:

  - `default_to_dict`/`default_from_dict` (`core/serialization.py`) — notes this is the on-disk pipeline YAML format, incompatible with `base_serialization`'s.
  - `_serialize_value_with_schema` (`utils/base_serialization.py`) — notes it's for runtime values, not Components, and points back to the note above.
  - `_serializable_value` (`tracing/utils.py`) — notes it's deliberately one-way/lossy, unlike the schema serializer.
  - `_serialize_content_part` (`dataclasses/chat_message.py`) — notes the short tags are a deliberate hand-writable public format.
  - `_serialize_object` (`components/generators/utils.py`) — notes it skips private attributes for OpenAI SDK objects, unlike the generic serializer.

  These came out of an investigation into duplicated/scattered serialization code (see related PRs). Most of what looked like duplication turned out to be intentional separation — these notes capture the reasoning directly in the code so it doesn't get
  "helpfully" merged later.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
