### PR TITLE
docs: add documentation pages for the Agent pack

### DIFF
--- a/docs-website/docs/pipeline-components/agents-1/agent-pack.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack.mdx
@@ -1,0 +1,67 @@
+---
+title: "Agent Pack"
+id: agent-pack
+slug: "/agent-pack"
+description: "Agent Pack is a collection of complex, pre-configured Agents you can run as they are, customize or copy as a blueprint."
+---
+
+# Agent Pack
+
+Agent Pack is a collection of complex, pre-configured Haystack Agents you can run as they are, customize, or copy as a blueprint for your own architecture.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **API reference** | Agent Pack |
+| **GitHub link**   | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack |
+| **Package name**  | `agent-pack-haystack` |
+
+</div>
+
+:::warning
+Agent Pack is experimental for the moment. Its APIs and agent architectures can change in any release, without following the usual deprecation policy.
+:::
+
+## Overview
+
+Building a capable agent takes more than an LLM and a list of tools. It takes an architecture: how work is split across sub-agents, how tools are described so the model uses them correctly, how context is kept small as evidence accumulates, and where to hook in the steps that happen before and after the agent loop. Those decisions are what separate a demo from an agent that holds up.
+
+Agent Pack packages those decisions into working agents. Each one is a complete, tested architecture built entirely from Haystack primitives ([`Agent`](./agent.mdx), [Tools](../../tools/tool.mdx), [hooks](./hooks.mdx), [`State`](./state.mdx), and Pipelines), assembled behind a single `create_*` entry point.
+
+There are three ways to use them, and all three are equally valid:
+
+- **Run one as it is.** Call `create_deep_research_agent()`, pass a question, get a report. The defaults are chosen to work out of the box.
+- **Customize it.** Every entry point takes keyword arguments for the models, the tools, and the limits that shape the agent's behavior, so you can adapt it without forking it.
+- **Copy it.** Read the implementation and lift the parts you need into your own agent. The agents are deliberately not monolithic, and nothing important is hidden behind an abstraction you can't see through. If the architecture is what you want but the specifics aren't, copying is the intended path, not a workaround.
+
+That last point is the reason Agent Pack looks the way it does. These are reference architectures as much as they are ready-made agents. The techniques inside them, such as delegating to sub-agents in isolated contexts, compressing what those sub-agents return, and putting a tool's input grammar in its parameter description rather than the system prompt, are general. They transfer to agents that have nothing to do with research or RAG.
+
+## Installation
+
+```shell
+pip install agent-pack-haystack
+```
+
+Each agent has its own optional runtime dependencies and required API keys. See its page for the exact install line.
+
+## Available agents
+
+| Agent | Description |
+| --- | --- |
+| [Deep Research Agent](agent-pack/deep-research-agent.mdx) | Researches a question on the web and produces a structured, cited markdown report. |
+| Advanced RAG Agent | Inspects document store metadata and builds Haystack filters to narrow its retrieval. |
+
+## Why it lives outside Haystack
+
+Agent Pack is a separate package rather than part of `haystack-ai`, and that is a deliberate trade-off.
+
+Good agent architectures are still moving fast. Keeping the pack outside core means we can change an agent's design when we learn something better, release on its own schedule, and avoid committing to stability before these patterns have settled. In exchange, you get agents that improve quickly rather than agents frozen around an early guess. That is also why the pack is explicitly unstable for now: pin `agent-pack-haystack` if you depend on it.
+
+The pack is also how we find out what Haystack itself is missing. Building real agents surfaces gaps in the framework that are invisible in the abstract. When a gap shows up, we can implement it in the pack first, and then, if it turns out to be generally useful, refine it and move it into core. Several features have already taken that path.
+
+For now the pack ships specific agents rather than a general framework for building them. If enough repeated patterns emerge across agents to justify a shared harness, we will introduce one then, rather than designing it up front and hoping the agents fit.
+
+## Feedback
+
+If you hit something these agents can't express, or a gap in Haystack that made building your own agent harder than it should be, [open an issue](https://github.com/deepset-ai/haystack-core-integrations/issues). Those reports are what drives both the pack and the framework forward.

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack.mdx
@@ -28,7 +28,7 @@ However, building a robust agent often requires more: an architecture that split
 Agent Pack combines these techniques into working agents. Each one is a complete architecture built from Haystack primitives ([`Agent`](./agent.mdx), [Tools](../../tools/tool.mdx), [hooks](./hooks.mdx), [`State`](./state.mdx), and Pipelines), exposed behind a single `create_*` entry point.
 
 There are three ways to use an agent from the pack:
-- **Run it as is.** Call `create_deep_research_agent()`, pass a question, get a report. The defaults are chosen to work out of the box.
+- **Run it as is.** Each agent has a factory that builds a ready-to-run agent with defaults chosen to work out of the box. For example, `create_deep_research_agent()` returns an agent that takes a question and produces a report.
 - **Customize it.** Each entry point exposes parameters for changing models, adding tools, and configuring behavior specific to that type of agent. (*This interface is still being refined to make customization more consistent and flexible.*)
 - **Copy it.** Read the implementation and take inspiration for your agents. These agents are built with this use case in mind, so individual parts should be easy to adapt.
 

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack.mdx
@@ -47,7 +47,7 @@ Each agent has its own additional runtime dependencies and may require API keys.
 | Agent | Description |
 | --- | --- |
 | [Deep Research Agent](agent-pack/deep-research-agent.mdx) | Researches a question on the web and produces a structured Markdown report with citations. |
-| [Advanced RAG Agent](agent-pack/advanced-rag-agent.mdx) | Inspects document store metadata and builds Haystack filters to narrow retrieval. |
+| [Advanced RAG Agent](agent-pack/advanced-rag-agent.mdx) | Inspects document-store metadata and builds Haystack filters to retrieve precisely, then answers with citations. |
 
 ## Experimental
 

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack.mdx
@@ -2,12 +2,12 @@
 title: "Agent Pack"
 id: agent-pack
 slug: "/agent-pack"
-description: "Agent Pack is a collection of complex, pre-configured Agents you can run as they are, customize or copy as a blueprint."
+description: "Agent Pack is a collection of complex, pre-configured agents you can run as they are, customize or copy as a blueprint."
 ---
 
 # Agent Pack
 
-Agent Pack is a collection of complex, pre-configured Haystack Agents you can run as they are, customize, or copy as a blueprint for your own architecture.
+Agent Pack is a collection of complex, pre-configured Haystack agents you can run as they are, customize, or copy as a blueprint for your own architecture.
 
 <div className="key-value-table">
 
@@ -19,23 +19,20 @@ Agent Pack is a collection of complex, pre-configured Haystack Agents you can ru
 
 </div>
 
-:::warning
-Agent Pack is experimental for the moment. Its APIs and agent architectures can change in any release, without following the usual deprecation policy.
-:::
-
 ## Overview
 
-Building a capable agent takes more than an LLM and a list of tools. It takes an architecture: how work is split across sub-agents, how tools are described so the model uses them correctly, how context is kept small as evidence accumulates, and where to hook in the steps that happen before and after the agent loop. Those decisions are what separate a demo from an agent that holds up.
+Language Models and Tools are the core building blocks of agents.
 
-Agent Pack packages those decisions into working agents. Each one is a complete, tested architecture built entirely from Haystack primitives ([`Agent`](./agent.mdx), [Tools](../../tools/tool.mdx), [hooks](./hooks.mdx), [`State`](./state.mdx), and Pipelines), assembled behind a single `create_*` entry point.
+However, building a robust agent often requires more: an architecture that splits the work across sub-agents, techniques for keeping context small but focused, and ways to influence and interact with the agent loop.
 
-There are three ways to use them, and all three are equally valid:
+Agent Pack combines these techniques into working agents. Each one is a complete architecture built from Haystack primitives ([`Agent`](./agent.mdx), [Tools](../../tools/tool.mdx), [hooks](./hooks.mdx), [`State`](./state.mdx), and Pipelines), exposed behind a single `create_*` entry point.
 
-- **Run one as it is.** Call `create_deep_research_agent()`, pass a question, get a report. The defaults are chosen to work out of the box.
-- **Customize it.** Every entry point takes keyword arguments for the models, the tools, and the limits that shape the agent's behavior, so you can adapt it without forking it.
-- **Copy it.** Read the implementation and lift the parts you need into your own agent. The agents are deliberately not monolithic, and nothing important is hidden behind an abstraction you can't see through. If the architecture is what you want but the specifics aren't, copying is the intended path, not a workaround.
+There are three ways to use an agent from the pack:
+- **Run it as is.** Call `create_deep_research_agent()`, pass a question, get a report. The defaults are chosen to work out of the box.
+- **Customize it.** Each entry point exposes parameters for changing models, adding tools, and configuring behavior specific to that type of agent. (*This interface is still being refined to make customization more consistent and flexible.*)
+- **Copy it.** Read the implementation and take inspiration for your agents. These agents are built with this use case in mind, so individual parts should be easy to adapt.
 
-That last point is the reason Agent Pack looks the way it does. These are reference architectures as much as they are ready-made agents. The techniques inside them, such as delegating to sub-agents in isolated contexts, compressing what those sub-agents return, and putting a tool's input grammar in its parameter description rather than the system prompt, are general. They transfer to agents that have nothing to do with research or RAG.
+In other words, you can use the agents in Agent Pack as either ready-made solutions or reference architectures.
 
 ## Installation
 
@@ -43,25 +40,27 @@ That last point is the reason Agent Pack looks the way it does. These are refere
 pip install agent-pack-haystack
 ```
 
-Each agent has its own optional runtime dependencies and required API keys. See its page for the exact install line.
+Each agent has its own additional runtime dependencies and may require API keys. See its documentation page for these details.
 
 ## Available agents
 
 | Agent | Description |
 | --- | --- |
-| [Deep Research Agent](agent-pack/deep-research-agent.mdx) | Researches a question on the web and produces a structured, cited markdown report. |
-| Advanced RAG Agent | Inspects document store metadata and builds Haystack filters to narrow its retrieval. |
+| [Deep Research Agent](agent-pack/deep-research-agent.mdx) | Researches a question on the web and produces a structured Markdown report with citations. |
+| [Advanced RAG Agent](agent-pack/advanced-rag-agent.mdx) | Inspects document store metadata and builds Haystack filters to narrow retrieval. |
 
-## Why it lives outside Haystack
+## Experimental
 
-Agent Pack is a separate package rather than part of `haystack-ai`, and that is a deliberate trade-off.
+:::warning
+Agent Pack is experimental for the moment. Its APIs and agent architectures can change in any release, without following the usual deprecation policy.
+:::
 
-Good agent architectures are still moving fast. Keeping the pack outside core means we can change an agent's design when we learn something better, release on its own schedule, and avoid committing to stability before these patterns have settled. In exchange, you get agents that improve quickly rather than agents frozen around an early guess. That is also why the pack is explicitly unstable for now: pin `agent-pack-haystack` if you depend on it.
+Agent Pack is distributed separately from `haystack-ai` and its code lives in `haystack-core-integrations`.
 
-The pack is also how we find out what Haystack itself is missing. Building real agents surfaces gaps in the framework that are invisible in the abstract. When a gap shows up, we can implement it in the pack first, and then, if it turns out to be generally useful, refine it and move it into core. Several features have already taken that path.
+Agentic architectures are evolving fast. Keeping it outside `haystack-ai` allows us to improve these agents rapidly, release updates independently, and avoid committing to stability before these patterns have settled.
 
-For now the pack ships specific agents rather than a general framework for building them. If enough repeated patterns emerge across agents to justify a shared harness, we will introduce one then, rather than designing it up front and hoping the agents fit.
+Developing complex agents also helps us identify missing capabilities in Haystack. When a gap shows up, we can implement it in the pack first, and then, if it turns out to be generally useful, refine it and move it into Haystack.
 
 ## Feedback
 
-If you hit something these agents can't express, or a gap in Haystack that made building your own agent harder than it should be, [open an issue](https://github.com/deepset-ai/haystack-core-integrations/issues). Those reports are what drives both the pack and the framework forward.
+If you find a bug or have an idea for a complex agent that could belong in the pack, [open an issue](https://github.com/deepset-ai/haystack-core-integrations/issues).

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack/advanced-rag-agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack/advanced-rag-agent.mdx
@@ -132,6 +132,25 @@ agent = create_advanced_rag_agent(
 )
 ```
 
+### Using the tools on their own
+
+The four document-store-backed tools (see [How it works](#how-it-works)) are exported individually and also bundled as `DocumentStoreToolset`, so you can drop them into your own `Agent` with your own prompt:
+
+```python
+from haystack_integrations.agent_pack.advanced_rag import DocumentStoreToolset
+
+agent = Agent(
+    chat_generator=...,
+    tools=[DocumentStoreToolset(document_store), my_retrieval_tool],
+)
+```
+
+## Supported document stores
+
+The metadata tools rely on document store methods that are not part of the base `DocumentStore` protocol: `get_metadata_fields_info`, `get_metadata_field_unique_values`, and `get_metadata_field_min_max`. [`InMemoryDocumentStore`](../../../document-stores/inmemorydocumentstore.mdx) and most document store integrations implement them (OpenSearch, Elasticsearch, Weaviate, Chroma, pgvector, Qdrant, Pinecone, MongoDB Atlas, Astra, and more).
+
+Each tool fails fast at construction time with a clear error if the store doesn't support the method it needs, so stores that implement only some of the methods can still use the matching subset of tools.
+
 ## Configuration
 
 Everything is configured through keyword arguments to `create_advanced_rag_agent`. All parameters are keyword-only. Only `document_store` and `retriever` are required, the rest are optional.
@@ -190,7 +209,7 @@ The agent's tools:
 
 `fetch_documents_by_filter` returns its results in reading order, grouping documents by parent file and sorting by split or page. It shows at most `max_docs` per call and reports the total match count, so larger match sets can be paged through with the tool's `offset` input. On stores that can count documents by filter, an over-broad filter is refused before any documents are fetched, and the refusal is returned to the LLM as an error it recovers from by narrowing the filter.
 
-## The filter grammar
+### The filter grammar
 
 To help the LLM construct valid [Haystack filters](../../../concepts/metadata-filtering.mdx) consistently, the filter grammar is included in the description of the `filters` parameter of `search_documents` and `fetch_documents_by_filter`, rather than placed entirely in the system prompt. The model receives it contextually at the point of tool use:
 
@@ -200,22 +219,3 @@ To help the LLM construct valid [Haystack filters](../../../concepts/metadata-fi
 - field names must be prefixed with `meta.`
 
 The system prompt adds the workflow rules: inspect fields first, verify values before filtering, and relax the filter when a search comes back empty.
-
-## Using the tools on their own
-
-The four document-store-backed tools are exported individually and also bundled as `DocumentStoreToolset`, so you can drop them into your own `Agent` with your own prompt:
-
-```python
-from haystack_integrations.agent_pack.advanced_rag import DocumentStoreToolset
-
-agent = Agent(
-    chat_generator=...,
-    tools=[DocumentStoreToolset(document_store), my_retrieval_tool],
-)
-```
-
-## Supported document stores
-
-The metadata tools rely on document store methods that are not part of the base `DocumentStore` protocol: `get_metadata_fields_info`, `get_metadata_field_unique_values`, and `get_metadata_field_min_max`. [`InMemoryDocumentStore`](../../../document-stores/inmemorydocumentstore.mdx) and most document store integrations implement them (OpenSearch, Elasticsearch, Weaviate, Chroma, pgvector, Qdrant, Pinecone, MongoDB Atlas, Astra, and more).
-
-Each tool fails fast at construction time with a clear error if the store doesn't support the method it needs, so stores that implement only some of the methods can still use the matching subset of tools.

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack/advanced-rag-agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack/advanced-rag-agent.mdx
@@ -26,6 +26,18 @@ A metadata-aware RAG agent: instead of guessing which metadata fields exist, it 
 Part of [Agent Pack](../agent-pack.mdx), which is experimental for the moment. Its APIs and agent architectures can change in any release, without following the usual deprecation policy.
 :::
 
+## When to use this agent
+
+Use the advanced RAG agent when:
+
+- You have a large, heterogeneous corpus (many topics, sources, or document types mixed together) with well-structured metadata. The agent uses that metadata to narrow retrieval, making results more precise than relevance ranking alone.
+- You need to retrieve exact or complete subsets of documents by metadata ("all pages of this file", "everything from source X"), not just the most relevant matches.
+
+It's less useful when:
+
+- There's no metadata, or the metadata isn't useful for narrowing retrieval.
+- The corpus is small and homogeneous, so plain top-k retrieval already returns the right documents.
+
 ## Installation
 
 ```shell

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack/advanced-rag-agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack/advanced-rag-agent.mdx
@@ -32,7 +32,7 @@ Part of [Agent Pack](../agent-pack.mdx), which is experimental for the moment. I
 pip install agent-pack-haystack arrow
 ```
 
-`arrow` is an optional runtime dependency: it renders today's date into the system prompt, so the agent can build filters for relative dates like "the last 5 years".
+`arrow` (required with the default system prompt) renders today's date so the agent can build filters for relative dates like "the last 5 years".
 
 Set `OPENAI_API_KEY` in the environment.
 

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack/advanced-rag-agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack/advanced-rag-agent.mdx
@@ -1,0 +1,221 @@
+---
+title: "Advanced RAG Agent"
+id: advanced-rag-agent
+slug: "/advanced-rag-agent"
+description: "A metadata-aware RAG agent: it inspects the document store and can construct Haystack filters to narrow its retrieval."
+---
+
+# Advanced RAG Agent
+
+A metadata-aware RAG agent: instead of guessing which metadata fields exist, it inspects the document store (fields, values, ranges) and can construct Haystack filters to narrow its retrieval.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Mandatory init variables** | `document_store`: The document store to inspect and fetch from<br />`retriever`: A relevance-scoring retriever or retrieval `Pipeline` |
+| **Mandatory run variables**  | `messages`: A list of [`ChatMessage`](../../../concepts/data-classes/chatmessage.mdx)s |
+| **Output variables**         | `last_message`: The answer, citing documents as `[doc <short-id>]`<br />`documents`: Every document the agent retrieved, deduplicated |
+| **API reference**            | Agent Pack |
+| **GitHub link**              | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack/src/haystack_integrations/agent_pack/advanced_rag |
+| **Package name**             | `agent-pack-haystack` |
+
+</div>
+
+:::warning
+Part of [Agent Pack](../agent-pack.mdx), which is experimental for the moment. Its APIs and agent architectures can change in any release, without following the usual deprecation policy.
+:::
+
+## Installation
+
+```shell
+pip install agent-pack-haystack arrow
+```
+
+`arrow` is an optional runtime dependency: it renders today's date into the system prompt, so the agent can build filters for relative dates like "the last 5 years".
+
+Set `OPENAI_API_KEY` in the environment.
+
+## Usage
+
+Index a corpus with varied metadata and ask a question the agent can only answer well by inspecting the metadata, building a filter, and retrieving with it:
+
+```python
+from haystack import Document
+from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+from haystack.dataclasses import ChatMessage
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack_integrations.agent_pack import create_advanced_rag_agent
+
+document_store = InMemoryDocumentStore()
+document_store.write_documents(
+    [
+        Document(
+            content="CRISPR gene editing corrected a hereditary blindness mutation in a clinical trial.",
+            meta={"category": "science", "year": 2021, "rating": 4.6},
+        ),
+        Document(
+            content="A quantum computer demonstrated error-corrected logical qubits.",
+            meta={"category": "science", "year": 2023, "rating": 4.8},
+        ),
+        Document(
+            content="Dolly the sheep became the first mammal cloned from an adult somatic cell.",
+            meta={"category": "science", "year": 1996, "rating": 4.2},
+        ),
+        Document(
+            content="The Berlin Wall fell, a decisive moment in the end of the Cold War.",
+            meta={"category": "history", "year": 1989, "rating": 4.7},
+        ),
+        Document(
+            content="Argentina won the FIFA World Cup final against France on penalties.",
+            meta={"category": "sports", "year": 2022, "rating": 4.9},
+        ),
+    ],
+)
+
+agent = create_advanced_rag_agent(
+    document_store=document_store,
+    retriever=InMemoryBM25Retriever(document_store=document_store, top_k=5),
+)
+
+result = agent.run(
+    messages=[ChatMessage.from_user("What science advances happened after 2015?")],
+)
+
+print(result["last_message"].text)  # the answer, citing documents as [doc <short-id>]
+for doc in result["documents"]:  # every document the agent retrieved, deduplicated
+    print(f"[doc {doc.id[:8]}] {doc.meta} :: {doc.content[:60]}")
+```
+
+The agent lists the metadata fields, verifies the `category` values and the `year` range, builds a [filter](../../../concepts/metadata-filtering.mdx) like `{"operator": "AND", "conditions": [{"field": "meta.category", "operator": "==", "value": "science"}, {"field": "meta.year", "operator": ">", "value": 2015}]}`, retrieves with it, and answers citing the CRISPR and quantum documents. Filtering is optional: when metadata can't narrow a question, the agent retrieves without one.
+
+:::note
+The retrieval you provide should be scoring-based: keyword (BM25), embedding, or hybrid. Direct, unscored fetching by metadata is already covered by the built-in `fetch_documents_by_filter` tool.
+:::
+
+### Using a retrieval pipeline instead of a single retriever
+
+To use a multi-component retrieval flow, pass a retrieval `Pipeline` as the `retriever` and provide mappings for the query, filters, and document output. For example, hybrid retrieval with reciprocal rank fusion:
+
+```python
+from haystack import Pipeline
+from haystack.components.embedders import OpenAITextEmbedder
+from haystack.components.joiners import DocumentJoiner
+from haystack.components.retrievers.in_memory import (
+    InMemoryBM25Retriever,
+    InMemoryEmbeddingRetriever,
+)
+
+pipeline = Pipeline()
+pipeline.add_component(
+    "bm25_retriever",
+    InMemoryBM25Retriever(document_store=document_store),
+)
+pipeline.add_component("text_embedder", OpenAITextEmbedder())
+pipeline.add_component(
+    "embedding_retriever",
+    InMemoryEmbeddingRetriever(document_store=document_store),
+)
+pipeline.add_component("joiner", DocumentJoiner(join_mode="reciprocal_rank_fusion"))
+pipeline.connect("text_embedder.embedding", "embedding_retriever.query_embedding")
+pipeline.connect("bm25_retriever.documents", "joiner.documents")
+pipeline.connect("embedding_retriever.documents", "joiner.documents")
+
+agent = create_advanced_rag_agent(
+    document_store=document_store,
+    retriever=pipeline,
+    retrieval_pipeline_input_mapping={
+        "query": ["bm25_retriever.query", "text_embedder.text"],
+        "filters": ["bm25_retriever.filters", "embedding_retriever.filters"],
+    },
+    retrieval_pipeline_output_mapping={"joiner.documents": "documents"},
+)
+```
+
+## Configuration
+
+Everything is configured through keyword arguments to `create_advanced_rag_agent`. All parameters are keyword-only. Only `document_store` and `retriever` are required, the rest are optional.
+
+### Retrieval
+
+- `document_store` is the store the metadata inspection tools and the `fetch_documents_by_filter` tool run against.
+- `retriever` becomes the `search_documents` tool. It can be either:
+  - a standalone retriever component whose `run` method accepts `query` and `filters`, or
+  - a retrieval `Pipeline`.
+
+  Examples of standalone components include [`InMemoryBM25Retriever`](../../retrievers/inmemorybm25retriever.mdx) and embedding retrievers wrapped in `TextEmbeddingRetriever`.
+- `retrieval_pipeline_input_mapping` maps the tool inputs to pipeline input sockets, and must have exactly the keys `query` and `filters`, for example `{"query": ["embedder.text"], "filters": ["retriever.filters"]}`. Required when `retriever` is a `Pipeline`.
+- `retrieval_pipeline_output_mapping` maps pipeline output sockets to tool outputs, for example `{"retriever.documents": "documents"}`. Only valid when `retriever` is a `Pipeline`.
+
+### Models and prompt
+
+- `llm` is the LLM that drives the agent loop. Defaults to `OpenAIResponsesChatGenerator("gpt-5.4")` with low reasoning effort.
+- `backup_answer_llm` is the LLM the built-in `BackupAnswerHook` uses to write a best-effort answer when the run is cut off by `max_agent_steps`. Defaults to a separate `OpenAIResponsesChatGenerator("gpt-5.4")` with low reasoning effort.
+- `system_prompt` overrides the pre-made system prompt.
+
+### Limits
+
+- `max_agent_steps` caps the agent loop. Defaults to `20`.
+- `max_fetched_docs` sets how many documents `fetch_documents_by_filter` shows per fetch. Defaults to `10`. A filter fetch is not bounded by a retriever's `top_k`, so this caps the tool result instead; the scored `search_documents` tool is bounded by the `top_k` configured on your retrieval components.
+- `tool_concurrency_limit` caps the number of tool calls executed in parallel within one agent step. Defaults to `4`.
+
+### Extension
+
+- `extra_tools` takes additional tools or toolsets, appended after the built-in document-store toolset and the retrieval tool.
+- `state_schema` merges additional entries into the agent's [`State`](../state.mdx) schema. The built-in `documents` entry always takes precedence.
+- `hooks` merges additional [hooks](../hooks.mdx) per hook point with the built-in ones. For `after_run`, the built-in backup-answer hook runs first, so custom hooks see the final answer.
+- `raise_on_tool_invocation_failure` makes a failing tool call raise when `True`, instead of returning the error to the LLM as a message it can recover from. Defaults to `False`.
+
+## How it works
+
+The architecture consists of a single Haystack [`Agent`](../agent.mdx) that works through three logical stages using five tools:
+
+- **Inspect metadata.** The agent discovers which metadata fields exist, then inspects their values or ranges.
+- **Retrieve documents.** It either runs relevance-based retrieval, optionally narrowed by a metadata filter, or fetches documents directly when metadata uniquely identifies them.
+- **Answer.** It answers using only the retrieved documents and cites them as `[doc <short-id>]`.
+
+Every retrieved document is accumulated in the agent's [`State`](../state.mdx) under the `documents` key and deduplicated by id. As a result, `agent.run(...)` returns both the answer (in `last_message`) and the complete set of documents retrieved during the run, alongside the standard [`Agent`](../agent.mdx) outputs `messages`, `step_count`, `token_usage`, and `tool_call_counts`. The answer cites each document by the first 8 characters of its id (for example `[doc a1b2c3d4]`); resolve a citation against the returned list with `doc.id.startswith(...)`.
+
+If the run is cut off by `max_agent_steps` before an answer is written, a `BackupAnswerHook` (an `after_run` hook) makes one extra LLM call to produce a best-effort answer from the evidence gathered so far, so `last_message` always carries a text answer.
+
+The agent's tools:
+
+| Tool | What it is | What it does |
+| --- | --- | --- |
+| `list_metadata_fields` | `ListMetadataFieldsTool` | Lists all metadata fields and their types. The system prompt instructs the agent to call this first. |
+| `get_metadata_field_values` | `GetMetadataFieldValuesTool` | Returns the distinct values of a field, so filters use values that actually exist. Listing is capped for high-cardinality fields, and the total count is reported when the store provides one. |
+| `get_metadata_field_range` | `GetMetadataFieldRangeTool` | Returns min and max of a numeric or orderable field (for example years, ratings, ISO dates). |
+| `fetch_documents_by_filter` | `FetchDocumentsByFilterTool` | Fetches documents directly through a metadata filter, when relevance scoring is unnecessary (for example a known title or file). |
+| `search_documents` | [`ComponentTool`](../../../tools/componenttool.mdx) over your retriever, or [`PipelineTool`](../../../tools/pipelinetool.mdx) over your retrieval pipeline | Retrieves documents for a query by relevance, optionally narrowed by a metadata filter. Bounded by the `top_k` of your retrieval components. An empty result nudges the agent to relax the filter. |
+
+`fetch_documents_by_filter` returns its results in reading order, grouping documents by parent file and sorting by split or page. It shows at most `max_docs` per call and reports the total match count, so larger match sets can be paged through with the tool's `offset` input. On stores that can count documents by filter, an over-broad filter is refused before any documents are fetched, and the refusal is returned to the LLM as an error it recovers from by narrowing the filter.
+
+## The filter grammar
+
+To help the LLM construct valid [Haystack filters](../../../concepts/metadata-filtering.mdx) consistently, the filter grammar is included in the description of the `filters` parameter of `search_documents` and `fetch_documents_by_filter`, rather than placed entirely in the system prompt. The model receives it contextually at the point of tool use:
+
+- single condition: `{"field": "meta.category", "operator": "==", "value": "science"}`
+- comparison operators: `==, !=, >, >=, <, <=, in, not in`
+- logical grouping: `{"operator": "AND"|"OR"|"NOT", "conditions": [...]}` (nestable)
+- field names must be prefixed with `meta.`
+
+The system prompt adds the workflow rules: inspect fields first, verify values before filtering, and relax the filter when a search comes back empty.
+
+## Using the tools on their own
+
+The four document-store-backed tools are exported individually and also bundled as `DocumentStoreToolset`, so you can drop them into your own `Agent` with your own prompt:
+
+```python
+from haystack_integrations.agent_pack.advanced_rag import DocumentStoreToolset
+
+agent = Agent(
+    chat_generator=...,
+    tools=[DocumentStoreToolset(document_store), my_retrieval_tool],
+)
+```
+
+## Supported document stores
+
+The metadata tools rely on document store methods that are not part of the base `DocumentStore` protocol: `get_metadata_fields_info`, `get_metadata_field_unique_values`, and `get_metadata_field_min_max`. [`InMemoryDocumentStore`](../../../document-stores/inmemorydocumentstore.mdx) and most document store integrations implement them (OpenSearch, Elasticsearch, Weaviate, Chroma, pgvector, Qdrant, Pinecone, MongoDB Atlas, Astra, and more).
+
+Each tool fails fast at construction time with a clear error if the store doesn't support the method it needs, so stores that implement only some of the methods can still use the matching subset of tools.

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
@@ -89,11 +89,11 @@ Scope and Write are plain LLM calls (a [`ChatPromptBuilder`](../../builders/chat
 
 `brief`, `notes`, and `report` are declared in the agent's `state_schema`, so they come back as outputs of a single `agent.run(...)` call.
 
-## The agents
+### The agents
 
 The Research phase uses two nested agents. Each one is a Haystack `Agent`: an LLM that loops, calling tools, until it decides to answer.
 
-### Orchestrator
+#### Orchestrator
 
 The orchestrator is the lead agent: it receives the research brief and coordinates the whole investigation.
 
@@ -109,7 +109,7 @@ The orchestrator's tools:
 | `research_subtopic` | The sub-researcher agent, exposed as a tool ([`ComponentTool`](../../../tools/componenttool.mdx)) | Researches a single sub-question in an isolated context and returns a compressed, cited summary. Only that summary is shown to the orchestrator; the summary is also appended to `notes`. |
 | `think_tool` | A no-op reflection tool | Lets the orchestrator pause to plan sub-questions and assess coverage between rounds. |
 
-### Sub-researcher
+#### Sub-researcher
 
 The sub-researcher is a reusable agent that answers a single sub-question. The orchestrator runs it many times in parallel, each in its own isolated context. This is the key idea: each sub-researcher processes the raw search results privately and returns only a concise summary, so the orchestrator's context stays small and the final report stays coherent.
 
@@ -125,7 +125,7 @@ The sub-researcher's tools:
 | `read_url` | [`PipelineTool`](../../../tools/pipelinetool.mdx) over a fetch, route, convert-to-text, and summarize pipeline | Fetches a page (`LinkContentFetcher`), routes by MIME type (`FileTypeRouter`) to `HTMLToDocument` (Trafilatura) or `PyPDFToDocument` so PDFs are parsed too, and summarizes the page toward a question the agent passes, so only the relevant text enters the agent's context, not the full page. Used only when a search snippet is too shallow. |
 | `think_tool` | A no-op reflection tool | "What did I learn? What's missing? Stop or continue?" between searches. |
 
-## Context management
+### Context management
 
 The core challenge in a deep research agent is keeping each context window small and focused. Raw web content (search results, full pages, PDFs) is large and noisy. If it all accumulated in a single context, the model's output quality would degrade. We avoid that with isolation and compression:
 

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
@@ -25,6 +25,22 @@ A deep research agent: give it a question, and it researches the web and produce
 Part of [Agent Pack](../agent-pack.mdx), which is experimental for the moment. Its APIs and agent architectures can change in any release, without following the usual deprecation policy.
 :::
 
+## When to use this agent
+
+Use the deep research agent when you need more than a quick answer. It's designed for questions that require gathering information from many web sources, evaluating them, and producing a structured report with citations.
+
+Typical use cases include:
+
+- Researching a broad topic across many sources.
+- Comparing products, companies, technologies, or scientific findings.
+- Preparing a literature review or market overview.
+- Answering complex questions that benefit from investigating several sub-topics in parallel.
+
+It's less useful when:
+
+- A single web search or RAG lookup is enough. The multi-agent workflow adds latency and cost.
+- The information lives in a private knowledge base rather than on the public web. For that, use the [Advanced RAG Agent](./advanced-rag-agent.mdx).
+
 ## Installation
 
 ```shell

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
@@ -1,0 +1,168 @@
+---
+title: "Deep Research Agent"
+id: deep-research-agent
+slug: "/deep-research-agent"
+description: "A deep research agent: give it a question, and it researches the web and produces a structured, cited markdown report."
+---
+
+# Deep Research Agent
+
+A small, working deep research agent: give it a question, and it researches the web and produces a structured, cited markdown report.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Mandatory run variables** | `messages`: A list of [`ChatMessage`](../../../concepts/data-classes/chatmessage.mdx)s |
+| **Output variables**        | `report`: The final cited markdown report<br />`brief`, `notes`: The intermediate research brief and collected summaries |
+| **API reference**           | Agent Pack |
+| **GitHub link**             | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack/src/haystack_integrations/agent_pack/deep_research |
+| **Package name**            | `agent-pack-haystack` |
+
+</div>
+
+:::warning
+Part of [Agent Pack](../agent-pack.mdx), which is experimental for the moment. Its APIs and agent architectures can change in any release, without following the usual deprecation policy.
+:::
+
+## Installation
+
+```shell
+pip install agent-pack-haystack tavily-haystack trafilatura pypdf arrow
+```
+
+`tavily-haystack`, `trafilatura`, `pypdf`, and `arrow` are optional runtime dependencies of the deep research agent (web search, HTML and PDF parsing, and date rendering). Install them alongside `agent-pack-haystack` to use it.
+
+Set `OPENAI_API_KEY` and `TAVILY_API_KEY` in the environment.
+
+## Usage
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.agent_pack import create_deep_research_agent
+
+agent = create_deep_research_agent()
+result = agent.run(messages=[ChatMessage.from_user("your research question")])
+print(result["report"])
+```
+
+`agent.run(...)` returns a dictionary whose main output is `report`, the final markdown report. The dictionary also carries the intermediate `brief` (a `str`) and `notes` (a `list[str]`), plus the standard [`Agent`](../agent.mdx) outputs `messages`, `last_message`, `step_count`, `token_usage`, and `tool_call_counts`.
+
+## Configuration
+
+Everything is configured through keyword arguments to `create_deep_research_agent`. All parameters are keyword-only and optional.
+
+### Models
+
+Each phase takes its own [ChatGenerator](../../generators/openairesponseschatgenerator.mdx), so you can mix models by cost and capability, or swap in a different provider.
+
+- `scope_llm` is the LLM that rewrites the user query into a focused research brief. Defaults to `OpenAIResponsesChatGenerator("gpt-5.4")`.
+- `orchestrator_llm` is the LLM that plans the investigation and delegates the sub-questions. Defaults to `OpenAIResponsesChatGenerator("gpt-5.4")`.
+- `researcher_llm` is the LLM that drives each sub-researcher's search, read, and think loop. Defaults to `OpenAIResponsesChatGenerator("gpt-5.4-mini")`.
+- `summarizer_llm` is the LLM used inside the `read_url` tool to summarize a fetched page toward the question. Defaults to `OpenAIResponsesChatGenerator("gpt-5.4-mini")`.
+- `writer_llm` is the LLM that turns the brief plus collected notes into the final report. Defaults to `OpenAIResponsesChatGenerator("gpt-5.4")`.
+
+### Breadth and depth
+
+- `max_subtopics` is the maximum number of sub-questions the orchestrator may delegate (breadth). Defaults to `5`.
+- `max_concurrent_researchers` is the maximum number of sub-researchers that run at the same time. Defaults to `5`.
+- `max_orchestrator_steps` is the maximum number of steps for the orchestrator's agent loop (reflect and delegate rounds). Defaults to `8`.
+- `max_researcher_steps` is the maximum number of steps for each sub-researcher's agent loop. Defaults to `20`.
+
+### Search and reading
+
+- `max_search_results` is the number of results returned per `web_search` call. Defaults to `10`.
+- `max_content_length` is the maximum number of raw page characters fed to the summarizer, before summarization. Defaults to `50000`.
+
+## How it works
+
+The whole thing is a single Haystack [`Agent`](../agent.mdx), the orchestrator, with two [hooks](../hooks.mdx) that bracket its loop. The three logical phases are Scope, Research, and Write:
+
+```
+  user query
+      │
+      ▼
+┌──────────────┐
+│  1. SCOPE    │   before_run hook: rewrite the question into a focused research brief
+└──────┬───────┘
+       │ brief
+       ▼
+┌──────────────┐   the agent loop (see "The agents" below):
+│ 2. RESEARCH  │   the orchestrator splits the brief into sub-questions,
+│ (agent loop) │   delegates each to a sub-researcher, and collects their summaries
+└──────┬───────┘
+       │ brief + notes
+       ▼
+┌──────────────┐
+│  3. WRITE    │   after_run hook: brief + notes → cited markdown report
+└──────┬───────┘
+       │
+       ▼
+   report (markdown, with inline [text](url) citations)
+```
+
+Scope and Write are plain LLM calls (a [`ChatPromptBuilder`](../../builders/chatpromptbuilder.mdx) and an [`OpenAIResponsesChatGenerator`](../../generators/openairesponseschatgenerator.mdx)), wrapped as serializable hook classes (`ScopeHook`, `WriteHook`):
+
+- Scope runs as a `before_run` hook: before the orchestrator's loop starts, it turns the user query into a brief, stored on the agent's [`State`](../state.mdx).
+- Write runs as an `after_run` hook: when the orchestrator's loop finishes, it turns the brief plus collected `notes` into the final report.
+
+`brief`, `notes`, and `report` are declared in the agent's `state_schema`, so they come back as outputs of a single `agent.run(...)` call.
+
+## The agents
+
+The Research phase is built from two nested agents. An agent here is a Haystack `Agent`: an LLM that loops, calling tools, until it decides to answer.
+
+### Orchestrator
+
+The lead agent. It receives the research brief and coordinates the whole investigation.
+
+- **Job:** split the brief into a few focused, non-overlapping sub-questions, delegate each one, check coverage, and stop when there's enough.
+- **Parallelism:** it emits several delegation calls in a single turn, and they run concurrently (bounded by `max_concurrent_researchers`).
+- **Memory:** the summaries returned by sub-researchers are appended to a shared `notes` list (the agent's `State`), which the writer later turns into the report.
+- **Stops when:** it replies with plain text (research complete) or hits `max_orchestrator_steps`.
+
+Its tools:
+
+| Tool | What it is | What it does |
+| --- | --- | --- |
+| `research_subtopic` | The sub-researcher agent, exposed as a tool ([`ComponentTool`](../../../tools/componenttool.mdx)) | Researches ONE sub-question in an isolated context and returns a compressed, cited summary. Only that summary is shown to the orchestrator; the summary is also appended to `notes`. |
+| `think_tool` | A no-op reflection tool | Lets the orchestrator pause to plan sub-questions and assess coverage between rounds. |
+
+### Sub-researcher
+
+A reusable agent that answers ONE sub-question. The orchestrator runs it many times (in parallel), each in its own isolated context. This is the key idea: each sub-researcher processes the raw search results privately and returns only a concise summary, so the orchestrator's context stays small and the final report stays coherent.
+
+- **Job:** search the web, optionally read promising pages, reflect, then write a compressed summary with inline citations to the exact source URLs.
+- **Returns:** its final text message *is* the summary (it exits as soon as it writes plain text).
+- **Bounded by:** `max_researcher_steps`.
+
+Its tools:
+
+| Tool | What it is | What it does |
+| --- | --- | --- |
+| `web_search` | [`TavilyWebSearchTool`](../../../tools/ready-made-tools/tavilywebsearchtool.mdx) from the Tavily integration | Runs a web search and returns the top results as title, exact URL, and snippet. |
+| `read_url` | [`PipelineTool`](../../../tools/pipelinetool.mdx) over a fetch, route, convert-to-text, and summarize pipeline | Fetches a page (`LinkContentFetcher`), routes by MIME type (`FileTypeRouter`) to `HTMLToDocument` (Trafilatura) or `PyPDFToDocument` so PDFs are parsed too, and summarizes the page toward a question the agent passes, so only the relevant text enters the agent's context, not the full page. Used only when a search snippet is too shallow. |
+| `think_tool` | A no-op reflection tool | "What did I learn? What's missing? Stop or continue?" between searches. |
+
+## Context management
+
+The core challenge in a deep research agent is keeping each context window small and focused. Raw web content (search results, full pages, PDFs) is large and noisy. If it all accumulated in a single context, the model's output quality would degrade. We avoid that with isolation and compression:
+
+- Each sub-researcher runs as its own agent with its own `State`, so all the messy intermediate content (every search result, every fetched page) stays in *its* private context.
+- It finishes by writing one short summary (its final message). Only that summary leaves the sub-researcher: the raw content never reaches the orchestrator or the writer.
+
+Two settings on the `research_subtopic` tool decide where that summary goes:
+
+| Setting (on `research_subtopic`) | Controls | Effect |
+| --- | --- | --- |
+| `outputs_to_string={"source": "last_message"}` | What the orchestrator's LLM sees as the tool result | Only the summary text comes back, not the sub-researcher's full message history. Keeps the orchestrator's context clean. |
+| `outputs_to_state={"notes": {...}}` | What gets saved for the writer | The same summary is appended (as text) to the shared `notes` list, which becomes the writer's input. |
+
+So each summary travels two ways, into the orchestrator's reasoning (so it can decide whether to dig further) and into the `notes` accumulator (so the writer can use it), while the bulky raw research stays isolated and is thrown away:
+
+```
+sub-researcher  (private context: searches, pages, reflections)
+      │  writes ONE short summary
+      ├─ outputs_to_string → orchestrator's LLM   (decide: done, or dig more?)
+      └─ outputs_to_state  → notes → writer        (final report)
+```

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
@@ -31,7 +31,7 @@ Part of [Agent Pack](../agent-pack.mdx), which is experimental for the moment. I
 pip install agent-pack-haystack tavily-haystack trafilatura pypdf arrow
 ```
 
-`tavily-haystack`, `trafilatura`, `pypdf`, and `arrow` are optional runtime dependencies of the deep research agent (web search, HTML and PDF parsing, and date rendering). Install them alongside `agent-pack-haystack` to use it.
+`tavily-haystack`, `trafilatura`, `pypdf`, and `arrow` are separate installs the deep research agent needs at runtime (web search, HTML and PDF parsing, and date rendering).
 
 Set `OPENAI_API_KEY` and `TAVILY_API_KEY` in the environment.
 

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
@@ -2,19 +2,19 @@
 title: "Deep Research Agent"
 id: deep-research-agent
 slug: "/deep-research-agent"
-description: "A deep research agent: give it a question, and it researches the web and produces a structured, cited markdown report."
+description: "A deep research agent: give it a question, and it researches the web and produces a structured, cited Markdown report."
 ---
 
 # Deep Research Agent
 
-A small, working deep research agent: give it a question, and it researches the web and produces a structured, cited markdown report.
+A deep research agent: give it a question, and it researches the web and produces a structured, cited Markdown report.
 
 <div className="key-value-table">
 
 |  |  |
 | --- | --- |
 | **Mandatory run variables** | `messages`: A list of [`ChatMessage`](../../../concepts/data-classes/chatmessage.mdx)s |
-| **Output variables**        | `report`: The final cited markdown report<br />`brief`, `notes`: The intermediate research brief and collected summaries |
+| **Output variables**        | `report`: The final cited Markdown report<br />`brief`, `notes`: The intermediate research brief and collected summaries |
 | **API reference**           | Agent Pack |
 | **GitHub link**             | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack/src/haystack_integrations/agent_pack/deep_research |
 | **Package name**            | `agent-pack-haystack` |
@@ -46,7 +46,7 @@ result = agent.run(messages=[ChatMessage.from_user("your research question")])
 print(result["report"])
 ```
 
-`agent.run(...)` returns a dictionary whose main output is `report`, the final markdown report. The dictionary also carries the intermediate `brief` (a `str`) and `notes` (a `list[str]`), plus the standard [`Agent`](../agent.mdx) outputs `messages`, `last_message`, `step_count`, `token_usage`, and `tool_call_counts`.
+`agent.run(...)` returns a dictionary whose main output is `report`, the final Markdown report. The dictionary also carries the intermediate `brief` (a `str`) and `notes` (a `list[str]`), plus the standard [`Agent`](../agent.mdx) outputs `messages`, `last_message`, `step_count`, `token_usage`, and `tool_call_counts`.
 
 ## Configuration
 
@@ -54,7 +54,7 @@ Everything is configured through keyword arguments to `create_deep_research_agen
 
 ### Models
 
-Each phase takes its own [ChatGenerator](../../generators/openairesponseschatgenerator.mdx), so you can mix models by cost and capability, or swap in a different provider.
+Each phase takes its own ChatGenerator, so you can mix models by cost and capability, or swap in a different provider.
 
 - `scope_llm` is the LLM that rewrites the user query into a focused research brief. Defaults to `OpenAIResponsesChatGenerator("gpt-5.4")`.
 - `orchestrator_llm` is the LLM that plans the investigation and delegates the sub-questions. Defaults to `OpenAIResponsesChatGenerator("gpt-5.4")`.
@@ -76,30 +76,11 @@ Each phase takes its own [ChatGenerator](../../generators/openairesponseschatgen
 
 ## How it works
 
-The whole thing is a single Haystack [`Agent`](../agent.mdx), the orchestrator, with two [hooks](../hooks.mdx) that bracket its loop. The three logical phases are Scope, Research, and Write:
+The architecture is built around a single top-level Haystack [`Agent`](../agent.mdx), which acts as the orchestrator. Two [hooks](../hooks.mdx) run before and after its loop, creating three logical phases: Scope, Research, and Write. During the Research phase, the orchestrator invokes isolated sub-researcher agents, each its own `Agent`, through a tool:
 
-```
-  user query
-      │
-      ▼
-┌──────────────┐
-│  1. SCOPE    │   before_run hook: rewrite the question into a focused research brief
-└──────┬───────┘
-       │ brief
-       ▼
-┌──────────────┐   the agent loop (see "The agents" below):
-│ 2. RESEARCH  │   the orchestrator splits the brief into sub-questions,
-│ (agent loop) │   delegates each to a sub-researcher, and collects their summaries
-└──────┬───────┘
-       │ brief + notes
-       ▼
-┌──────────────┐
-│  3. WRITE    │   after_run hook: brief + notes → cited markdown report
-└──────┬───────┘
-       │
-       ▼
-   report (markdown, with inline [text](url) citations)
-```
+- **Scope.** The user question is rewritten into a focused research brief.
+- **Research.** The orchestrator splits the brief into focused sub-questions, delegates each to a sub-researcher, and collects their summaries.
+- **Write.** The brief and the collected summaries become the final report: Markdown with inline `[text](url)` citations.
 
 Scope and Write are plain LLM calls (a [`ChatPromptBuilder`](../../builders/chatpromptbuilder.mdx) and an [`OpenAIResponsesChatGenerator`](../../generators/openairesponseschatgenerator.mdx)), wrapped as serializable hook classes (`ScopeHook`, `WriteHook`):
 
@@ -110,33 +91,33 @@ Scope and Write are plain LLM calls (a [`ChatPromptBuilder`](../../builders/chat
 
 ## The agents
 
-The Research phase is built from two nested agents. An agent here is a Haystack `Agent`: an LLM that loops, calling tools, until it decides to answer.
+The Research phase uses two nested agents. Each one is a Haystack `Agent`: an LLM that loops, calling tools, until it decides to answer.
 
 ### Orchestrator
 
-The lead agent. It receives the research brief and coordinates the whole investigation.
+The orchestrator is the lead agent: it receives the research brief and coordinates the whole investigation.
 
 - **Job:** split the brief into a few focused, non-overlapping sub-questions, delegate each one, check coverage, and stop when there's enough.
 - **Parallelism:** it emits several delegation calls in a single turn, and they run concurrently (bounded by `max_concurrent_researchers`).
 - **Memory:** the summaries returned by sub-researchers are appended to a shared `notes` list (the agent's `State`), which the writer later turns into the report.
 - **Stops when:** it replies with plain text (research complete) or hits `max_orchestrator_steps`.
 
-Its tools:
+The orchestrator's tools:
 
 | Tool | What it is | What it does |
 | --- | --- | --- |
-| `research_subtopic` | The sub-researcher agent, exposed as a tool ([`ComponentTool`](../../../tools/componenttool.mdx)) | Researches ONE sub-question in an isolated context and returns a compressed, cited summary. Only that summary is shown to the orchestrator; the summary is also appended to `notes`. |
+| `research_subtopic` | The sub-researcher agent, exposed as a tool ([`ComponentTool`](../../../tools/componenttool.mdx)) | Researches a single sub-question in an isolated context and returns a compressed, cited summary. Only that summary is shown to the orchestrator; the summary is also appended to `notes`. |
 | `think_tool` | A no-op reflection tool | Lets the orchestrator pause to plan sub-questions and assess coverage between rounds. |
 
 ### Sub-researcher
 
-A reusable agent that answers ONE sub-question. The orchestrator runs it many times (in parallel), each in its own isolated context. This is the key idea: each sub-researcher processes the raw search results privately and returns only a concise summary, so the orchestrator's context stays small and the final report stays coherent.
+The sub-researcher is a reusable agent that answers a single sub-question. The orchestrator runs it many times in parallel, each in its own isolated context. This is the key idea: each sub-researcher processes the raw search results privately and returns only a concise summary, so the orchestrator's context stays small and the final report stays coherent.
 
 - **Job:** search the web, optionally read promising pages, reflect, then write a compressed summary with inline citations to the exact source URLs.
 - **Returns:** its final text message *is* the summary (it exits as soon as it writes plain text).
 - **Bounded by:** `max_researcher_steps`.
 
-Its tools:
+The sub-researcher's tools:
 
 | Tool | What it is | What it does |
 | --- | --- | --- |
@@ -158,11 +139,11 @@ Two settings on the `research_subtopic` tool decide where that summary goes:
 | `outputs_to_string={"source": "last_message"}` | What the orchestrator's LLM sees as the tool result | Only the summary text comes back, not the sub-researcher's full message history. Keeps the orchestrator's context clean. |
 | `outputs_to_state={"notes": {...}}` | What gets saved for the writer | The same summary is appended (as text) to the shared `notes` list, which becomes the writer's input. |
 
-So each summary travels two ways, into the orchestrator's reasoning (so it can decide whether to dig further) and into the `notes` accumulator (so the writer can use it), while the bulky raw research stays isolated and is thrown away:
+So each summary travels two ways, into the orchestrator's reasoning (so it can decide whether to dig further) and into the `notes` accumulator (so the writer can use it), while the bulky raw research stays isolated and is not propagated beyond the sub-researcher:
 
 ```
 sub-researcher  (private context: searches, pages, reflections)
-      │  writes ONE short summary
+      │  writes one short summary
       ├─ outputs_to_string → orchestrator's LLM   (decide: done, or dig more?)
       └─ outputs_to_state  → notes → writer        (final report)
 ```

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -177,6 +177,7 @@ export default {
                 id: 'pipeline-components/agents-1/agent-pack',
               },
               items: [
+                'pipeline-components/agents-1/agent-pack/advanced-rag-agent',
                 'pipeline-components/agents-1/agent-pack/deep-research-agent',
               ],
             },

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -169,6 +169,17 @@ export default {
               ],
             },
             'pipeline-components/agents-1/state',
+            {
+              type: 'category',
+              label: 'Agent Pack',
+              link: {
+                type: 'doc',
+                id: 'pipeline-components/agents-1/agent-pack',
+              },
+              items: [
+                'pipeline-components/agents-1/agent-pack/deep-research-agent',
+              ],
+            },
           ],
         },
         {


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/467

### Proposed Changes:
- document the Agent pack and its agents
  - most of the content for specific Agents comes from the Readmes 

### How did you test it?
Vercel preview

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
