### PR TITLE
fix: handle empty or missing tool-call arguments in from_openai_dict_format

### DIFF
--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -792,10 +792,13 @@ class ChatMessage:
             if tool_calls:
                 haystack_tool_calls = []
                 for tc in tool_calls:
+                    # Zero-argument tool calls from OpenAI-compatible servers may send an
+                    # empty string, null, or omit `arguments` entirely; treat all as {}.
+                    raw_arguments = tc["function"].get("arguments")
                     haystack_tc = ToolCall(
                         id=tc.get("id"),
                         tool_name=tc["function"]["name"],
-                        arguments=json.loads(tc["function"]["arguments"]),
+                        arguments=json.loads(raw_arguments) if raw_arguments else {},
                     )
                     haystack_tool_calls.append(haystack_tc)
             return cls.from_assistant(text=content, name=name, tool_calls=haystack_tool_calls)

--- a/releasenotes/notes/chatmsg-from-openai-dict-f15b50d38bdf9abb.yaml
+++ b/releasenotes/notes/chatmsg-from-openai-dict-f15b50d38bdf9abb.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    Add the ``from_openai_dict_format`` class method to the ``ChatMessage`` class. It allows you to create a ``ChatMessage``
+    Add the `from_openai_dict_format` class method to the `ChatMessage` class. It allows you to create a `ChatMessage`
     from a dictionary in the format expected by OpenAI's Chat API.

--- a/releasenotes/notes/chatmsg-from-openai-dict-f15b50d38bdf9abb.yaml
+++ b/releasenotes/notes/chatmsg-from-openai-dict-f15b50d38bdf9abb.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    Add the `from_openai_dict_format` class method to the `ChatMessage` class. It allows you to create a `ChatMessage`
+    Add the ``from_openai_dict_format`` class method to the ``ChatMessage`` class. It allows you to create a ``ChatMessage``
     from a dictionary in the format expected by OpenAI's Chat API.

--- a/releasenotes/notes/fix-openai-toolcall-empty-arguments-53c5621622bc1866.yaml
+++ b/releasenotes/notes/fix-openai-toolcall-empty-arguments-53c5621622bc1866.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed `ChatMessage.from_openai_dict_format` crashing on zero-argument tool
+    calls. OpenAI-compatible servers (vLLM, llama.cpp, Ollama, LM Studio, ...) may
+    send an empty string or omit the `arguments` field for a tool call that takes
+    no arguments; this previously raised `json.JSONDecodeError` or `KeyError`.
+    Such tool calls are now parsed into a `ToolCall` with empty `arguments`.

--- a/releasenotes/notes/fix-openai-toolcall-empty-arguments-53c5621622bc1866.yaml
+++ b/releasenotes/notes/fix-openai-toolcall-empty-arguments-53c5621622bc1866.yaml
@@ -1,8 +1,8 @@
 ---
 fixes:
   - |
-    Fixed `ChatMessage.from_openai_dict_format` crashing on zero-argument tool
+    Fixed ``ChatMessage.from_openai_dict_format`` crashing on zero-argument tool
     calls. OpenAI-compatible servers (vLLM, llama.cpp, Ollama, LM Studio, ...) may
-    send an empty string or omit the `arguments` field for a tool call that takes
-    no arguments; this previously raised `json.JSONDecodeError` or `KeyError`.
-    Such tool calls are now parsed into a `ToolCall` with empty `arguments`.
+    send an empty string or omit the ``arguments`` field for a tool call that takes
+    no arguments; this previously raised ``json.JSONDecodeError`` or ``KeyError``.
+    Such tool calls are now parsed into a ``ToolCall`` with empty ``arguments``.

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -966,6 +966,27 @@ class TestFromOpenaiDictFormat:
         assert tool_call.tool_name == "get_weather"
         assert tool_call.arguments == {"location": "Berlin"}
 
+    def test_from_openai_dict_format_tool_call_with_empty_arguments(self):
+        # OpenAI-compatible servers (vLLM, llama.cpp, Ollama, ...) emit an empty
+        # string for a zero-argument tool call; it must not crash.
+        openai_msg = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "call_1", "function": {"name": "now", "arguments": ""}}],
+        }
+        message = ChatMessage.from_openai_dict_format(openai_msg)
+        assert message.tool_call == ToolCall(id="call_1", tool_name="now", arguments={})
+
+    def test_from_openai_dict_format_tool_call_with_missing_arguments(self):
+        # Some servers omit the `arguments` key entirely for zero-argument calls.
+        openai_msg = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "call_1", "function": {"name": "now"}}],
+        }
+        message = ChatMessage.from_openai_dict_format(openai_msg)
+        assert message.tool_call.arguments == {}
+
     def test_from_openai_dict_format_tool_message(self):
         openai_msg = {"role": "tool", "content": "The weather is sunny", "tool_call_id": "call_123"}
         message = ChatMessage.from_openai_dict_format(openai_msg)

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -985,6 +985,7 @@ class TestFromOpenaiDictFormat:
             "tool_calls": [{"id": "call_1", "function": {"name": "now"}}],
         }
         message = ChatMessage.from_openai_dict_format(openai_msg)
+        assert message.tool_call is not None
         assert message.tool_call.arguments == {}
 
     def test_from_openai_dict_format_tool_message(self):


### PR DESCRIPTION
### Problem

`ChatMessage.from_openai_dict_format` parses tool-call arguments with:

```python
arguments=json.loads(tc["function"]["arguments"])
```

This assumes `arguments` is always present and always a valid JSON string. A
**zero-argument** tool call from an OpenAI-compatible server (vLLM, llama.cpp,
Ollama, LM Studio, ...) commonly sends an empty string, `null`, or omits the key:

```python
# empty string  -> json.JSONDecodeError
{"id": "1", "function": {"name": "now", "arguments": ""}}
# missing key   -> KeyError('arguments')
{"id": "1", "function": {"name": "now"}}
```

`_validate_openai_message` only checks that a `function` field exists, so nothing
guards this — and the method's docstring explicitly courts these "shallow
OpenAI-compatible APIs".

### Fix

Treat empty/null/missing `arguments` as an empty dict, leaving valid-JSON parsing
unchanged:

```python
raw_arguments = tc["function"].get("arguments")
arguments = json.loads(raw_arguments) if raw_arguments else {}
```

### Tests

Added two tests in `test/dataclasses/test_chat_message.py` (empty-string and
missing-key arguments). Both fail before the change (`JSONDecodeError` /
`KeyError`) and pass after. All 15 `from_openai_dict_format` tests pass.

```
$ python -m pytest test/dataclasses/test_chat_message.py -k from_openai_dict_format
15 passed
```

`ruff check` / `ruff format --check` pass. Added a release note.

---

*Disclosure: I used AI assistance (Claude) to find this crash-on-edge-input and
draft the tests. I reviewed the change, ran the suite, and take responsibility
for its correctness.*
