### PR TITLE
docs: add Haystack v3 migration skill tip to migration guide

### DIFF
--- a/docs-website/docs/overview/migration.mdx
+++ b/docs-website/docs/overview/migration.mdx
@@ -13,6 +13,10 @@ This guide is designed for those with previous experience with Haystack 2.x who 
 
 Haystack 3.x is an evolution of Haystack 2.x, not a rewrite: components, pipelines, and the `Agent` work as before. Most applications only need import updates and small, mechanical changes. The complete list of breaking changes with extended examples is maintained in [MIGRATION.md](https://github.com/deepset-ai/haystack/blob/main/MIGRATION.md) in the Haystack repository.
 
+:::tip[Migrate with a coding agent]
+Want help migrating with a coding agent? [Fill out this form](https://landing.deepset.ai/haystack-v3-migration-skill) to get access to the Haystack v3 migration skill.
+:::
+
 ## Update Your Installation
 
 The package name is unchanged:

--- a/docs-website/versioned_docs/version-3.0/overview/migration.mdx
+++ b/docs-website/versioned_docs/version-3.0/overview/migration.mdx
@@ -13,6 +13,10 @@ This guide is designed for those with previous experience with Haystack 2.x who 
 
 Haystack 3.x is an evolution of Haystack 2.x, not a rewrite: components, pipelines, and the `Agent` work as before. Most applications only need import updates and small, mechanical changes. The complete list of breaking changes with extended examples is maintained in [MIGRATION.md](https://github.com/deepset-ai/haystack/blob/main/MIGRATION.md) in the Haystack repository.
 
+:::tip[Migrate with a coding agent]
+Want help migrating with a coding agent? [Fill out this form](https://landing.deepset.ai/haystack-v3-migration-skill) to get access to the Haystack v3 migration skill.
+:::
+
 ## Update Your Installation
 
 The package name is unchanged:


### PR DESCRIPTION
### Related Issues

- relates to #12073

### Proposed Changes:

Cherry-picks the "Migrate with a coding agent" tip introduced in #12073 into `main`.

Because #12073 only touched the latest docs, this PR applies the same tip to **both** copies of the migration guide so it shows up in the latest and the versioned 3.0 documentation:

- `docs-website/docs/overview/migration.mdx` (latest)
- `docs-website/versioned_docs/version-3.0/overview/migration.mdx` (versioned 3.0)

The added block:

```
:::tip[Migrate with a coding agent]
Want help migrating with a coding agent? [Fill out this form](https://landing.deepset.ai/haystack-v3-migration-skill) to get access to the Haystack v3 migration skill.
:::
```

### How did you test it?

Docs-only change. Verified the tip is inserted in both files directly after the "Haystack 3.x is an evolution..." intro paragraph and that the admonition syntax matches the source PR (#12073).

### Notes for the reviewer

The source PR #12073 landed only in the latest docs; the versioned dir was renamed from `version-3.0-unstable` to `version-3.0` by #12076, so the versioned target here is `versioned_docs/version-3.0/overview/migration.mdx`.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
