### PR TITLE
docs: clarify OpenSearch authentication setup

### DIFF
--- a/docs-website/docs/document-stores/opensearch-document-store.mdx
+++ b/docs-website/docs/document-stores/opensearch-document-store.mdx
@@ -71,6 +71,13 @@ document_store.write_documents(
 print(document_store.count_documents())
 ```
 
+The `http_auth` value depends on how your OpenSearch instance is deployed:
+
+- For the local Docker example above, use the OpenSearch admin user and the value you set in `OPENSEARCH_INITIAL_ADMIN_PASSWORD`.
+- For Amazon OpenSearch Service, do not use the local Docker password or IAM console password as `http_auth`.
+  Configure the authentication method required by your domain instead. For IAM-based access, pass an AWS SigV4 auth
+  object, such as `AWSV4SignerAuth`, as shown in the [OpenSearch Python client documentation](https://docs.opensearch.org/latest/clients/python-low-level/#connecting-to-amazon-opensearch-service).
+
 ### Supported Retrievers
 
 [`OpenSearchBM25Retriever`](../pipeline-components/retrievers/opensearchbm25retriever.mdx): A keyword-based Retriever that fetches documents matching a query from the Document Store.

--- a/docs-website/versioned_docs/version-2.31/document-stores/opensearch-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.31/document-stores/opensearch-document-store.mdx
@@ -71,6 +71,13 @@ document_store.write_documents(
 print(document_store.count_documents())
 ```
 
+The `http_auth` value depends on how your OpenSearch instance is deployed:
+
+- For the local Docker example above, use the OpenSearch admin user and the value you set in `OPENSEARCH_INITIAL_ADMIN_PASSWORD`.
+- For Amazon OpenSearch Service, do not use the local Docker password or IAM console password as `http_auth`.
+  Configure the authentication method required by your domain instead. For IAM-based access, pass an AWS SigV4 auth
+  object, such as `AWSV4SignerAuth`, as shown in the [OpenSearch Python client documentation](https://docs.opensearch.org/latest/clients/python-low-level/#connecting-to-amazon-opensearch-service).
+
 ### Supported Retrievers
 
 [`OpenSearchBM25Retriever`](../pipeline-components/retrievers/opensearchbm25retriever.mdx): A keyword-based Retriever that fetches documents matching a query from the Document Store.


### PR DESCRIPTION
### Related Issues

- fixes #9171

### Proposed Changes:

Clarifies that the `http_auth` value for `OpenSearchDocumentStore` depends on the deployment type:

- local Docker uses the OpenSearch admin user and the `OPENSEARCH_INITIAL_ADMIN_PASSWORD` value from the container setup
- Amazon OpenSearch Service should use the domain's configured authentication method instead of the local Docker password or IAM console password
- IAM-based Amazon OpenSearch Service access can use an AWS SigV4 auth object, such as `AWSV4SignerAuth`, with a link to the OpenSearch Python client documentation

The clarification is added to both the unstable docs page and the latest stable `version-2.31` copy.

### How did you test it?

- `uvx hatch run pre-commit run --files docs-website/docs/document-stores/opensearch-document-store.mdx docs-website/versioned_docs/version-2.31/document-stores/opensearch-document-store.mdx`
- `npm run build` from `docs-website/`
- `git diff --check`

### Notes for the reviewer

Documentation-only change; no release note is included.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
