### PR TITLE
fix: rebuild namedtuples in _deepcopy_with_exceptions

### DIFF
--- a/haystack/core/pipeline/utils.py
+++ b/haystack/core/pipeline/utils.py
@@ -33,6 +33,11 @@ def _deepcopy_with_exceptions(obj: Any) -> Any:
     from haystack.tools.tool import Tool
     from haystack.tools.toolset import Toolset
 
+    # namedtuples are tuple subclasses whose __new__ takes the fields positionally,
+    # so they must be rebuilt by unpacking rather than from a single iterable.
+    if isinstance(obj, tuple) and hasattr(obj, "_fields"):
+        return type(obj)(*(_deepcopy_with_exceptions(v) for v in obj))
+
     if isinstance(obj, (list, tuple, set)):
         return type(obj)(_deepcopy_with_exceptions(v) for v in obj)
 

--- a/releasenotes/notes/fix-deepcopy-namedtuple-c7aa157bc9aef85b.yaml
+++ b/releasenotes/notes/fix-deepcopy-namedtuple-c7aa157bc9aef85b.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed ``_deepcopy_with_exceptions`` crashing when a value is a ``namedtuple``
+    (or any ``typing.NamedTuple``). The list/tuple/set branch rebuilt the
+    container with ``type(obj)(<generator>)``, but a namedtuple's ``__new__``
+    expects its fields as positional arguments rather than a single iterable, so
+    copying a component input or parameter that contained a namedtuple raised a
+    ``TypeError``. Namedtuples are now rebuilt by unpacking their deep-copied
+    fields.

--- a/test/core/pipeline/test_utils.py
+++ b/test/core/pipeline/test_utils.py
@@ -4,6 +4,7 @@
 
 import logging
 import warnings
+from collections import namedtuple
 
 import pytest
 
@@ -254,6 +255,19 @@ class TestDeepcopyWithFallback:
         original = {"component": comp}
         res = _deepcopy_with_exceptions(original)
         assert res["component"] is original["component"]
+
+    def test_deepcopy_with_fallback_namedtuple(self):
+        Point = namedtuple("Point", ["x", "y"])
+        inner = Copyable()
+        original = {"point": Point(inner, 2)}
+        copy = _deepcopy_with_exceptions(original)
+        # A namedtuple must be reconstructed as its own type. Its __new__ takes
+        # positional fields, so the plain ``type(obj)(<generator>)`` path used for
+        # lists/tuples/sets would raise a TypeError instead of copying it.
+        assert isinstance(copy["point"], Point)
+        assert copy["point"].y == 2
+        # Its contents are deep-copied, matching how plain tuples are handled.
+        assert copy["point"].x is not original["point"].x
 
 
 class TestArgsDeprecated:


### PR DESCRIPTION
### What

`_deepcopy_with_exceptions` (used when Haystack copies component inputs/params) is designed to degrade gracefully: if an object cannot be deep-copied it returns the original and logs. But its container branch crashes on a `namedtuple`:

```python
if isinstance(obj, (list, tuple, set)):
    return type(obj)(_deepcopy_with_exceptions(v) for v in obj)
```

A `namedtuple` is a `tuple` subclass, so it takes this branch — but `type(obj)(<generator>)` calls the namedtuple's `__new__` with a **single iterable**, whereas its `__new__` expects the fields as **positional** arguments. The result is an uncaught `TypeError`, which propagates out of the copy (also through any dict/list that contains the namedtuple), defeating the function's own graceful-fallback contract.

Reproduction:

```python
from collections import namedtuple
from haystack.core.pipeline.utils import _deepcopy_with_exceptions

Point = namedtuple("Point", ["x", "y"])
_deepcopy_with_exceptions({"pt": Point(1, 2)})
# TypeError: Point.__new__() missing 1 required positional argument: 'y'
```

### Fix

Handle namedtuples explicitly (detected via the `_fields` attribute) **before** the generic list/tuple/set branch, rebuilding them by unpacking their deep-copied fields. Plain tuples/lists/sets are unaffected.

### Test

Added `TestDeepcopyWithFallback::test_deepcopy_with_fallback_namedtuple`, which fails before the change (the `TypeError` above) and passes after, verifying the namedtuple is reconstructed as its own type with deep-copied contents.

Verified locally: the full `test/core/pipeline/test_utils.py` suite passes (27 passed). `ruff check` and `ruff format --check` are clean. Added a release note.

---
*Authored with AI assistance (Claude Code); the change and tests were reviewed and verified locally by me.*
