### PR TITLE
test: adopt MockTextEmbedder in tests

### DIFF
--- a/test/components/retrievers/test_multi_query_embedding_retriever.py
+++ b/test/components/retrievers/test_multi_query_embedding_retriever.py
@@ -6,24 +6,16 @@ import os
 from typing import Any
 from unittest.mock import ANY, AsyncMock, Mock
 
-import numpy as np
 import pytest
 
 from haystack import Document, Pipeline, component
-from haystack.components.embedders import OpenAIDocumentEmbedder, OpenAITextEmbedder
+from haystack.components.embedders import MockTextEmbedder, OpenAIDocumentEmbedder, OpenAITextEmbedder
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.query import QueryExpander
 from haystack.components.retrievers import InMemoryEmbeddingRetriever, MultiQueryEmbeddingRetriever
 from haystack.components.writers import DocumentWriter
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.document_stores.types import DuplicatePolicy
-
-
-@component
-class MockQueryEmbedder:
-    @component.output_types(embedding=list[float])
-    def run(self, text: str) -> dict[str, list[float]]:
-        return {"embedding": np.ones(384).tolist()}
 
 
 class TestMultiQueryEmbeddingRetriever:
@@ -74,7 +66,7 @@ class TestMultiQueryEmbeddingRetriever:
 
     def test_init_with_default_parameters(self, in_memory_doc_store):
         embedding_retriever = InMemoryEmbeddingRetriever(document_store=in_memory_doc_store)
-        query_embedder = MockQueryEmbedder()
+        query_embedder = MockTextEmbedder()
         retriever = MultiQueryEmbeddingRetriever(retriever=embedding_retriever, query_embedder=query_embedder)
         assert retriever.retriever == embedding_retriever
         assert retriever.query_embedder == query_embedder
@@ -82,7 +74,7 @@ class TestMultiQueryEmbeddingRetriever:
 
     def test_init_with_custom_parameters(self, in_memory_doc_store):
         embedding_retriever = InMemoryEmbeddingRetriever(document_store=in_memory_doc_store)
-        query_embedder = MockQueryEmbedder()
+        query_embedder = MockTextEmbedder()
         retriever = MultiQueryEmbeddingRetriever(
             retriever=embedding_retriever, query_embedder=query_embedder, max_workers=2
         )
@@ -92,7 +84,7 @@ class TestMultiQueryEmbeddingRetriever:
 
     def test_run_with_empty_queries(self, in_memory_doc_store):
         multi_retriever = MultiQueryEmbeddingRetriever(
-            retriever=InMemoryEmbeddingRetriever(document_store=in_memory_doc_store), query_embedder=MockQueryEmbedder()
+            retriever=InMemoryEmbeddingRetriever(document_store=in_memory_doc_store), query_embedder=MockTextEmbedder()
         )
         result = multi_retriever.run(queries=[])
         assert "documents" in result
@@ -100,7 +92,7 @@ class TestMultiQueryEmbeddingRetriever:
 
     def test_run_with_empty_results(self, in_memory_doc_store):
         multi_retriever = MultiQueryEmbeddingRetriever(
-            retriever=InMemoryEmbeddingRetriever(document_store=in_memory_doc_store), query_embedder=MockQueryEmbedder()
+            retriever=InMemoryEmbeddingRetriever(document_store=in_memory_doc_store), query_embedder=MockTextEmbedder()
         )
         result = multi_retriever.run(queries=["query"])
         assert "documents" in result
@@ -109,7 +101,7 @@ class TestMultiQueryEmbeddingRetriever:
     def test_to_dict(self, in_memory_doc_store):
         multi_retriever = MultiQueryEmbeddingRetriever(
             retriever=InMemoryEmbeddingRetriever(document_store=in_memory_doc_store),
-            query_embedder=MockQueryEmbedder(),
+            query_embedder=MockTextEmbedder(),
             max_workers=2,
         )
         result = multi_retriever.to_dict()
@@ -139,8 +131,16 @@ class TestMultiQueryEmbeddingRetriever:
                     },
                 },
                 "query_embedder": {
-                    "type": "retrievers.test_multi_query_embedding_retriever.MockQueryEmbedder",
-                    "init_parameters": {},
+                    "type": "haystack.components.embedders.mock_text_embedder.MockTextEmbedder",
+                    "init_parameters": {
+                        "embedding": None,
+                        "embedding_fn": None,
+                        "dimension": 768,
+                        "model": "mock-model",
+                        "meta": {},
+                        "prefix": "",
+                        "suffix": "",
+                    },
                 },
                 "max_workers": 2,
             },
@@ -219,7 +219,7 @@ class TestMultiQueryEmbeddingRetriever:
                 return {"documents": [doc3, doc2]}
 
         multi_retriever = MultiQueryEmbeddingRetriever(
-            retriever=MockRetriever(), query_embedder=MockQueryEmbedder(), max_workers=1
+            retriever=MockRetriever(), query_embedder=MockTextEmbedder(), max_workers=1
         )
         result = multi_retriever.run(queries=["query1", "query2"])
 

--- a/test/components/retrievers/test_multi_query_embedding_retriever_async.py
+++ b/test/components/retrievers/test_multi_query_embedding_retriever_async.py
@@ -8,19 +8,9 @@ import numpy as np
 import pytest
 
 from haystack import Document, Pipeline, component
+from haystack.components.embedders import MockTextEmbedder
 from haystack.components.retrievers import InMemoryEmbeddingRetriever, MultiQueryEmbeddingRetriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-
-
-@component
-class MockQueryEmbedder:
-    @component.output_types(embedding=list[float])
-    def run(self, text: str) -> dict[str, list[float]]:
-        return {"embedding": np.ones(384).tolist()}
-
-    @component.output_types(embedding=list[float])
-    async def run_async(self, text: str) -> dict[str, list[float]]:
-        return {"embedding": np.ones(384).tolist()}
 
 
 class TestMultiQueryEmbeddingRetrieverAsync:
@@ -28,7 +18,7 @@ class TestMultiQueryEmbeddingRetrieverAsync:
     async def test_run_async_with_empty_queries(self):
         multi_retriever = MultiQueryEmbeddingRetriever(
             retriever=InMemoryEmbeddingRetriever(document_store=InMemoryDocumentStore()),
-            query_embedder=MockQueryEmbedder(),
+            query_embedder=MockTextEmbedder(),
         )
         result = await multi_retriever.run_async(queries=[])
         assert "documents" in result
@@ -62,7 +52,7 @@ class TestMultiQueryEmbeddingRetrieverAsync:
             ) -> dict[str, list[Document]]:
                 return {"documents": [doc_low, doc_high, doc_mid]}
 
-        multi_retriever = MultiQueryEmbeddingRetriever(retriever=MockRetriever(), query_embedder=MockQueryEmbedder())
+        multi_retriever = MultiQueryEmbeddingRetriever(retriever=MockRetriever(), query_embedder=MockTextEmbedder())
         result = await multi_retriever.run_async(queries=["query1", "query2"])
 
         scores = [doc.score for doc in result["documents"]]
@@ -96,7 +86,7 @@ class TestMultiQueryEmbeddingRetrieverAsync:
             ) -> dict[str, list[Document]]:
                 return {"documents": [doc3, doc2]}
 
-        multi_retriever = MultiQueryEmbeddingRetriever(retriever=MockRetriever(), query_embedder=MockQueryEmbedder())
+        multi_retriever = MultiQueryEmbeddingRetriever(retriever=MockRetriever(), query_embedder=MockTextEmbedder())
         result = await multi_retriever.run_async(queries=["query1", "query2"])
 
         assert "documents" in result
@@ -131,9 +121,7 @@ class TestMultiQueryEmbeddingRetrieverAsync:
             ) -> dict[str, list[Document]]:
                 return {"documents": [Document(content="Solar energy", id="doc1", score=0.9)]}
 
-        multi_retriever = MultiQueryEmbeddingRetriever(
-            retriever=SyncOnlyRetriever(), query_embedder=MockQueryEmbedder()
-        )
+        multi_retriever = MultiQueryEmbeddingRetriever(retriever=SyncOnlyRetriever(), query_embedder=MockTextEmbedder())
         result = await multi_retriever.run_async(queries=["query1", "query2"])
         assert "documents" in result
         assert len(result["documents"]) == 1
@@ -188,7 +176,7 @@ class TestMultiQueryEmbeddingRetrieverAsync:
         in_memory_retriever = InMemoryEmbeddingRetriever(document_store=document_store_with_categorized_docs)
         filters = {"field": "category", "operator": "==", "value": "solar"}
         multi_retriever = MultiQueryEmbeddingRetriever(
-            retriever=in_memory_retriever, query_embedder=MockQueryEmbedder()
+            retriever=in_memory_retriever, query_embedder=MockTextEmbedder(dimension=384)
         )
         result = await multi_retriever.run_async(
             queries=["energy", "sunlight", "photovoltaic"], retriever_kwargs={"filters": filters}
@@ -202,7 +190,7 @@ class TestMultiQueryEmbeddingRetrieverAsync:
     async def test_run_async_with_pipeline(self):
         multi_retriever = MultiQueryEmbeddingRetriever(
             retriever=InMemoryEmbeddingRetriever(document_store=InMemoryDocumentStore()),
-            query_embedder=MockQueryEmbedder(),
+            query_embedder=MockTextEmbedder(),
         )
         pipeline = Pipeline()
         pipeline.add_component("retriever", multi_retriever)

--- a/test/components/retrievers/test_text_embedding_retriever.py
+++ b/test/components/retrievers/test_text_embedding_retriever.py
@@ -6,22 +6,14 @@ import os
 from typing import Any
 from unittest.mock import ANY, AsyncMock, Mock
 
-import numpy as np
 import pytest
 
 from haystack import Document, component
-from haystack.components.embedders import OpenAIDocumentEmbedder, OpenAITextEmbedder
+from haystack.components.embedders import MockTextEmbedder, OpenAIDocumentEmbedder, OpenAITextEmbedder
 from haystack.components.retrievers import InMemoryEmbeddingRetriever, TextEmbeddingRetriever
 from haystack.components.writers import DocumentWriter
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.document_stores.types import DuplicatePolicy
-
-
-@component
-class MockTextEmbedder:
-    @component.output_types(embedding=list[float])
-    def run(self, text: str) -> dict[str, list[float]]:
-        return {"embedding": np.ones(384).tolist()}
 
 
 class TestTextEmbeddingRetriever:
@@ -113,8 +105,16 @@ class TestTextEmbeddingRetriever:
                     },
                 },
                 "text_embedder": {
-                    "type": "retrievers.test_text_embedding_retriever.MockTextEmbedder",
-                    "init_parameters": {},
+                    "type": "haystack.components.embedders.mock_text_embedder.MockTextEmbedder",
+                    "init_parameters": {
+                        "embedding": None,
+                        "embedding_fn": None,
+                        "dimension": 768,
+                        "model": "mock-model",
+                        "meta": {},
+                        "prefix": "",
+                        "suffix": "",
+                    },
                 },
             },
         }

--- a/test/components/retrievers/test_text_embedding_retriever_async.py
+++ b/test/components/retrievers/test_text_embedding_retriever_async.py
@@ -8,19 +8,9 @@ import numpy as np
 import pytest
 
 from haystack import Document, Pipeline, component
+from haystack.components.embedders import MockTextEmbedder
 from haystack.components.retrievers import InMemoryEmbeddingRetriever, TextEmbeddingRetriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-
-
-@component
-class MockTextEmbedder:
-    @component.output_types(embedding=list[float])
-    def run(self, text: str) -> dict[str, list[float]]:
-        return {"embedding": np.ones(384).tolist()}
-
-    @component.output_types(embedding=list[float])
-    async def run_async(self, text: str) -> dict[str, list[float]]:
-        return {"embedding": np.ones(384).tolist()}
 
 
 class TestTextEmbeddingRetrieverAsync:
@@ -114,7 +104,7 @@ class TestTextEmbeddingRetrieverAsync:
     async def test_run_async_with_filters(self, document_store_with_categorized_docs):
         retriever = TextEmbeddingRetriever(
             retriever=InMemoryEmbeddingRetriever(document_store=document_store_with_categorized_docs),
-            text_embedder=MockTextEmbedder(),
+            text_embedder=MockTextEmbedder(dimension=384),
         )
         filters = {"field": "category", "operator": "==", "value": "solar"}
         result = await retriever.run_async(query="energy", filters=filters)

--- a/test/core/pipeline/breakpoints/test_pipeline_breakpoints_rag_hybrid.py
+++ b/test/core/pipeline/breakpoints/test_pipeline_breakpoints_rag_hybrid.py
@@ -10,18 +10,12 @@ import pytest
 from haystack import Document, Pipeline, component
 from haystack.components.builders.answer_builder import AnswerBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
+from haystack.components.embedders import MockTextEmbedder
 from haystack.components.joiners import DocumentJoiner
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever, InMemoryEmbeddingRetriever
 from haystack.core.errors import BreakpointException
 from haystack.dataclasses.breakpoints import Breakpoint
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-
-
-@component
-class FakeEmbedder:
-    @component.output_types(documents=list[Document], embedding=list[float])
-    def run(self, text: str) -> dict[str, list[Document] | list[float]]:
-        return {"embedding": [random() for _ in range(100)]}
 
 
 @component
@@ -67,7 +61,7 @@ class TestPipelineBreakpoints:
 
         pipeline = Pipeline()
         pipeline.add_component("bm25_retriever", InMemoryBM25Retriever(document_store=document_store))
-        pipeline.add_component("query_embedder", FakeEmbedder())
+        pipeline.add_component("query_embedder", MockTextEmbedder(dimension=100))
         pipeline.add_component("embedding_retriever", InMemoryEmbeddingRetriever(document_store=document_store))
         pipeline.add_component("doc_joiner", DocumentJoiner())
         pipeline.add_component("ranker", FakeRanker())

--- a/test/core/pipeline/features/test_run.py
+++ b/test/core/pipeline/features/test_run.py
@@ -22,6 +22,7 @@ from haystack.components.converters import (
     OutputAdapter,
     TextFileToDocument,
 )
+from haystack.components.embedders import MockTextEmbedder
 from haystack.components.joiners import AnswerJoiner, BranchJoiner, DocumentJoiner, StringJoiner
 from haystack.components.preprocessors import DocumentCleaner, DocumentSplitter
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
@@ -1702,12 +1703,6 @@ def that_is_linear_with_conditional_branching_and_multiple_joins():
             return {"LEGIT": query}
 
     @component
-    class FakeEmbedder:
-        @component.output_types(embeddings=list[float])
-        def run(self, text: str) -> dict[str, list[float]]:
-            return {"embeddings": [1.0, 2.0, 3.0]}
-
-    @component
     class FakeRanker:
         @component.output_types(documents=list[Document])
         def run(self, query: str, documents: list[Document]) -> dict[str, list[Document]]:
@@ -1728,7 +1723,7 @@ def that_is_linear_with_conditional_branching_and_multiple_joins():
             return {"documents": [doc2]}
 
     pipeline.add_component(name="router", instance=FakeRouter())
-    pipeline.add_component(name="text_embedder", instance=FakeEmbedder())
+    pipeline.add_component(name="text_embedder", instance=MockTextEmbedder(embedding=[1.0, 2.0, 3.0]))
     pipeline.add_component(name="retriever", instance=FakeEmbeddingRetriever())
     pipeline.add_component(name="emptyretriever", instance=FakeRetriever())
     pipeline.add_component(name="joinerfinal", instance=DocumentJoiner())
@@ -1752,7 +1747,12 @@ def that_is_linear_with_conditional_branching_and_multiple_joins():
         [
             PipelineRunData(
                 inputs={"router": {"query": "I'm a legit question"}},
-                expected_outputs={"joinerfinal": {"documents": [doc1, doc2]}},
+                expected_outputs={
+                    "text_embedder": {
+                        "meta": {"model": "mock-model", "usage": {"prompt_tokens": 4, "total_tokens": 4}}
+                    },
+                    "joinerfinal": {"documents": [doc1, doc2]},
+                },
                 expected_component_calls={
                     ("router", 1): {"query": "I'm a legit question"},
                     ("text_embedder", 1): {"text": "I'm a legit question"},

--- a/test/core/pipeline/test_pipeline_crash_regular_pipeline_snapshot_is_raised.py
+++ b/test/core/pipeline/test_pipeline_crash_regular_pipeline_snapshot_is_raised.py
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
 import pytest
 
 from haystack import Document, Pipeline
 from haystack.components.builders import ChatPromptBuilder
+from haystack.components.embedders import MockTextEmbedder
 from haystack.components.joiners import DocumentJoiner
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.core.component import component
@@ -29,14 +29,6 @@ class InvalidOutputEmbeddingRetriever:
         # Return an int instead of the expected dict with 'documents' key
         # This will cause the pipeline to crash when trying to pass it to the next component
         return 42  # type: ignore[return-value]
-
-
-@component
-class MockTextEmbedder:
-    @component.output_types(embedding=list[float])
-    def run(self, text: str) -> dict[str, list[float]]:
-        embedding = np.ones(384).tolist()  # Mock embedding of size 384
-        return {"embedding": embedding}
 
 
 class TestPipelineOutputsRaisedInException:


### PR DESCRIPTION
### Related Issues

- `MockTextEmbedder` was introduced in https://github.com/deepset-ai/haystack/pull/11709 for testing purposes

### Proposed Changes:
- adopt `MockTextEmbedder` in our tests for consistency and simplicity (where it makes sense)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
