### PR TITLE
fix: add missing output sockes to LLM evaluators

### DIFF
--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -162,7 +162,9 @@ class ContextRelevanceEvaluator(LLMEvaluator):
             progress_bar=progress_bar,
         )
 
-    @component.output_types(score=float, results=list[dict[str, Any]])
+    @component.output_types(
+        score=float, individual_scores=list[float], results=list[dict[str, Any]], meta=list[dict[str, Any]] | None
+    )
     def run(self, **inputs: Any) -> dict[str, Any]:
         """
         Run the LLM evaluator.
@@ -174,6 +176,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         :returns:
             A dictionary with the following outputs:
                 - `score`: Mean context relevance score over all the provided input questions.
+                - `individual_scores`: A list of context relevance scores for each input question.
                 - `results`: A list of dictionaries with `relevant_statements`, `score`, and `status` for each input
                   context. `status` is `evaluated` for valid results and `error` for failed evaluations.
         """
@@ -181,7 +184,9 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         # Post-process the raw results to calculate relevance metrics and scores
         return self._postprocess_results(result)
 
-    @component.output_types(score=float, results=list[dict[str, Any]])
+    @component.output_types(
+        score=float, individual_scores=list[float], results=list[dict[str, Any]], meta=list[dict[str, Any]] | None
+    )
     async def run_async(self, **inputs: Any) -> dict[str, Any]:
         """
         Run the LLM evaluator asynchronously.
@@ -193,6 +198,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         :returns:
             A dictionary with the following outputs:
                 - `score`: Mean context relevance score over all the provided input questions.
+                - `individual_scores`: A list of context relevance scores for each input question.
                 - `results`: A list of dictionaries with `relevant_statements`, `score`, and `status` for each input
                   context. `status` is `evaluated` for valid results and `error` for failed evaluations.
         """

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -150,7 +150,9 @@ class FaithfulnessEvaluator(LLMEvaluator):
             progress_bar=progress_bar,
         )
 
-    @component.output_types(individual_scores=list[float], score=float, results=list[dict[str, Any]])
+    @component.output_types(
+        individual_scores=list[float], score=float, results=list[dict[str, Any]], meta=list[dict[str, Any]] | None
+    )
     def run(self, **inputs: Any) -> dict[str, Any]:
         """
         Run the LLM evaluator.
@@ -172,7 +174,9 @@ class FaithfulnessEvaluator(LLMEvaluator):
         # Post-process the raw results to calculate relevance metrics and scores
         return self._postprocess_results(result)
 
-    @component.output_types(individual_scores=list[float], score=float, results=list[dict[str, Any]])
+    @component.output_types(
+        individual_scores=list[float], score=float, results=list[dict[str, Any]], meta=list[dict[str, Any]] | None
+    )
     async def run_async(self, **inputs: Any) -> dict[str, Any]:
         """
         Run the LLM evaluator asynchronously.

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -198,7 +198,7 @@ class LLMEvaluator:
                 )
                 raise ValueError(msg)
 
-    @component.output_types(results=list[dict[str, Any]])
+    @component.output_types(results=list[dict[str, Any]], meta=list[dict[str, Any]] | None)
     def run(self, **inputs: Any) -> dict[str, Any]:
         """
         Run the LLM evaluator.
@@ -262,7 +262,7 @@ class LLMEvaluator:
 
         return {"results": results, "meta": metadata or None}
 
-    @component.output_types(results=list[dict[str, Any]])
+    @component.output_types(results=list[dict[str, Any]], meta=list[dict[str, Any]] | None)
     async def run_async(self, **inputs: Any) -> dict[str, Any]:
         """
         Run the LLM evaluator asynchronously

--- a/releasenotes/notes/declare-evaluator-output-sockets-3a1f5c2e4b7d9018.yaml
+++ b/releasenotes/notes/declare-evaluator-output-sockets-3a1f5c2e4b7d9018.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Declare the ``meta`` output of ``LLMEvaluator``, ``ContextRelevanceEvaluator``, and ``FaithfulnessEvaluator``, and
+    the ``individual_scores`` output of ``ContextRelevanceEvaluator``. These outputs were already returned but not
+    declared, so they could not be connected to other components in a Pipeline.

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -55,6 +55,8 @@ class TestContextRelevanceEvaluator:
         assert component._chat_generator.api_key.resolve_value() == "test-api-key"
         assert component._chat_generator.generation_kwargs == {"response_format": {"type": "json_object"}, "seed": 42}
 
+        assert set(component.__haystack_output__._sockets_dict) == {"score", "individual_scores", "results", "meta"}
+
     def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         component = ContextRelevanceEvaluator()

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -70,6 +70,8 @@ class TestFaithfulnessEvaluator:
         assert component._chat_generator.api_key.resolve_value() == "test-api-key"
         assert component._chat_generator.generation_kwargs == {"response_format": {"type": "json_object"}, "seed": 42}
 
+        assert set(component.__haystack_output__._sockets_dict) == {"score", "individual_scores", "results", "meta"}
+
     def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         component = FaithfulnessEvaluator()

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -33,6 +33,8 @@ class TestLLMEvaluator:
         assert isinstance(component._chat_generator, OpenAIChatGenerator)
         assert component._chat_generator.generation_kwargs == {"response_format": {"type": "json_object"}, "seed": 42}
 
+        assert set(component.__haystack_output__._sockets_dict) == {"results", "meta"}
+
     def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         component = LLMEvaluator(


### PR DESCRIPTION
### Related Issues

I noticed that these evaluators were missing output sockets, so for example the following Pipeline would have failed at connection:
```python
from haystack import Pipeline, component
from haystack.components.evaluators import ContextRelevanceEvaluator


@component
class ScoreReporter:
    @component.output_types(report=str)
    def run(self, individual_scores: list[float]):
        return {"report": f"received scores: {individual_scores}"}


pipeline = Pipeline()
pipeline.add_component("evaluator", ContextRelevanceEvaluator())
pipeline.add_component("reporter", ScoreReporter())

pipeline.connect("evaluator.individual_scores", "reporter.individual_scores")
# PipelineConnectError, 'evaluator.individual_scores' does not exist.
```

### Proposed Changes:
- add the missing output sockets and minimally test them

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
