### PR TITLE
chore: exclude docs-website from GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Exclude the Docusaurus documentation site from GitHub's language statistics
+# (github-linguist). Otherwise the ~5,700 .mdx files there dominate the count
+# and the repo is misclassified as MDX instead of Python.
+# See: https://github.com/github-linguist/linguist/blob/main/docs/troubleshooting.md
+docs-website/** linguist-documentation


### PR DESCRIPTION
### Related Issues

- The repo is classified by GitHub as **MDX (~85%)** and therefore trends under [github.com/trending/mdx](https://github.com/trending/mdx) instead of the Python list.

### Proposed Changes:

`github-linguist` counts file bytes to determine repository languages. The Docusaurus documentation site under `docs-website/` contributes **~5,745 `.mdx` files**, which dwarf the 525 `.py` source files and cause the repo to be classified as MDX.

This PR adds a root `.gitattributes` marking the documentation site as documentation, which drops it from the language statistics ([Linguist overrides docs](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md)):

```gitattributes
docs-website/** linguist-documentation
```

### How did you test it?

Ran `github-linguist` locally (via Docker) against the committed tree, before and after the override:

| Language | Before | After |
|----------|--------|-------|
| MDX      | 85.14% | — (excluded) |
| Python   | 14.23% | **98.24%** |
| HTML     | 0.23%  | 1.63% |

### Notes for the reviewer

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings. <!-- N/A: config-only change, no code -->
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `chore:`.
- [x] I have documented my code. <!-- .gitattributes includes explanatory comments -->
- [ ] I have added a release note file. <!-- N/A: no user-facing library change -->
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)