### PR TITLE
docs: remove docs redirect that breaks Docusaurus build

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -186,10 +186,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             to: '/docs/pipelines',
           },
           {
-            from: '/docs/asyncpipeline',
-            to: '/docs/pipelines',
-          },
-          {
             from: '/docs/prompt_node',
             to: '/docs/promptbuilder',
           },


### PR DESCRIPTION
### Related Issues

See https://vercel.com/deepset-ai/haystack-docs/6E4mN6rKzXqhcgwejCvS5ciWLhEi and https://github.com/deepset-ai/haystack/issues/11933

### Proposed Changes:
- remove the redirect that breaks Docusaurus build

### How did you test it?
Vercel

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
