### PR TITLE
fix: apply FilterPolicy.MERGE correctly in in-memory retrievers

### DIFF
--- a/haystack/components/retrievers/in_memory/bm25_retriever.py
+++ b/haystack/components/retrievers/in_memory/bm25_retriever.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-from haystack.document_stores.types import FilterPolicy
+from haystack.document_stores.types import FilterPolicy, apply_filter_policy
 
 
 @component
@@ -143,10 +143,7 @@ class InMemoryBM25Retriever:
         :raises ValueError:
             If the specified DocumentStore is not found or is not a InMemoryDocumentStore instance.
         """
-        if self.filter_policy == FilterPolicy.MERGE and filters:
-            filters = {**(self.filters or {}), **filters}
-        else:
-            filters = filters or self.filters
+        filters = apply_filter_policy(self.filter_policy, self.filters, filters)
         if top_k is None:
             top_k = self.top_k
         if scale_score is None:
@@ -181,10 +178,7 @@ class InMemoryBM25Retriever:
         :raises ValueError:
             If the specified DocumentStore is not found or is not a InMemoryDocumentStore instance.
         """
-        if self.filter_policy == FilterPolicy.MERGE and filters:
-            filters = {**(self.filters or {}), **filters}
-        else:
-            filters = filters or self.filters
+        filters = apply_filter_policy(self.filter_policy, self.filters, filters)
         if top_k is None:
             top_k = self.top_k
         if scale_score is None:

--- a/haystack/components/retrievers/in_memory/embedding_retriever.py
+++ b/haystack/components/retrievers/in_memory/embedding_retriever.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-from haystack.document_stores.types import FilterPolicy
+from haystack.document_stores.types import FilterPolicy, apply_filter_policy
 
 
 @component
@@ -163,10 +163,7 @@ class InMemoryEmbeddingRetriever:
         :raises ValueError:
             If the specified DocumentStore is not found or is not an InMemoryDocumentStore instance.
         """
-        if self.filter_policy == FilterPolicy.MERGE and filters:
-            filters = {**(self.filters or {}), **filters}
-        else:
-            filters = filters or self.filters
+        filters = apply_filter_policy(self.filter_policy, self.filters, filters)
         if top_k is None:
             top_k = self.top_k
         if scale_score is None:
@@ -214,10 +211,7 @@ class InMemoryEmbeddingRetriever:
         :raises ValueError:
             If the specified DocumentStore is not found or is not an InMemoryDocumentStore instance.
         """
-        if self.filter_policy == FilterPolicy.MERGE and filters:
-            filters = {**(self.filters or {}), **filters}
-        else:
-            filters = filters or self.filters
+        filters = apply_filter_policy(self.filter_policy, self.filters, filters)
         if top_k is None:
             top_k = self.top_k
         if scale_score is None:

--- a/releasenotes/notes/filter-policy-merge-in-memory-retrievers-f49dfcb2a1332e8b.yaml
+++ b/releasenotes/notes/filter-policy-merge-in-memory-retrievers-f49dfcb2a1332e8b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix ``FilterPolicy.MERGE`` in ``InMemoryBM25Retriever`` and
+    ``InMemoryEmbeddingRetriever`` so initialization filters are combined with
+    runtime comparison filters instead of being silently overwritten.

--- a/test/components/retrievers/test_in_memory_bm25_retriever.py
+++ b/test/components/retrievers/test_in_memory_bm25_retriever.py
@@ -154,10 +154,7 @@ class TestMemoryBM25Retriever:
             filter_policy=FilterPolicy.MERGE,
         )
 
-        result = retriever.run(
-            query="python",
-            filters={"field": "meta.year", "operator": ">=", "value": 2020},
-        )
+        result = retriever.run(query="python", filters={"field": "meta.year", "operator": ">=", "value": 2020})
 
         assert [doc.content for doc in result["documents"]] == ["python article current"]
 
@@ -178,8 +175,7 @@ class TestMemoryBM25Retriever:
         )
 
         result = await retriever.run_async(
-            query="python",
-            filters={"field": "meta.year", "operator": ">=", "value": 2020},
+            query="python", filters={"field": "meta.year", "operator": ">=", "value": 2020}
         )
 
         assert [doc.content for doc in result["documents"]] == ["python article current"]

--- a/test/components/retrievers/test_in_memory_bm25_retriever.py
+++ b/test/components/retrievers/test_in_memory_bm25_retriever.py
@@ -139,6 +139,51 @@ class TestMemoryBM25Retriever:
         assert len(result["documents"]) == 5
         assert result["documents"][0].content == "PHP is a popular programming language"
 
+    def test_run_with_filter_policy_merge_combines_init_and_runtime_filters(self, in_memory_doc_store):
+        in_memory_doc_store.write_documents(
+            [
+                Document(content="python article current", meta={"type": "article", "year": 2020}),
+                Document(content="python blog current", meta={"type": "blog", "year": 2021}),
+                Document(content="python article archived", meta={"type": "article", "year": 2019}),
+            ]
+        )
+
+        retriever = InMemoryBM25Retriever(
+            in_memory_doc_store,
+            filters={"field": "meta.type", "operator": "==", "value": "article"},
+            filter_policy=FilterPolicy.MERGE,
+        )
+
+        result = retriever.run(
+            query="python",
+            filters={"field": "meta.year", "operator": ">=", "value": 2020},
+        )
+
+        assert [doc.content for doc in result["documents"]] == ["python article current"]
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_filter_policy_merge_combines_init_and_runtime_filters(self, in_memory_doc_store):
+        in_memory_doc_store.write_documents(
+            [
+                Document(content="python article current", meta={"type": "article", "year": 2020}),
+                Document(content="python blog current", meta={"type": "blog", "year": 2021}),
+                Document(content="python article archived", meta={"type": "article", "year": 2019}),
+            ]
+        )
+
+        retriever = InMemoryBM25Retriever(
+            in_memory_doc_store,
+            filters={"field": "meta.type", "operator": "==", "value": "article"},
+            filter_policy=FilterPolicy.MERGE,
+        )
+
+        result = await retriever.run_async(
+            query="python",
+            filters={"field": "meta.year", "operator": ">=", "value": 2020},
+        )
+
+        assert [doc.content for doc in result["documents"]] == ["python article current"]
+
     def test_invalid_run_wrong_store_type(self):
         SomeOtherDocumentStore = document_store_class("SomeOtherDocumentStore")
         with pytest.raises(TypeError, match="document_store must be an instance of InMemoryDocumentStore"):

--- a/test/components/retrievers/test_in_memory_embedding_retriever.py
+++ b/test/components/retrievers/test_in_memory_embedding_retriever.py
@@ -141,6 +141,77 @@ class TestMemoryEmbeddingRetriever:
         assert len(result["documents"]) == top_k
         assert result["documents"][0].embedding == [1.0, 1.0, 1.0, 1.0]
 
+    def test_run_with_filter_policy_merge_combines_init_and_runtime_filters(self):
+        ds = InMemoryDocumentStore(embedding_similarity_function="cosine")
+        ds.write_documents(
+            [
+                Document(
+                    content="python article current",
+                    embedding=[1.0, 0.0, 0.0, 0.0],
+                    meta={"type": "article", "year": 2020},
+                ),
+                Document(
+                    content="python blog current",
+                    embedding=[1.0, 0.0, 0.0, 0.0],
+                    meta={"type": "blog", "year": 2021},
+                ),
+                Document(
+                    content="python article archived",
+                    embedding=[1.0, 0.0, 0.0, 0.0],
+                    meta={"type": "article", "year": 2019},
+                ),
+            ]
+        )
+
+        retriever = InMemoryEmbeddingRetriever(
+            ds,
+            filters={"field": "meta.type", "operator": "==", "value": "article"},
+            filter_policy=FilterPolicy.MERGE,
+        )
+
+        result = retriever.run(
+            query_embedding=[1.0, 0.0, 0.0, 0.0],
+            filters={"field": "meta.year", "operator": ">=", "value": 2020},
+        )
+
+        assert [doc.content for doc in result["documents"]] == ["python article current"]
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_filter_policy_merge_combines_init_and_runtime_filters(self):
+        ds = InMemoryDocumentStore(embedding_similarity_function="cosine")
+        ds.write_documents(
+            [
+                Document(
+                    content="python article current",
+                    embedding=[1.0, 0.0, 0.0, 0.0],
+                    meta={"type": "article", "year": 2020},
+                ),
+                Document(
+                    content="python blog current",
+                    embedding=[1.0, 0.0, 0.0, 0.0],
+                    meta={"type": "blog", "year": 2021},
+                ),
+                Document(
+                    content="python article archived",
+                    embedding=[1.0, 0.0, 0.0, 0.0],
+                    meta={"type": "article", "year": 2019},
+                ),
+            ]
+        )
+
+        retriever = InMemoryEmbeddingRetriever(
+            ds,
+            filters={"field": "meta.type", "operator": "==", "value": "article"},
+            filter_policy=FilterPolicy.MERGE,
+        )
+
+        result = await retriever.run_async(
+            query_embedding=[1.0, 0.0, 0.0, 0.0],
+            filters={"field": "meta.year", "operator": ">=", "value": 2020},
+        )
+
+        assert [doc.content for doc in result["documents"]] == ["python article current"]
+
     def test_invalid_run_wrong_store_type(self):
         SomeOtherDocumentStore = document_store_class("SomeOtherDocumentStore")
         with pytest.raises(TypeError, match="document_store must be an instance of InMemoryDocumentStore"):

--- a/test/components/retrievers/test_in_memory_embedding_retriever.py
+++ b/test/components/retrievers/test_in_memory_embedding_retriever.py
@@ -151,9 +151,7 @@ class TestMemoryEmbeddingRetriever:
                     meta={"type": "article", "year": 2020},
                 ),
                 Document(
-                    content="python blog current",
-                    embedding=[1.0, 0.0, 0.0, 0.0],
-                    meta={"type": "blog", "year": 2021},
+                    content="python blog current", embedding=[1.0, 0.0, 0.0, 0.0], meta={"type": "blog", "year": 2021}
                 ),
                 Document(
                     content="python article archived",
@@ -164,14 +162,11 @@ class TestMemoryEmbeddingRetriever:
         )
 
         retriever = InMemoryEmbeddingRetriever(
-            ds,
-            filters={"field": "meta.type", "operator": "==", "value": "article"},
-            filter_policy=FilterPolicy.MERGE,
+            ds, filters={"field": "meta.type", "operator": "==", "value": "article"}, filter_policy=FilterPolicy.MERGE
         )
 
         result = retriever.run(
-            query_embedding=[1.0, 0.0, 0.0, 0.0],
-            filters={"field": "meta.year", "operator": ">=", "value": 2020},
+            query_embedding=[1.0, 0.0, 0.0, 0.0], filters={"field": "meta.year", "operator": ">=", "value": 2020}
         )
 
         assert [doc.content for doc in result["documents"]] == ["python article current"]
@@ -187,9 +182,7 @@ class TestMemoryEmbeddingRetriever:
                     meta={"type": "article", "year": 2020},
                 ),
                 Document(
-                    content="python blog current",
-                    embedding=[1.0, 0.0, 0.0, 0.0],
-                    meta={"type": "blog", "year": 2021},
+                    content="python blog current", embedding=[1.0, 0.0, 0.0, 0.0], meta={"type": "blog", "year": 2021}
                 ),
                 Document(
                     content="python article archived",
@@ -200,14 +193,11 @@ class TestMemoryEmbeddingRetriever:
         )
 
         retriever = InMemoryEmbeddingRetriever(
-            ds,
-            filters={"field": "meta.type", "operator": "==", "value": "article"},
-            filter_policy=FilterPolicy.MERGE,
+            ds, filters={"field": "meta.type", "operator": "==", "value": "article"}, filter_policy=FilterPolicy.MERGE
         )
 
         result = await retriever.run_async(
-            query_embedding=[1.0, 0.0, 0.0, 0.0],
-            filters={"field": "meta.year", "operator": ">=", "value": 2020},
+            query_embedding=[1.0, 0.0, 0.0, 0.0], filters={"field": "meta.year", "operator": ">=", "value": 2020}
         )
 
         assert [doc.content for doc in result["documents"]] == ["python article current"]


### PR DESCRIPTION
### Related Issues

- fixes #12065

### Proposed Changes:

`InMemoryBM25Retriever` and `InMemoryEmbeddingRetriever` both documented `FilterPolicy.MERGE`, but for the common comparison-filter shape they were effectively behaving like `REPLACE`: the runtime filter overwrote the init-time filter instead of narrowing the result set.

This PR switches both retrievers to the shared `apply_filter_policy()` helper in their sync and async paths, so init and runtime filters are combined correctly. It also adds focused regression tests for the broken behavior in both retrievers and includes a release note.

### How did you test it?

- Ran `hatch run test:unit test/components/retrievers/test_in_memory_bm25_retriever.py test/components/retrievers/test_in_memory_embedding_retriever.py`
- Ran `hatch run test:unit test/document_stores/test_filter_policy.py test/components/retrievers`
- Ran `hatch run test:types`
- Manually verified the important cases against in-memory BM25 and embedding retrieval:
    - `MERGE` combines init and runtime filters
    - `REPLACE` still preserves the old override behavior
    - same-field `MERGE` still follows the helper's existing warning/runtime-wins behavior

### Notes for the reviewer

- The production change is intentionally small and only touches the two in-memory retrievers that implement `filter_policy`.
- Wrapper retrievers were not changed because they just pass filters through to the underlying retriever.
- The new tests cover both sync and async execution paths.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
