### PR TITLE
ci: updating CodeQL Perform CodeQL Analysis step to 4.37.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}


### PR DESCRIPTION
### Proposed Changes:

- Both `Initialize CodeQL` and `Perform CodeQL Analysis` need to run the same version
- Updating Perform CodeQL Analysis to 4.37.0

Here's the failing PR:

- https://github.com/deepset-ai/haystack/actions/runs/29025682369/job/86144590377?pr=11938