### PR TITLE
fix: treat [0] document references as out of range in AnswerBuilder

### DIFF
--- a/haystack/components/builders/answer_builder.py
+++ b/haystack/components/builders/answer_builder.py
@@ -223,13 +223,14 @@ class AnswerBuilder:
                 )
 
                 for idx in doc_idxs:
-                    try:
-                        doc = documents[idx]
-                    except IndexError:
+                    # An explicit bounds check is needed because references are 1-based: a reference like [0]
+                    # yields idx = -1, which Python would otherwise silently resolve to the last document.
+                    if not 0 <= idx < len(documents):
                         logger.warning(
                             "Document index '{index}' referenced in Generator output is out of range. ", index=idx + 1
                         )
                         continue
+                    doc = documents[idx]
 
                     doc_meta: dict[str, Any] = dict(doc.meta or {})
                     doc_meta["source_index"] = idx + 1

--- a/releasenotes/notes/answer-builder-zero-reference-out-of-range-64aab56f8b5f65c3.yaml
+++ b/releasenotes/notes/answer-builder-zero-reference-out-of-range-64aab56f8b5f65c3.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    AnswerBuilder now treats a `[0]` document reference as out of range instead of silently attaching
-    the last document. References are 1-based, so `[0]` produced a negative index that bypassed the
-    out-of-range guard, marking an unrelated document as `referenced` with a wrong `source_index`.
-    The same applied to expanded reference ranges starting at 0 (e.g. `[0-1]`).
+    AnswerBuilder now treats a ``[0]`` document reference as out of range instead of silently attaching
+    the last document. References are 1-based, so ``[0]`` produced a negative index that bypassed the
+    out-of-range guard, marking an unrelated document as ``referenced`` with a wrong ``source_index``.
+    The same applied to expanded reference ranges starting at 0 (e.g. ``[0-1]``).

--- a/releasenotes/notes/answer-builder-zero-reference-out-of-range-64aab56f8b5f65c3.yaml
+++ b/releasenotes/notes/answer-builder-zero-reference-out-of-range-64aab56f8b5f65c3.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    AnswerBuilder now treats a `[0]` document reference as out of range instead of silently attaching
+    the last document. References are 1-based, so `[0]` produced a negative index that bypassed the
+    out-of-range guard, marking an unrelated document as `referenced` with a wrong `source_index`.
+    The same applied to expanded reference ranges starting at 0 (e.g. `[0-1]`).

--- a/test/components/builders/test_answer_builder.py
+++ b/test/components/builders/test_answer_builder.py
@@ -186,6 +186,38 @@ class TestAnswerBuilder:
         assert len(answers[0].documents) == 0
         assert "Document index '3' referenced in Generator output is out of range." in caplog.text
 
+    def test_run_with_documents_with_zero_reference(self, caplog):
+        # References are 1-based, so [0] is out of range and must not silently
+        # resolve to the last document via a negative index.
+        component = AnswerBuilder(reference_pattern="\\[(\\d+)\\]")
+        with caplog.at_level(logging.WARNING):
+            output = component.run(
+                query="test query",
+                replies=["Answer: AnswerString[0]"],
+                meta=[{}],
+                documents=[Document(content="test doc 1"), Document(content="test doc 2")],
+            )
+        answers = output["answers"]
+        assert len(answers) == 1
+        assert len(answers[0].documents) == 0
+        assert "Document index '0' referenced in Generator output is out of range." in caplog.text
+
+    def test_run_with_zero_reference_in_expanded_range(self, caplog):
+        component = AnswerBuilder(reference_pattern="\\[([\\d\\s,-]+)\\]", expand_reference_ranges=True)
+        with caplog.at_level(logging.WARNING):
+            output = component.run(
+                query="test query",
+                replies=["Answer: AnswerString[0-1]"],
+                meta=[{}],
+                documents=[Document(content="test doc 1"), Document(content="test doc 2")],
+            )
+        answers = output["answers"]
+        assert len(answers) == 1
+        assert len(answers[0].documents) == 1
+        assert answers[0].documents[0].content == "test doc 1"
+        assert answers[0].documents[0].meta["referenced"] is True
+        assert "Document index '0' referenced in Generator output is out of range." in caplog.text
+
     def test_run_with_reference_pattern_set_at_runtime(self):
         component = AnswerBuilder(reference_pattern="unused pattern")
         output = component.run(


### PR DESCRIPTION
### Related Issues

- None filed — bug found while reviewing the reference-extraction path; happy to open one if preferred.

### Proposed Changes:

`AnswerBuilder` documents references as 1-based, so extracted indices are decremented by 1. When an LLM cites `[0]` (LLMs frequently 0-index), the extracted index becomes `-1`. The out-of-range guard relies on `documents[idx]` raising `IndexError`, but Python resolves `documents[-1]` to the *last* document — so the guard never fires and an unrelated document is silently attached to the answer, marked `referenced=True` with a bogus `source_index=0`:

```python
docs = [Document(content="doc A"), Document(content="doc B"), Document(content="doc C")]
builder = AnswerBuilder(reference_pattern="\[(\d+)\]")
out = builder.run(query="q", replies=["The answer is X [0]"], documents=docs)
# before: doc C attached, referenced=True, source_index=0
# after:  no doc attached + warning "Document index '0' ... is out of range."
```

Expanded reference ranges starting at 0 (`[0-1]`, `expand_reference_ranges=True`) hit the same hole via `range(start - 1, end)`.

Fix: replace the `try/except IndexError` with an explicit bounds check (`0 <= idx < len(documents)`), keeping the exact same warning message and skip behaviour for all out-of-range references.

### How did you test it?

- Repro script run on `main` (wrong doc attached) and with the fix (warning + no doc) for both `[0]` and `[0-1]`.
- Two new unit tests (`[0]` and `[0-1]`-range cases), which fail on `main` and pass with the fix.
- Full `test/components/builders/test_answer_builder.py`: 32 passed.

### Notes for the reviewer

- No behaviour change for valid or too-large references — only negative indices, which were previously impossible to reject.
- Aware of open PR #11953 touching the same loop for referenced-doc ordering; this change is 3 lines and easy to rebase either way.
- Disclaimer per contributing guidelines: this fix was AI-assisted; I reviewed it and ran the repro and tests locally.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
