### PR TITLE
fix: Toolset.add drops tools from lazy child toolsets

### DIFF
--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -248,9 +248,13 @@ class Toolset:
         if not isinstance(tool, (Tool, Toolset)):
             raise TypeError(f"Expected Tool or Toolset, got {type(tool).__name__}")
 
-        # Warm up the source before flattening so that lazily-loaded toolsets (e.g. MCPToolset)
-        # expose their tools, and so newly added tools are ready to use right away.
-        if self._is_warmed_up and hasattr(tool, "warm_up"):
+        # A child Toolset must be warmed before it is flattened below via list(tool):
+        # a lazily-loaded Toolset only materializes its tools in warm_up(), so warming
+        # it here keeps those tools from being flattened away and silently lost (a later
+        # parent warm_up() could not recover them). This holds regardless of the parent's
+        # own warm-up state. A plain Tool keeps the existing behavior: it is warmed here
+        # only when the parent is already warmed up.
+        if isinstance(tool, Toolset) or (self._is_warmed_up and hasattr(tool, "warm_up")):
             tool.warm_up()
 
         new_tools = [tool] if isinstance(tool, Tool) else list(tool)

--- a/releasenotes/notes/Fix-Toolset.add-dropping-lazy-child-toolset-tools-ef6a9bdd4882cade.yaml
+++ b/releasenotes/notes/Fix-Toolset.add-dropping-lazy-child-toolset-tools-ef6a9bdd4882cade.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed `Toolset.add()` silently dropping the tools of a lazily-loaded child
+    `Toolset` (one that materializes its tools in `warm_up()`) when it was added
+    to a not-yet-warmed parent. The child `Toolset` is now warmed before it is
+    flattened, so its tools are retained and duplicate-name validation runs
+    against them. Adding a plain `Tool` to a cold parent is unchanged: it is
+    still warmed only when the parent is warmed up.

--- a/test/tools/test_toolset.py
+++ b/test/tools/test_toolset.py
@@ -419,6 +419,51 @@ class TestToolsetWarmUp:
         assert added.warm_up_count == 1
         assert all(tool.warm_up_count == 1 for tool in added_tools)
 
+    def test_add_lazy_toolset_before_warm_up_retains_lazily_loaded_tools(self):
+        """A lazily-loaded child Toolset added to a not-yet-warmed parent must be warmed
+        before it is flattened, so its tools are retained instead of silently dropped."""
+
+        class LazyToolset(Toolset):
+            def __init__(self):
+                super().__init__([])
+                self.warm_up_count = 0
+
+            def warm_up(self) -> None:
+                if self._is_warmed_up:
+                    return
+                self.warm_up_count += 1
+                self.tools.append(WarmUpCountingTool("lazy"))
+                self._is_warmed_up = True
+
+        lazy = LazyToolset()
+        parent = Toolset()  # cold parent
+        parent.add(lazy)
+
+        # The lazy child is warmed exactly once so its tool materializes and is kept.
+        assert lazy.warm_up_count == 1
+        assert [tool.name for tool in parent] == ["lazy"]
+        # A later parent warm_up() does not re-warm the (already warmed) child.
+        parent.warm_up()
+        assert lazy.warm_up_count == 1
+
+    def test_add_lazy_toolset_before_warm_up_detects_duplicate_names(self, add_tool):
+        """Duplicate-name validation must run against a lazy child's materialized tools,
+        so a collision is detected rather than hidden by the tools being dropped."""
+
+        class LazyDuplicateToolset(Toolset):
+            def __init__(self):
+                super().__init__([])
+
+            def warm_up(self) -> None:
+                if self._is_warmed_up:
+                    return
+                self.tools.append(WarmUpCountingTool("add"))
+                self._is_warmed_up = True
+
+        parent = Toolset([add_tool])  # already contains a tool named "add"
+        with pytest.raises(ValueError):
+            parent.add(LazyDuplicateToolset())
+
     def test_plus_returns_new_unwarmed_toolset(self):
         ts1 = Toolset([WarmUpCountingTool("a")])
         ts1.warm_up()


### PR DESCRIPTION
## Summary

`Toolset.add()` warmed the object being added only when the parent was already warmed up. For a lazily-loaded child `Toolset` (one that materializes its tools in `warm_up()`), adding it to a not-yet-warmed parent meant it was flattened with `list(tool)` while still empty, so its tools were silently dropped and a later `parent.warm_up()` could not recover them. This contradicts the method's own comment about warming the source before flattening.

Fixes #12009

## Changes

- `haystack/tools/toolset.py`: in `Toolset.add()`, warm a child `Toolset` before flattening it, regardless of the parent's warm-up state. Adding a plain `Tool` to a cold parent is unchanged (still warmed only when the parent is warmed up).
- `test/tools/test_toolset.py`: regression tests for adding a lazy child `Toolset` to a cold parent (tools retained) and for duplicate-name validation against the materialized tools.
- Release note under `releasenotes/notes/`.

## Testing

- `test/tools/test_toolset.py` — 33 passed (31 existing + 2 new).
- Both new tests fail against the pre-fix code, so they guard the actual regression.
- `ruff format --check` and `ruff check` pass on the changed files.

Reproduction from the issue, before the fix:

```python
lazy = LazyToolset()      # builds its tool in warm_up()
parent = Toolset()        # not warmed
parent.add(lazy)
# {'lazy_warmups': 0, 'parent_tools': []}  -> tools dropped
```

After the fix the child is warmed before flattening, so `parent` contains the lazy tool.
