### PR TITLE
fix: prune deleted BM25 vocabulary entries

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -507,6 +507,9 @@ class InMemoryDocumentStore:
             doc_len = doc_stats.doc_len
 
             self._freq_vocab_for_idf.subtract(Counter(freq.keys()))
+            for token in freq:
+                if self._freq_vocab_for_idf[token] <= 0:
+                    del self._freq_vocab_for_idf[token]
             try:
                 self._avg_doc_len = (self._avg_doc_len * (len(self._bm25_attr) + 1) - doc_len) / len(self._bm25_attr)
             except ZeroDivisionError:

--- a/releasenotes/notes/prune-zero-frequency-bm25-vocabulary-2669497a2350057b.yaml
+++ b/releasenotes/notes/prune-zero-frequency-bm25-vocabulary-2669497a2350057b.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Remove zero-frequency vocabulary entries after deleting documents from
+    ``InMemoryDocumentStore`` so previous document history no longer changes
+    BM25Okapi scores for the active corpus.

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -763,6 +763,26 @@ class TestMemoryDocumentStore(
         # After removing "hello world" (2 tokens), only "foo bar baz" (3 tokens) remains
         assert in_memory_doc_store._avg_doc_len == pytest.approx(3.0)
 
+    def test_bm25_okapi_scores_do_not_depend_on_deleted_documents(self):
+        active_documents = [
+            Document(id="d1", content="common alpha"),
+            Document(id="d2", content="common beta"),
+            Document(id="d3", content="common gamma"),
+        ]
+        fresh_store = InMemoryDocumentStore(bm25_algorithm="BM25Okapi", shared=False)
+        reused_store = InMemoryDocumentStore(bm25_algorithm="BM25Okapi", shared=False)
+        deleted_document = Document(content="one two three four five six seven eight nine ten")
+
+        reused_store.write_documents([deleted_document])
+        reused_store.delete_documents([deleted_document.id])
+        fresh_store.write_documents(active_documents)
+        reused_store.write_documents(active_documents)
+
+        fresh_scores = {doc.id: doc.score for doc in fresh_store.bm25_retrieval(query="common", top_k=3)}
+        reused_scores = {doc.id: doc.score for doc in reused_store.bm25_retrieval(query="common", top_k=3)}
+
+        assert reused_scores == pytest.approx(fresh_scores)
+
 
 class TestMemoryDocumentStoreNotShared(TestMemoryDocumentStore):
     """


### PR DESCRIPTION
### Related Issues

- fixes #11993

### Proposed Changes:

`InMemoryDocumentStore.delete_documents()` now removes vocabulary entries whose document frequency reaches zero after subtraction. This prevents terms that exist only in deleted documents from changing the epsilon-adjusted average IDF used by `BM25Okapi`.

PR #7549 introduced incremental BM25 indexing to avoid rebuilding the corpus for each query. Its deletion path used `Counter.subtract()`, which retains zero-count keys, while the scoring path treated every Counter key as part of the active vocabulary. The change repairs that state invariant at deletion time without giving up incremental indexing.

The PR also adds a regression test comparing a fresh store with a store that previously contained a deleted document, plus a release note.

### How did you test it?

- Added `TestMemoryDocumentStore::test_bm25_okapi_scores_do_not_depend_on_deleted_documents`.

### Notes for the reviewer

The cleanup is limited to the distinct terms in each deleted document.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md).
- [ ] I have updated the related issue with new insights and changes.
- [x] I added unit tests; no public docstring change is needed.
- [x] The planned title follows the conventional-commit format: `fix: prune deleted BM25 vocabulary entries`.
- [x] The user-visible behavior is documented in a release note.
- [x] I have added the required release note.
- [x] I have run the full pre-commit checks.
