### PR TITLE
docs: add TokenLab OpenAI-compatible generator example

### DIFF
--- a/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
@@ -39,6 +39,20 @@ You can pass any chat completion parameters valid for the `openai.ChatCompletion
 
 `OpenAIChatGenerator` can support custom deployments of your OpenAI models through the `api_base_url` init parameter.
 
+You can also use `api_base_url` with OpenAI-compatible providers. For example, TokenLab exposes a `/v1` endpoint that can
+be used with the same generator:
+
+```python
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.utils import Secret
+
+generator = OpenAIChatGenerator(
+    api_key=Secret.from_env_var("TOKENLAB_API_KEY"),
+    api_base_url="https://api.tokenlab.sh/v1",
+    model="claude-sonnet-5",
+)
+```
+
 ### Structured Output
 
 `OpenAIChatGenerator` supports structured output generation, allowing you to receive responses in a predictable format. You can use Pydantic models or JSON schemas to define the structure of the output through the `response_format` parameter in `generation_kwargs`.


### PR DESCRIPTION
## Summary
- Show TokenLab usage through OpenAIChatGenerator's existing api_base_url option.
- Keep the change docs-only and scoped to the project's existing OpenAI-compatible configuration surface.

## Validation
- git diff --check
