### PR TITLE
fix: guard FallbackChatGenerator.warm_up() against repeated initialization

### DIFF
--- a/haystack/components/generators/chat/fallback.py
+++ b/haystack/components/generators/chat/fallback.py
@@ -60,6 +60,7 @@ class FallbackChatGenerator:
             raise ValueError(msg)
 
         self.chat_generators = list(chat_generators)
+        self._warmed_up = False
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the component, including nested chat generators."""
@@ -87,18 +88,22 @@ class FallbackChatGenerator:
         return default_from_dict(cls, data)
 
     def warm_up(self) -> None:
-        """Warm up all underlying chat generators."""
-        for gen in self.chat_generators:
-            if hasattr(gen, "warm_up"):
-                gen.warm_up()
+        """Warm up all underlying chat generators (called at most once)."""
+        if not self._warmed_up:
+            for gen in self.chat_generators:
+                if hasattr(gen, "warm_up"):
+                    gen.warm_up()
+            self._warmed_up = True
 
     async def warm_up_async(self) -> None:
-        """Warm up all underlying chat generators on the serving event loop."""
-        for gen in self.chat_generators:
-            if hasattr(gen, "warm_up_async"):
-                await gen.warm_up_async()
-            elif hasattr(gen, "warm_up"):
-                gen.warm_up()
+        """Warm up all underlying chat generators on the serving event loop (called at most once)."""
+        if not self._warmed_up:
+            for gen in self.chat_generators:
+                if hasattr(gen, "warm_up_async"):
+                    await gen.warm_up_async()
+                elif hasattr(gen, "warm_up"):
+                    gen.warm_up()
+            self._warmed_up = True
 
     def close(self) -> None:
         """Release the underlying chat generators' resources."""

--- a/releasenotes/notes/fix-fallback-warm-up-lifecycle-da9d4b4af6a25872.yaml
+++ b/releasenotes/notes/fix-fallback-warm-up-lifecycle-da9d4b4af6a25872.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    ``FallbackChatGenerator`` now follows the same ``warm_up`` lifecycle semantics as
+    every other Haystack component. Previously, ``warm_up()`` was called on every
+    ``run()`` and ``run_async()`` invocation, meaning wrapped generators could be
+    initialized multiple times. This is now guarded by a ``_warmed_up`` flag so that
+    each underlying generator is warmed up at most once, regardless of how many times
+    the component is invoked.

--- a/test/components/generators/chat/test_fallback.py
+++ b/test/components/generators/chat/test_fallback.py
@@ -385,12 +385,37 @@ class TestComponentLifecycle:
         for gen in gens:
             gen.warm_up.assert_called_once()
 
+    def test_warm_up_only_called_once_across_multiple_run_calls(self):
+        """warm_up() must not be re-invoked on every run(); generators are initialized at most once."""
+        gens = [Mock(spec=["run", "warm_up"]) for _ in range(2)]
+        for gen in gens:
+            gen.run.return_value = {"replies": [ChatMessage.from_assistant("ok")], "meta": {}}
+        fallback = FallbackChatGenerator(chat_generators=gens)
+        # Call run() three times
+        for _ in range(3):
+            fallback.run([ChatMessage.from_user("hi")])
+        # warm_up must have been called exactly once despite three run() calls
+        for gen in gens:
+            gen.warm_up.assert_called_once()
+
     async def test_warm_up_async_delegates_to_every_generator(self):
         gens = [Mock(spec=["run", "warm_up_async"]) for _ in range(3)]
         for gen in gens:
             gen.warm_up_async = AsyncMock()
         fallback = FallbackChatGenerator(chat_generators=gens)
         await fallback.warm_up_async()
+        for gen in gens:
+            gen.warm_up_async.assert_awaited_once()
+
+    async def test_warm_up_async_only_called_once_across_multiple_run_async_calls(self):
+        """warm_up_async() must not be re-invoked on every run_async(); generators are initialized at most once."""
+        gens = [Mock(spec=["run_async", "warm_up_async"]) for _ in range(2)]
+        for gen in gens:
+            gen.warm_up_async = AsyncMock()
+            gen.run_async = AsyncMock(return_value={"replies": [ChatMessage.from_assistant("ok")], "meta": {}})
+        fallback = FallbackChatGenerator(chat_generators=gens)
+        for _ in range(3):
+            await fallback.run_async([ChatMessage.from_user("hi")])
         for gen in gens:
             gen.warm_up_async.assert_awaited_once()
 


### PR DESCRIPTION
**Related Issues**

Fixes #11976

---

**Proposed Changes**

- Add `self._warmed_up = False` to `FallbackChatGenerator.__init__`.
- Guard `warm_up()` with `if not self._warmed_up: ... self._warmed_up = True` so wrapped generators are initialized at most once, matching the lifecycle semantics of other Haystack components.
- Apply the same guard to `warm_up_async()`.
- Add two regression tests:
  - `test_warm_up_only_called_once_across_multiple_run_calls`
  - `test_warm_up_async_only_called_once_across_multiple_run_async_calls`
- Add a release note.

---

**How did you test it?**

```bash
hatch run test:unit test/components/generators/chat/test_fallback.py
```

All 32 tests passed.

---

**Notes for the reviewer**

This PR fixes a lifecycle contract inconsistency in `FallbackChatGenerator`.

`run()` and `run_async()` currently invoke `warm_up()` on every execution. Unlike other Haystack components that perform one-time lazy initialization, `FallbackChatGenerator` repeatedly delegates `warm_up()` to its wrapped generators. This means a custom generator with non-idempotent initialization logic may be reinitialized every time it is used through `FallbackChatGenerator`.

This change introduces a `_warmed_up` guard, consistent with the pattern already used by components such as `Agent` and other generators. Wrapped generators are now warmed up at most once, while preserving existing behavior for generators whose `warm_up()` implementations are already idempotent.

---

**Checklist**

- [x] Read contributors guidelines and code of conduct
- [ ] Updated related issue
- [x] Added unit tests
- [ ] Used conventional commit type in PR title
- [x] Documented code
- [x] Added release note
- [ ] Run pre-commit hooks and fixed any issues