### PR TITLE
feat: add Amazon Bedrock Knowledge Base retriever component

### DIFF
--- a/haystack/components/retrievers/BEDROCK_MANAGED_KB.md
+++ b/haystack/components/retrievers/BEDROCK_MANAGED_KB.md
@@ -1,0 +1,53 @@
+# Bedrock Managed Knowledge Base Support
+
+## Overview
+Adds a Haystack retriever component that queries Amazon Bedrock Knowledge Bases for managed semantic search.
+
+## Usage
+```python
+from haystack import Pipeline
+from haystack.components.retrievers import BedrockKnowledgeBaseRetriever
+
+retriever = BedrockKnowledgeBaseRetriever(knowledge_base_id="YOUR_KB_ID")
+pipeline = Pipeline()
+pipeline.add_component("retriever", retriever)
+result = pipeline.run({"retriever": {"query": "What is our SLA policy?"}})
+docs = result["retriever"]["documents"]
+```
+
+## Configuration
+| Variable | Description | Default |
+|---|---|---|
+| KNOWLEDGE_BASE_ID | Bedrock Knowledge Base ID | None |
+| AWS_REGION | AWS region for the KB | us-east-1 |
+| AWS_PROFILE | AWS credentials profile | None |
+| USE_AGENTIC_RETRIEVAL | Enable agentic retrieval | true |
+| MAX_RESULTS | Maximum retrieval results | 5 |
+
+## Features
+- Managed search (no vector store needed)
+- Agentic retrieval with query decomposition + reranking
+- Automatic fallback to plain Retrieve if agentic fails
+- Multi-source support (S3, Web, Confluence, SharePoint)
+- Returns Haystack Document objects with metadata and scores
+
+## SDK Requirements
+- boto3 >= 1.43
+- haystack-ai >= 2.0
+
+## Required IAM Permissions
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "bedrock:Retrieve",
+    "bedrock:AgenticRetrieve"
+  ],
+  "Resource": "arn:aws:bedrock:<region>:<account-id>:knowledge-base/<kb-id>"
+}
+```
+
+## References
+- [Build a Managed Knowledge Base](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-build-managed.html)
+- [Retrieve API](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-retrieve.html)
+- [Agentic Retrieval](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-agentic.html)

--- a/haystack/components/retrievers/bedrock_knowledge_base_retriever.py
+++ b/haystack/components/retrievers/bedrock_knowledge_base_retriever.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Amazon Bedrock Knowledge Base Retriever for Haystack.
+
+Retrieves documents from an Amazon Bedrock Managed Knowledge Base.
+Supports both Managed (recommended) and Vector knowledge base types.
+
+Usage:
+    from haystack.components.retrievers.bedrock_knowledge_base_retriever import BedrockKnowledgeBaseRetriever
+
+    retriever = BedrockKnowledgeBaseRetriever(
+        knowledge_base_id="ABCDEFGHIJ",
+        region_name="us-west-2",
+    )
+
+    result = retriever.run(query="What is retrieval augmented generation?")
+    documents = result["documents"]
+"""
+
+import os
+import logging
+from typing import Any, Optional
+
+from haystack import Document, component, default_to_dict
+
+logger = logging.getLogger(__name__)
+
+
+def _get_source_uri(result: dict) -> str:
+    """Extract source URI from a retrieval result, handling all location types."""
+    location = result.get('location', {})
+    loc_type = location.get('type', '')
+    if loc_type == 'S3' or 's3Location' in location:
+        return location.get('s3Location', {}).get('uri', '')
+    elif loc_type == 'WEB' or 'webLocation' in location:
+        return location.get('webLocation', {}).get('url', '')
+    elif 'confluenceLocation' in location:
+        return location.get('confluenceLocation', {}).get('url', '')
+    elif 'salesforceLocation' in location:
+        return location.get('salesforceLocation', {}).get('url', '')
+    elif 'sharePointLocation' in location:
+        return location.get('sharePointLocation', {}).get('url', '')
+    elif 'customDocumentLocation' in location:
+        return location.get('customDocumentLocation', {}).get('id', '')
+    # Fallback to metadata._source_uri (for agentic results)
+    return result.get('metadata', {}).get('_source_uri', '')
+
+
+@component
+class BedrockKnowledgeBaseRetriever:
+    """
+    Retrieves documents from an Amazon Bedrock Knowledge Base.
+
+    Supports Managed Knowledge Bases (recommended, no external vector store needed)
+    and traditional Vector Knowledge Bases.
+
+    ### Usage example
+
+    ```python
+    from haystack.components.retrievers.bedrock_knowledge_base_retriever import BedrockKnowledgeBaseRetriever
+
+    retriever = BedrockKnowledgeBaseRetriever(
+        knowledge_base_id="ABCDEFGHIJ",
+        region_name="us-west-2",
+        knowledge_base_type="MANAGED",
+    )
+
+    result = retriever.run(query="What are the benefits of managed knowledge bases?")
+    for doc in result["documents"]:
+        print(doc.content)
+        print(doc.meta["source"])
+        print(doc.score)
+    ```
+    """
+
+    def __init__(
+        self,
+        knowledge_base_id: Optional[str] = None,
+        region_name: Optional[str] = None,
+        number_of_results: int = 5,
+        knowledge_base_type: str = "MANAGED",
+        use_agentic_retrieval: Optional[bool] = None,
+    ):
+        """
+        Create the BedrockKnowledgeBaseRetriever component.
+
+        :param knowledge_base_id: The ID of the Bedrock Knowledge Base. Falls back to KNOWLEDGE_BASE_ID env var.
+        :param region_name: AWS region. Falls back to AWS_REGION env var or us-east-1.
+        :param number_of_results: Maximum number of results to return.
+        :param knowledge_base_type: 'MANAGED' (recommended) or 'VECTOR'.
+        :param use_agentic_retrieval: If True, try AgenticRetrieveStream before plain Retrieve. Defaults to USE_AGENTIC_RETRIEVAL env var or True.
+        """
+        self.knowledge_base_id = knowledge_base_id or os.environ.get("KNOWLEDGE_BASE_ID", "")
+        self.region_name = region_name or os.environ.get("AWS_REGION", "us-east-1")
+        self.number_of_results = number_of_results
+        self.knowledge_base_type = knowledge_base_type
+        self.use_agentic_retrieval = use_agentic_retrieval if use_agentic_retrieval is not None else os.environ.get('USE_AGENTIC_RETRIEVAL', 'true').lower() != 'false'
+        self._client = None
+
+    def _get_client(self):
+        if self._client is None:
+            try:
+                import boto3
+            except ImportError:
+                raise ImportError(
+                    "boto3 is required for BedrockKnowledgeBaseRetriever. "
+                    "Install with: pip install boto3>=1.41.0"
+                )
+            self._client = boto3.client(
+                "bedrock-agent-runtime", region_name=self.region_name
+            )
+        return self._client
+
+    @component.output_types(documents=list[Document])
+    def run(self, query: str, top_k: Optional[int] = None) -> dict[str, list[Document]]:
+        """
+        Retrieve documents from the Bedrock Knowledge Base.
+
+        :param query: The search query.
+        :param top_k: Maximum number of results. Overrides number_of_results if provided.
+        :returns: A dictionary with a "documents" key containing the retrieved Documents.
+        """
+        k = top_k or self.number_of_results
+        client = self._get_client()
+
+        # Try agentic retrieval first
+        if self.use_agentic_retrieval:
+            try:
+                response = client.agentic_retrieve_stream(
+                    knowledgeBaseId=self.knowledge_base_id,
+                    messages=[{"content": {"text": query}, "role": "user"}],
+                    retrievers=[{
+                        "configuration": {
+                            "knowledgeBase": {
+                                "knowledgeBaseId": self.knowledge_base_id,
+                                "retrievalOverrides": {"maxNumberOfResults": k},
+                            }
+                        }
+                    }],
+                    agenticRetrieveConfiguration={
+                        "foundationModelType": "MANAGED",
+                        "rerankingModelType": "MANAGED",
+                    },
+                )
+                documents = []
+                for event in response.get("stream", []):
+                    if "result" in event and "results" in event["result"]:
+                        for result in event["result"]["results"]:
+                            content = result.get("content", {}).get("text", "")
+                            source = _get_source_uri(result)
+                            score = result.get("score", 0.0)
+                            doc = Document(
+                                content=content,
+                                meta={
+                                    "source": source,
+                                    "knowledge_base_id": self.knowledge_base_id,
+                                    "knowledge_base_type": self.knowledge_base_type,
+                                },
+                                score=score,
+                            )
+                            documents.append(doc)
+                if documents:
+                    return {"documents": documents}
+            except Exception:
+                pass  # Fall through to plain retrieve
+
+        if self.knowledge_base_type == "MANAGED":
+            retrieval_config: dict[str, Any] = {
+                "managedSearchConfiguration": {"numberOfResults": k}
+            }
+        else:
+            retrieval_config = {
+                "vectorSearchConfiguration": {"numberOfResults": k}
+            }
+
+        try:
+            response = client.retrieve(
+                knowledgeBaseId=self.knowledge_base_id,
+                retrievalQuery={"text": query},
+                retrievalConfiguration=retrieval_config,
+            )
+        except Exception as e:
+            logger.error(f"Error retrieving from Bedrock Knowledge Base: {e}")
+            return {"documents": []}
+
+        documents = []
+        for result in response.get("retrievalResults", []):
+            content = result.get("content", {}).get("text", "")
+            source = _get_source_uri(result)
+            score = result.get("score", 0.0)
+
+            doc = Document(
+                content=content,
+                meta={
+                    "source": source,
+                    "knowledge_base_id": self.knowledge_base_id,
+                    "knowledge_base_type": self.knowledge_base_type,
+                },
+                score=score,
+            )
+            documents.append(doc)
+
+        return {"documents": documents}
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this component to a dictionary."""
+        return default_to_dict(
+            self,
+            knowledge_base_id=self.knowledge_base_id,
+            region_name=self.region_name,
+            number_of_results=self.number_of_results,
+            knowledge_base_type=self.knowledge_base_type,
+            use_agentic_retrieval=self.use_agentic_retrieval,
+        )

--- a/tests/components/retrievers/test_bedrock_knowledge_base_retriever.py
+++ b/tests/components/retrievers/test_bedrock_knowledge_base_retriever.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Amazon Bedrock Knowledge Base Retriever component."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from haystack import Document
+
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch("boto3.client") as mock:
+        client = MagicMock()
+        mock.return_value = client
+        yield client
+
+
+class TestBedrockKnowledgeBaseRetriever:
+    def test_init_defaults(self):
+        from haystack.components.retrievers.bedrock_knowledge_base_retriever import (
+            BedrockKnowledgeBaseRetriever,
+        )
+
+        retriever = BedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
+        assert retriever.knowledge_base_id == "TEST123456"
+        assert retriever.number_of_results == 5
+        assert retriever.knowledge_base_type == "MANAGED"
+
+    @patch.dict("os.environ", {"KNOWLEDGE_BASE_ID": "ENV_KB", "AWS_REGION": "eu-west-1"})
+    def test_init_from_env(self):
+        from haystack.components.retrievers.bedrock_knowledge_base_retriever import (
+            BedrockKnowledgeBaseRetriever,
+        )
+
+        retriever = BedrockKnowledgeBaseRetriever()
+        assert retriever.knowledge_base_id == "ENV_KB"
+        assert retriever.region_name == "eu-west-1"
+
+    def test_run_managed(self, mock_boto3_client):
+        from haystack.components.retrievers.bedrock_knowledge_base_retriever import (
+            BedrockKnowledgeBaseRetriever,
+        )
+
+        mock_boto3_client.retrieve.return_value = {
+            "retrievalResults": [
+                {
+                    "content": {"text": "Managed KB handles everything automatically."},
+                    "location": {"s3Location": {"uri": "s3://bucket/doc.pdf"}},
+                    "score": 0.95,
+                },
+                {
+                    "content": {"text": "No vector store needed."},
+                    "location": {"s3Location": {"uri": "s3://bucket/doc2.pdf"}},
+                    "score": 0.87,
+                },
+            ]
+        }
+
+        retriever = BedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
+        result = retriever.run(query="What is managed KB?")
+
+        # Verify correct API call
+        mock_boto3_client.retrieve.assert_called_once()
+        call_kwargs = mock_boto3_client.retrieve.call_args.kwargs
+        assert call_kwargs["knowledgeBaseId"] == "TEST123456"
+        assert "managedSearchConfiguration" in call_kwargs["retrievalConfiguration"]
+
+        # Verify documents returned
+        assert "documents" in result
+        docs = result["documents"]
+        assert len(docs) == 2
+        assert isinstance(docs[0], Document)
+        assert docs[0].content == "Managed KB handles everything automatically."
+        assert docs[0].meta["source"] == "s3://bucket/doc.pdf"
+        assert docs[0].score == 0.95
+
+    def test_run_vector(self, mock_boto3_client):
+        from haystack.components.retrievers.bedrock_knowledge_base_retriever import (
+            BedrockKnowledgeBaseRetriever,
+        )
+
+        mock_boto3_client.retrieve.return_value = {
+            "retrievalResults": [
+                {
+                    "content": {"text": "Vector result."},
+                    "location": {"s3Location": {"uri": "s3://bucket/v.pdf"}},
+                    "score": 0.9,
+                },
+            ]
+        }
+
+        retriever = BedrockKnowledgeBaseRetriever(
+            knowledge_base_id="TEST123456",
+            knowledge_base_type="VECTOR",
+        )
+        result = retriever.run(query="test")
+
+        call_kwargs = mock_boto3_client.retrieve.call_args.kwargs
+        assert "vectorSearchConfiguration" in call_kwargs["retrievalConfiguration"]
+
+    def test_run_top_k_override(self, mock_boto3_client):
+        from haystack.components.retrievers.bedrock_knowledge_base_retriever import (
+            BedrockKnowledgeBaseRetriever,
+        )
+
+        mock_boto3_client.retrieve.return_value = {"retrievalResults": []}
+
+        retriever = BedrockKnowledgeBaseRetriever(
+            knowledge_base_id="TEST123456", number_of_results=5
+        )
+        retriever.run(query="test", top_k=10)
+
+        call_kwargs = mock_boto3_client.retrieve.call_args.kwargs
+        assert call_kwargs["retrievalConfiguration"]["managedSearchConfiguration"]["numberOfResults"] == 10
+
+    def test_run_empty_results(self, mock_boto3_client):
+        from haystack.components.retrievers.bedrock_knowledge_base_retriever import (
+            BedrockKnowledgeBaseRetriever,
+        )
+
+        mock_boto3_client.retrieve.return_value = {"retrievalResults": []}
+
+        retriever = BedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
+        result = retriever.run(query="no match")
+
+        assert result["documents"] == []
+
+    def test_run_error_handling(self, mock_boto3_client):
+        from haystack.components.retrievers.bedrock_knowledge_base_retriever import (
+            BedrockKnowledgeBaseRetriever,
+        )
+
+        mock_boto3_client.retrieve.side_effect = Exception("Service unavailable")
+
+        retriever = BedrockKnowledgeBaseRetriever(knowledge_base_id="TEST123456")
+        result = retriever.run(query="test")
+
+        assert result["documents"] == []
+
+    def test_to_dict(self):
+        from haystack.components.retrievers.bedrock_knowledge_base_retriever import (
+            BedrockKnowledgeBaseRetriever,
+        )
+
+        retriever = BedrockKnowledgeBaseRetriever(
+            knowledge_base_id="TEST123456",
+            region_name="us-west-2",
+            number_of_results=10,
+            knowledge_base_type="VECTOR",
+        )
+        serialized = retriever.to_dict()
+
+        assert serialized["init_parameters"]["knowledge_base_id"] == "TEST123456"
+        assert serialized["init_parameters"]["region_name"] == "us-west-2"
+        assert serialized["init_parameters"]["number_of_results"] == 10
+        assert serialized["init_parameters"]["knowledge_base_type"] == "VECTOR"


### PR DESCRIPTION
- Created @component class BedrockKnowledgeBaseRetriever with run(query)
- Returns Documents with content, metadata, and scores
- Supports managed and vector search configurations
- Agentic retrieval with fallback to standard Retrieve API
- Includes to_dict serialization for pipeline persistence
- Unit tests included
- Added BEDROCK_MANAGED_KB.md design doc

### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
