### PR TITLE
fix: Fix tracing of a pipelines outputs

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -386,7 +386,6 @@ class Pipeline(PipelineBase):
             "haystack.pipeline.run",
             tags={
                 "haystack.pipeline.input_data": data,
-                "haystack.pipeline.output_data": pipeline_outputs,
                 "haystack.pipeline.metadata": self.metadata,
                 "haystack.pipeline.max_runs_per_component": self._max_runs_per_component,
                 "haystack.pipeline.execution_mode": "sync",
@@ -516,6 +515,9 @@ class Pipeline(PipelineBase):
                     "2. The component did not reach the visit count specified in the pipeline_breakpoint",
                     break_point=break_point,
                 )
+
+            # Set here so the tag reflects the final outputs.
+            span.set_content_tag("haystack.pipeline.output_data", pipeline_outputs)
 
             return pipeline_outputs
 
@@ -907,7 +909,6 @@ class Pipeline(PipelineBase):
             "haystack.pipeline.run",
             tags={
                 "haystack.pipeline.input_data": data,
-                "haystack.pipeline.output_data": pipeline_outputs,
                 "haystack.pipeline.metadata": self.metadata,
                 "haystack.pipeline.max_runs_per_component": self._max_runs_per_component,
                 "haystack.pipeline.execution_mode": "async",
@@ -1050,6 +1051,9 @@ class Pipeline(PipelineBase):
                     running_tasks, scheduled_components, return_when=asyncio.ALL_COMPLETED
                 ):
                     yield partial_outputs
+
+                # Set here so the tag reflects the final outputs.
+                parent_span.set_content_tag("haystack.pipeline.output_data", pipeline_outputs)
 
                 # Yield the final pipeline outputs.
                 yield pipeline_outputs

--- a/releasenotes/notes/fix-pipeline-output-data-trace-tag-6f9e2c1a4b8d3e70.yaml
+++ b/releasenotes/notes/fix-pipeline-output-data-trace-tag-6f9e2c1a4b8d3e70.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed the ``haystack.pipeline.output_data`` tracing tag being empty. The tag was set at the start of
+    ``Pipeline.run``/``run_async`` from the still-empty outputs, and since tracing backends coerce a tag value
+    when it is set, the recorded output was always an empty dictionary. It is now set once the run completes so
+    it reflects the final pipeline outputs. The tag is also gated behind content tracing
+    (``HAYSTACK_CONTENT_TRACING_ENABLED``), consistent with the component-level input/output tags.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,7 +15,7 @@ from haystack import component, tracing
 from haystack.core.serialization import allow_deserialization_module
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.testing.test_utils import set_all_seeds
-from test.tracing.utils import SpyingTracer
+from test.tracing.utils import EagerSpyingTracer, SpyingTracer
 
 set_all_seeds(0)
 
@@ -101,6 +101,18 @@ def spying_tracer() -> Generator[SpyingTracer, None, None]:
     tracer = SpyingTracer()
     tracing.enable_tracing(tracer)
     tracer.is_content_tracing_enabled = True
+
+    yield tracer
+
+    # Make sure to disable tracing after the test to avoid affecting other tests
+    tracing.disable_tracing()
+
+
+@pytest.fixture()
+def eager_spying_tracer() -> Generator[EagerSpyingTracer, None, None]:
+    # Coerces tags when set, mirroring real backends. Content tracing is left to the test to toggle.
+    tracer = EagerSpyingTracer()
+    tracing.enable_tracing(tracer)
 
     yield tracer
 

--- a/test/core/pipeline/test_tracing.py
+++ b/test/core/pipeline/test_tracing.py
@@ -12,8 +12,8 @@ from _pytest.monkeypatch import MonkeyPatch
 
 from haystack import Pipeline, component
 from haystack.dataclasses import Document
-from haystack.tracing.tracer import disable_tracing, enable_tracing, tracer
-from test.tracing.utils import EagerSpyingTracer, SpyingSpan, SpyingTracer
+from haystack.tracing.tracer import tracer
+from test.tracing.utils import SpyingSpan, SpyingTracer
 
 
 @component
@@ -158,53 +158,28 @@ class TestTracing:
         ]
 
     @pytest.mark.parametrize("run_async", [False, True])
-    def test_pipeline_output_data_recorded_after_run(self, pipeline, run_async, monkeypatch):
+    @pytest.mark.parametrize("content_tracing", [True, False])
+    def test_pipeline_output_data_trace_tag(
+        self, pipeline, run_async, content_tracing, eager_spying_tracer, monkeypatch
+    ):
         """
-        Verify the haystack.pipeline.output_data tag holds the final pipeline outputs.
+        output_data holds the final outputs and is gated behind content tracing.
 
-        Real tracing backends coerce a tag value when `set_tag` is called (at span start), not lazily at
-        span end. If output_data is set from the still-empty outputs dict at span start, production traces
-        capture an empty pipeline output. Parametrized to cover the sync (`run`) and async (`run_async`) paths.
+        EagerSpyingTracer coerces tags when set (like real backends), so it catches output_data being set from the
+        still-empty outputs dict at span start.
         """
-        monkeypatch.setattr(tracer, "is_content_tracing_enabled", True)
-        eager_tracer = EagerSpyingTracer()
-        enable_tracing(eager_tracer)
-        try:
-            if run_async:
-                asyncio.run(pipeline.run_async(data={"word": "world"}))
-            else:
-                pipeline.run(data={"word": "world"})
-        finally:
-            disable_tracing()
+        monkeypatch.setattr(tracer, "is_content_tracing_enabled", content_tracing)
+        if run_async:
+            asyncio.run(pipeline.run_async(data={"word": "world"}))
+        else:
+            pipeline.run(data={"word": "world"})
 
-        pipeline_span = eager_tracer.spans[0]
-        assert pipeline_span.operation_name == "haystack.pipeline.run"
-        assert json.loads(pipeline_span.tags["haystack.pipeline.input_data"]) == {"hello": {"word": "world"}}
-        assert json.loads(pipeline_span.tags["haystack.pipeline.output_data"]) == {
-            "hello2": {"output": "Hello, Hello, world!!"}
-        }
-
-    @pytest.mark.parametrize("run_async", [False, True])
-    def test_pipeline_output_data_gated_by_content_tracing(self, pipeline, run_async, monkeypatch):
-        """
-        output_data carries the pipeline's answer content, so it is emitted only when content tracing is
-        enabled. input_data stays a normal tag and is always emitted.
-        """
-        monkeypatch.setattr(tracer, "is_content_tracing_enabled", False)
-        eager_tracer = EagerSpyingTracer()
-        enable_tracing(eager_tracer)
-        try:
-            if run_async:
-                asyncio.run(pipeline.run_async(data={"word": "world"}))
-            else:
-                pipeline.run(data={"word": "world"})
-        finally:
-            disable_tracing()
-
-        pipeline_span = eager_tracer.spans[0]
-        assert "haystack.pipeline.output_data" not in pipeline_span.tags
-        assert json.loads(pipeline_span.tags["haystack.pipeline.input_data"]) == {"hello": {"word": "world"}}
-        assert pipeline_span.tags["haystack.pipeline.execution_mode"] == ("async" if run_async else "sync")
+        tags = eager_spying_tracer.spans[0].tags
+        assert json.loads(tags["haystack.pipeline.input_data"]) == {"hello": {"word": "world"}}
+        if content_tracing:
+            assert json.loads(tags["haystack.pipeline.output_data"]) == {"hello2": {"output": "Hello, Hello, world!!"}}
+        else:
+            assert "haystack.pipeline.output_data" not in tags
 
     @pytest.mark.parametrize("run_async", [False, True])
     def test_span_input_not_affected_by_component_mutation(self, run_async, spying_tracer, monkeypatch):

--- a/test/core/pipeline/test_tracing.py
+++ b/test/core/pipeline/test_tracing.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import json
 from dataclasses import replace
 from unittest.mock import ANY
 
@@ -11,8 +12,8 @@ from _pytest.monkeypatch import MonkeyPatch
 
 from haystack import Pipeline, component
 from haystack.dataclasses import Document
-from haystack.tracing.tracer import tracer
-from test.tracing.utils import SpyingSpan, SpyingTracer
+from haystack.tracing.tracer import disable_tracing, enable_tracing, tracer
+from test.tracing.utils import EagerSpyingTracer, SpyingSpan, SpyingTracer
 
 
 @component
@@ -155,6 +156,55 @@ class TestTracing:
                 span_id=ANY,
             ),
         ]
+
+    @pytest.mark.parametrize("run_async", [False, True])
+    def test_pipeline_output_data_recorded_after_run(self, pipeline, run_async, monkeypatch):
+        """
+        Verify the haystack.pipeline.output_data tag holds the final pipeline outputs.
+
+        Real tracing backends coerce a tag value when `set_tag` is called (at span start), not lazily at
+        span end. If output_data is set from the still-empty outputs dict at span start, production traces
+        capture an empty pipeline output. Parametrized to cover the sync (`run`) and async (`run_async`) paths.
+        """
+        monkeypatch.setattr(tracer, "is_content_tracing_enabled", True)
+        eager_tracer = EagerSpyingTracer()
+        enable_tracing(eager_tracer)
+        try:
+            if run_async:
+                asyncio.run(pipeline.run_async(data={"word": "world"}))
+            else:
+                pipeline.run(data={"word": "world"})
+        finally:
+            disable_tracing()
+
+        pipeline_span = eager_tracer.spans[0]
+        assert pipeline_span.operation_name == "haystack.pipeline.run"
+        assert json.loads(pipeline_span.tags["haystack.pipeline.input_data"]) == {"hello": {"word": "world"}}
+        assert json.loads(pipeline_span.tags["haystack.pipeline.output_data"]) == {
+            "hello2": {"output": "Hello, Hello, world!!"}
+        }
+
+    @pytest.mark.parametrize("run_async", [False, True])
+    def test_pipeline_output_data_gated_by_content_tracing(self, pipeline, run_async, monkeypatch):
+        """
+        output_data carries the pipeline's answer content, so it is emitted only when content tracing is
+        enabled. input_data stays a normal tag and is always emitted.
+        """
+        monkeypatch.setattr(tracer, "is_content_tracing_enabled", False)
+        eager_tracer = EagerSpyingTracer()
+        enable_tracing(eager_tracer)
+        try:
+            if run_async:
+                asyncio.run(pipeline.run_async(data={"word": "world"}))
+            else:
+                pipeline.run(data={"word": "world"})
+        finally:
+            disable_tracing()
+
+        pipeline_span = eager_tracer.spans[0]
+        assert "haystack.pipeline.output_data" not in pipeline_span.tags
+        assert json.loads(pipeline_span.tags["haystack.pipeline.input_data"]) == {"hello": {"word": "world"}}
+        assert pipeline_span.tags["haystack.pipeline.execution_mode"] == ("async" if run_async else "sync")
 
     @pytest.mark.parametrize("run_async", [False, True])
     def test_span_input_not_affected_by_component_mutation(self, run_async, spying_tracer, monkeypatch):

--- a/test/tracing/utils.py
+++ b/test/tracing/utils.py
@@ -9,6 +9,7 @@ from collections.abc import Iterator
 from typing import Any
 
 from haystack.tracing import Span, Tracer
+from haystack.tracing.utils import coerce_tag_value
 
 
 @dataclasses.dataclass
@@ -46,6 +47,44 @@ class SpyingTracer(Tracer):
         self, operation_name: str, tags: dict[str, Any] | None = None, parent_span: Span | None = None
     ) -> Iterator[Span]:
         new_span = SpyingSpan(operation_name, parent_span)
+        for key, value in (tags or {}).items():
+            new_span.set_tag(key, value)
+
+        self.spans.append(new_span)
+
+        yield new_span
+
+
+@dataclasses.dataclass
+class EagerSpyingSpan(Span):
+    """
+    A span that coerces tag values when `set_tag` is called.
+
+    This mirrors real tracing backends (e.g. OpenTelemetry, Datadog), which serialize a tag value eagerly
+    when it is set instead of holding a live reference to it. It is useful to catch tags that are set from a
+    mutable object before that object has been populated.
+    """
+
+    operation_name: str
+    parent_span: Span | None = None
+    tags: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    def set_tag(self, key: str, value: Any) -> None:
+        self.tags[key] = coerce_tag_value(value)
+
+
+class EagerSpyingTracer(Tracer):
+    def current_span(self) -> Span | None:
+        return self.spans[-1] if self.spans else None
+
+    def __init__(self) -> None:
+        self.spans: list[EagerSpyingSpan] = []
+
+    @contextlib.contextmanager
+    def trace(
+        self, operation_name: str, tags: dict[str, Any] | None = None, parent_span: Span | None = None
+    ) -> Iterator[Span]:
+        new_span = EagerSpyingSpan(operation_name, parent_span)
         for key, value in (tags or {}).items():
             new_span.set_tag(key, value)
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fixed the ``haystack.pipeline.output_data`` tracing tag being empty. The tag was set at the start of ``Pipeline.run``/``run_async`` from the still-empty outputs, and since tracing backends coerce a tag value when it is set, the recorded output was always an empty dictionary. It is now set once the run completes so it reflects the final pipeline outputs. The tag is also gated behind content tracing (``HAYSTACK_CONTENT_TRACING_ENABLED``), consistent with the component-level input/output tags.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

I discovered this while working with Marc on the debugging feature in platform. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
