### PR TITLE
docs: add more docs about how to securely read files

### DIFF
--- a/haystack/components/converters/image/document_to_image.py
+++ b/haystack/components/converters/image/document_to_image.py
@@ -79,7 +79,11 @@ class DocumentToImageContent:
 
         :param file_path_meta_field: The metadata field in the Document that contains the file path to the image or PDF.
         :param root_path: The root directory path where document files are located. If provided, file paths in
-            document metadata will be resolved relative to this path. If None, file paths are treated as absolute paths.
+            document metadata will be resolved relative to this path and are guaranteed to stay within it. If None,
+            file paths are treated as absolute paths with no containment check.
+            Security: this component reads the file referenced by `file_path_meta_field` from the host filesystem. If
+            document metadata may be influenced by untrusted input, set `root_path` to a dedicated data directory so
+            that path-traversal payloads (e.g. absolute paths or `../`) are rejected instead of read.
         :param detail: Optional detail level of the image (only supported by OpenAI). Can be "auto", "high", or "low".
             This will be passed to the created ImageContent objects.
         :param size: If provided, resizes the image to fit within the specified dimensions (width, height) while

--- a/haystack/components/converters/image/image_utils.py
+++ b/haystack/components/converters/image/image_utils.py
@@ -250,7 +250,9 @@ def _extract_image_sources_info(
         resolved_file_path = Path(root_path, file_path)
 
         # When root_path is set, ensure the resolved path stays within it to block path-traversal
-        # payloads (e.g. "../../etc/passwd") coming from document metadata.
+        # payloads (e.g. "../../etc/passwd") coming from document metadata. When root_path is unset,
+        # file paths are treated as absolute by design and no containment check is applied; callers that
+        # process untrusted metadata should configure root_path (see component docstrings).
         if root_path:
             resolved_file_path = resolved_file_path.resolve()
             resolved_root = Path(root_path).resolve()

--- a/haystack/components/extractors/image/llm_document_content_extractor.py
+++ b/haystack/components/extractors/image/llm_document_content_extractor.py
@@ -151,7 +151,11 @@ class LLMDocumentContentExtractor:
         :param prompt: Prompt for extraction. Must not contain Jinja variables.
         :param file_path_meta_field: The metadata field in the Document that contains the file path to the image or PDF.
         :param root_path: The root directory path where document files are located. If provided, file paths in
-            document metadata will be resolved relative to this path. If None, file paths are treated as absolute paths.
+            document metadata will be resolved relative to this path and are guaranteed to stay within it. If None,
+            file paths are treated as absolute paths with no containment check.
+            Security: this component reads the file referenced by `file_path_meta_field` from the host filesystem. If
+            document metadata may be influenced by untrusted input, set `root_path` to a dedicated data directory so
+            that path-traversal payloads (e.g. absolute paths or `../`) are rejected instead of read.
         :param detail: Optional detail level of the image (only supported by OpenAI). Can be "auto", "high", or "low".
         :param size: If provided, resizes the image to fit within (width, height) while keeping aspect ratio.
         :param raise_on_failure: If True, exceptions from the LLM are raised. If False, failed documents are returned.


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/494

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

I'm adding docs to explain in the components that accept a `root_path` that we don't try to defend file reads that are considered to be absolute paths. We better highlight that if application developers want to prevent aribtrary file reads that a root path should be set.  

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
