### PR TITLE
fix: warm child Toolset before flattening in Toolset.add()

### DIFF
--- a/haystack/tools/toolset.py
+++ b/haystack/tools/toolset.py
@@ -248,9 +248,15 @@ class Toolset:
         if not isinstance(tool, (Tool, Toolset)):
             raise TypeError(f"Expected Tool or Toolset, got {type(tool).__name__}")
 
-        # Warm up the source before flattening so that lazily-loaded toolsets (e.g. MCPToolset)
-        # expose their tools, and so newly added tools are ready to use right away.
-        if self._is_warmed_up and hasattr(tool, "warm_up"):
+        if isinstance(tool, Toolset):
+            # Always warm a child Toolset before flattening so that lazily-loaded tools
+            # (those a subclass materialises in warm_up()) are available regardless of
+            # whether this parent has already been warmed up. The child's warm_up() is
+            # idempotent, so calling it on an already-warm child is safe.
+            tool.warm_up()
+        elif self._is_warmed_up and hasattr(tool, "warm_up"):
+            # For a plain Tool, warm immediately only when the parent is already warm;
+            # parent.warm_up() will handle it later otherwise.
             tool.warm_up()
 
         new_tools = [tool] if isinstance(tool, Tool) else list(tool)

--- a/releasenotes/notes/fix-toolset-add-lazy-warmup-021fea0781aeac20.yaml
+++ b/releasenotes/notes/fix-toolset-add-lazy-warmup-021fea0781aeac20.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed ``Toolset.add()`` silently dropping all tools when a lazy child ``Toolset``
+    (one that materialises its tools in ``warm_up()``) was added to a parent that had
+    not yet been warmed up. The child is now always warmed before being flattened,
+    regardless of the parent's warm state.

--- a/test/tools/test_toolset.py
+++ b/test/tools/test_toolset.py
@@ -419,6 +419,57 @@ class TestToolsetWarmUp:
         assert added.warm_up_count == 1
         assert all(tool.warm_up_count == 1 for tool in added_tools)
 
+    def test_add_lazy_toolset_to_cold_parent_retains_tools(self):
+        """Regression: add() must warm a child Toolset before flattening even when the parent is cold.
+
+        Previously the guard was ``if self._is_warmed_up``, so a child Toolset added to a
+        cold parent was flattened while still empty, silently discarding all its tools.
+        """
+
+        class LazyToolset(Toolset):
+            def __init__(self):
+                super().__init__([])
+                self.warmups = 0
+
+            def warm_up(self):
+                if self._is_warmed_up:
+                    return
+                self.warmups += 1
+                self.tools.append(WarmUpCountingTool("lazy"))
+                self._is_warmed_up = True
+
+        lazy = LazyToolset()
+        parent = Toolset()  # cold parent
+        parent.add(lazy)
+
+        assert lazy.warmups == 1, "child Toolset must be warmed before flattening"
+        assert [t.name for t in parent] == ["lazy"], "lazy tool must appear in parent"
+
+    def test_add_lazy_toolset_warm_up_is_idempotent(self):
+        """Adding an already-warm child Toolset to a warm parent does not warm it again."""
+        child = WarmUpCountingToolset([WarmUpCountingTool("a")])
+        child.warm_up()
+        assert child.warm_up_count == 1
+
+        parent = Toolset()
+        parent.warm_up()
+        parent.add(child)
+
+        assert child.warm_up_count == 1, "child must not be warmed a second time"
+
+    def test_add_plain_tool_to_cold_parent_does_not_warm_it(self):
+        """Adding a plain Tool to a cold parent must NOT warm it eagerly (regression guard).
+
+        Plain tools are warmed by parent.warm_up(); warming them early would be wrong.
+        """
+        tool = WarmUpCountingTool("a")
+        parent = Toolset()
+        parent.add(tool)
+
+        assert tool.warm_up_count == 0, "plain Tool must not be warmed before parent.warm_up()"
+        parent.warm_up()
+        assert tool.warm_up_count == 1
+
     def test_plus_returns_new_unwarmed_toolset(self):
         ts1 = Toolset([WarmUpCountingTool("a")])
         ts1.warm_up()


### PR DESCRIPTION
Fixes #12009

## Summary

`Toolset.add()` silently dropped all tools when a lazy child `Toolset` (one that materialises its tools in `warm_up()`) was added to a parent that had not yet been warmed up.

The guard was:

```python
if self._is_warmed_up and hasattr(tool, "warm_up"):
    tool.warm_up()

new_tools = [tool] if isinstance(tool, Tool) else list(tool)
```

Because `self._is_warmed_up` was `False` for a cold parent, the child was never warmed before `list(tool)` flattened it. The list was empty and the tools were silently lost — no exception raised.

**Fix:** warm every child `Toolset` unconditionally before flattening. The child's `warm_up()` is idempotent, so calling it on an already-warm child is safe. Plain `Tool` objects retain the existing behaviour: warmed immediately only when the parent is already warm.

```python
if isinstance(tool, Toolset):
    # Always warm a child Toolset before flattening so lazily-loaded tools
    # are available regardless of whether the parent has been warmed yet.
    tool.warm_up()
elif self._is_warmed_up and hasattr(tool, "warm_up"):
    tool.warm_up()
```

## Tests

Three regression tests added to `TestToolsetWarmUp`:

| Test | Covers |
|------|--------|
| `test_add_lazy_toolset_to_cold_parent_retains_tools` | Main bug: lazy child added to cold parent retains its tools |
| `test_add_lazy_toolset_warm_up_is_idempotent` | Already-warm child added to warm parent is not warmed again |
| `test_add_plain_tool_to_cold_parent_does_not_warm_it` | Regression guard: plain `Tool` added to cold parent is still not warmed eagerly |

All 34 tests in `test/tools/test_toolset.py` pass.