### PR TITLE
docs: clarify LostInTheMiddleRanker threshold units

### DIFF
--- a/docs-website/docs/pipeline-components/rankers/lostinthemiddleranker.mdx
+++ b/docs-website/docs/pipeline-components/rankers/lostinthemiddleranker.mdx
@@ -32,6 +32,11 @@ In contrast to other rankers, `LostInTheMiddleRanker` assumes that the input doc
 
 If you specify the `word_count_threshold` when running the component, the Ranker includes all documents up until the point where adding another document would exceed the given threshold. The last document that exceeds the threshold will be included in the resulting list of Documents, but all following documents will be discarded.
 
+`word_count_threshold` counts whitespace-separated words with Python's `str.split()`. It is not a tokenizer-aware budget,
+so the same value can represent many more tokens for code, URLs, non-Latin text, or punctuation-heavy content. If you
+are trying to stay within an LLM context window, use a conservative threshold or count tokens before passing documents to
+this Ranker.
+
 You can also specify the `top_k` parameter to set the maximum number of documents to return.
 
 ## Usage

--- a/docs-website/versioned_docs/version-2.31/pipeline-components/rankers/lostinthemiddleranker.mdx
+++ b/docs-website/versioned_docs/version-2.31/pipeline-components/rankers/lostinthemiddleranker.mdx
@@ -32,6 +32,11 @@ In contrast to other rankers, `LostInTheMiddleRanker` assumes that the input doc
 
 If you specify the `word_count_threshold` when running the component, the Ranker includes all documents up until the point where adding another document would exceed the given threshold. The last document that exceeds the threshold will be included in the resulting list of Documents, but all following documents will be discarded.
 
+`word_count_threshold` counts whitespace-separated words with Python's `str.split()`. It is not a tokenizer-aware budget,
+so the same value can represent many more tokens for code, URLs, non-Latin text, or punctuation-heavy content. If you
+are trying to stay within an LLM context window, use a conservative threshold or count tokens before passing documents to
+this Ranker.
+
 You can also specify the `top_k` parameter to set the maximum number of documents to return.
 
 ## Usage

--- a/haystack/components/rankers/lost_in_the_middle.py
+++ b/haystack/components/rankers/lost_in_the_middle.py
@@ -46,7 +46,9 @@ class LostInTheMiddleRanker:
         be breached will be included in the resulting list of documents, but all subsequent documents will be
         discarded.
 
-        :param word_count_threshold: The maximum total number of words across all documents selected by the ranker.
+        :param word_count_threshold: The maximum total number of whitespace-separated words across all documents
+            selected by the ranker. This is not a token budget; use a conservative value if the downstream LLM
+            context limit is measured in tokens.
         :param top_k: The maximum number of documents to return.
         """
         if isinstance(word_count_threshold, int) and word_count_threshold <= 0:
@@ -71,7 +73,9 @@ class LostInTheMiddleRanker:
 
         :param documents: List of Documents to reorder.
         :param top_k: The maximum number of documents to return.
-        :param word_count_threshold: The maximum total number of words across all documents selected by the ranker.
+        :param word_count_threshold: The maximum total number of whitespace-separated words across all documents
+            selected by the ranker. This is not a token budget; use a conservative value if the downstream LLM
+            context limit is measured in tokens.
         :returns:
             A dictionary with the following keys:
             - `documents`: Reranked list of Documents


### PR DESCRIPTION
### Related Issues

- Refs #11351

### Proposed Changes:

- Clarify that `LostInTheMiddleRanker.word_count_threshold` counts whitespace-separated words, not tokenizer-aware tokens.
- Add the same clarification to the current and 2.31 versioned docs page.
- Keep runtime behavior unchanged, matching the maintainer guidance in #11351.

### How did you test it?

- `hatch run fmt-check haystack/components/rankers/lost_in_the_middle.py`
- `hatch -e test run pytest test/components/rankers/test_lost_in_the_middle.py`
- `git diff --check`

### Notes for the reviewer

No release note was added because this is a docs/docstring-only clarification with no behavior change.

This PR was generated with an AI assistant. I reviewed the changes and ran the relevant tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights, or the PR body contains the relevant context.
- I have added unit tests and updated the docstrings, where applicable.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes), or the change is docs-only / not user-facing runtime behavior.
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue, or run the focused equivalent checks listed above.
