### PR TITLE
refactor: unifying import class logic into a single place/function

### DIFF
--- a/haystack/core/serialization.py
+++ b/haystack/core/serialization.py
@@ -7,10 +7,8 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
-from haystack import logging
 from haystack.core.component.component import _hook_component_init
 from haystack.core.errors import DeserializationError, SerializationError
-from haystack.core.serialization_security import _check_builtin_is_type, _check_module_allowed
 
 # `allow_deserialization_module` is re-exported here to enable all serialization-specific imports
 # from haystack.core.serialization.
@@ -18,10 +16,7 @@ from haystack.core.serialization_security import _check_builtin_is_type, _check_
 from haystack.core.serialization_security import allow_deserialization_module as allow_deserialization_module
 from haystack.utils.auth import Secret
 from haystack.utils.device import ComponentDevice
-from haystack.utils.type_serialization import thread_safe_import
-
-logger = logging.getLogger(__name__)
-
+from haystack.utils.type_serialization import _import_class_by_name
 
 T = TypeVar("T")
 
@@ -372,21 +367,4 @@ def import_class_by_name(fully_qualified_name: str) -> type[object]:
     :raises ImportError: If the class cannot be imported or found.
     :raises DeserializationError: If the module is not on the deserialization allowlist.
     """
-    module_path, class_name = fully_qualified_name.rsplit(".", 1)
-    _check_module_allowed(module_path)
-    try:
-        logger.debug(
-            "Attempting to import class '{cls_name}' from module '{md_path}'", cls_name=class_name, md_path=module_path
-        )
-        module = thread_safe_import(module_path)
-        resolved = getattr(module, class_name)
-        # `builtins` is on the allowlist; a class reference must resolve to an actual type. This
-        # rejects dangerous builtins like `eval`/`compile` (e.g. a nested
-        # `{"type": "builtins.compile"}` payload in `default_from_dict`) while letting builtin
-        # types through.
-        if module_path == "builtins":
-            _check_builtin_is_type(resolved, fully_qualified_name)
-        return resolved
-    except (ImportError, AttributeError) as error:
-        logger.exception("Failed to import class '{full_name}'", full_name=fully_qualified_name)
-        raise ImportError(f"Could not import class '{fully_qualified_name}'") from error
+    return _import_class_by_name(fully_qualified_name)

--- a/haystack/utils/type_serialization.py
+++ b/haystack/utils/type_serialization.py
@@ -5,14 +5,16 @@
 import builtins
 import importlib
 import inspect
-import sys
 import typing
 from threading import Lock
 from types import GenericAlias, ModuleType, NoneType, UnionType
 from typing import Any, Union, get_args
 
+from haystack import logging
 from haystack.core.errors import DeserializationError
 from haystack.core.serialization_security import _check_builtin_is_type, _check_module_allowed
+
+logger = logging.getLogger(__name__)
 
 _import_lock = Lock()
 
@@ -188,30 +190,10 @@ def deserialize_type(type_str: str) -> Any:
     # Handle non-generic types
     # First, check if there's a module prefix
     if "." in type_str:
-        parts = type_str.split(".")
-        module_name = ".".join(parts[:-1])
-        type_name = parts[-1]
-
-        _check_module_allowed(module_name)
-
-        module = sys.modules.get(module_name)
-        if module is None:
-            try:
-                module = thread_safe_import(module_name)
-            except ImportError as e:
-                raise DeserializationError(f"Could not import the module: {module_name}") from e
-
-        # Get the class from the module
-        if hasattr(module, type_name):
-            resolved = getattr(module, type_name)
-            # `builtins` is on the allowlist; a type annotation must resolve to an actual type. This
-            # lets builtin types through (e.g. `builtins.memoryview`) while rejecting builtin
-            # functions like `builtins.eval`.
-            if module_name == "builtins":
-                _check_builtin_is_type(resolved, type_str)
-            return resolved
-
-        raise DeserializationError(f"Could not locate the type: {type_name} in the module: {module_name}")
+        try:
+            return _import_class_by_name(type_str)
+        except ImportError as e:
+            raise DeserializationError(str(e)) from e
 
     # No module prefix, check builtins and typing
     # Special cases for None / NoneType first: `getattr(builtins, "None")` returns the `None`
@@ -248,3 +230,35 @@ def thread_safe_import(module_name: str) -> ModuleType:
     """
     with _import_lock:
         return importlib.import_module(module_name)
+
+
+def _import_class_by_name(fully_qualified_name: str) -> Any:
+    """
+    Imports an attribute (typically a class) given its fully qualified name.
+
+    Checks the module against the deserialization allowlist (see
+    `haystack.core.serialization_security`) and, for `builtins`, that the resolved attribute is
+    an actual type — rejecting dangerous builtins like `eval`/`compile`.
+
+    :param fully_qualified_name: the fully qualified name, e.g. "my_package.MyClass"
+    :returns: the imported attribute.
+    :raises ImportError: If the module cannot be imported or the attribute doesn't exist on it.
+    :raises DeserializationError: If the module is not on the deserialization allowlist, or the
+        resolved builtin is not a type.
+    """
+    module_path, attr_name = fully_qualified_name.rsplit(".", 1)
+    _check_module_allowed(module_path)
+    try:
+        logger.debug(
+            "Attempting to import '{attr_name}' from module '{module_path}'",
+            attr_name=attr_name,
+            module_path=module_path,
+        )
+        module = thread_safe_import(module_path)
+        resolved = getattr(module, attr_name)
+        if module_path == "builtins":
+            _check_builtin_is_type(resolved, fully_qualified_name)
+        return resolved
+    except (ImportError, AttributeError) as error:
+        logger.exception("Failed to import '{full_name}'", full_name=fully_qualified_name)
+        raise ImportError(f"Could not import '{fully_qualified_name}'") from error

--- a/releasenotes/notes/consolidate-duplicated-class-import-logic-e60ccec6da98eee4.yaml
+++ b/releasenotes/notes/consolidate-duplicated-class-import-logic-e60ccec6da98eee4.yaml
@@ -1,0 +1,7 @@
+
+enhancements:
+  - |
+    Removed duplicated class-import logic between ``core/serialization.py`` and
+    ``utils/type_serialization.py``, including the deserialization-allowlist and
+    builtin-type-safety checks, by sharing a single internal implementation.
+    No change to public behavior or to the security checks themselves.


### PR DESCRIPTION
### Related Issues

- partly fixes #[450](https://github.com/deepset-ai/haystack-private/issues/450)

### Proposed Changes:

- `import_class_by_name` (`core/serialization.py`) and `deserialize_type` (`utils/type_serialization.py`) each reimplemented the same "split a dotted path, import the module, `getattr` the class" logic
- moved the shared logic into `type_serialization.py` as `_import_class_by_name`, with both the allowlist check (`_check_module_allowed`) and the builtin-type check (`_check_builtin_is_type`) preserved exactly as before, just centralized in one place instead of two.

### How did you test it?

- Ran the full test suite, including `test/core/test_serialization_security.py` specifically (allowlist rejection, per-call allowlist extension, dangerous-builtin rejection, `unsafe=True` bypass).

### Notes for the reviewer

- `import_class_by_name` is now a one-line wrapper around `_import_class_by_name`, which is private to `type_serialization.py`. 9 files import `import_class_by_name` from `core/serialization.py`, so keeping this wrapper avoids either exposing a private name externally or touching 9 call sites for no functional gain. 
- The same pattern exists for `deserialize_chatgenerator_inplace` wrapping `deserialize_component_inplace`. Happy to discuss if we should change this.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
