### PR TITLE
ci: adapt workflows in preparation for 3.0

### DIFF
--- a/.github/utils/promote_unstable_docs_docusaurus.py
+++ b/.github/utils/promote_unstable_docs_docusaurus.py
@@ -23,10 +23,8 @@ if __name__ == "__main__":
         sys.exit("Version must be formatted like so <major>.<minor>")
 
     target_version = f"{args.version}"  # e.g., "2.20" - the target release version
-    major, minor = args.version.split(".")
 
     target_unstable = f"{target_version}-unstable"  # e.g., "2.20-unstable"
-    previous_stable = f"{major}.{int(minor) - 1}"  # e.g., "2.19" - previous stable release
 
     versions = [
         folder.replace("version-", "")
@@ -83,9 +81,15 @@ if __name__ == "__main__":
     with open("docs-website/reference_versions.json", "w") as f:
         json.dump(reference_versions_list, f)
 
-    # in docusaurus.config.js, replace previous stable version with the target version
+    # in docusaurus.config.js, replace the current stable version (lastVersion) with the target version
     with open("docs-website/docusaurus.config.js") as f:
         config = f.read()
+    last_version_matches = set(re.findall(r"lastVersion: '([^']+)'", config))
+    if not last_version_matches:
+        sys.exit("Could not find any lastVersion entry in docusaurus.config.js")
+    if len(last_version_matches) > 1:
+        sys.exit(f"Found inconsistent lastVersion entries in docusaurus.config.js: {last_version_matches}")
+    previous_stable = last_version_matches.pop()  # e.g., "2.19" - previous stable release
     config = config.replace(f"lastVersion: '{previous_stable}'", f"lastVersion: '{target_version}'")  # "2.19" -> "2.20"
     with open("docs-website/docusaurus.config.js", "w") as f:
         f.write(config)

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -12,7 +12,7 @@ on:
       - 'pyproject.toml'
       - 'VERSION.txt'
     tags:
-      - "v2.[0-9]+.[0-9]+*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 env:
   DOCKER_REPO_NAME: deepset/haystack
@@ -52,7 +52,7 @@ jobs:
 
       - name: Detect stable version
         run: |
-          if [[ "${{ steps.meta.outputs.version }}" =~ ^v2\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "${{ steps.meta.outputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "IS_STABLE=true" >> "$GITHUB_ENV"
             echo "Stable version detected"
           else

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:  # this is useful to re-generate the release page without a new tag being pushed
   push:
     tags:
-      - "v2.[0-9]+.[0-9]+*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
       # Ignore release versions tagged with -rc0 suffix
-      - "!v2.[0-9]+.[0-9]-rc0"
+      - "!v[0-9]+.[0-9]+.[0-9]-rc0"
 
 permissions:
   contents: read

--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -79,7 +79,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           beforeDefaultRemarkPlugins: [require('./src/remark/versionedReferenceLinks')],
           versions: {
             current: {
-              label: '2.32-unstable',
+              label: '3.0-unstable',
               path: 'next',
               banner: 'unreleased',
             },
@@ -132,7 +132,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         exclude: ['**/_templates/**'],
         versions: {
           current: {
-            label: '2.32-unstable',
+            label: '3.0-unstable',
             path: 'next',
             banner: 'unreleased',
           },


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/459

### Proposed Changes:
- adapt workflows to be more version-agnostic: do not require v2 tags
- fix unstable docs version: must be `3.0-unstable` (not `2.32-unstable`)
- in the script to promote unstable docs, get the actual previous unstable version from docusaurus config, not from the target version

### How did you test it?
Just quick local verifications.

**My plan after the PR is to create a fork and try the release process end to end (without artifacts) to be more sure.**

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
