### PR TITLE
fix: stop default_from_dict from mutating the caller's data dict

### DIFF
--- a/haystack/core/serialization.py
+++ b/haystack/core/serialization.py
@@ -290,7 +290,10 @@ def default_from_dict(cls: type[T], data: dict[str, Any]) -> T:
     :raises DeserializationError:
         If the `type` field in `data` is missing or it doesn't match the type of `cls`.
     """
-    init_params = data.get("init_parameters", {})
+    # Copy so that replacing serialized sub-objects (Secret/ComponentDevice/nested components) with their
+    # deserialized instances below does not mutate the caller's ``data`` dict in place. Without this, a second
+    # deserialization of the same dict would receive already-parsed objects instead of their serialized form.
+    init_params = dict(data.get("init_parameters", {}))
     if "type" not in data:
         raise DeserializationError("Missing 'type' in serialization data")
     if data["type"] != generate_qualified_class_name(cls):

--- a/releasenotes/notes/fix-default-from-dict-input-mutation-e26045ee8d31e24d.yaml
+++ b/releasenotes/notes/fix-default-from-dict-input-mutation-e26045ee8d31e24d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed ``default_from_dict`` (and therefore ``component_from_dict``) mutating the caller's ``data``
+    dictionary in place when deserializing nested objects such as ``Secret`` or ``ComponentDevice``.
+    The serialized sub-dictionaries were being replaced by their deserialized instances inside the input
+    dict; the input is now left unchanged, so the same ``data`` can be safely deserialized more than once.

--- a/test/core/test_serialization.py
+++ b/test/core/test_serialization.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
+from copy import deepcopy
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -229,6 +231,24 @@ def test_component_from_dict_with_secret():
     assert isinstance(comp.api_key, Secret)
     assert isinstance(comp.token, Secret)
     assert comp.regular_param == "test"
+
+
+def test_component_from_dict_does_not_mutate_input():
+    """default_from_dict must not mutate the caller's data dict when deserializing nested objects."""
+    serialized_secret = Secret.from_env_var("TEST_API_KEY").to_dict()
+    data: dict[str, Any] = {
+        "type": generate_qualified_class_name(CustomComponentWithSecrets),
+        "init_parameters": {"api_key": serialized_secret, "regular_param": "test"},
+    }
+    expected = deepcopy(data)
+
+    comp = component_from_dict(CustomComponentWithSecrets, data, "test_component")
+
+    # the returned component is correctly deserialized ...
+    assert isinstance(comp.api_key, Secret)
+    # ... but the caller's dict is left untouched (the Secret sub-dict is not replaced in place)
+    assert data == expected
+    assert isinstance(data["init_parameters"]["api_key"], dict)
 
 
 def test_component_to_dict_and_from_dict_roundtrip_with_secret():


### PR DESCRIPTION
### Related Issues

- Follow-up to the same input-mutation class as #11872 (merged, `FileToFileContent`) and #11908 (`Answer.from_dict`), this time at the core serialization utility every component flows through.

### Proposed Changes:

`default_from_dict()` took a **reference** to `data["init_parameters"]` and then, while auto-deserializing nested objects, replaced the serialized sub-dicts with their live instances **in place**:

```python
init_params = data.get("init_parameters", {})   # reference into the caller's dict
...
init_params[key] = Secret.from_dict(value)       # mutates data["init_parameters"] in place
```

So after `Component.from_dict(data)` (which routes through `default_from_dict`), the caller's `data` is silently corrupted — its serialized `Secret` / `ComponentDevice` / nested-component dicts are swapped for live objects. A second deserialization of the same `data`, or any later re-serialization / comparison, then misbehaves.

`PipelineBase.from_dict` already deep-copies `data` before deserializing precisely to avoid this; the public `default_from_dict` / `component_from_dict` utilities did not. The fix copies `init_parameters` before mutating it (shallow is enough — only its top-level keys are reassigned).

### How did you test it?

- Added `test_component_from_dict_does_not_mutate_input`, which deserializes a dict containing a serialized `Secret` and asserts (a) the returned component is correct and (b) the input dict is unchanged (`data == deepcopy(data)` taken before the call). It **fails on `main`** (the input's `api_key` sub-dict becomes an `EnvVarSecret`) and passes with the fix.
- `python -m pytest test/core/test_serialization.py` → all green (23 tests).
- `ruff check` / `ruff format --check` clean on both files.

### Notes for the reviewer

Minimal one-line change at the single choke point (`component_from_dict` delegates here), so it covers every path. This complements #11908's dataclass-level fix by closing the same leak in the core utility.

This PR was written with the help of an AI assistant. I have reviewed the changes and run the relevant tests locally.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] Conventional commit type in the PR title (`fix:`).
- [x] I have added a unit test and documented the change.
- [x] I have added a release note file.
