### PR TITLE
fix: fix doc store mixin to use correct doc store method

### DIFF
--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -1052,7 +1052,7 @@ class CountUniqueMetadataByFilterTest:
 
     @staticmethod
     def test_count_unique_metadata_by_filter_with_multiple_filters(document_store: DocumentStore):
-        """Test counting with multiple filters"""
+        """Test count_unique_metadata_by_filter() with multiple filters."""
         docs = [
             Document(content="Doc 1", meta={"category": "A", "year": 2023}),
             Document(content="Doc 2", meta={"category": "A", "year": 2024}),
@@ -1060,16 +1060,17 @@ class CountUniqueMetadataByFilterTest:
             Document(content="Doc 4", meta={"category": "B", "year": 2024}),
         ]
         document_store.write_documents(docs)
-        count = document_store.count_documents_by_filter(  # type:ignore[attr-defined]
+        counts = document_store.count_unique_metadata_by_filter(  # type:ignore[attr-defined]
             filters={
                 "operator": "AND",
                 "conditions": [
                     {"field": "meta.category", "operator": "==", "value": "B"},
                     {"field": "meta.year", "operator": "==", "value": 2023},
                 ],
-            }
+            },
+            metadata_fields=["category", "year"],
         )
-        assert count == 1
+        assert counts == {"category": 1, "year": 1}
 
 
 class GetMetadataFieldsInfoTest:

--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -1054,12 +1054,14 @@ class CountUniqueMetadataByFilterTest:
     def test_count_unique_metadata_by_filter_with_multiple_filters(document_store: DocumentStore):
         """Test count_unique_metadata_by_filter() with multiple filters."""
         docs = [
-            Document(content="Doc 1", meta={"category": "A", "year": 2023}),
-            Document(content="Doc 2", meta={"category": "A", "year": 2024}),
-            Document(content="Doc 3", meta={"category": "B", "year": 2023}),
-            Document(content="Doc 4", meta={"category": "B", "year": 2024}),
+            Document(content="Doc 1", meta={"category": "B", "year": 2023, "status": "draft"}),
+            Document(content="Doc 2", meta={"category": "B", "year": 2023, "status": "draft"}),
+            Document(content="Doc 3", meta={"category": "B", "year": 2023, "status": "published"}),
+            Document(content="Doc 4", meta={"category": "B", "year": 2024, "status": "draft"}),
         ]
         document_store.write_documents(docs)
+        # The compound filter matches three documents with duplicated values, so the counts only come
+        # out right when the store both applies the filter and properly counts the values.
         counts = document_store.count_unique_metadata_by_filter(  # type:ignore[attr-defined]
             filters={
                 "operator": "AND",
@@ -1068,9 +1070,9 @@ class CountUniqueMetadataByFilterTest:
                     {"field": "meta.year", "operator": "==", "value": 2023},
                 ],
             },
-            metadata_fields=["category", "year"],
+            metadata_fields=["status", "year"],
         )
-        assert counts == {"category": 1, "year": 1}
+        assert counts == {"status": 2, "year": 1}
 
 
 class GetMetadataFieldsInfoTest:

--- a/haystack/testing/document_store_async.py
+++ b/haystack/testing/document_store_async.py
@@ -305,13 +305,15 @@ class CountUniqueMetadataByFilterAsyncTest:
     async def test_count_unique_metadata_by_filter_async_with_multiple_filters(document_store: AsyncDocumentStore):
         """Test counting unique metadata asynchronously with multiple filters."""
         docs = [
-            Document(content="Doc 1", meta={"category": "A", "year": 2023}),
-            Document(content="Doc 2", meta={"category": "A", "year": 2024}),
-            Document(content="Doc 3", meta={"category": "B", "year": 2023}),
-            Document(content="Doc 4", meta={"category": "B", "year": 2024}),
+            Document(content="Doc 1", meta={"category": "B", "year": 2023, "status": "draft"}),
+            Document(content="Doc 2", meta={"category": "B", "year": 2023, "status": "draft"}),
+            Document(content="Doc 3", meta={"category": "B", "year": 2023, "status": "published"}),
+            Document(content="Doc 4", meta={"category": "B", "year": 2024, "status": "draft"}),
         ]
         await document_store.write_documents_async(docs)
 
+        # The compound filter matches three documents with duplicated values, so the counts only come
+        # out right when the store both applies the filter and properly counts the values.
         counts = await document_store.count_unique_metadata_by_filter_async(  # type:ignore[attr-defined]
             filters={
                 "operator": "AND",
@@ -320,9 +322,9 @@ class CountUniqueMetadataByFilterAsyncTest:
                     {"field": "meta.year", "operator": "==", "value": 2023},
                 ],
             },
-            metadata_fields=["category", "year"],
+            metadata_fields=["status", "year"],
         )
-        assert counts == {"category": 1, "year": 1}
+        assert counts == {"status": 2, "year": 1}
 
 
 class DeleteByFilterAsyncTest:

--- a/releasenotes/notes/fix-count-unique-metadata-mixin-test-5415d442cdb70c15.yaml
+++ b/releasenotes/notes/fix-count-unique-metadata-mixin-test-5415d442cdb70c15.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed ``CountUniqueMetadataByFilterTest.test_count_unique_metadata_by_filter_with_multiple_filters``
+    in the document store testing mixins: it called ``count_documents_by_filter`` instead of
+    ``count_unique_metadata_by_filter``. The test now exercises the intended method with a compound
+    filter, matching its async counterpart.


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Update the `test_count_unique_metadata_by_filter_with_multiple_filters` to correctly use the `count_unique_metadata_by_filter` instead of `count_documents_by_filter`. The async version was already using the correct method. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
