### PR TITLE
docs: add doc page for TavilyWebSearchTool

### DIFF
--- a/docs-website/docs/tools/ready-made-tools.mdx
+++ b/docs-website/docs/tools/ready-made-tools.mdx
@@ -21,3 +21,5 @@ These are the ready-made Tools and Toolsets available in Haystack:
 | [GitHubRepoViewerTool](ready-made-tools/githubrepoviewertool.mdx) | Navigates and fetches content from GitHub repositories. |
 | [Mem0MemoryRetrieverTool](ready-made-tools/mem0memorytools.mdx) | Retrieves long-term memories from Mem0 for Agent workflows. |
 | [Mem0MemoryWriterTool](ready-made-tools/mem0memorytools.mdx) | Stores long-term memories in Mem0 for future Agent runs. |
+| [MirageShellTool](ready-made-tools/mirageshelltool.mdx) | Gives Agents a bash shell over a Mirage unified virtual filesystem, mounting backends like S3, Google Drive, and Postgres as one file tree. |
+| [TavilyWebSearchTool](ready-made-tools/tavilywebsearchtool.mdx) | Searches the web with Tavily and returns results Agents can cite. |

--- a/docs-website/docs/tools/ready-made-tools/tavilywebsearchtool.mdx
+++ b/docs-website/docs/tools/ready-made-tools/tavilywebsearchtool.mdx
@@ -1,0 +1,102 @@
+---
+title: "TavilyWebSearchTool"
+id: tavilywebsearchtool
+slug: "/tavilywebsearchtool"
+description: "A Tool that allows Agents to search the web with Tavily."
+---
+
+# TavilyWebSearchTool
+
+A Tool that allows Agents to search the web with Tavily.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Mandatory init variables** | `api_key`: The Tavily API key. Can be set with the `TAVILY_API_KEY` env var. |
+| **API reference**            | [Tavily](/reference/integrations-tavily) |
+| **GitHub link**              | https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/tavily/src/haystack_integrations/tools/tavily/websearch_tool.py |
+| **Package name**             | `tavily-haystack` |
+
+</div>
+
+## Overview
+
+`TavilyWebSearchTool` wraps the [`TavilyWebSearch`](../../pipeline-components/websearch/tavilywebsearch.mdx) component, providing a tool interface for use in agent workflows and tool-based pipelines.
+
+The tool parameters are derived from the component's `run` method, so the LLM can pass a `query` and, optionally, `search_params` that override the ones set at initialization time.
+
+Results are formatted as a string, with each result showing a title, the exact URL, and a content snippet. This makes it straightforward for the LLM to cite its sources.
+
+### Parameters
+
+All parameters are keyword-only.
+
+- `api_key` is _mandatory_ and holds the Tavily API key. The default setting reads it from the `TAVILY_API_KEY` environment variable.
+- `top_k` is _optional_ and sets the maximum number of results to return. If unset, the `TavilyWebSearch` default applies.
+- `search_params` is _optional_ and takes additional parameters for the Tavily search API. Supported keys include `search_depth`, `include_answer`, `include_raw_content`, `include_domains`, and `exclude_domains`.
+- `name` is _optional_ and defaults to "web_search". Specifies the name of the tool.
+- `description` is _optional_ and provides context to the LLM about what the tool does. If not provided, a default description is applied.
+
+## Usage
+
+Install the Tavily integration to use the `TavilyWebSearchTool`:
+
+```shell
+pip install tavily-haystack
+```
+
+### On its own
+
+Basic usage to search the web:
+
+```python
+from haystack_integrations.tools.tavily import TavilyWebSearchTool
+
+tool = TavilyWebSearchTool(top_k=3)
+
+result = tool.invoke(query="What is Haystack by deepset?")
+
+for document in result["documents"]:
+    print(document.meta["title"], "-", document.meta["url"])
+```
+
+```bash
+GitHub - deepset-ai/haystack: Open-source AI orchestration framework ... - https://github.com/deepset-ai/haystack
+deepset - Wikipedia - https://en.wikipedia.org/wiki/Deepset
+Haystack | Haystack - https://haystack.deepset.ai
+```
+
+### With an Agent
+
+You can use `TavilyWebSearchTool` with the [Agent](../../pipeline-components/agents-1/agent.mdx) component. The Agent will automatically invoke the tool when it needs information from the web.
+
+```python
+from haystack.components.agents import Agent
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.tools.tavily import TavilyWebSearchTool
+
+web_search = TavilyWebSearchTool(top_k=5, search_params={"search_depth": "advanced"})
+
+agent = Agent(
+    chat_generator=OpenAIChatGenerator(model="gpt-5-mini"),
+    tools=[web_search],
+)
+
+result = agent.run(messages=[ChatMessage.from_user("What is Haystack by deepset?")])
+
+print(result["last_message"].text)
+```
+
+```bash
+Haystack (by deepset) is an open-source Python framework for building production-ready
+LLM applications, especially Retrieval-Augmented Generation (RAG), semantic search,
+question answering, and agentic workflows.
+
+It provides modular components and pipelines (document stores, retrievers, rankers,
+generators, routers, and tool integrations) so you can compose and control how data
+flows before a model sees it.
+
+Source repo: https://github.com/deepset-ai/haystack
+```

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -721,6 +721,7 @@ export default {
             'tools/ready-made-tools/githubrepoviewertool',
             'tools/ready-made-tools/mem0memorytools',
             'tools/ready-made-tools/mirageshelltool',
+            'tools/ready-made-tools/tavilywebsearchtool',
           ],
         },
       ],

--- a/docs-website/versioned_docs/version-2.31/tools/ready-made-tools.mdx
+++ b/docs-website/versioned_docs/version-2.31/tools/ready-made-tools.mdx
@@ -21,3 +21,5 @@ These are the ready-made Tools and Toolsets available in Haystack:
 | [GitHubRepoViewerTool](ready-made-tools/githubrepoviewertool.mdx) | Navigates and fetches content from GitHub repositories. |
 | [Mem0MemoryRetrieverTool](ready-made-tools/mem0memorytools.mdx) | Retrieves long-term memories from Mem0 for Agent workflows. |
 | [Mem0MemoryWriterTool](ready-made-tools/mem0memorytools.mdx) | Stores long-term memories in Mem0 for future Agent runs. |
+| [MirageShellTool](ready-made-tools/mirageshelltool.mdx) | Gives Agents a bash shell over a Mirage unified virtual filesystem, mounting backends like S3, Google Drive, and Postgres as one file tree. |
+| [TavilyWebSearchTool](ready-made-tools/tavilywebsearchtool.mdx) | Searches the web with Tavily and returns results Agents can cite. |

--- a/docs-website/versioned_docs/version-2.31/tools/ready-made-tools/tavilywebsearchtool.mdx
+++ b/docs-website/versioned_docs/version-2.31/tools/ready-made-tools/tavilywebsearchtool.mdx
@@ -1,0 +1,102 @@
+---
+title: "TavilyWebSearchTool"
+id: tavilywebsearchtool
+slug: "/tavilywebsearchtool"
+description: "A Tool that allows Agents to search the web with Tavily."
+---
+
+# TavilyWebSearchTool
+
+A Tool that allows Agents to search the web with Tavily.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Mandatory init variables** | `api_key`: The Tavily API key. Can be set with the `TAVILY_API_KEY` env var. |
+| **API reference**            | [Tavily](/reference/integrations-tavily) |
+| **GitHub link**              | https://github.com/deepset-ai/haystack-core-integrations/blob/main/integrations/tavily/src/haystack_integrations/tools/tavily/websearch_tool.py |
+| **Package name**             | `tavily-haystack` |
+
+</div>
+
+## Overview
+
+`TavilyWebSearchTool` wraps the [`TavilyWebSearch`](../../pipeline-components/websearch/tavilywebsearch.mdx) component, providing a tool interface for use in agent workflows and tool-based pipelines.
+
+The tool parameters are derived from the component's `run` method, so the LLM can pass a `query` and, optionally, `search_params` that override the ones set at initialization time.
+
+Results are formatted as a string, with each result showing a title, the exact URL, and a content snippet. This makes it straightforward for the LLM to cite its sources.
+
+### Parameters
+
+All parameters are keyword-only.
+
+- `api_key` is _mandatory_ and holds the Tavily API key. The default setting reads it from the `TAVILY_API_KEY` environment variable.
+- `top_k` is _optional_ and sets the maximum number of results to return. If unset, the `TavilyWebSearch` default applies.
+- `search_params` is _optional_ and takes additional parameters for the Tavily search API. Supported keys include `search_depth`, `include_answer`, `include_raw_content`, `include_domains`, and `exclude_domains`.
+- `name` is _optional_ and defaults to "web_search". Specifies the name of the tool.
+- `description` is _optional_ and provides context to the LLM about what the tool does. If not provided, a default description is applied.
+
+## Usage
+
+Install the Tavily integration to use the `TavilyWebSearchTool`:
+
+```shell
+pip install tavily-haystack
+```
+
+### On its own
+
+Basic usage to search the web:
+
+```python
+from haystack_integrations.tools.tavily import TavilyWebSearchTool
+
+tool = TavilyWebSearchTool(top_k=3)
+
+result = tool.invoke(query="What is Haystack by deepset?")
+
+for document in result["documents"]:
+    print(document.meta["title"], "-", document.meta["url"])
+```
+
+```bash
+GitHub - deepset-ai/haystack: Open-source AI orchestration framework ... - https://github.com/deepset-ai/haystack
+deepset - Wikipedia - https://en.wikipedia.org/wiki/Deepset
+Haystack | Haystack - https://haystack.deepset.ai
+```
+
+### With an Agent
+
+You can use `TavilyWebSearchTool` with the [Agent](../../pipeline-components/agents-1/agent.mdx) component. The Agent will automatically invoke the tool when it needs information from the web.
+
+```python
+from haystack.components.agents import Agent
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.tools.tavily import TavilyWebSearchTool
+
+web_search = TavilyWebSearchTool(top_k=5, search_params={"search_depth": "advanced"})
+
+agent = Agent(
+    chat_generator=OpenAIChatGenerator(model="gpt-5-mini"),
+    tools=[web_search],
+)
+
+result = agent.run(messages=[ChatMessage.from_user("What is Haystack by deepset?")])
+
+print(result["last_message"].text)
+```
+
+```bash
+Haystack (by deepset) is an open-source Python framework for building production-ready
+LLM applications, especially Retrieval-Augmented Generation (RAG), semantic search,
+question answering, and agentic workflows.
+
+It provides modular components and pipelines (document stores, retrievers, rankers,
+generators, routers, and tool integrations) so you can compose and control how data
+flows before a model sees it.
+
+Source repo: https://github.com/deepset-ai/haystack
+```

--- a/docs-website/versioned_sidebars/version-2.31-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.31-sidebars.json
@@ -718,7 +718,8 @@
             "tools/ready-made-tools/githubprcreatortool",
             "tools/ready-made-tools/githubrepoviewertool",
             "tools/ready-made-tools/mem0memorytools",
-            "tools/ready-made-tools/mirageshelltool"
+            "tools/ready-made-tools/mirageshelltool",
+            "tools/ready-made-tools/tavilywebsearchtool"
           ]
         }
       ]


### PR DESCRIPTION
### Related Issues

- this ready-made Tool was introduced in https://github.com/deepset-ai/haystack-core-integrations/pull/3597. It wraps a ` TavilyWebSearch` component

### Proposed Changes:
- add minimal documentation page for the Tool
- (add Mirage to the table of ready-made Tools since it was missing)

### How did you test it?
Vercel preview

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
