### PR TITLE
fix: make _ToolsetWrapper.__getitem__ support negative indices

### DIFF
--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -426,12 +426,8 @@ class _ToolsetWrapper(Toolset):
         return sum(1 for _ in self)
 
     def __getitem__(self, index: int) -> Tool:
-        """Get a tool by index across all toolsets."""
-        # Leverage iteration instead of manual index tracking
-        for i, tool in enumerate(self):
-            if i == index:
-                return tool
-        raise IndexError("ToolsetWrapper index out of range")
+        """Get a tool by index across all toolsets (supports negative indices)."""
+        return list(self)[index]
 
     def __add__(self, other: Toolset | Tool | list[Tool]) -> "_ToolsetWrapper":
         """Add another toolset or tool to this wrapper."""

--- a/test/tools/test_toolset_wrapper.py
+++ b/test/tools/test_toolset_wrapper.py
@@ -107,6 +107,22 @@ class TestToolsetWrapper:
         assert add_tool in result
         assert multiply_tool in result
 
+    def test_wrapper_getitem_supports_negative_index(self, add_tool, multiply_tool, subtract_tool):
+        """Test that __getitem__ supports negative indices like the base Toolset."""
+        result = Toolset([add_tool]) + Toolset([multiply_tool, subtract_tool])
+        assert len(result) == 3
+        assert result[-1] is subtract_tool
+        assert result[-2] is multiply_tool
+        assert result[-3] is add_tool
+
+    def test_wrapper_getitem_out_of_range_raises(self, add_tool, multiply_tool):
+        """Test that an out-of-range index raises IndexError."""
+        result = Toolset([add_tool]) + Toolset([multiply_tool])
+        with pytest.raises(IndexError):
+            _ = result[5]
+        with pytest.raises(IndexError):
+            _ = result[-5]
+
     def test_wrapper_with_agent(self, add_tool, multiply_tool, monkeypatch):
         """Test that _ToolsetWrapper works with Agent."""
         monkeypatch.setenv("OPENAI_API_KEY", "test")


### PR DESCRIPTION
## Summary
- `_ToolsetWrapper.__getitem__` used a forward `enumerate` scan with `if i == index` that only worked for non-negative indices. Requesting a negative index (e.g. `combined[-1]`) raised `IndexError`, while the base `Toolset.__getitem__` correctly handles negative indices via `list(self)[index]`.
- Mirror the base class implementation so combined toolsets behave consistently with a single `Toolset`.

Closes #11759

## Test plan
- Added `test_wrapper_getitem_supports_negative_index` and `test_wrapper_getitem_out_of_range_raises` in `test/tools/test_toolset_wrapper.py`.
- Ran the full `test/tools/test_toolset_wrapper.py` suite: 16 passed.