### PR TITLE
docs: redirect docs for 2.x removed/renamed components

### DIFF
--- a/docs-website/docs/pipeline-components/agents-1/agent-pack/advanced-rag-agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack/advanced-rag-agent.mdx
@@ -16,7 +16,7 @@ A metadata-aware RAG agent: instead of guessing which metadata fields exist, it 
 | **Mandatory init variables** | `document_store`: The document store to inspect and fetch from<br />`retriever`: A relevance-scoring retriever or retrieval `Pipeline` |
 | **Mandatory run variables**  | `messages`: A list of [`ChatMessage`](../../../concepts/data-classes/chatmessage.mdx)s |
 | **Output variables**         | `last_message`: The answer, citing documents as `[doc <short-id>]`<br />`documents`: Every document the agent retrieved, deduplicated |
-| **API reference**            | Agent Pack |
+| **API reference**            | [Agent Pack](/reference/integrations-agent-pack) |
 | **GitHub link**              | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack/src/haystack_integrations/agent_pack/advanced_rag |
 | **Package name**             | `agent-pack-haystack` |
 

--- a/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent-pack/deep-research-agent.mdx
@@ -15,7 +15,7 @@ A deep research agent: give it a question, and it researches the web and produce
 | --- | --- |
 | **Mandatory run variables** | `messages`: A list of [`ChatMessage`](../../../concepts/data-classes/chatmessage.mdx)s |
 | **Output variables**        | `report`: The final cited Markdown report<br />`brief`, `notes`: The intermediate research brief and collected summaries |
-| **API reference**           | Agent Pack |
+| **API reference**           | [Agent Pack](/reference/integrations-agent-pack) |
 | **GitHub link**             | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack/src/haystack_integrations/agent_pack/deep_research |
 | **Package name**            | `agent-pack-haystack` |
 

--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -205,6 +205,55 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             from: '/docs/generators-vs-chat-generators',
             to: '/docs/choosing-the-right-generator#generators-vs-chatgenerators',
           },
+          // Components removed or renamed in Haystack 3.0
+          {
+            from: '/docs/openaigenerator',
+            to: '/docs/openaichatgenerator',
+          },
+          {
+            from: '/docs/azureopenaigenerator',
+            to: '/docs/azureopenaichatgenerator',
+          },
+          {
+            from: '/docs/huggingfaceapigenerator',
+            to: '/docs/huggingfaceapichatgenerator',
+          },
+          {
+            from: '/docs/huggingfacelocalgenerator',
+            to: '/docs/transformerschatgenerator',
+          },
+          {
+            from: '/docs/huggingfacelocalchatgenerator',
+            to: '/docs/transformerschatgenerator',
+          },
+          {
+            from: '/docs/dalleimagegenerator',
+            to: '/docs/openaiimagegenerator',
+          },
+          {
+            from: '/docs/extractivereader',
+            to: '/docs/transformersextractivereader',
+          },
+          {
+            from: '/docs/namedentityextractor',
+            to: '/docs/transformersnamedentityextractor',
+          },
+          {
+            from: '/docs/transformerssimilarityranker',
+            to: '/docs/sentencetransformerssimilarityranker',
+          },
+          {
+            from: '/docs/toolinvoker',
+            to: '/docs/agent',
+          },
+          {
+            from: '/docs/asyncpipeline',
+            to: '/docs/pipelines',
+          },
+          {
+            from: '/docs/function-calling',
+            to: '/docs/tool',
+          },
         ],
       },
     ],


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/11933

### Proposed Changes:
- set appropriate redirects for docs pages of components removed or renamed from Haystack 3.0
- link Agent Pack's Agents docs to their API reference (Not done before because the package was not published yet)

### How did you test it?
Vercel. Tried getting an old page -> got redirected


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
