### PR TITLE
docs: add Agent Pack documentation

### DIFF
--- a/docs-website/docs/concepts/agents.mdx
+++ b/docs-website/docs/concepts/agents.mdx
@@ -44,6 +44,7 @@ Key capabilities include:
 - **Streaming**: Stream token-by-token output with a `streaming_callback`.
 - **Human-in-the-loop**: Intercept tool calls for human review before execution. See [Human in the Loop](../pipeline-components/agents-1/human-in-the-loop.mdx).
 - **Multi-agent systems**: Wrap an `Agent` as a `ComponentTool` to build coordinator/specialist architectures. See [Multi-Agent Systems](./agents/multi-agent-systems.mdx).
+- **Ready-made agents**: The [Agent Pack](./agents/agent-pack.mdx) ships pre-configured agents — a [Deep Research Agent](./agents/agent-pack/deep-research-agent.mdx) and an [Advanced RAG Agent](./agents/agent-pack/advanced-rag-agent.mdx) — each created with a single factory function call.
 - **MCP server exposure**: Expose your agent as an MCP server using [Hayhooks](../development/hayhooks.mdx), making it callable from any MCP-compatible client such as Claude Desktop or Cursor.
 - **Multimodal inputs**: Pass images alongside text using `ImageContent` in `ChatMessage` content parts, or return `ImageContent` from tools for dynamic image analysis. Requires a vision-capable model such as `gpt-5` or `gemini-2.5-flash`. See [Multimodal Inputs](../pipeline-components/agents-1/agent.mdx#multimodal-inputs).
 

--- a/docs-website/docs/concepts/agents/agent-pack.mdx
+++ b/docs-website/docs/concepts/agents/agent-pack.mdx
@@ -1,0 +1,77 @@
+---
+title: "Agent Pack"
+id: agent-pack
+slug: "/agent-pack"
+description: "Agent Pack ships pre-configured Haystack Agents - a web deep research agent and a metadata-aware advanced RAG agent - each created with a single factory function call."
+---
+
+# Agent Pack
+
+Agent Pack is a collection of pre-configured, ready-to-run Haystack [`Agent`](../../pipeline-components/agents-1/agent.mdx)s.
+Each agent comes with tested prompts, tool wiring, and sensible budgets, and is created with a single factory function call.
+Use an agent as-is, reconfigure it through keyword arguments, or read its "How it works" section and copy the patterns into your own agents.
+
+{/* TODO: switch the API reference link to /reference/integrations-agent-pack after the first agent-pack-haystack release */}
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **API reference** | [Agent Pack](https://docs.haystack.deepset.ai/reference/integrations-agent-pack) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack |
+| **Package name** | `agent-pack-haystack` |
+
+</div>
+
+## Installation
+
+```shell
+pip install agent-pack-haystack
+```
+
+Some agents have optional runtime dependencies (for example, web search or PDF parsing) — the install command on each agent's page lists them.
+By default, the agents use OpenAI models, so set `OPENAI_API_KEY` in your environment; the Deep Research Agent additionally needs `TAVILY_API_KEY` for web search.
+
+:::note
+Until the first `agent-pack-haystack` release, install the package from GitHub instead:
+
+```shell
+pip install "agent-pack-haystack @ git+https://github.com/deepset-ai/haystack-core-integrations.git#subdirectory=integrations/agent_pack"
+```
+:::
+
+## The Agents
+
+| Agent | Factory function | What it does | Requires |
+| --- | --- | --- | --- |
+| [Deep Research Agent](./agent-pack/deep-research-agent.mdx) | `create_deep_research_agent` | Researches a question on the web with parallel sub-researchers and writes a structured, cited markdown report. | `OPENAI_API_KEY`, `TAVILY_API_KEY` |
+| [Advanced RAG Agent](./agent-pack/advanced-rag-agent.mdx) | `create_advanced_rag_agent` | Metadata-aware RAG over your document store: inspects metadata fields, builds filters, retrieves, and answers with document citations. | A document store and a retriever, `OPENAI_API_KEY` |
+
+## Usage Pattern
+
+Every factory function follows the same shape: import it from `haystack_integrations.agent_pack`, call it with keyword arguments, and run the returned agent with a user message:
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.agent_pack import create_deep_research_agent
+
+agent = create_deep_research_agent()
+result = agent.run(messages=[ChatMessage.from_user("your question")])
+```
+
+The factories return a plain Haystack [`Agent`](../../pipeline-components/agents-1/agent.mdx) — you can serialize it with `to_dict`/`from_dict`, stream its output, add it to a pipeline, or wrap it as a tool of another agent, like any agent you build yourself.
+
+## When to Use Agent Pack vs. Building Your Own Agent
+
+- **Use an Agent Pack agent** when your use case matches what it does — a cited report from web research, or question answering over a document store with rich metadata — and you want working prompts, tool wiring, and budgets out of the box.
+- **Build your own agent** with the [Agent](../../pipeline-components/agents-1/agent.mdx) component (see [Agents](../agents.mdx) and [Multi-Agent Systems](./multi-agent-systems.mdx)) when you need different phases, tools, or control flow.
+- **Mix both**: each agent page documents its architecture in enough detail to copy the patterns, and some building blocks are importable on their own — for example, the Advanced RAG Agent's `DocumentStoreToolset` drops into any custom agent.
+
+## Additional References
+
+📖 Related docs:
+
+- [Agent](../../pipeline-components/agents-1/agent.mdx)
+- [Multi-Agent Systems](./multi-agent-systems.mdx)
+- [Hooks](../../pipeline-components/agents-1/hooks.mdx)
+- [State](../../pipeline-components/agents-1/state.mdx)

--- a/docs-website/docs/concepts/agents/agent-pack/advanced-rag-agent.mdx
+++ b/docs-website/docs/concepts/agents/agent-pack/advanced-rag-agent.mdx
@@ -1,0 +1,247 @@
+---
+title: "Advanced RAG Agent"
+id: advanced-rag-agent
+slug: "/advanced-rag-agent"
+description: "A pre-built metadata-aware RAG agent for Haystack: it inspects your document store's metadata fields, values, and ranges, builds filters, retrieves, and answers with document citations."
+---
+
+# Advanced RAG Agent
+
+A **metadata-aware RAG agent** from the [Agent Pack](../agent-pack.mdx): instead of guessing which metadata fields exist, it inspects the document store (fields, values, ranges) and can construct Haystack filters to narrow its retrieval.
+
+{/* TODO: switch the API reference link to /reference/integrations-agent-pack after the first agent-pack-haystack release */}
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Factory function** | `create_advanced_rag_agent` |
+| **Mandatory init variables** | `document_store`: The document store to inspect and fetch from <br /> <br />`retriever`: A retriever component or retrieval pipeline for relevance search |
+| **Environment variables** | `OPENAI_API_KEY`: Your OpenAI API key (default models) |
+| **API reference** | [Agent Pack](https://docs.haystack.deepset.ai/reference/integrations-agent-pack) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack/src/haystack_integrations/agent_pack/advanced_rag |
+| **Package name** | `agent-pack-haystack` |
+
+</div>
+
+## Quick Start
+
+Install the package together with `arrow`, an optional runtime dependency that renders today's date into the system prompt, so the agent can build filters for relative dates like "the last 5 years":
+
+```shell
+pip install agent-pack-haystack arrow
+```
+
+Set `OPENAI_API_KEY` in the environment. Then index a corpus with varied metadata and ask a question the agent can only answer well by inspecting the metadata, building a filter, and retrieving with it:
+
+```python
+from haystack import Document
+from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+from haystack.dataclasses import ChatMessage
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack_integrations.agent_pack import create_advanced_rag_agent
+
+document_store = InMemoryDocumentStore()
+document_store.write_documents(
+    [
+        Document(
+            content="CRISPR gene editing corrected a hereditary blindness mutation in a clinical trial.",
+            meta={"category": "science", "year": 2021, "rating": 4.6},
+        ),
+        Document(
+            content="A quantum computer demonstrated error-corrected logical qubits.",
+            meta={"category": "science", "year": 2023, "rating": 4.8},
+        ),
+        Document(
+            content="Dolly the sheep became the first mammal cloned from an adult somatic cell.",
+            meta={"category": "science", "year": 1996, "rating": 4.2},
+        ),
+        Document(
+            content="The Berlin Wall fell, a decisive moment in the end of the Cold War.",
+            meta={"category": "history", "year": 1989, "rating": 4.7},
+        ),
+        Document(
+            content="Argentina won the FIFA World Cup final against France on penalties.",
+            meta={"category": "sports", "year": 2022, "rating": 4.9},
+        ),
+    ],
+)
+
+agent = create_advanced_rag_agent(
+    document_store=document_store,
+    retriever=InMemoryBM25Retriever(document_store=document_store, top_k=5),
+)
+
+result = agent.run(
+    messages=[ChatMessage.from_user("What science advances happened after 2015?")],
+)
+
+print(result["last_message"].text)  # the answer, citing documents as [doc <short-id>]
+for doc in result["documents"]:  # every document the agent retrieved, deduplicated
+    print(f"[doc {doc.id[:8]}] {doc.meta} :: {doc.content[:60]}")
+```
+
+The agent lists the metadata fields, verifies the `category` values and the `year` range, builds a filter like `{"operator": "AND", "conditions": [{"field": "meta.category", "operator": "==", "value": "science"}, {"field": "meta.year", "operator": ">", "value": 2015}]}`, retrieves with it, and answers citing the CRISPR and quantum documents. Filtering is optional — when metadata can't narrow a question, the agent retrieves without one.
+
+The retrieval you provide should be **scoring-based** — keyword (BM25), embedding, or hybrid. Direct, unscored fetching by metadata is already covered by the built-in `fetch_documents_by_filter` tool.
+
+## Outputs and Citations
+
+`agent.run(...)` returns a dictionary with:
+
+- `last_message` (`ChatMessage`): the answer, citing documents by the first 8 characters of their id, for example `[doc a1b2c3d4]`,
+- `documents` (`list[Document]`): every document the agent retrieved during the run, deduplicated by id, in first-retrieved order — resolve citations against it with `doc.id.startswith(...)`,
+
+plus the standard `Agent` outputs `messages`, `step_count`, `token_usage`, and `tool_call_counts`.
+
+## Configuration
+
+Everything is configured through keyword arguments to `create_advanced_rag_agent`.
+
+**Retrieval**
+
+- `retriever` (required): what retrieves for the `search_documents` tool. Either a standalone retriever component whose `run` method accepts `query` and `filters` (such as `InMemoryBM25Retriever`), or a custom retrieval `Pipeline` — see [Using a Retrieval Pipeline](#using-a-retrieval-pipeline).
+- `retrieval_pipeline_input_mapping`: required when `retriever` is a `Pipeline`. Maps the tool inputs to pipeline input sockets; must have exactly the keys `"query"` and `"filters"`.
+- `retrieval_pipeline_output_mapping`: optional when `retriever` is a `Pipeline`. Maps pipeline output sockets to tool outputs, for example `{"retriever.documents": "documents"}`.
+
+**LLMs and prompt**
+
+- `llm`: drives the agent loop. Defaults to `OpenAIResponsesChatGenerator("gpt-5.4")` with low reasoning effort; any [ChatGenerator](../../../pipeline-components/generators.mdx) works.
+- `backup_answer_llm`: writes the best-effort answer when the run is cut off by `max_agent_steps`. Defaults to a separate `OpenAIResponsesChatGenerator("gpt-5.4")` with low reasoning effort.
+- `system_prompt`: overrides the pre-made system prompt. The default prompt renders today's date and therefore needs the optional `arrow` dependency.
+
+**Budgets and behavior**
+
+- `max_agent_steps` (default `20`): maximum steps for the agent loop. If the loop is cut off by this limit before an answer is written, the built-in `BackupAnswerHook` makes one extra LLM call from the evidence gathered so far, so `last_message` always carries a text answer.
+- `max_fetched_docs` (default `10`): maximum documents `fetch_documents_by_filter` shows per fetch. A filter fetch is not bounded by a retriever's `top_k`, so this caps the tool result instead; the scored `search_documents` tool is bounded by the `top_k` configured on your retrieval components.
+- `tool_concurrency_limit` (default `4`): maximum tool calls executed in parallel within one agent step.
+- `raise_on_tool_invocation_failure` (default `False`): if `True`, a failing tool call raises instead of being returned to the LLM as an error message it can recover from.
+
+**Extensibility**
+
+- `extra_tools`: additional tools or toolsets, appended after the built-in document-store toolset and the retrieval tool.
+- `state_schema`: additional entries merged into the agent's state schema. The built-in `documents` entry always takes precedence.
+- `hooks`: additional [hooks](../../../pipeline-components/agents-1/hooks.mdx) per hook point, merged with the built-in ones. For `after_run`, the built-in backup-answer hook runs first, so custom hooks see the final answer.
+
+### Using a Retrieval Pipeline
+
+For anything beyond a single retriever, pass a retrieval `Pipeline` as the `retriever`, plus an input mapping that tells the tool which sockets receive the query and the filters — for example, hybrid retrieval with reciprocal rank fusion:
+
+```python
+from haystack import Pipeline
+from haystack.components.embedders import OpenAITextEmbedder
+from haystack.components.joiners import DocumentJoiner
+from haystack.components.retrievers.in_memory import (
+    InMemoryBM25Retriever,
+    InMemoryEmbeddingRetriever,
+)
+
+pipeline = Pipeline()
+pipeline.add_component(
+    "bm25_retriever",
+    InMemoryBM25Retriever(document_store=document_store),
+)
+pipeline.add_component("text_embedder", OpenAITextEmbedder())
+pipeline.add_component(
+    "embedding_retriever",
+    InMemoryEmbeddingRetriever(document_store=document_store),
+)
+pipeline.add_component("joiner", DocumentJoiner(join_mode="reciprocal_rank_fusion"))
+pipeline.connect("text_embedder.embedding", "embedding_retriever.query_embedding")
+pipeline.connect("bm25_retriever.documents", "joiner.documents")
+pipeline.connect("embedding_retriever.documents", "joiner.documents")
+
+agent = create_advanced_rag_agent(
+    document_store=document_store,
+    retriever=pipeline,
+    retrieval_pipeline_input_mapping={
+        "query": ["bm25_retriever.query", "text_embedder.text"],
+        "filters": ["bm25_retriever.filters", "embedding_retriever.filters"],
+    },
+    retrieval_pipeline_output_mapping={"joiner.documents": "documents"},
+)
+```
+
+## How It Works
+
+The whole thing is a single Haystack `Agent` that loops over five tools:
+
+```text
+  user question
+      │
+      ▼
+┌──────────────────┐
+│ 1. INSPECT       │  list_metadata_fields → which fields exist and their types
+│    METADATA      │  get_metadata_field_values / get_metadata_field_range → what they contain
+└──────┬───────────┘
+       │ field names, values, ranges
+       ▼
+┌──────────────────┐
+│ 2. RETRIEVE      │  search_documents(query, filters) — relevance search, optionally filtered;
+│                  │  fetch_documents_by_filter(filters) — direct fetch when the exact documents
+│                  │  are identifiable by metadata alone
+└──────┬───────────┘
+       │ documents (id + metadata + content)
+       ▼
+┌──────────────────┐
+│ 3. ANSWER        │  answer from the retrieved documents only, citing them as [doc <short-id>]
+└──────────────────┘
+```
+
+Every retrieved document is accumulated into the agent's [State](../../../pipeline-components/agents-1/state.mdx) under the `documents` key (deduplicated by id), so `agent.run(...)` returns the full `list[Document]` alongside the answer.
+
+If the run is cut off by `max_agent_steps` before an answer is written, a `BackupAnswerHook` (an `after_run` [hook](../../../pipeline-components/agents-1/hooks.mdx)) makes one extra LLM call to produce a best-effort answer from the evidence gathered so far, so `last_message` always carries a text answer.
+
+### The Tools
+
+| Tool | What it is | What it does |
+| --- | --- | --- |
+| `list_metadata_fields` | `ListMetadataFieldsTool` | Lists all metadata fields and their types. The system prompt instructs the agent to call this first. |
+| `get_metadata_field_values` | `GetMetadataFieldValuesTool` | Returns the distinct values of a field, so filters use values that actually exist (listing capped for high-cardinality fields; the total count is reported when the store provides one). |
+| `get_metadata_field_range` | `GetMetadataFieldRangeTool` | Returns min/max of a numeric or orderable field (e.g. years, ratings, ISO dates). |
+| `fetch_documents_by_filter` | `FetchDocumentsByFilterTool` | Fetches documents directly by metadata filter, without relevance scoring — for grabbing specific documents (e.g. a known title or file). Results are put into reading order (grouped by parent file, sorted by split/page), `max_docs` per call; larger match sets are paged via the tool's `offset` input. On stores that support counting documents by filter, over-broad filters are refused *before* fetching, as an error the LLM recovers from by narrowing. |
+| `search_documents` | [ComponentTool](../../../tools/componenttool.mdx) over your retriever, or [PipelineTool](../../../tools/pipelinetool.mdx) over your retrieval pipeline | Retrieves documents for a query by relevance, optionally narrowed by a metadata filter. Bounded by the `top_k` of your retrieval components; an empty result nudges the agent to relax the filter. |
+
+### Reusing the Toolset
+
+The four document-store-backed tools are exported individually and also bundled as `DocumentStoreToolset`, so you can drop them into your own `Agent` with your own prompt:
+
+```python
+from haystack_integrations.agent_pack.advanced_rag import DocumentStoreToolset
+
+agent = Agent(
+    chat_generator=...,
+    tools=[DocumentStoreToolset(document_store), my_retrieval_tool],
+)
+```
+
+The agent and every tool serialize via `to_dict`/`from_dict`. See [Toolset](../../../tools/toolset.mdx) for how toolsets work.
+
+### The Filter Grammar
+
+The Haystack [metadata filter syntax](../../metadata-filtering.mdx) is not something an LLM knows reliably without guidance. Rather than a long system prompt, the grammar is embedded in the **description of the `filters` parameter** of `search_documents` and `fetch_documents_by_filter`, so the model receives it contextually at the point of tool use:
+
+- single condition: `{"field": "meta.category", "operator": "==", "value": "science"}`
+- comparison operators: `==, !=, >, >=, <, <=, in, not in`
+- logical grouping: `{"operator": "AND"|"OR"|"NOT", "conditions": [...]}` (nestable)
+- field names must be prefixed with `meta.`
+
+The system prompt adds the workflow rules: inspect fields first, verify values before filtering, and relax the filter when a search comes back empty.
+
+### Supported Document Stores
+
+The metadata tools rely on [Document Store](../../document-store.mdx) methods that are not part of the base `DocumentStore` protocol: `get_metadata_fields_info`, `get_metadata_field_unique_values`, and `get_metadata_field_min_max`. `InMemoryDocumentStore` and most document store integrations implement them (OpenSearch, Elasticsearch, Weaviate, Chroma, pgvector, Qdrant, Pinecone, MongoDB Atlas, Astra, and more). Each tool fails fast at construction time with a clear error if the store doesn't support the method it needs — stores that implement only some of the methods can still use the matching subset of tools.
+
+## Additional References
+
+📖 Related docs:
+
+- [Agent Pack](../agent-pack.mdx)
+- [Metadata Filtering](../../metadata-filtering.mdx)
+- [Agent](../../../pipeline-components/agents-1/agent.mdx)
+- [Hooks](../../../pipeline-components/agents-1/hooks.mdx)
+- [Toolset](../../../tools/toolset.mdx)
+
+💻 Source code:
+
+- [advanced_rag on GitHub](https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack/src/haystack_integrations/agent_pack/advanced_rag)

--- a/docs-website/docs/concepts/agents/agent-pack/deep-research-agent.mdx
+++ b/docs-website/docs/concepts/agents/agent-pack/deep-research-agent.mdx
@@ -1,0 +1,202 @@
+---
+title: "Deep Research Agent"
+id: deep-research-agent
+slug: "/deep-research-agent"
+description: "A pre-built Haystack deep research agent: give it a question and it researches the web with parallel sub-researchers and writes a structured, cited markdown report."
+---
+
+# Deep Research Agent
+
+A small, working **deep research agent** from the [Agent Pack](../agent-pack.mdx): give it a question, and it researches the web and produces a structured, cited markdown report.
+
+{/* TODO: switch the API reference link to /reference/integrations-agent-pack after the first agent-pack-haystack release */}
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Factory function** | `create_deep_research_agent` |
+| **Environment variables** | `OPENAI_API_KEY`: Your OpenAI API key (default models) <br /> <br />`TAVILY_API_KEY`: Your [Tavily](https://tavily.com) API key (web search) |
+| **API reference** | [Agent Pack](https://docs.haystack.deepset.ai/reference/integrations-agent-pack) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack/src/haystack_integrations/agent_pack/deep_research |
+| **Package name** | `agent-pack-haystack` |
+
+</div>
+
+## Quick Start
+
+Install the package together with the agent's optional runtime dependencies — `tavily-haystack` for web search, `trafilatura` and `pypdf` for HTML and PDF parsing, and `arrow` for date rendering:
+
+```shell
+pip install agent-pack-haystack tavily-haystack trafilatura pypdf arrow
+```
+
+Set `OPENAI_API_KEY` and `TAVILY_API_KEY` in the environment, then run:
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.agent_pack import create_deep_research_agent
+
+agent = create_deep_research_agent()
+result = agent.run(messages=[ChatMessage.from_user("your research question")])
+print(result["report"])
+```
+
+A run makes many LLM calls and web searches, so expect it to take minutes rather than seconds.
+
+## Outputs
+
+`agent.run(...)` returns a dictionary whose main output is:
+
+- `report` (`str`): the final markdown report, with inline `[text](url)` citations.
+
+It also carries the intermediate results:
+
+- `brief` (`str`): the focused research brief the question was rewritten into,
+- `notes` (`list[str]`): the compressed summaries collected from the sub-researchers,
+
+plus the standard `Agent` outputs `messages`, `last_message`, `step_count`, `token_usage`, and `tool_call_counts`.
+
+## Configuration
+
+Everything is configured through keyword arguments to `create_deep_research_agent`.
+
+The agent uses five LLMs, each swappable independently for any [ChatGenerator](../../../pipeline-components/generators.mdx):
+
+| Parameter | Role | Default |
+| --- | --- | --- |
+| `scope_llm` | Rewrites the user query into a focused research brief. | `OpenAIResponsesChatGenerator("gpt-5.4")` |
+| `orchestrator_llm` | Plans the investigation and delegates the sub-questions. | `OpenAIResponsesChatGenerator("gpt-5.4")` |
+| `researcher_llm` | Drives each sub-researcher's search/read/think loop. | `OpenAIResponsesChatGenerator("gpt-5.4-mini")` |
+| `summarizer_llm` | Summarizes a fetched page toward the question inside the `read_url` tool. | `OpenAIResponsesChatGenerator("gpt-5.4-mini")` |
+| `writer_llm` | Turns the brief plus collected notes into the final report. | `OpenAIResponsesChatGenerator("gpt-5.4")` |
+
+Six budgets bound the depth, breadth, and cost of a run:
+
+| Parameter | Default | Controls |
+| --- | --- | --- |
+| `max_subtopics` | `5` | Maximum number of sub-questions the orchestrator may delegate (breadth). |
+| `max_concurrent_researchers` | `5` | Maximum number of sub-researchers that run at the same time. |
+| `max_orchestrator_steps` | `8` | Maximum steps for the orchestrator's agent loop (reflect → delegate rounds). |
+| `max_researcher_steps` | `20` | Maximum steps for each sub-researcher's agent loop. |
+| `max_search_results` | `10` | Number of results returned per `web_search` call. |
+| `max_content_length` | `50000` | Maximum raw page characters fed to the summarizer, before summarization. |
+
+For example, to run cheaper and faster with a different model for the research work:
+
+```python
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack_integrations.agent_pack import create_deep_research_agent
+
+agent = create_deep_research_agent(
+    researcher_llm=OpenAIChatGenerator(model="gpt-5.4-nano"),
+    summarizer_llm=OpenAIChatGenerator(model="gpt-5.4-nano"),
+    max_subtopics=3,
+    max_researcher_steps=10,
+)
+```
+
+## How It Works
+
+The whole thing is a single Haystack `Agent` — the **orchestrator** — with two [hooks](../../../pipeline-components/agents-1/hooks.mdx) that bracket its loop. The three logical phases are **Scope → Research → Write**:
+
+```text
+  user query
+      │
+      ▼
+┌──────────────┐
+│  1. SCOPE    │   before_run hook: rewrite the question into a focused research brief
+└──────┬───────┘
+       │ brief
+       ▼
+┌──────────────┐   the agent loop (see "The agents" below):
+│ 2. RESEARCH  │   the orchestrator splits the brief into sub-questions,
+│ (agent loop) │   delegates each to a sub-researcher, and collects their summaries
+└──────┬───────┘
+       │ brief + notes
+       ▼
+┌──────────────┐
+│  3. WRITE    │   after_run hook: brief + notes → cited markdown report
+└──────┬───────┘
+       │
+       ▼
+   report (markdown, with inline [text](url) citations)
+```
+
+**Scope** and **Write** are plain LLM calls (a `ChatPromptBuilder` + an `OpenAIResponsesChatGenerator`), wrapped as serializable hook classes (`ScopeHook`, `WriteHook`):
+
+- **Scope** runs as a `before_run` hook: before the orchestrator's loop starts, it turns the user query into a brief, stored on the agent's [State](../../../pipeline-components/agents-1/state.mdx).
+- **Write** runs as an `after_run` hook: when the orchestrator's loop finishes, it turns the brief plus collected `notes` into the final report.
+
+`brief`, `notes`, and `report` are declared in the agent's `state_schema`, so they come back as outputs of a single `agent.run(...)` call.
+
+### The Orchestrator
+
+The Research phase is built from **two nested agents**. The orchestrator is the lead agent: it receives the research brief and coordinates the whole investigation.
+
+- **Job:** split the brief into a few focused, non-overlapping sub-questions, delegate each one, check coverage, and stop when there's enough.
+- **Parallelism:** it emits several delegation calls in a single turn, and they run **concurrently** (bounded by `max_concurrent_researchers`).
+- **Memory:** the summaries returned by sub-researchers are appended to a shared `notes` list (the agent's `State`), which the writer later turns into the report.
+- **Stops when:** it replies with plain text (research complete) or hits `max_orchestrator_steps`.
+
+Its tools:
+
+| Tool | What it is | What it does |
+| --- | --- | --- |
+| `research_subtopic` | the **sub-researcher agent**, exposed as a tool ([ComponentTool](../../../tools/componenttool.mdx)) | Researches ONE sub-question in an isolated context and returns a compressed, cited summary. Only that summary is shown to the orchestrator; the summary is also appended to `notes`. |
+| `think_tool` | a no-op reflection tool | Lets the orchestrator pause to plan sub-questions and assess coverage between rounds. |
+
+### The Sub-Researcher
+
+A reusable agent that answers ONE sub-question. The orchestrator runs it many times (in parallel), each in its **own isolated context** — this is the key idea: each sub-researcher processes the raw search results privately and returns only a concise summary, so the orchestrator's context stays small and the final report stays coherent.
+
+- **Job:** search the web, optionally read promising pages, reflect, then write a compressed summary with inline citations to the exact source URLs.
+- **Returns:** its final text message *is* the summary (it exits as soon as it writes plain text).
+- **Bounded by:** `max_researcher_steps`.
+
+Its tools:
+
+| Tool | What it is | What it does |
+| --- | --- | --- |
+| `web_search` | `TavilyWebSearchTool` from the Tavily integration | Runs a web search; returns the top results as `title + exact URL + snippet`. |
+| `read_url` | [PipelineTool](../../../tools/pipelinetool.mdx) over a fetch→route→convert-to-text→summarize pipeline | Fetches a page (`LinkContentFetcher`), routes by MIME type (`FileTypeRouter`) to `HTMLToDocument` (Trafilatura) or `PyPDFToDocument` so **PDFs are parsed too**, and **summarizes the page toward a question the agent passes** — so only the relevant text enters the agent's context, not the full page. Used only when a search snippet is too shallow. |
+| `think_tool` | a no-op reflection tool | "What did I learn? what's missing? stop or continue?" between searches. |
+
+### Context Management
+
+The core challenge in a deep research agent is keeping each context window small and focused. Raw web content (search results, full pages, PDFs) is large and noisy; if it all accumulated in a single context, the model's output quality would degrade. The agent avoids that with **isolation + compression**:
+
+- Each sub-researcher runs as its **own agent with its own `State`**, so all the messy intermediate content (every search result, every fetched page) stays in *its* private context.
+- It finishes by writing one **short summary** (its final message). Only that summary leaves the sub-researcher — the raw content never reaches the orchestrator or the writer.
+
+Two settings on the `research_subtopic` tool decide where that summary goes:
+
+| Setting (on `research_subtopic`) | Controls | Effect |
+| --- | --- | --- |
+| `outputs_to_string={"source": "last_message"}` | what the **orchestrator's LLM sees** as the tool result | Only the summary text comes back — not the sub-researcher's full message history. Keeps the orchestrator's context clean. |
+| `outputs_to_state={"notes": {...}}` | what gets **saved for the writer** | The same summary is appended (as text) to the shared `notes` list, which becomes the writer's input. |
+
+So each summary travels two ways — into the orchestrator's reasoning (so it can decide whether to dig further) and into the `notes` accumulator (so the writer can use it) — while the bulky raw research stays isolated and is thrown away:
+
+```text
+sub-researcher  (private context: searches, pages, reflections)
+      │  writes ONE short summary
+      ├─ outputs_to_string → orchestrator's LLM   (decide: done, or dig more?)
+      └─ outputs_to_state  → notes → writer        (final report)
+```
+
+This isolation + compression pattern isn't specific to deep research — you can lift it for your own coordinator/specialist architectures. See [Multi-Agent Systems](../multi-agent-systems.mdx) for the general approach.
+
+## Additional References
+
+📖 Related docs:
+
+- [Agent Pack](../agent-pack.mdx)
+- [Multi-Agent Systems](../multi-agent-systems.mdx)
+- [Hooks](../../../pipeline-components/agents-1/hooks.mdx)
+- [ComponentTool](../../../tools/componenttool.mdx)
+- [PipelineTool](../../../tools/pipelinetool.mdx)
+
+💻 Source code:
+
+- [deep_research on GitHub](https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack/src/haystack_integrations/agent_pack/deep_research)

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -38,6 +38,18 @@ export default {
           },
           items: [
             'concepts/agents/multi-agent-systems',
+            {
+              type: 'category',
+              label: 'Agent Pack',
+              link: {
+                type: 'doc',
+                id: 'concepts/agents/agent-pack',
+              },
+              items: [
+                'concepts/agents/agent-pack/deep-research-agent',
+                'concepts/agents/agent-pack/advanced-rag-agent',
+              ],
+            },
           ],
         },
         {


### PR DESCRIPTION
### Related Issues

- Fixes https://github.com/deepset-ai/haystack-private/issues/467

### Proposed Changes:

Adds documentation for the `agent_pack` integration ([`agent-pack-haystack`](https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack)), which currently isn't covered by the Haystack docs at all.

New "Agent Pack" category under **Haystack Concepts → Agents** (sibling of Multi-Agent Systems):

- `docs/concepts/agents/agent-pack.mdx` — landing page: what the pack is, installation, overview table of the agents, shared usage pattern, and when to use the pack vs. building your own Agent.
- `docs/concepts/agents/agent-pack/deep-research-agent.mdx` — `create_deep_research_agent`: quick start, outputs, configuration (swappable LLMs + budgets), and a "How it works" architecture deep dive (Scope→Research→Write hooks, orchestrator/sub-researcher, context isolation & compression).
- `docs/concepts/agents/agent-pack/advanced-rag-agent.mdx` — `create_advanced_rag_agent`: quick start, outputs & citations, configuration, retrieval-pipeline example, and a deep dive (tool loop, `DocumentStoreToolset` reuse, filter grammar, supported document stores).

Each agent page is two-level: high-level factory-function usage on top for users who just want to import and run an agent, and lower-level architecture details below for users who want to copy the patterns.

Also adds a "Ready-made agents" bullet to `docs/concepts/agents.mdx` and registers the pages in `sidebars.js`. Pages target the *next* docs version only (no `versioned_docs` mirror), since `agent-pack-haystack` is not released on PyPI yet.

### How did you test it?

- `npm run build` in `docs-website` passes (config throws on broken links/anchors, so all cross-references are validated).
- Verified in the build output that the three pages render at `/docs/next/agent-pack`, `/docs/next/deep-research-agent`, `/docs/next/advanced-rag-agent`, appear in the sidebar, and the ASCII architecture diagrams render in monospace.
- Code snippets and parameter defaults are taken from the package READMEs and factory docstrings in haystack-core-integrations.

### Notes for the reviewer

- The **API reference** rows link to `https://docs.haystack.deepset.ai/reference/integrations-agent-pack` as a full external URL: the reference page is CI-generated on the first `agent_pack` release tag, so a root-relative link would fail the build today. Each occurrence carries a TODO comment to switch after release.
- The landing page has a `:::note` with the git-install command; it should be removed once `agent-pack-haystack` is on PyPI. Draft until the release timing is clear.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- ~I have added unit tests and updated the docstrings.~ (docs-only)
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `docs:`.
- I have documented my code.
- ~I have added a release note file~ (docs-website change, no release note needed)
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)