### PR TITLE
fix: do not mutate Tool schemas (and handle empty tools) in OpenAIResponsesChatGenerator

### DIFF
--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -228,7 +228,7 @@ class OpenAIResponsesChatGenerator:
 
     def _warm_up_tools(self) -> None:
         if not self._tools_warmed_up:
-            is_openai_tool = isinstance(self.tools, list) and isinstance(self.tools[0], dict)
+            is_openai_tool = isinstance(self.tools, list) and bool(self.tools) and isinstance(self.tools[0], dict)
             # We only warm up Haystack tools, not OpenAI/MCP tools
             # The type ignore is needed because mypy cannot infer the type correctly
             if not is_openai_tool:
@@ -539,7 +539,10 @@ class OpenAIResponsesChatGenerator:
                     function_spec = {**t.tool_spec}
                     if not tools_strict:
                         function_spec["strict"] = False
-                    function_spec["parameters"]["additionalProperties"] = False
+                    # Copy the parameters schema before editing it. ``tool_spec`` exposes
+                    # ``Tool.parameters`` by reference, so mutating it here would permanently alter
+                    # the user's Tool (and any other generator that shares the same Tool instance).
+                    function_spec["parameters"] = {**function_spec["parameters"], "additionalProperties": False}
                     tool_definitions.append({"type": "function", **function_spec})
 
             openai_tools = {"tools": tool_definitions}

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -539,8 +539,8 @@ class OpenAIResponsesChatGenerator:
                     function_spec = {**t.tool_spec}
                     if not tools_strict:
                         function_spec["strict"] = False
-                    # Copy the parameters schema before editing it. ``tool_spec`` exposes
-                    # ``Tool.parameters`` by reference, so mutating it here would permanently alter
+                    # Copy the parameters schema before editing it. tool_spec exposes
+                    # Tool.parameters by reference, so mutating it here would permanently alter
                     # the user's Tool (and any other generator that shares the same Tool instance).
                     function_spec["parameters"] = {**function_spec["parameters"], "additionalProperties": False}
                     tool_definitions.append({"type": "function", **function_spec})

--- a/releasenotes/notes/fix-openai-responses-tool-schema-mutation-e500ad2c85715f8c.yaml
+++ b/releasenotes/notes/fix-openai-responses-tool-schema-mutation-e500ad2c85715f8c.yaml
@@ -1,10 +1,10 @@
 ---
 fixes:
   - |
-    `OpenAIResponsesChatGenerator` no longer mutates the `parameters` schema of the `Tool`
-    objects passed to it. Previously every run wrote `additionalProperties: False` into the
-    user's live `Tool.parameters`, silently altering the tool for any other generator that
-    shared the same `Tool` instance and making serialization round trips unstable.
+    ``OpenAIResponsesChatGenerator`` no longer mutates the ``parameters`` schema of the ``Tool``
+    objects passed to it. Previously every run wrote ``additionalProperties: False`` into the
+    user's live ``Tool.parameters``, silently altering the tool for any other generator that
+    shared the same ``Tool`` instance and making serialization round trips unstable.
   - |
-    `OpenAIResponsesChatGenerator` no longer raises `IndexError` when it is warmed up with an
-    empty `tools` list.
+    ``OpenAIResponsesChatGenerator`` no longer raises ``IndexError`` when it is warmed up with an
+    empty ``tools`` list.

--- a/releasenotes/notes/fix-openai-responses-tool-schema-mutation-e500ad2c85715f8c.yaml
+++ b/releasenotes/notes/fix-openai-responses-tool-schema-mutation-e500ad2c85715f8c.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    `OpenAIResponsesChatGenerator` no longer mutates the `parameters` schema of the `Tool`
+    objects passed to it. Previously every run wrote `additionalProperties: False` into the
+    user's live `Tool.parameters`, silently altering the tool for any other generator that
+    shared the same `Tool` instance and making serialization round trips unstable.
+  - |
+    `OpenAIResponsesChatGenerator` no longer raises `IndexError` when it is warmed up with an
+    empty `tools` list.

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -420,6 +420,14 @@ class TestComponentLifecycle:
         generator.warm_up()
         assert generator._tools_warmed_up
 
+    def test_warm_up_with_empty_tools_list_does_not_raise(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
+        # An empty list is a valid ``tools`` value (e.g. when built programmatically); warming up
+        # must not index ``tools[0]`` unguarded.
+        generator = OpenAIResponsesChatGenerator(tools=[])
+        generator.warm_up()
+        assert generator._tools_warmed_up
+
     def test_warm_up_with_openai_tools_does_not_raise(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
         generator = OpenAIResponsesChatGenerator(
@@ -492,6 +500,21 @@ class TestRun:
             chat_messages = [ChatMessage.from_user("What's the weather like in Paris and Berlin?")]
             component = OpenAIResponsesChatGenerator(tools=duplicate_tools)
             component.run(chat_messages)
+
+    def test_prepare_api_call_does_not_mutate_tool_parameters(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        parameters = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+        tool = Tool(name="weather", description="get the weather", parameters=parameters, function=print)
+
+        generator = OpenAIResponsesChatGenerator(tools_strict=False)
+        api_args = generator._prepare_api_call(messages=[ChatMessage.from_user("hi")], tools=[tool])
+
+        # The tool's own schema must not be modified in place, otherwise the same Tool passed to
+        # another generator (or serialized) would carry an additionalProperties flag it never had.
+        assert "additionalProperties" not in tool.parameters
+        assert tool.parameters == {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+        # ...while the payload actually sent to the API still carries additionalProperties=False.
+        assert api_args["tools"][0]["parameters"]["additionalProperties"] is False
 
     def test_run_with_wrong_model(self):
         mock_client = MagicMock()


### PR DESCRIPTION
### Related Issues

None — two self-contained bugs found in `OpenAIResponsesChatGenerator` tool handling.

### Proposed Changes

**1. Do not mutate the user's `Tool` schema in place.**
In `_prepare_api_call`, tool definitions were built like:

```python
function_spec = {**t.tool_spec}
function_spec["parameters"]["additionalProperties"] = False
```

`Tool.tool_spec` returns `{"name": ..., "description": ..., "parameters": self.parameters}` — `parameters` **by reference** — and `{**t.tool_spec}` only shallow-copies the outer dict. So `additionalProperties: False` was written permanently into the caller's live `Tool.parameters`. Consequences: the same `Tool` passed to another generator (e.g. `OpenAIChatGenerator` with `tools_strict=False`, which intentionally leaves schemas open) is contaminated, and `tool.to_dict()` / a serialize→load→serialize round trip is no longer stable. Fixed by building the definition on a copied parameters dict: `{**function_spec["parameters"], "additionalProperties": False}`.

**2. Guard `_warm_up_tools` against an empty tools list.**
`is_openai_tool = isinstance(self.tools, list) and isinstance(self.tools[0], dict)` raised `IndexError` for `tools=[]` (an ordinary value when tools are built programmatically). Every sibling check already guards emptiness; this one now does too via `bool(self.tools)`.

### How did you test it?

Unit tests in `test/components/generators/chat/test_openai_responses.py`:
- `test_prepare_api_call_does_not_mutate_tool_parameters` — asserts the original `Tool.parameters` is untouched while the API payload still carries `additionalProperties=False`.
- `test_warm_up_with_empty_tools_list_does_not_raise` — warms up with `tools=[]` without error.

Both fail against the current code (`AssertionError` / `IndexError` respectively) and pass with the fix. Full `test_openai_responses.py` unit suite passes; `ruff check`/`ruff format --check` clean.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
- [x] I have added a release note file
