### PR TITLE
test: remove stale test modules from slow tests triggering list

### DIFF
--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -61,13 +61,9 @@ jobs:
             changes:
               - "haystack/components/evaluators/sas_evaluator.py"
               - "haystack/components/generators/openai_dalle.py"
-              - "haystack/components/preprocessors/embedding_based_document_splitter.py"
-              - "haystack/components/retrievers/multi_query_embedding_retriever.py"
 
               - "test/components/evaluators/test_sas_evaluator.py"
               - "test/components/generators/test_openai_dalle.py"
-              - "test/components/preprocessors/test_embedding_based_document_splitter.py"
-              - "test/components/retrievers/test_multi_query_embedding_retriever.py"
 
   slow-integration-tests:
     name: Slow Tests / ${{ matrix.os }}


### PR DESCRIPTION
### Related Issues
In https://github.com/deepset-ai/haystack/pull/11646 I removed the `slow` marker from some tests but did not remove the modules from the `slow` list.

So, now these modules trigger the `slow` test workflow (including all slow/unstable tests) even if they no longer contain slow tests.


### Proposed Changes:
- remove test modules from the `slow` list

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
