### PR TITLE
chore: consolidate outputs to state string

### DIFF
--- a/haystack/tools/tool.py
+++ b/haystack/tools/tool.py
@@ -380,6 +380,33 @@ def _check_duplicate_tool_names(tools: list[Tool] | None) -> None:
         raise ValueError(f"Duplicate tool names found: {duplicate_tool_names}")
 
 
+def _convert_handler(config: dict[str, Any], converter: Callable[[Any], Any]) -> dict[str, Any]:
+    """
+    Copies a single output config, converting its "handler" entry (if present) via `converter`.
+
+    :param config: A single output configuration dictionary that may contain a "handler" key.
+    :param converter: `serialize_callable` or `deserialize_callable`, applied to the "handler" value.
+    :returns: A copy of `config` with the "handler" value converted, if present.
+    """
+    new_config = config.copy()
+    if "handler" in config:
+        new_config["handler"] = converter(config["handler"])
+    return new_config
+
+
+def _convert_handler_in_configs(
+    configs: dict[str, dict[str, Any]], converter: Callable[[Any], Any]
+) -> dict[str, dict[str, Any]]:
+    """
+    Applies `_convert_handler` to every config in a dictionary of named output configs.
+
+    :param configs: A mapping of keys to output configuration dictionaries.
+    :param converter: `serialize_callable` or `deserialize_callable`, applied to each "handler" value.
+    :returns: A new mapping with the same keys, each config converted via `_convert_handler`.
+    """
+    return {key: _convert_handler(config, converter) for key, config in configs.items()}
+
+
 def _serialize_outputs_to_state(outputs_to_state: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
     """
     Serializes the outputs_to_state dictionary, converting any callable handlers to their string representation.
@@ -387,13 +414,7 @@ def _serialize_outputs_to_state(outputs_to_state: dict[str, dict[str, Any]]) -> 
     :param outputs_to_state: The outputs_to_state dictionary to serialize.
     :returns: The serialized outputs_to_state dictionary.
     """
-    serialized_outputs = {}
-    for key, config in outputs_to_state.items():
-        serialized_config = config.copy()
-        if "handler" in config:
-            serialized_config["handler"] = serialize_callable(config["handler"])
-        serialized_outputs[key] = serialized_config
-    return serialized_outputs
+    return _convert_handler_in_configs(outputs_to_state, serialize_callable)
 
 
 def _deserialize_outputs_to_state(outputs_to_state: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
@@ -403,13 +424,7 @@ def _deserialize_outputs_to_state(outputs_to_state: dict[str, dict[str, Any]]) -
     :param outputs_to_state: The outputs_to_state dictionary to deserialize.
     :returns: The deserialized outputs_to_state dictionary.
     """
-    deserialized_outputs = {}
-    for key, config in outputs_to_state.items():
-        deserialized_config = config.copy()
-        if "handler" in config:
-            deserialized_config["handler"] = deserialize_callable(config["handler"])
-        deserialized_outputs[key] = deserialized_config
-    return deserialized_outputs
+    return _convert_handler_in_configs(outputs_to_state, deserialize_callable)
 
 
 def _serialize_outputs_to_string(outputs_to_string: dict[str, Any]) -> dict[str, Any]:
@@ -421,19 +436,10 @@ def _serialize_outputs_to_string(outputs_to_string: dict[str, Any]) -> dict[str,
     """
     if "source" in outputs_to_string or "handler" in outputs_to_string or "raw_result" in outputs_to_string:
         # Single output configuration
-        serialized_outputs = outputs_to_string.copy()
-        if "handler" in outputs_to_string:
-            serialized_outputs["handler"] = serialize_callable(outputs_to_string["handler"])
-        return serialized_outputs
+        return _convert_handler(outputs_to_string, serialize_callable)
 
     # Multiple outputs configuration
-    serialized_outputs = {}
-    for key, config in outputs_to_string.items():
-        serialized_config = config.copy()
-        if "handler" in config:
-            serialized_config["handler"] = serialize_callable(config["handler"])
-        serialized_outputs[key] = serialized_config
-    return serialized_outputs
+    return _convert_handler_in_configs(outputs_to_string, serialize_callable)
 
 
 def _deserialize_outputs_to_string(outputs_to_string: dict[str, Any]) -> dict[str, Any]:
@@ -445,16 +451,7 @@ def _deserialize_outputs_to_string(outputs_to_string: dict[str, Any]) -> dict[st
     """
     if "source" in outputs_to_string or "handler" in outputs_to_string or "raw_result" in outputs_to_string:
         # Single output configuration
-        deserialized_outputs = outputs_to_string.copy()
-        if "handler" in outputs_to_string:
-            deserialized_outputs["handler"] = deserialize_callable(outputs_to_string["handler"])
-        return deserialized_outputs
+        return _convert_handler(outputs_to_string, deserialize_callable)
 
     # Multiple outputs configuration
-    deserialized_outputs = {}
-    for key, config in outputs_to_string.items():
-        deserialized_config = config.copy()
-        if "handler" in config:
-            deserialized_config["handler"] = deserialize_callable(config["handler"])
-        deserialized_outputs[key] = deserialized_config
-    return deserialized_outputs
+    return _convert_handler_in_configs(outputs_to_string, deserialize_callable)

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -9,7 +9,12 @@ import pytest
 from haystack.dataclasses import TextContent
 from haystack.tools import Tool, _check_duplicate_tool_names
 from haystack.tools.errors import ToolInvocationError
-from haystack.tools.tool import _deserialize_outputs_to_string, _serialize_outputs_to_string
+from haystack.tools.tool import (
+    _deserialize_outputs_to_state,
+    _deserialize_outputs_to_string,
+    _serialize_outputs_to_state,
+    _serialize_outputs_to_string,
+)
 
 
 def get_weather_report(city: str) -> str:
@@ -246,6 +251,32 @@ class TestTool:
         assert deserialized == {
             "report": {"source": "report", "handler": format_string},
             "temp": {"source": "temperature", "handler": format_string},
+        }
+
+    def test_serialize_outputs_to_state(self):
+        config = {
+            "documents": {"source": "docs", "handler": format_string},
+            "summary": {"source": "docs", "handler": get_weather_report},
+            "raw_docs": {"source": "docs"},
+        }
+        serialized = _serialize_outputs_to_state(config)
+        assert serialized == {
+            "documents": {"source": "docs", "handler": "test_tool.format_string"},
+            "summary": {"source": "docs", "handler": "test_tool.get_weather_report"},
+            "raw_docs": {"source": "docs"},
+        }
+
+    def test_deserialize_outputs_to_state(self):
+        serialized = {
+            "documents": {"source": "docs", "handler": "test_tool.format_string"},
+            "summary": {"source": "docs", "handler": "test_tool.get_weather_report"},
+            "raw_docs": {"source": "docs"},
+        }
+        deserialized = _deserialize_outputs_to_state(serialized)
+        assert deserialized == {
+            "documents": {"source": "docs", "handler": format_string},
+            "summary": {"source": "docs", "handler": get_weather_report},
+            "raw_docs": {"source": "docs"},
         }
 
     def test_inputs_from_state_validation_with_invalid_parameter(self):

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
+from typing import Any
 
 import pytest
 
@@ -254,7 +255,7 @@ class TestTool:
         }
 
     def test_serialize_outputs_to_state(self):
-        config = {
+        config: dict[str, dict[str, Any]] = {
             "documents": {"source": "docs", "handler": format_string},
             "summary": {"source": "docs", "handler": get_weather_report},
             "raw_docs": {"source": "docs"},


### PR DESCRIPTION
### Related Issues

- partly fixes https://github.com/deepset-ai/haystack-private/issues/450

### Proposed Changes:

- 4 functions in `tools/tool.py` had the same small loop copy-pasted: copy a config dict, and if it has a handler, convert it with `serialize_callable`/`deserialize_callable`.
- Pulled that loop out into two small shared helpers (`_convert_handler`, `_convert_handler_in_configs`), and had all 4 functions call them instead. 
- The logic difference between the two config types stays where it was.

### How did you test it?

- Added `test_serialize_outputs_to_state`/`test_deserialize_outputs_to_state` first (they had no dedicated unit tests before, only indirect coverage via `Tool.to_dict`/`from_dict` round-trips), confirmed they pass against the old implementation, then refactored.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
