### PR TITLE
fix: crash when a tool parameter is named `properties` (create_tool_from_function, @tool, ComponentTool)

### DIFF
--- a/haystack/tools/from_function.py
+++ b/haystack/tools/from_function.py
@@ -344,10 +344,14 @@ def _remove_title_from_schema(schema: dict[str, Any]) -> None:
         The JSON schema to remove the 'title' keyword from.
     """
     for key, value in list(schema.items()):
-        # Make sure not to remove parameters named title
-        if key == "properties" and isinstance(value, dict) and "title" in value:
-            for sub_val in value.values():
-                _remove_title_from_schema(sub_val)
+        # Keys of a 'properties' mapping are property names, not schema keywords.
+        # Recurse only into the property sub-schemas so that parameters named
+        # 'title' (or any other keyword, e.g. 'properties') are never removed or
+        # misinterpreted as schema keywords.
+        if key == "properties" and isinstance(value, dict):
+            for sub_schema in value.values():
+                if isinstance(sub_schema, dict):
+                    _remove_title_from_schema(sub_schema)
         elif key == "title":
             del schema[key]
         elif isinstance(value, dict):

--- a/releasenotes/notes/fix-tool-schema-parameter-named-properties-9c8689341280f5b2.yaml
+++ b/releasenotes/notes/fix-tool-schema-parameter-named-properties-9c8689341280f5b2.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixed an `AttributeError: 'str' object has no attribute 'items'` raised by `create_tool_from_function`,
-    the `@tool` decorator, and `ComponentTool` when a tool parameter is named `properties`.
-    Keys inside a JSON schema `properties` mapping are property names and are no longer misinterpreted
-    as schema keywords when stripping the auto-generated `title` keywords.
+    Fixed an ``AttributeError: 'str' object has no attribute 'items'`` raised by ``create_tool_from_function``,
+    the ``@tool`` decorator, and ``ComponentTool`` when a tool parameter is named ``properties``.
+    Keys inside a JSON schema ``properties`` mapping are property names and are no longer misinterpreted
+    as schema keywords when stripping the auto-generated ``title`` keywords.

--- a/releasenotes/notes/fix-tool-schema-parameter-named-properties-9c8689341280f5b2.yaml
+++ b/releasenotes/notes/fix-tool-schema-parameter-named-properties-9c8689341280f5b2.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an `AttributeError: 'str' object has no attribute 'items'` raised by `create_tool_from_function`,
+    the `@tool` decorator, and `ComponentTool` when a tool parameter is named `properties`.
+    Keys inside a JSON schema `properties` mapping are property names and are no longer misinterpreted
+    as schema keywords when stripping the auto-generated `title` keywords.

--- a/test/tools/test_from_function.py
+++ b/test/tools/test_from_function.py
@@ -323,6 +323,46 @@ def test_remove_title_from_schema_do_not_remove_title_property():
     assert schema == {"properties": {"parameter1": {"type": "string"}, "title": {"type": "string"}}, "type": "object"}
 
 
+def test_remove_title_from_schema_property_named_properties():
+    """Test that a property named 'properties' is not misinterpreted as the 'properties' schema keyword."""
+    schema = {
+        "properties": {
+            "entity_id": {"type": "string", "title": "Entity Id"},
+            "properties": {"type": "object", "additionalProperties": True, "title": "Properties"},
+        },
+        "title": "set_properties",
+        "type": "object",
+    }
+
+    _remove_title_from_schema(schema)
+
+    assert schema == {
+        "properties": {"entity_id": {"type": "string"}, "properties": {"type": "object", "additionalProperties": True}},
+        "type": "object",
+    }
+
+
+def test_from_function_with_parameter_named_properties():
+    """Creating a tool from a function with a parameter named 'properties' must not crash."""
+
+    def set_properties(
+        entity_id: Annotated[str, "the entity to update"], properties: Annotated[dict, "the properties to set"]
+    ) -> str:
+        """Set properties on an entity."""
+        return f"Set {properties} on {entity_id}"
+
+    tool = create_tool_from_function(function=set_properties)
+
+    assert tool.parameters == {
+        "type": "object",
+        "properties": {
+            "entity_id": {"type": "string", "description": "the entity to update"},
+            "properties": {"type": "object", "additionalProperties": True, "description": "the properties to set"},
+        },
+        "required": ["entity_id", "properties"],
+    }
+
+
 def test_remove_title_from_schema_handle_no_title_in_top_level():
     schema = {
         "properties": {


### PR DESCRIPTION
### Related Issues

- No existing issue: searched open and closed issues/PRs for `remove_title_from_schema`, `'str' object has no attribute 'items'`, and tool-schema `AttributeError` and found no report of this bug.

### Proposed Changes:

Creating a `Tool` from any function whose signature has a parameter named `properties` crashes with `AttributeError: 'str' object has no attribute 'items'`. All of `create_tool_from_function`, the `@tool` decorator, and `ComponentTool` (which imports the same helper) are affected, and a parameter named `properties` is quite realistic for LLM tools (e.g. "set/update entity properties" tools for graph or DB backends):

```python
from typing import Annotated
from haystack.tools import tool

@tool
def set_properties(
    entity_id: Annotated[str, "the entity"],
    properties: Annotated[dict, "properties to set"],
) -> str:
    """Set properties on an entity."""
    return "ok"
# AttributeError: 'str' object has no attribute 'items'
#   (raised from _remove_title_from_schema, haystack/tools/from_function.py:346)
```

**Root cause:** `_remove_title_from_schema` special-cases `key == "properties" and isinstance(value, dict) and "title" in value` so that a property *named* `title` is not deleted. But the keys of a `properties` mapping are property *names*, not schema keywords, and the guard only fires when a property named `title` happens to exist. When a property is named `properties`, one level deeper the iteration hits `key == "properties"` whose value is that property's Pydantic sub-schema — which always contains a `title` keyword — so the branch triggers and recurses into raw scalar values like `"Properties"` and `"string"`, calling `.items()` on a `str`.

**Fix:** the `properties` branch now applies unconditionally and only recurses into `dict` sub-schemas, so property names are never interpreted as schema keywords. The existing behavior of preserving a property named `title` (while still stripping the `title` keyword inside its sub-schema) is unchanged and remains covered by `test_remove_title_from_schema_do_not_remove_title_property`.

Also added a release note under `releasenotes/notes/`.

### How did you test it?

- Added `test_remove_title_from_schema_property_named_properties` (unit test for the helper) and `test_from_function_with_parameter_named_properties` (end-to-end `create_tool_from_function` test). Both fail on `main` with the `AttributeError` above and pass with the fix.
- Ran the full tools unit-test suite locally: `pytest test/tools/ -m "not integration"` → `269 passed, 11 deselected`.
- `ruff check` / `ruff format --check` and `mypy haystack/tools/from_function.py` pass on the changed files.

### Notes for the reviewer

- Open PR #12023 refactors `from_function.py` but only moves the `_remove_title_from_schema(schema)` call site; it does not touch the helper, so this fix is orthogonal (trivial rebase either way).
- This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
