### PR TITLE
chore!: remove unused `raise_on_invalid_filter_syntax` utility function

### DIFF
--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -14,7 +14,7 @@ _import_structure = {
     "callable_serialization": ["deserialize_callable", "serialize_callable"],
     "device": ["ComponentDevice", "Device", "DeviceMap", "DeviceType"],
     "deserialization": ["deserialize_chatgenerator_inplace", "deserialize_component_inplace"],
-    "filters": ["document_matches_filter", "raise_on_invalid_filter_syntax"],
+    "filters": ["document_matches_filter"],
     "jinja2_extensions": ["Jinja2TimeExtension"],
     "jupyter": ["is_in_jupyter"],
     "misc": ["expit", "expand_page_range"],
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
     from .device import DeviceMap as DeviceMap
     from .device import DeviceType as DeviceType
     from .filters import document_matches_filter as document_matches_filter
-    from .filters import raise_on_invalid_filter_syntax as raise_on_invalid_filter_syntax
     from .jinja2_extensions import Jinja2TimeExtension as Jinja2TimeExtension
     from .jupyter import is_in_jupyter as is_in_jupyter
     from .misc import expand_page_range as expand_page_range

--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -12,15 +12,6 @@ from haystack.dataclasses import ByteStream, Document
 from haystack.errors import FilterError
 
 
-def raise_on_invalid_filter_syntax(filters: dict[str, Any] | None = None) -> None:
-    """
-    Raise an error if the filter syntax is invalid.
-    """
-    if filters and ("operator" not in filters or "conditions" not in filters):
-        msg = "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
-        raise FilterError(msg)
-
-
 def document_matches_filter(filters: dict[str, Any], document: Document | ByteStream) -> bool:
     """
     Return whether `filters` match the Document or the ByteStream.

--- a/releasenotes/notes/rm-raise_on_invalid_filter_syntax-a1e88026e3f6c6b0.yaml
+++ b/releasenotes/notes/rm-raise_on_invalid_filter_syntax-a1e88026e3f6c6b0.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    The ``raise_on_invalid_filter_syntax`` utility function has been removed. Its implementation was incorrect
+    and never used across Haystack and Haystack Core Integrations.


### PR DESCRIPTION
### Related Issues

I noticed `raise_on_invalid_filter_syntax` utility function:
- never used across Haystack ecosystem
- wrong implementation: a possible better implementation can be found in many document stores like [Pgvector](https://github.com/deepset-ai/haystack-core-integrations/blob/8791ef766bf11dc8f59e7f86667fbe541d2f4b34/integrations/pgvector/src/haystack_integrations/document_stores/pgvector/filters.py#L26)

### Proposed Changes:
- remove it

### How did you test it?
CI

### Notes for the reviewer
I also considered fixing it and then reusing it across core integrations, but it seemed high effort for low value

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
