### PR TITLE
fix: MarkdownHeaderSplitter drops content before an embedded header or code-fence comment

### DIFF
--- a/haystack/components/preprocessors/markdown_header_splitter.py
+++ b/haystack/components/preprocessors/markdown_header_splitter.py
@@ -223,7 +223,7 @@ class MarkdownHeaderSplitter:
 
             if not self.keep_headers:  # skip header extraction if keep_headers
                 # extract header information
-                header_match = re.search(self._header_pattern, doc.content)
+                header_match = re.match(self._header_pattern, doc.content)
                 if header_match:
                     content_for_splitting = doc.content[header_match.end() :]
 

--- a/releasenotes/notes/fix-markdown-splitter-content-loss-3e4f5a6b7c8d9012.yaml
+++ b/releasenotes/notes/fix-markdown-splitter-content-loss-3e4f5a6b7c8d9012.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed ``MarkdownHeaderSplitter`` dropping content when ``keep_headers=False``.
+    The secondary split re-stripped a leading header with a non-anchored search,
+    which matched the first ``#`` line anywhere in the body (an embedded
+    lower-level header, or a ``#`` comment inside a fenced code block) and
+    discarded everything before it. The match is now anchored to the start of the
+    content, so only a genuine leading header is stripped.

--- a/test/components/preprocessors/test_markdown_header_splitter.py
+++ b/test/components/preprocessors/test_markdown_header_splitter.py
@@ -250,6 +250,29 @@ def test_preserve_document_metadata():
     assert split_docs[0].content == "\nContent"
 
 
+def test_secondary_split_keeps_content_before_embedded_header():
+    """With keep_headers=False, prose before an embedded lower-level header must
+    not be dropped during the secondary split."""
+    splitter = MarkdownHeaderSplitter(
+        keep_headers=False, header_split_levels=[1], secondary_split="word", split_length=100
+    )
+    docs = splitter.run(documents=[Document(content="# Main\nintro paragraph text\n## Sub\nmore text\n")])["documents"]
+    combined = "".join(doc.content or "" for doc in docs)
+    assert "intro paragraph text" in combined
+
+
+def test_secondary_split_keeps_content_before_code_fence_comment():
+    """With keep_headers=False, prose before a '#' comment inside a fenced code block must
+    not be dropped during the secondary split (the comment is not a real header)."""
+    splitter = MarkdownHeaderSplitter(
+        keep_headers=False, header_split_levels=[1], secondary_split="word", split_length=100
+    )
+    content = "# Main\nsome intro text\n```python\n# a comment in code\n```\nmore text\n"
+    docs = splitter.run(documents=[Document(content=content)])["documents"]
+    combined = "".join(doc.content or "" for doc in docs)
+    assert "some intro text" in combined
+
+
 # Error and edge case handling
 def test_non_text_document():
     """Test that the component correctly handles non-text documents."""


### PR DESCRIPTION
### What

`MarkdownHeaderSplitter` silently drops document content when `keep_headers=False` and a secondary split is configured.

In `_apply_secondary_splitting`, the header-stripping step used a non-anchored `re.search(self._header_pattern, doc.content)`. Because the header pattern is `(?m)^(#{1,6}) (.+)$` (MULTILINE), `re.search` matches the **first `#` line anywhere in the chunk**, not just a genuine leading header. Everything before that match (`doc.content[header_match.end():]`) is then discarded.

This triggers whenever a chunk contains a `#` line that is not its leading header, for example:
- an **embedded lower-level header** that was merged into the chunk (e.g. a `##` when `header_split_levels=[1]`), or
- a `#` **comment inside a fenced code block** (e.g. a Python comment).

Anyone using `MarkdownHeaderSplitter(keep_headers=False, secondary_split=...)` on realistic Markdown (nested sections or code samples) loses the prose that precedes the first such `#` line.

### Fix

Anchor the match to the start of the chunk with `re.match` instead of `re.search`, so only a header at the very beginning of the content is stripped. `re.match` anchors to position 0 regardless of the MULTILINE flag, leaving embedded headers and code-fence comments untouched.

```diff
-header_match = re.search(self._header_pattern, doc.content)
+header_match = re.match(self._header_pattern, doc.content)
```

### Before / after

```python
from haystack import Document
from haystack.components.preprocessors.markdown_header_splitter import MarkdownHeaderSplitter

splitter = MarkdownHeaderSplitter(
    keep_headers=False, header_split_levels=[1], secondary_split="word", split_length=100
)
content = "# Main\nsome intro text\n```python\n# a comment in code\n```\nmore text\n"
docs = splitter.run(documents=[Document(content=content)])["documents"]
combined = "".join(d.content or "" for d in docs)

# Before: "\n```\nmore text\n"   -> "some intro text" and the code fence are lost
# After:  "\nsome intro text\n```python\n# a comment in code\n```\nmore text\n"
```

### Tests

Two regression tests in `test/components/preprocessors/test_markdown_header_splitter.py`, one per trigger case:
- `test_secondary_split_keeps_content_before_embedded_header`
- `test_secondary_split_keeps_content_before_code_fence_comment`

Both fail on the pre-fix source (content dropped) and pass with the fix; the full file (34 tests) passes. A release note is included under `releasenotes/notes/`.