### PR TITLE
fix: validate non-string keys in nested dicts during component serialization

### DIFF
--- a/haystack/core/serialization.py
+++ b/haystack/core/serialization.py
@@ -106,7 +106,7 @@ def _validate_component_to_dict_output(component: Any, name: str, data: dict[str
                 check_dict(v)
 
     def check_dict(d: dict[str, Any]) -> None:
-        if any(not isinstance(k, str) for k in data):
+        if any(not isinstance(k, str) for k in d):
             raise SerializationError(
                 f"Component '{name}' of type '{type(component).__name__}' has a non-string key in the serialized data."
             )

--- a/releasenotes/notes/fix-check-dict-nested-non-string-key-99cf9ac9341463c2.yaml
+++ b/releasenotes/notes/fix-check-dict-nested-non-string-key-99cf9ac9341463c2.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed ``component_to_dict`` serialization validation not detecting non-string keys in nested
+    dictionaries. The check only inspected the top-level dictionary, so a non-string key inside a
+    nested ``init_parameters`` value passed validation and could later fail during marshalling; nested
+    dictionaries are now validated too.

--- a/test/core/test_serialization.py
+++ b/test/core/test_serialization.py
@@ -144,6 +144,21 @@ def test_component_to_dict_invalid_type():
         component_to_dict(UnserializableClass(1, "s", CustomData(99, "aa")), "invalid_component")
 
 
+@component()
+class NestedNonStringKeyClass:
+    def __init__(self, mapping: dict[Any, Any]) -> None:
+        self.mapping = mapping
+
+    def run(self):
+        pass
+
+
+def test_component_to_dict_nested_non_string_key():
+    # A non-string key nested inside init_parameters must be rejected too, not just at the top level.
+    with pytest.raises(SerializationError, match="non-string key"):
+        component_to_dict(NestedNonStringKeyClass(mapping={1: "a"}), "invalid_component")
+
+
 @component
 class CustomComponentWithSecrets:
     def __init__(self, api_key: Secret | None = None, token: Secret | None = None, regular_param: str | None = None):


### PR DESCRIPTION
### Related Issues

- N/A — a self-contained serialization-validation bug found by code review (independent of the recently-merged `default_from_dict` fix, though it happens to live in the same module).

### Proposed Changes:

`_validate_component_to_dict_output` walks a component's serialized data and rejects non-string keys (which don't round-trip through JSON). Its inner `check_dict(d)` is recursive, but the non-string-key check iterated the outer closure variable `data` (the top-level dict) instead of its own parameter `d`:

```python
def check_dict(d: dict[str, Any]) -> None:
    if any(not isinstance(k, str) for k in data):   # <-- checks the top-level dict every time
        raise SerializationError(...)
    ...
    elif isinstance(v, dict):
        check_dict(v)                                 # recurses, but the guard ignores v's keys
```

So only the **top-level** keys were ever checked. A non-string key inside a nested `init_parameters` value (e.g. `{"mapping": {1: "a"}}`) passed validation and could later fail opaquely at YAML/JSON marshal time — exactly what this validator exists to catch early. Fix: check the recursed dict's own keys (`for k in d`).

### How did you test it?

- Added `test_component_to_dict_nested_non_string_key`, which serializes a component whose `init_parameters` contains a nested `{1: "a"}` and asserts `component_to_dict` raises `SerializationError`. It **fails on `main`** (`DID NOT RAISE`) and passes with the fix.
- `python -m pytest test/core/test_serialization.py` → all green (27 tests).
- `ruff check` / `ruff format --check` clean on both files.

### Notes for the reviewer

One-word fix (`data` → `d`) restoring the intended recursive validation; the value-type check on the same recursion already used `v` correctly, so only the key check was affected.

This PR was written with the help of an AI assistant. I have reviewed the changes and run the relevant tests locally.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] Conventional commit type in the PR title (`fix:`).
- [x] I have added a unit test and documented the change.
- [x] I have added a release note file.
