### PR TITLE
fix(agents): preserve tool-call order for unknown tools when raise_on_failure=False

### DIFF
--- a/haystack/components/agents/tool_calling.py
+++ b/haystack/components/agents/tool_calling.py
@@ -343,7 +343,7 @@ def _prepare_tool_args(
 
 def _resolve_tool_calls(
     messages_with_tool_calls: list[ChatMessage], tools_with_names: dict[str, Tool], *, raise_on_failure: bool
-) -> tuple[list[ToolCall], list[Tool], list[ChatMessage]]:
+) -> tuple[list[ToolCall], list[Tool], list[int], list[tuple[int, ChatMessage]]]:
     """
     Walk all tool calls in `messages_with_tool_calls` and resolve each to its Tool.
 
@@ -351,15 +351,22 @@ def _resolve_tool_calls(
     `_schedule_tool_calls`) so that a tool reading from State observes writes made by tools that ran earlier in the same
      step.
 
-    :returns: (tool_calls, resolved_tools, error_messages)
+    The original position of every call (across all messages) is tracked so that callers can return tool results in
+    call order regardless of outcome: unknown-tool errors carry their position alongside the message, and valid calls
+    carry theirs in a parallel list.
+
+    :returns: (tool_calls, resolved_tools, valid_call_positions, error_entries)
         - tool_calls: ToolCall objects for each valid call, in call order
         - resolved_tools: the resolved Tool for each entry in `tool_calls` (parallel list)
-        - error_messages: ChatMessages for tool-not-found errors (when raise_on_failure is False)
+        - valid_call_positions: original position of each valid call, parallel to `tool_calls`
+        - error_entries: (original_position, ChatMessage) for each tool-not-found error (when raise_on_failure is False)
     """
     tool_calls: list[ToolCall] = []
     resolved_tools: list[Tool] = []
-    error_messages: list[ChatMessage] = []
+    valid_call_positions: list[int] = []
+    error_entries: list[tuple[int, ChatMessage]] = []
 
+    position = 0
     for message in messages_with_tool_calls:
         for tool_call in message.tool_calls:
             tool_name = tool_call.tool_name
@@ -369,13 +376,35 @@ def _resolve_tool_calls(
                 if raise_on_failure:
                     raise error
                 logger.error("{error_exception}", error_exception=error)
-                error_messages.append(ChatMessage.from_tool(tool_result=str(error), origin=tool_call, error=True))
+                error_message = ChatMessage.from_tool(tool_result=str(error), origin=tool_call, error=True)
+                error_entries.append((position, error_message))
+                position += 1
                 continue
 
             tool_calls.append(tool_call)
             resolved_tools.append(tools_with_names[tool_name])
+            valid_call_positions.append(position)
+            position += 1
 
-    return tool_calls, resolved_tools, error_messages
+    return tool_calls, resolved_tools, valid_call_positions, error_entries
+
+
+def _merge_results_in_call_order(
+    results: list[ChatMessage | None], valid_call_positions: list[int], error_entries: list[tuple[int, ChatMessage]]
+) -> list[ChatMessage]:
+    """
+    Combine executed tool results and unknown-tool errors back into original tool-call order.
+
+    Each valid result is placed at the position its call had in the original sequence, and each error at its own
+    position, so that returned messages match the order the model requested regardless of outcome.
+    """
+    ordered: list[ChatMessage | None] = [None] * (len(results) + len(error_entries))
+    for position, error_message in error_entries:
+        ordered[position] = error_message
+    for result, position in zip(results, valid_call_positions, strict=True):
+        if result is not None:
+            ordered[position] = result
+    return [message for message in ordered if message is not None]
 
 
 def _keys_intersect(a: _StateKeys, b: _StateKeys) -> bool:
@@ -529,11 +558,11 @@ def _run_tool(
     if not messages_with_tool_calls:
         return [], state
 
-    tool_calls, resolved_tools, error_messages = _resolve_tool_calls(
+    tool_calls, resolved_tools, valid_call_positions, error_entries = _resolve_tool_calls(
         messages_with_tool_calls, tools_with_names, raise_on_failure=raise_on_failure
     )
     if not tool_calls:
-        return error_messages, state
+        return [message for _, message in error_entries], state
 
     # Group the calls into batches that honor read-after-write dependencies on State (see `_schedule_tool_calls`).
     batches = _schedule_tool_calls(tool_calls, resolved_tools)
@@ -572,7 +601,7 @@ def _run_tool(
                     streaming_callback(_create_tool_result_streaming_chunk(message, tool_calls[idx], stream_index))
                     stream_index += 1
 
-    tool_messages = error_messages + [m for m in results if m is not None]
+    tool_messages = _merge_results_in_call_order(results, valid_call_positions, error_entries)
 
     # We emit a final empty chunk with finish_reason "tool_call_results" to signal the end of the tool results stream.
     if tool_messages and streaming_callback is not None:
@@ -611,11 +640,11 @@ async def _run_tool_async(
     if not messages_with_tool_calls:
         return [], state
 
-    tool_calls, resolved_tools, error_messages = _resolve_tool_calls(
+    tool_calls, resolved_tools, valid_call_positions, error_entries = _resolve_tool_calls(
         messages_with_tool_calls, tools_with_names, raise_on_failure=raise_on_failure
     )
     if not tool_calls:
-        return error_messages, state
+        return [message for _, message in error_entries], state
 
     # Group the calls into batches that honor read-after-write dependencies on State (see `_schedule_tool_calls`).
     batches = _schedule_tool_calls(tool_calls, resolved_tools)
@@ -655,7 +684,7 @@ async def _run_tool_async(
                 )
                 stream_index += 1
 
-    tool_messages = error_messages + [m for m in results if m is not None]
+    tool_messages = _merge_results_in_call_order(results, valid_call_positions, error_entries)
 
     # We emit a final empty chunk with finish_reason "tool_call_results" to signal the end of the tool results stream.
     if tool_messages and streaming_callback is not None:

--- a/releasenotes/notes/fix-tool-result-order-unknown-tool-929828894261f9c3.yaml
+++ b/releasenotes/notes/fix-tool-result-order-unknown-tool-929828894261f9c3.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    When running an `Agent` (or the underlying tool-calling helpers) with
+    `raise_on_failure=False`, tool-result messages for unknown tools are now
+    returned in the original tool-call order. Previously, unknown-tool error
+    messages were moved ahead of all successful results, so for a tool-call
+    order like `[known, unknown]` the returned messages came back as
+    `[unknown, known]`. Both the synchronous and asynchronous execution paths
+    now preserve the order requested by the model.

--- a/test/components/agents/test_tool_calling.py
+++ b/test/components/agents/test_tool_calling.py
@@ -651,6 +651,51 @@ class TestRunToolErrorHandling:
         assert tool_message.tool_call_results[0].error
         assert "not found" in tool_message.tool_call_results[0].result
 
+    # Scenarios exercising unknown tools at different positions relative to a valid call.
+    _ORDER_SCENARIOS = {
+        "unknown_last": ["weather_tool", "missing"],
+        "unknown_first": ["missing", "weather_tool"],
+        "unknown_middle": ["weather_tool", "missing", "weather_tool"],
+        "multiple_unknown": ["missing_a", "weather_tool", "missing_b"],
+    }
+
+    @staticmethod
+    def _tool_calls_for(tool_names):
+        return [
+            ToolCall(
+                tool_name=name, arguments={} if name.startswith("missing") else {"location": "Berlin"}, id=f"call_{i}"
+            )
+            for i, name in enumerate(tool_names)
+        ]
+
+    @staticmethod
+    def _assert_call_order_preserved(tool_messages, tool_names):
+        results = [message.tool_call_results[0] for message in tool_messages]
+        # Returned messages stay in the original tool-call order regardless of outcome.
+        assert [result.origin.tool_name for result in results] == tool_names
+        assert [result.origin.id for result in results] == [f"call_{i}" for i in range(len(tool_names))]
+        # The error flag is set exactly for the unknown tools, not shuffled across positions.
+        assert [result.error for result in results] == [name.startswith("missing") for name in tool_names]
+
+    @pytest.mark.parametrize("tool_names", _ORDER_SCENARIOS.values(), ids=list(_ORDER_SCENARIOS.keys()))
+    def test_unknown_tool_preserves_call_order(self, weather_tool, tool_names):
+        # With raise_on_failure=False, unknown-tool errors used to be returned ahead of all successful results,
+        # so the returned order no longer matched the model's tool-call order (e.g. [ok, missing] -> [missing, ok]).
+        message = ChatMessage.from_assistant(tool_calls=self._tool_calls_for(tool_names))
+        tool_messages, _ = _run_tool(
+            messages=[message], state=State(schema={}), tools=[weather_tool], raise_on_failure=False
+        )
+        self._assert_call_order_preserved(tool_messages, tool_names)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool_names", _ORDER_SCENARIOS.values(), ids=list(_ORDER_SCENARIOS.keys()))
+    async def test_unknown_tool_preserves_call_order_async(self, weather_tool, tool_names):
+        message = ChatMessage.from_assistant(tool_calls=self._tool_calls_for(tool_names))
+        tool_messages, _ = await _run_tool_async(
+            messages=[message], state=State(schema={}), tools=[weather_tool], raise_on_failure=False
+        )
+        self._assert_call_order_preserved(tool_messages, tool_names)
+
     def test_tool_invocation_error(self, faulty_tool):
         tool_call = ToolCall(tool_name="faulty_tool", arguments={"location": "Berlin"})
         tool_call_message = ChatMessage.from_assistant(tool_calls=[tool_call])


### PR DESCRIPTION
### Related Issues

- fixes #12010

### Proposed Changes:

When `raise_on_failure=False`, an unknown tool changed the order of the returned tool-result messages.

`_resolve_tool_calls()` collected unknown-tool errors in a separate `error_messages` list while valid calls were indexed only among the valid calls. `_run_tool()` / `_run_tool_async()` then returned `error_messages + [results...]`, so every error was moved ahead of every successful result. For a tool-call order of `[known, unknown]` the returned messages came back as `[unknown, known]`, which breaks the surrounding contract that results stay in tool-call order and can make Agent history, hooks, and positional consumers observe a different order than the model requested.

The fix retains each call's original position while resolving:

- `_resolve_tool_calls()` now also returns `valid_call_positions` (parallel to `tool_calls`) and `error_entries` as `(position, message)` pairs.
- A small helper `_merge_results_in_call_order()` places executed results and unknown-tool errors back into their original slots, so the returned list matches the model's tool-call order for all outcomes.
- Applied identically to the sync (`_run_tool`) and async (`_run_tool_async`) paths. Streaming and State write-merge ordering are unchanged.

### How did you test it?

- Added sync and async regression tests (`test_unknown_tool_preserves_call_order[_async]`) parametrized over an unknown tool at the start, in the middle, at the end, and multiple unknown tools; they assert the returned order, the preserved tool-call IDs, and that the `error` flag lands on the right positions. These fail on `main` (e.g. `[ok, missing]` → `[missing, ok]`) and pass with the fix.
- Full `test/components/agents/test_tool_calling.py` suite passes (72 tests).
- `ruff check`, `ruff format --check`, and `mypy` are clean on the changed files.

### Notes for the reviewer

The `[None] * len(tool_calls)` results list and the `if m is not None` filter are preserved from the original code, so a result that never gets populated is still dropped rather than surfaced as a gap. The early-return path when there are no valid calls returns only the error messages, which are already in call order among themselves.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title: `fix:`.
- [x] I have documented my code.
- [x] I have added a release note file, following the contributors guidelines.
- [x] I have run pre-commit hooks and fixed any issue.
