### PR TITLE
fix: support negative indices in _ToolsetWrapper.__getitem__

### DIFF
--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -427,6 +427,8 @@ class _ToolsetWrapper(Toolset):
 
     def __getitem__(self, index: int) -> Tool:
         """Get a tool by index across all toolsets."""
+        if index < 0:
+            index += len(self)
         # Leverage iteration instead of manual index tracking
         for i, tool in enumerate(self):
             if i == index:

--- a/releasenotes/notes/fix-toolsetwrapper-negative-index-7c3f1a9b2e4d5f60.yaml
+++ b/releasenotes/notes/fix-toolsetwrapper-negative-index-7c3f1a9b2e4d5f60.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    ``_ToolsetWrapper.__getitem__`` now supports negative indices, so a combined ``Toolset``
+    (created via ``+``) indexes like a list. For example, ``combined[-1]`` returns the last tool,
+    matching the behavior of a plain ``Toolset``.

--- a/test/tools/test_toolset_wrapper.py
+++ b/test/tools/test_toolset_wrapper.py
@@ -107,6 +107,16 @@ class TestToolsetWrapper:
         assert add_tool in result
         assert multiply_tool in result
 
+    def test_wrapper_supports_negative_indexing(self, add_tool, multiply_tool):
+        """A combined Toolset must index like a list, including negative indices.
+
+        See issue #11759: _ToolsetWrapper.__getitem__ only scanned forward and raised
+        IndexError for negative indices, unlike a plain Toolset.
+        """
+        result = Toolset([add_tool]) + Toolset([multiply_tool])
+        assert result[-1].name == multiply_tool.name
+        assert result[-2].name == add_tool.name
+
     def test_wrapper_with_agent(self, add_tool, multiply_tool, monkeypatch):
         """Test that _ToolsetWrapper works with Agent."""
         monkeypatch.setenv("OPENAI_API_KEY", "test")


### PR DESCRIPTION
A combined `Toolset` (`_ToolsetWrapper`, produced by `+`) only scanned forward in `__getitem__` and raised `IndexError` for negative indices, breaking the documented list-like contract.

Normalize negative indices via `len(self)` so `combined[-1]` returns the last tool, matching a plain `Toolset`.

Adds a regression test and a release note.

Fixes #11759