### PR TITLE
fix: CSVToDocument row mode no longer crashes the batch on a row with extra fields

### DIFF
--- a/haystack/components/converters/csv.py
+++ b/haystack/components/converters/csv.py
@@ -163,7 +163,12 @@ class CSVToDocument:
 
             # Create DictReader; if this fails, raise (no fallback)
             try:
-                reader = csv.DictReader(io.StringIO(data), delimiter=self.delimiter, quotechar=self.quotechar)
+                # ``restkey`` ensures surplus fields on ragged rows (rows with more values than the
+                # header, e.g. an unquoted comma inside a value) land under an explicit string key
+                # instead of the default ``None`` key, which would break ``Document`` id generation.
+                reader = csv.DictReader(
+                    io.StringIO(data), delimiter=self.delimiter, quotechar=self.quotechar, restkey="extra_columns"
+                )
             except Exception as e:
                 raise RuntimeError(f"CSVToDocument(row): could not parse CSV rows for {source}: {e}") from e
 

--- a/releasenotes/notes/csv-to-document-row-mode-extra-fields-8783f95b2b564383.yaml
+++ b/releasenotes/notes/csv-to-document-row-mode-extra-fields-8783f95b2b564383.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed ``CSVToDocument`` in ``conversion_mode="row"`` crashing the entire batch when a CSV row
+    has more fields than the header (ragged rows, e.g. an unquoted comma inside a value). Surplus
+    values are now stored under an explicit ``extra_columns`` metadata key instead of the ``None``
+    key, which previously broke Document id generation and discarded results from all sources.

--- a/test/components/converters/test_csv_to_document.py
+++ b/test/components/converters/test_csv_to_document.py
@@ -219,3 +219,26 @@ class TestCSVToDocument:
         monkeypatch.setattr(csv_mod.csv, "DictReader", broken_reader, raising=True)
         with pytest.raises(RuntimeError):
             _ = conv.run(sources=[f], content_column="a")
+
+    def test_row_mode_ragged_row_does_not_crash(self):
+        # A data row with more fields than the header (e.g. an unquoted comma inside a value).
+        # Previously the surplus value landed under the None key, which broke Document id
+        # generation (TypeError sorting None against str keys) and aborted the whole batch.
+        valid = ByteStream(data=b"text,author\r\nfine,Ada\r\n", meta={"file_path": "valid.csv"})
+        ragged = ByteStream(data=b"text,note\r\nhello,city,state\r\n", meta={"file_path": "ragged.csv"})
+
+        conv = CSVToDocument(conversion_mode="row")
+        out = conv.run(sources=[valid, ragged], content_column="text")
+        docs = out["documents"]
+
+        # Both sources yielded a Document; the earlier valid source is not lost.
+        assert len(docs) == 2
+        assert docs[0].content == "fine"
+        assert docs[0].meta["author"] == "Ada"
+
+        ragged_doc = docs[1]
+        assert ragged_doc.content == "hello"
+        assert ragged_doc.meta["note"] == "city"
+        # Surplus value is preserved under an explicit (non-None) string meta key.
+        assert None not in ragged_doc.meta
+        assert "state" in ragged_doc.meta["extra_columns"]


### PR DESCRIPTION
Anyone using `CSVToDocument` with `conversion_mode="row"` on real-world CSV data hits this: a single data row that contains more fields than the header aborts the entire `run()` call. This happens with genuinely ragged files, an extra trailing delimiter, or the very common case of an unquoted comma inside a value.

The converter parses rows with `csv.DictReader` using the default `restkey=None`. Surplus fields on an over-long row are collected under the Python key `None`, and `_build_document_from_row` copies every row key into `Document.meta`. When the `Document` is constructed, `Document._create_id()` runs `json.dumps(self.meta, sort_keys=True, ...)`, and sorting a `None` key against `str` keys raises `TypeError: '<' not supported between instances of 'NoneType' and 'str'`. The converter wraps this in a `RuntimeError` and re-raises, so the whole batch fails: every other source is skipped and any Documents already built from earlier valid sources are discarded. (File mode is unaffected because it never parses rows.)

The fix passes an explicit string `restkey="extra_columns"` to `csv.DictReader`, so surplus values land under a normal string metadata key instead of `None`. Document id generation then works and the surplus data is preserved rather than crashing the run.

Before:

```python
from haystack.components.converters.csv import CSVToDocument
from haystack.dataclasses import ByteStream

conv = CSVToDocument(conversion_mode="row")
# header has 2 columns, data row has 3 fields (e.g. an unquoted comma)
src = ByteStream(data=b"text,note\r\nhello,city,state\r\n", meta={})
conv.run(sources=[src], content_column="text")
# RuntimeError: CSVToDocument(row): failed to process row 0 ...:
#   '<' not supported between instances of 'NoneType' and 'str'
```

After:

```python
out = conv.run(sources=[src], content_column="text")
doc = out["documents"][0]
doc.content            # "hello"
doc.meta["note"]       # "city"
doc.meta["extra_columns"]  # ["state"]  -> surplus value preserved, no crash
```

A regression test (`test_row_mode_ragged_row_does_not_crash`) feeds a ragged row alongside a valid source and asserts both Documents are produced (the earlier valid source is no longer lost) and that the surplus value is stored under a non-`None` meta key. It fails on the pre-fix code with the `TypeError`/`RuntimeError` and passes with the fix.

A release note is included at `releasenotes/notes/csv-to-document-row-mode-extra-fields-d4e5f60718293041.yaml`.