### PR TITLE
fix: preserve lazy toolsets added before warm-up

### DIFF
--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -248,9 +248,9 @@ class Toolset:
         if not isinstance(tool, (Tool, Toolset)):
             raise TypeError(f"Expected Tool or Toolset, got {type(tool).__name__}")
 
-        # Warm up the source before flattening so that lazily-loaded toolsets (e.g. MCPToolset)
-        # expose their tools, and so newly added tools are ready to use right away.
-        if self._is_warmed_up and hasattr(tool, "warm_up"):
+        # Toolsets must be warmed before flattening so lazily loaded tools are not lost.
+        # Plain tools are still only warmed immediately when this Toolset is already warm.
+        if isinstance(tool, Toolset) or (self._is_warmed_up and hasattr(tool, "warm_up")):
             tool.warm_up()
 
         new_tools = [tool] if isinstance(tool, Tool) else list(tool)

--- a/releasenotes/notes/fix-toolset-add-lazy-c73a533f031c72d2.yaml
+++ b/releasenotes/notes/fix-toolset-add-lazy-c73a533f031c72d2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Ensure ``Toolset.add()`` warms lazy child toolsets before flattening them so dynamically loaded tools are
+    preserved.

--- a/test/tools/test_toolset.py
+++ b/test/tools/test_toolset.py
@@ -135,6 +135,22 @@ class WarmUpCountingToolset(Toolset):
         super().warm_up()
 
 
+class LazyWarmUpToolset(Toolset):
+    """A Toolset that only exposes its tools during warm_up()."""
+
+    def __init__(self, tools):
+        super().__init__([])
+        self._tools_to_load = tools
+        self.warm_up_count = 0
+
+    def warm_up(self) -> None:
+        if self._is_warmed_up:
+            return
+        self.warm_up_count += 1
+        self.tools.extend(self._tools_to_load)
+        super().warm_up()
+
+
 class TestToolset:
     def test_toolset_with_multiple_tools(self, add_tool, multiply_tool):
         """Test that a Toolset with multiple tools works properly."""
@@ -418,6 +434,31 @@ class TestToolsetWarmUp:
         # The added toolset's own warm_up() is invoked, warming its tools.
         assert added.warm_up_count == 1
         assert all(tool.warm_up_count == 1 for tool in added_tools)
+
+    def test_add_lazy_toolset_before_warm_up_preserves_loaded_tools(self):
+        toolset = Toolset()
+        added_tools = [WarmUpCountingTool("a"), WarmUpCountingTool("b")]
+        added = LazyWarmUpToolset(added_tools)
+
+        toolset.add(added)
+
+        assert added.warm_up_count == 1
+        assert [tool.name for tool in toolset] == ["a", "b"]
+        assert all(tool.warm_up_count == 1 for tool in added_tools)
+        assert toolset._is_warmed_up is False
+
+        added.warm_up()
+        assert added.warm_up_count == 1
+
+    def test_add_lazy_toolset_checks_loaded_tool_names_for_duplicates(self):
+        existing = WarmUpCountingTool("duplicate")
+        toolset = Toolset([existing])
+        added = LazyWarmUpToolset([WarmUpCountingTool("duplicate")])
+
+        with pytest.raises(ValueError, match="duplicate"):
+            toolset.add(added)
+
+        assert toolset.tools == [existing]
 
     def test_plus_returns_new_unwarmed_toolset(self):
         ts1 = Toolset([WarmUpCountingTool("a")])


### PR DESCRIPTION
### Related Issues

- fixes #12009

### Proposed Changes:

`Toolset.add()` only warmed the object being added when the parent had already been warmed. A lazy child `Toolset` was therefore flattened while still empty when added to a cold parent, and its tools could not be recovered later.

- Warm child `Toolset` instances before flattening them.
- Keep the existing cold-parent behavior for plain `Tool` instances.
- Add regression coverage for lazy loading, idempotent warm-up, and duplicate-name validation.
- Add a release note for the behavior fix.

### How did you test it?

- `hatch run test:unit test/tools/test_toolset.py -q` (33 passed)
- `hatch run test:types` (`Success: no issues found in 371 source files`)
- `hatch run pre-commit run --files haystack/tools/toolset.py test/tools/test_toolset.py releasenotes/notes/fix-toolset-add-lazy-c73a533f031c72d2.yaml`

### Notes for the reviewer

The change intentionally warms only child `Toolset` instances before flattening. Adding a plain `Tool` to a cold parent remains deferred until the parent is warmed.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.