### PR TITLE
fix(tools): support negative indices in toolset wrapper

### DIFF
--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -427,11 +427,7 @@ class _ToolsetWrapper(Toolset):
 
     def __getitem__(self, index: int) -> Tool:
         """Get a tool by index across all toolsets."""
-        # Leverage iteration instead of manual index tracking
-        for i, tool in enumerate(self):
-            if i == index:
-                return tool
-        raise IndexError("ToolsetWrapper index out of range")
+        return list(self)[index]
 
     def __add__(self, other: Toolset | Tool | list[Tool]) -> "_ToolsetWrapper":
         """Add another toolset or tool to this wrapper."""

--- a/releasenotes/notes/fix-toolset-wrapper-negative-index-97db43a7123191af.yaml
+++ b/releasenotes/notes/fix-toolset-wrapper-negative-index-97db43a7123191af.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix ``_ToolsetWrapper`` indexing so negative indices behave like ``Toolset`` indices when toolsets are combined.

--- a/test/tools/test_toolset_wrapper.py
+++ b/test/tools/test_toolset_wrapper.py
@@ -125,6 +125,26 @@ class TestToolsetWrapper:
         with pytest.raises(ValueError, match="Duplicate tool names found"):
             _ = result + toolset_with_dup
 
+    def test_wrapper_supports_negative_indices(self, add_tool, multiply_tool, subtract_tool):
+        """Test that _ToolsetWrapper supports negative indices like Toolset."""
+        wrapper = Toolset([add_tool]) + Toolset([multiply_tool, subtract_tool])
+        assert wrapper[-1] == subtract_tool
+        assert wrapper[-2] == multiply_tool
+        assert wrapper[-3] == add_tool
+
+    def test_wrapper_negative_indices_respect_filter(self, add_tool, multiply_tool, subtract_tool):
+        """Test that negative indexing uses the filtered tool view."""
+        wrapper = Toolset([add_tool, multiply_tool]) + Toolset([subtract_tool])
+        wrapper._selected_tool_names = {"add", "subtract"}
+        assert wrapper[-1] == subtract_tool
+        assert wrapper[-2] == add_tool
+
+    def test_wrapper_negative_index_out_of_range(self, add_tool, multiply_tool):
+        """Test that out-of-range negative indices raise IndexError."""
+        wrapper = Toolset([add_tool]) + Toolset([multiply_tool])
+        with pytest.raises(IndexError):
+            _ = wrapper[-3]
+
 
 class TestToolsetWrapperWarmUp:
     """Tests for warm_up behavior of _ToolsetWrapper."""


### PR DESCRIPTION
### Related Issues

- fixes #11759

### Proposed Changes:

`_ToolsetWrapper.__getitem__` previously iterated with `enumerate(self)` and compared forward indices only, so negative indices always raised `IndexError`. This PR makes wrapper indexing use the same list-backed behavior as `Toolset.__getitem__`, preserving filtered iteration while supporting negative indices.

### How did you test it?

- `uvx hatch run test:unit test/tools/test_toolset_wrapper.py`
- `uvx hatch run fmt haystack/tools/toolset.py test/tools/test_toolset_wrapper.py`
- `uvx hatch run test:types haystack/tools/toolset.py test/tools/test_toolset_wrapper.py`
- `uvx hatch run pre-commit run --files haystack/tools/toolset.py test/tools/test_toolset_wrapper.py releasenotes/notes/fix-toolset-wrapper-negative-index-97db43a7123191af.yaml`
- Parsed the release note YAML with `uvx hatch run python`
- `git diff --check`

### Notes for the reviewer

Added regression coverage for negative indices, filtered wrapper views, and out-of-range negative indices.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
