### PR TITLE
ci: use HAYSTACK_BOT_TOKEN for CLA draft gate

### DIFF
--- a/.github/workflows/cla_draft_gate.yml
+++ b/.github/workflows/cla_draft_gate.yml
@@ -40,10 +40,12 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          # GITHUB_TOKEN can normally convert PRs to draft and back. If those
-          # GraphQL mutations ever fail with "Resource not accessible by
-          # integration", add a classic PAT with `repo` scope as CLA_GATE_PAT.
-          github-token: ${{ secrets.CLA_GATE_PAT || github.token }}
+          # The convertPullRequestToDraft/markPullRequestReadyForReview GraphQL
+          # mutations require a user token; GITHUB_TOKEN fails with "Resource
+          # not accessible by integration" (seen on #12036). Use the bot PAT,
+          # which also lets the ready_for_review/review_requested events from
+          # restore() trigger the linked_issue_review workflow.
+          github-token: ${{ secrets.HAYSTACK_BOT_TOKEN }}
           script: |
             const CLA_CONTEXT = "license/cla";
             const LABEL = "cla-pending";


### PR DESCRIPTION
### Related Issues

- Follow-up to #11995. Root-caused on #12036.

### Proposed Changes:

The CLA draft gate on #12036 correctly posted the comment, removed the reviewer, and added the `cla-pending` label — but the PR was never converted to draft. The workflow run logs show why:

```
##[warning]PR #12036: Request failed due to following response errors:
 - Resource not accessible by integration
```

The `convertPullRequestToDraft` / `markPullRequestReadyForReview` GraphQL mutations require a **user** token; GitHub App installation tokens like `GITHUB_TOKEN` cannot call them, regardless of the granted `pull-requests: write` permission. This switches the workflow to `secrets.HAYSTACK_BOT_TOKEN` (already used by `release.yml` and `update-platform-components.yml`), with no silent fallback to `GITHUB_TOKEN` so a missing secret fails loudly instead of half-gating PRs again.

Side effects, both intentional:
- Gate/restore actions (comments, labels, draft toggles, review requests) now show as the bot account instead of `github-actions[bot]`.
- Because PAT-initiated events trigger workflows (unlike `GITHUB_TOKEN` events), the `ready_for_review`/`review_requested` events emitted by `restore()` now correctly trigger the `linked_issue_review` workflow after a contributor signs the CLA.

### How did you test it?

- Root cause confirmed from the `cla_draft_gate` run logs (runs 29559061351, 29542596075) and the state of #12036 (labeled + commented but not drafted).
- actionlint via pre-commit passed. The mutation itself can only be verified once this is on `main`, on the next PR the sweep gates.

### Notes for the reviewer

- Requires `HAYSTACK_BOT_TOKEN` to be a classic PAT with `repo` scope (it creates branches/PRs in `release.yml`, so it should be).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- No release note: CI-only change, not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)