### PR TITLE
feat: add `context_tokens` to internal `Agent`s State

### DIFF
--- a/docs-website/docs/pipeline-components/agents-1/hooks.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/hooks.mdx
@@ -46,6 +46,7 @@ The Agent manages a few state keys that hooks interact with. Like the run-metada
 - `continue_run`: Set by an `on_exit` hook to keep the Agent running.
 - `tools`: The tools available in the current step, for hooks to inspect.
 - `hook_context`: Request-scoped resources passed to `Agent.run(hook_context={...})` / `run_async(hook_context={...})`. Hooks read it with `state.data["hook_context"]` or `state.data.get("hook_context")` — use it for per-request resources such as a user ID, a WebSocket, or a database client. Avoid the plain `state.get("hook_context")` here: `State.get` returns a deep copy of the value, which often fails for the kinds of resources stored in this dict (such as a WebSocket or a database client).
+- `context_tokens`: An approximate count of the tokens currently in the context window, refreshed after each LLM call with that reply's prompt-plus-completion tokens (read it with `state.get("context_tokens")`). Unlike `token_usage`, which accumulates over the run, this is replaced on every call. It's `0` until the first reply that reports usage and doesn't count messages appended after the latest call. A `before_llm` hook can read it to trigger context compaction once it crosses a threshold.
 
 Hooks can also read the automatically tracked run metadata: `step_count`, `token_usage`, and `tool_call_counts`.
 

--- a/docs-website/docs/pipeline-components/agents-1/state.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/state.mdx
@@ -71,7 +71,7 @@ If you don't specify a handler, State automatically assigns a default based on t
 The `Agent` manages some state keys itself and rejects them in a user-provided `state_schema` with a `ValueError`:
 
 - The run-metadata keys `step_count`, `token_usage`, `tool_call_counts`, and `exit_reason`, which the Agent populates automatically during a run: tools and hooks can read them from the live `State`, and they are returned in the result dictionary. `exit_reason` reports why the Agent stopped (`"text"`, the name of the tool that triggered a tool exit condition, or `"max_agent_steps"`).
-- The hook-facing keys `continue_run` (set by an `on_exit` hook to keep the Agent running), `tools` (the tools available in the current step, for hooks to inspect), and `hook_context` (the request-scoped resources passed to `Agent.run(hook_context={...})`).
+- The hook-facing keys `continue_run` (set by an `on_exit` hook to keep the Agent running), `tools` (the tools available in the current step, for hooks to inspect), `hook_context` (the request-scoped resources passed to `Agent.run(hook_context={...})`), and `context_tokens` (an approximate count of the tokens currently in the context window, refreshed after each LLM call for hooks to read — for example, to trigger context compaction). Unlike the run-metadata keys, these are not returned in the result dictionary.
 
 If one of your state keys clashes, rename it (for example, `my_token_usage`).
 :::

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -82,10 +82,14 @@ _RUN_METADATA_STATE_KEYS: dict[str, dict[str, Any]] = {
 # - `continue_run`: set by an `on_exit` hook to keep the Agent running instead of stopping (re-read each exit attempt).
 # - `tools`: the flattened tools available in the current step, so a hook can inspect them (e.g. HITL confirmation).
 # - `hook_context`: per-run request-scoped resources passed to `run`/`run_async` for hooks to read.
+# - `context_tokens`: approximate current context-window size, refreshed after each LLM call, for hooks to read
+#   (e.g. a `before_llm` hook that triggers compaction once the context grows too large). Kept internal rather than
+#   exposed as an output because it is a best-effort snapshot; see `_record_context_tokens`.
 _INTERNAL_STATE_KEYS: dict[str, dict[str, Any]] = {
     "continue_run": {"type": bool, "handler": replace_values},
     "tools": {"type": list, "handler": replace_values},
     "hook_context": {"type": dict[str, Any], "handler": replace_values},
+    "context_tokens": {"type": int, "handler": replace_values},
 }
 
 
@@ -130,6 +134,54 @@ def _record_llm_usage(state: State, llm_messages: list[ChatMessage]) -> None:
             updated = True
     if updated:
         state.set("token_usage", current)
+
+
+# Input/output token key conventions across chat generators: most report OpenAI-style
+# `prompt_tokens`/`completion_tokens`; OpenAIResponsesChatGenerator reports `input_tokens`/`output_tokens`.
+_INPUT_TOKEN_KEYS = ("prompt_tokens", "input_tokens")
+_OUTPUT_TOKEN_KEYS = ("completion_tokens", "output_tokens")
+
+
+def _context_tokens_from_usage(usage: dict[str, Any]) -> int:
+    """
+    Sum the input and output tokens reported in a single `meta["usage"]` dict.
+
+    :param usage: A ChatMessage `meta["usage"]` payload.
+    :returns: Input plus output tokens, or 0 if neither key convention is present.
+    """
+
+    def _first_numeric(keys: tuple[str, ...]) -> int:
+        for key in keys:
+            value = usage.get(key)
+            # bool is an int subclass, so exclude it explicitly: True/False is not a token count.
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, (int, float)):
+                return int(value)
+        return 0
+
+    return _first_numeric(_INPUT_TOKEN_KEYS) + _first_numeric(_OUTPUT_TOKEN_KEYS)
+
+
+def _record_context_tokens(state: State, llm_messages: list[ChatMessage]) -> None:
+    """
+    Store the approximate current context-window token count from the latest LLM call.
+
+    A chat-generator call returns a single reply, so only the last message is inspected. Unlike
+    `token_usage`, which accumulates across the run, this value is replaced each call with that reply's
+    prompt-plus-completion tokens. Only writes when usage is reported, so generators that don't surface
+    usage leave the previous value untouched.
+
+    :param state: The Agent's State, used to write the latest `context_tokens` count.
+    :param llm_messages: The ChatMessage objects returned from the latest LLM call.
+    """
+    if not llm_messages:
+        return
+    usage = llm_messages[-1].meta.get("usage")
+    if isinstance(usage, dict):
+        tokens = _context_tokens_from_usage(usage)
+        if tokens:
+            state.set("context_tokens", tokens)
 
 
 def _record_tool_calls(state: State, tool_messages: list[ChatMessage]) -> None:
@@ -938,6 +990,7 @@ class Agent:
         state.set("messages", messages)
         state.set("step_count", 0)
         state.set("token_usage", {})
+        state.set("context_tokens", 0)
         state.set("tool_call_counts", {tool.name: 0 for tool in flat_tools})
         state.set("exit_reason", None)
         state.set("continue_run", False)
@@ -1187,6 +1240,7 @@ class Agent:
             llm_messages = result["replies"]
             exe_context.state.set("messages", llm_messages)
             _record_llm_usage(exe_context.state, llm_messages)
+            _record_context_tokens(exe_context.state, llm_messages)
 
             # Stop on the "no tool call" exit: no tools available, or a plain assistant text reply (see _is_text_exit).
             if not current_tools or _is_text_exit(llm_messages):
@@ -1251,6 +1305,7 @@ class Agent:
             llm_messages = result["replies"]
             exe_context.state.set("messages", llm_messages)
             _record_llm_usage(exe_context.state, llm_messages)
+            _record_context_tokens(exe_context.state, llm_messages)
 
             # Stop on the "no tool call" exit: no tools available, or a plain assistant text reply (see _is_text_exit).
             if not current_tools or _is_text_exit(llm_messages):

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -18,6 +18,7 @@ from haystack.components.agents.state.state import (
 )
 from haystack.components.agents.state.state_utils import merge_lists
 from haystack.components.agents.tool_calling import _run_tool, _run_tool_async
+from haystack.components.agents.utils import _record_context_tokens
 from haystack.components.builders import ChatPromptBuilder
 from haystack.components.generators.chat.types import ChatGenerator
 from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
@@ -134,54 +135,6 @@ def _record_llm_usage(state: State, llm_messages: list[ChatMessage]) -> None:
             updated = True
     if updated:
         state.set("token_usage", current)
-
-
-# Input/output token key conventions across chat generators: most report OpenAI-style
-# `prompt_tokens`/`completion_tokens`; OpenAIResponsesChatGenerator reports `input_tokens`/`output_tokens`.
-_INPUT_TOKEN_KEYS = ("prompt_tokens", "input_tokens")
-_OUTPUT_TOKEN_KEYS = ("completion_tokens", "output_tokens")
-
-
-def _context_tokens_from_usage(usage: dict[str, Any]) -> int:
-    """
-    Sum the input and output tokens reported in a single `meta["usage"]` dict.
-
-    :param usage: A ChatMessage `meta["usage"]` payload.
-    :returns: Input plus output tokens, or 0 if neither key convention is present.
-    """
-
-    def _first_numeric(keys: tuple[str, ...]) -> int:
-        for key in keys:
-            value = usage.get(key)
-            # bool is an int subclass, so exclude it explicitly: True/False is not a token count.
-            if isinstance(value, bool):
-                continue
-            if isinstance(value, (int, float)):
-                return int(value)
-        return 0
-
-    return _first_numeric(_INPUT_TOKEN_KEYS) + _first_numeric(_OUTPUT_TOKEN_KEYS)
-
-
-def _record_context_tokens(state: State, llm_messages: list[ChatMessage]) -> None:
-    """
-    Store the approximate current context-window token count from the latest LLM call.
-
-    A chat-generator call returns a single reply, so only the last message is inspected. Unlike
-    `token_usage`, which accumulates across the run, this value is replaced each call with that reply's
-    prompt-plus-completion tokens. Only writes when usage is reported, so generators that don't surface
-    usage leave the previous value untouched.
-
-    :param state: The Agent's State, used to write the latest `context_tokens` count.
-    :param llm_messages: The ChatMessage objects returned from the latest LLM call.
-    """
-    if not llm_messages:
-        return
-    usage = llm_messages[-1].meta.get("usage")
-    if isinstance(usage, dict):
-        tokens = _context_tokens_from_usage(usage)
-        if tokens:
-            state.set("context_tokens", tokens)
 
 
 def _record_tool_calls(state: State, tool_messages: list[ChatMessage]) -> None:

--- a/haystack/components/agents/utils.py
+++ b/haystack/components/agents/utils.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack.components.agents.state.state import State
+from haystack.dataclasses import ChatMessage
+
+# Input/output token key conventions across chat generators: most report OpenAI-style
+# `prompt_tokens`/`completion_tokens`; OpenAIResponsesChatGenerator reports `input_tokens`/`output_tokens`.
+_INPUT_TOKEN_KEYS = ("prompt_tokens", "input_tokens")
+_OUTPUT_TOKEN_KEYS = ("completion_tokens", "output_tokens")
+
+
+def _first_numeric(usage: dict[str, Any], keys: tuple[str, ...]) -> int:
+    """
+    Return the first numeric value found under `keys` in `usage`, or 0 if none is present.
+
+    :param usage: A ChatMessage `meta["usage"]` payload.
+    :param keys: Candidate keys to check, in priority order.
+    :returns: The first `int`/`float` value (as an `int`), or 0. bool values are skipped (not token counts).
+    """
+    for key in keys:
+        value = usage.get(key)
+        # bool is an int subclass, so exclude it explicitly: True/False is not a token count.
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            return int(value)
+    return 0
+
+
+def _context_tokens_from_usage(usage: dict[str, Any]) -> int:
+    """
+    Sum the input and output tokens reported in a single `meta["usage"]` dict.
+
+    :param usage: A ChatMessage `meta["usage"]` payload.
+    :returns: Input plus output tokens, or 0 if neither key convention is present.
+    """
+    return _first_numeric(usage, _INPUT_TOKEN_KEYS) + _first_numeric(usage, _OUTPUT_TOKEN_KEYS)
+
+
+def _record_context_tokens(state: State, llm_messages: list[ChatMessage]) -> None:
+    """
+    Store the approximate current context-window token count from the latest LLM call.
+
+    A chat-generator call returns a single reply, so only the last message is inspected. Unlike
+    `token_usage`, which accumulates across the run, this value is replaced each call with that reply's
+    prompt-plus-completion tokens. Only writes when usage is reported, so generators that don't surface
+    usage leave the previous value untouched.
+
+    :param state: The Agent's State, used to write the latest `context_tokens` count.
+    :param llm_messages: The ChatMessage objects returned from the latest LLM call.
+    """
+    if not llm_messages:
+        return
+    usage = llm_messages[-1].meta.get("usage")
+    if isinstance(usage, dict):
+        tokens = _context_tokens_from_usage(usage)
+        if tokens:
+            state.set("context_tokens", tokens)

--- a/releasenotes/notes/add-agent-context-tokens-831273f057452c71.yaml
+++ b/releasenotes/notes/add-agent-context-tokens-831273f057452c71.yaml
@@ -1,0 +1,11 @@
+---
+enhancements:
+  - |
+    The ``Agent`` now tracks an approximate current context-window size in its internal ``State`` under
+    ``context_tokens``, refreshed after every LLM call with that reply's prompt-plus-completion tokens
+    (normalized across the ``prompt_tokens``/``completion_tokens`` and ``input_tokens``/``output_tokens``
+    key conventions). Unlike ``token_usage``, which accumulates across the whole run, ``context_tokens``
+    is replaced each call. Hooks can read it via ``state.get("context_tokens")`` — for example, a
+    ``before_llm`` hook that triggers context compaction once the value crosses a threshold. It is a
+    best-effort snapshot: it is ``0`` when the generator does not report usage, and does not count
+    messages appended after the latest call until the next call refreshes it.

--- a/test/components/agents/__init__.py
+++ b/test/components/agents/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -19,7 +19,6 @@ from haystack import Document, Pipeline, component, tracing
 from haystack.components.agents.agent import Agent, _accumulate_usage, _select_tools_by_name
 from haystack.components.agents.state import State, merge_lists, replace_values
 from haystack.components.agents.tool_calling import _run_tool
-from haystack.components.agents.utils import _context_tokens_from_usage, _record_context_tokens
 from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
 from haystack.components.generators.chat import MockChatGenerator
@@ -1254,121 +1253,6 @@ class TestAgent:
         assert result["step_count"] == 1
         assert result["token_usage"] == {}
         assert result["tool_call_counts"] == {"weather_tool": 0}
-
-
-class TestContextTokensFromUsage:
-    """`_context_tokens_from_usage` normalizes real provider `meta["usage"]` shapes to input + output tokens.
-
-    Fixtures below are the actual shapes these providers report (nested detail dicts and all), so the test pins
-    the normalization against reality rather than a simplified stand-in.
-    """
-
-    # OpenAI Chat Completions (core repo): `_serialize_object(completion.usage)` -> the full CompletionUsage dump.
-    OPENAI_CHAT_USAGE = {
-        "prompt_tokens": 1117,
-        "completion_tokens": 46,
-        "total_tokens": 1163,
-        "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
-        "completion_tokens_details": {
-            "reasoning_tokens": 0,
-            "audio_tokens": 0,
-            "accepted_prediction_tokens": 0,
-            "rejected_prediction_tokens": 0,
-        },
-    }
-    # OpenAI Responses API (core repo): the only Haystack generator that uses input/output keys, each with a
-    # details dict.
-    OPENAI_RESPONSES_USAGE = {
-        "input_tokens": 75,
-        "input_tokens_details": {"cached_tokens": 0},
-        "output_tokens": 1186,
-        "output_tokens_details": {"reasoning_tokens": 1024},
-        "total_tokens": 1261,
-    }
-    # Anthropic chat generator (integration): remaps input/output -> prompt/completion and keeps the cache
-    # accounting (incl. the nested cache_creation breakdown).
-    ANTHROPIC_USAGE = {
-        "prompt_tokens": 2095,
-        "completion_tokens": 503,
-        "cache_creation_input_tokens": 0,
-        "cache_read_input_tokens": 1024,
-        "cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 0},
-        "service_tier": "standard",
-    }
-    # Amazon Bedrock chat generator (integration): prompt/completion/total plus cache accounting.
-    BEDROCK_USAGE = {
-        "prompt_tokens": 340,
-        "completion_tokens": 92,
-        "total_tokens": 432,
-        "cache_read_input_tokens": 0,
-        "cache_write_input_tokens": 0,
-        "cache_details": {},
-    }
-    # Google GenAI chat generator (integration): total_tokens folds in thoughts, so it exceeds prompt + completion.
-    # We deliberately use prompt+completion, so thoughts are excluded.
-    GOOGLE_GENAI_USAGE = {
-        "prompt_tokens": 20,
-        "completion_tokens": 50,
-        "total_tokens": 85,
-        "thoughts_token_count": 15,
-        "cached_content_token_count": 0,
-    }
-
-    @pytest.mark.parametrize(
-        "usage, expected",
-        [
-            (OPENAI_CHAT_USAGE, 1163),
-            (OPENAI_RESPONSES_USAGE, 1261),
-            (ANTHROPIC_USAGE, 2598),
-            (BEDROCK_USAGE, 432),
-            (GOOGLE_GENAI_USAGE, 70),  # 20 + 50, deliberately not the 85 total (which includes 15 thoughts tokens)
-            ({"prompt_tokens": 10}, 10),  # only one side reported -> partial count
-            ({"completion_tokens": 7}, 7),
-            ({}, 0),  # no usage reported
-            ({"foo": 5, "bar": 9}, 0),  # no recognized keys
-        ],
-    )
-    def test_normalizes_provider_shapes(self, usage, expected):
-        assert _context_tokens_from_usage(usage) == expected
-
-    def test_bool_values_are_not_counted_as_tokens(self):
-        # bool is an int subclass; True/False under a token key must be skipped, not summed.
-        assert _context_tokens_from_usage({"prompt_tokens": True, "completion_tokens": 5}) == 5
-
-
-class TestRecordContextTokens:
-    """`_record_context_tokens` replaces the value with the latest reply's input+output, only when usage is reported."""
-
-    def _state(self) -> State:
-        state = State(schema={"context_tokens": {"type": int, "handler": replace_values}})
-        state.set("context_tokens", 0)
-        return state
-
-    def test_records_latest_reply_usage(self):
-        state = self._state()
-        _record_context_tokens(
-            state, [_assistant_with_usage("Hi", usage={"prompt_tokens": 12, "completion_tokens": 3})]
-        )
-        assert state.get("context_tokens") == 15
-
-    def test_replaces_rather_than_accumulates(self):
-        state = self._state()
-        state.set("context_tokens", 999)
-        _record_context_tokens(state, [_assistant_with_usage("Hi", usage={"prompt_tokens": 4, "completion_tokens": 1})])
-        assert state.get("context_tokens") == 5
-
-    def test_no_messages_leaves_value_untouched(self):
-        state = self._state()
-        state.set("context_tokens", 42)
-        _record_context_tokens(state, [])
-        assert state.get("context_tokens") == 42
-
-    def test_missing_or_empty_usage_leaves_value_untouched(self):
-        # A reply without usage (or with empty usage) must not clobber the previous value, including the initial 0.
-        state = self._state()
-        _record_context_tokens(state, [ChatMessage.from_assistant("no usage here")])
-        _record_context_tokens(state, [_assistant_with_usage("empty", usage={})])
-        assert state.get("context_tokens") == 0
 
 
 class TestAgentContextTokens:

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -16,15 +16,10 @@ from openai import Stream
 from openai.types.chat import ChatCompletionChunk, chat_completion_chunk
 
 from haystack import Document, Pipeline, component, tracing
-from haystack.components.agents.agent import (
-    Agent,
-    _accumulate_usage,
-    _context_tokens_from_usage,
-    _record_context_tokens,
-    _select_tools_by_name,
-)
+from haystack.components.agents.agent import Agent, _accumulate_usage, _select_tools_by_name
 from haystack.components.agents.state import State, merge_lists, replace_values
 from haystack.components.agents.tool_calling import _run_tool
+from haystack.components.agents.utils import _context_tokens_from_usage, _record_context_tokens
 from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
 from haystack.components.generators.chat import MockChatGenerator
@@ -235,9 +230,10 @@ class TestAgent:
         assert {"step_count", "token_usage", "tool_call_counts", "exit_reason"}.isdisjoint(
             agent.__haystack_input__._sockets_dict.keys()
         )
-        # context_tokens is internal: exposed as neither an input nor an output socket
-        assert "context_tokens" not in agent.__haystack_input__._sockets_dict
-        assert "context_tokens" not in agent.__haystack_output__._sockets_dict
+        # Internal-only state keys (those that are not also run parameters) are exposed as neither inputs nor outputs.
+        for internal_key in ("continue_run", "context_tokens"):
+            assert internal_key not in agent.__haystack_input__._sockets_dict
+            assert internal_key not in agent.__haystack_output__._sockets_dict
 
     def test_to_dict(self, weather_tool, component_tool, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-key")

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -280,7 +280,7 @@ class TestAgent:
                                 "properties": {"location": {"type": "string"}},
                                 "required": ["location"],
                             },
-                            "function": "test_agent.weather_function",
+                            "function": "agents.test_agent.weather_function",
                             "async_function": None,
                             "outputs_to_string": None,
                             "inputs_from_state": None,
@@ -364,7 +364,7 @@ class TestAgent:
                                         "properties": {"location": {"type": "string"}},
                                         "required": ["location"],
                                     },
-                                    "function": "test_agent.weather_function",
+                                    "function": "agents.test_agent.weather_function",
                                     "async_function": None,
                                     "outputs_to_string": None,
                                     "inputs_from_state": None,
@@ -435,7 +435,7 @@ class TestAgent:
                                 "properties": {"location": {"type": "string"}},
                                 "required": ["location"],
                             },
-                            "function": "test_agent.weather_function",
+                            "function": "agents.test_agent.weather_function",
                             "async_function": None,
                             "outputs_to_string": None,
                             "inputs_from_state": None,
@@ -531,7 +531,7 @@ class TestAgent:
                                         "properties": {"location": {"type": "string"}},
                                         "required": ["location"],
                                     },
-                                    "function": "test_agent.weather_function",
+                                    "function": "agents.test_agent.weather_function",
                                     "async_function": None,
                                     "outputs_to_string": None,
                                     "inputs_from_state": None,
@@ -625,7 +625,7 @@ class TestAgent:
             init_parameters["chat_generator"]["type"]
             == "haystack.components.generators.chat.openai.OpenAIChatGenerator"
         )
-        assert init_parameters["streaming_callback"] == "test_agent.sync_streaming_callback"
+        assert init_parameters["streaming_callback"] == "agents.test_agent.sync_streaming_callback"
         assert init_parameters["tools"][0]["data"]["function"] == serialize_callable(weather_function)
         assert (
             init_parameters["tools"][1]["data"]["component"]["type"]
@@ -1482,7 +1482,7 @@ class TestAgentTracing:
         assert set(llm_tags) == {"haystack.agent.step.llm.input", "haystack.agent.step.llm.output"}
         assert (
             llm_tags["haystack.agent.step.llm.input"]
-            == '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}], "tools": [{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]}'  # noqa: E501
+            == '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}], "tools": [{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "agents.test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]}'  # noqa: E501
         )
         assert (
             llm_tags["haystack.agent.step.llm.output"]
@@ -1497,7 +1497,7 @@ class TestAgentTracing:
         _, run_tags = agent_spans[2]
         assert run_tags == {
             "haystack.agent.max_steps": 100,
-            "haystack.agent.tools": '[{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]',  # noqa: E501
+            "haystack.agent.tools": '[{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "agents.test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]',  # noqa: E501
             "haystack.agent.exit_conditions": '["text"]',
             "haystack.agent.state_schema": '{"messages": {"type": "list[haystack.dataclasses.chat_message.ChatMessage]", "handler": "haystack.components.agents.state.state_utils.merge_lists"}, "step_count": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "token_usage": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tool_call_counts": {"type": "dict[str, int]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "exit_reason": {"type": "str", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "continue_run": {"type": "bool", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tools": {"type": "list", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "hook_context": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "context_tokens": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}}',  # noqa: E501
             "haystack.agent.input": '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}], "streaming_callback": null}',  # noqa: E501
@@ -1651,7 +1651,7 @@ class TestAgentTracing:
         assert set(llm_tags) == {"haystack.agent.step.llm.input", "haystack.agent.step.llm.output"}
         assert (
             llm_tags["haystack.agent.step.llm.input"]
-            == '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}], "tools": [{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]}'  # noqa: E501
+            == '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}], "tools": [{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "agents.test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]}'  # noqa: E501
         )
         assert (
             llm_tags["haystack.agent.step.llm.output"]
@@ -1664,7 +1664,7 @@ class TestAgentTracing:
         _, run_tags = agent_spans[2]
         assert run_tags == {
             "haystack.agent.max_steps": 100,
-            "haystack.agent.tools": '[{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]',  # noqa: E501
+            "haystack.agent.tools": '[{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "agents.test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]',  # noqa: E501
             "haystack.agent.exit_conditions": '["text"]',
             "haystack.agent.state_schema": '{"messages": {"type": "list[haystack.dataclasses.chat_message.ChatMessage]", "handler": "haystack.components.agents.state.state_utils.merge_lists"}, "step_count": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "token_usage": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tool_call_counts": {"type": "dict[str, int]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "exit_reason": {"type": "str", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "continue_run": {"type": "bool", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tools": {"type": "list", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "hook_context": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "context_tokens": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}}',  # noqa: E501
             "haystack.agent.input": '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}], "streaming_callback": null}',  # noqa: E501

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -16,7 +16,13 @@ from openai import Stream
 from openai.types.chat import ChatCompletionChunk, chat_completion_chunk
 
 from haystack import Document, Pipeline, component, tracing
-from haystack.components.agents.agent import Agent, _accumulate_usage, _select_tools_by_name
+from haystack.components.agents.agent import (
+    Agent,
+    _accumulate_usage,
+    _context_tokens_from_usage,
+    _record_context_tokens,
+    _select_tools_by_name,
+)
 from haystack.components.agents.state import State, merge_lists, replace_values
 from haystack.components.agents.tool_calling import _run_tool
 from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
@@ -225,10 +231,13 @@ class TestAgent:
             "tool_call_counts": OutputSocket(name="tool_call_counts", type=dict[str, int], receivers=[]),
             "exit_reason": OutputSocket(name="exit_reason", type=str, receivers=[]),
         }
-        # Check that the internal-state keys are not set up as input sockets
+        # Check that the run-metadata keys are not set up as input sockets
         assert {"step_count", "token_usage", "tool_call_counts", "exit_reason"}.isdisjoint(
             agent.__haystack_input__._sockets_dict.keys()
         )
+        # context_tokens is internal: exposed as neither an input nor an output socket
+        assert "context_tokens" not in agent.__haystack_input__._sockets_dict
+        assert "context_tokens" not in agent.__haystack_output__._sockets_dict
 
     def test_to_dict(self, weather_tool, component_tool, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
@@ -487,6 +496,7 @@ class TestAgent:
             "continue_run": {"type": bool, "handler": replace_values},
             "tools": {"type": list, "handler": replace_values},
             "hook_context": {"type": dict[str, Any], "handler": replace_values},
+            "context_tokens": {"type": int, "handler": replace_values},
         }
         assert agent.tool_concurrency_limit == 5
         assert agent.tool_streaming_callback_passthrough is True
@@ -598,6 +608,7 @@ class TestAgent:
             "continue_run": {"type": bool, "handler": replace_values},
             "tools": {"type": list, "handler": replace_values},
             "hook_context": {"type": dict[str, Any], "handler": replace_values},
+            "context_tokens": {"type": int, "handler": replace_values},
         }
 
     def test_serde(self, weather_tool, component_tool, monkeypatch):
@@ -643,6 +654,7 @@ class TestAgent:
             "continue_run": {"type": bool, "handler": replace_values},
             "tools": {"type": list, "handler": replace_values},
             "hook_context": {"type": dict[str, Any], "handler": replace_values},
+            "context_tokens": {"type": int, "handler": replace_values},
         }
         assert deserialized_agent.streaming_callback is sync_streaming_callback
 
@@ -1162,7 +1174,7 @@ class TestAgent:
 
     def test_reserved_state_schema_keys_raise(self, monkeypatch, weather_tool):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
-        for reserved in ("step_count", "token_usage", "tool_call_counts", "exit_reason"):
+        for reserved in ("step_count", "token_usage", "context_tokens", "tool_call_counts", "exit_reason"):
             with pytest.raises(ValueError, match="reserved for Agent internal state"):
                 Agent(
                     chat_generator=OpenAIChatGenerator(), tools=[weather_tool], state_schema={reserved: {"type": int}}
@@ -1246,6 +1258,179 @@ class TestAgent:
         assert result["step_count"] == 1
         assert result["token_usage"] == {}
         assert result["tool_call_counts"] == {"weather_tool": 0}
+
+
+class TestContextTokensFromUsage:
+    """`_context_tokens_from_usage` normalizes real provider `meta["usage"]` shapes to input + output tokens.
+
+    Fixtures below are the actual shapes these providers report (nested detail dicts and all), so the test pins
+    the normalization against reality rather than a simplified stand-in.
+    """
+
+    # OpenAI Chat Completions (core repo): `_serialize_object(completion.usage)` -> the full CompletionUsage dump.
+    OPENAI_CHAT_USAGE = {
+        "prompt_tokens": 1117,
+        "completion_tokens": 46,
+        "total_tokens": 1163,
+        "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+        "completion_tokens_details": {
+            "reasoning_tokens": 0,
+            "audio_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0,
+        },
+    }
+    # OpenAI Responses API (core repo): the only Haystack generator that uses input/output keys, each with a
+    # details dict.
+    OPENAI_RESPONSES_USAGE = {
+        "input_tokens": 75,
+        "input_tokens_details": {"cached_tokens": 0},
+        "output_tokens": 1186,
+        "output_tokens_details": {"reasoning_tokens": 1024},
+        "total_tokens": 1261,
+    }
+    # Anthropic chat generator (integration): remaps input/output -> prompt/completion and keeps the cache
+    # accounting (incl. the nested cache_creation breakdown).
+    ANTHROPIC_USAGE = {
+        "prompt_tokens": 2095,
+        "completion_tokens": 503,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 1024,
+        "cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 0},
+        "service_tier": "standard",
+    }
+    # Amazon Bedrock chat generator (integration): prompt/completion/total plus cache accounting.
+    BEDROCK_USAGE = {
+        "prompt_tokens": 340,
+        "completion_tokens": 92,
+        "total_tokens": 432,
+        "cache_read_input_tokens": 0,
+        "cache_write_input_tokens": 0,
+        "cache_details": {},
+    }
+    # Google GenAI chat generator (integration): total_tokens folds in thoughts, so it exceeds prompt + completion.
+    # We deliberately use prompt+completion, so thoughts are excluded.
+    GOOGLE_GENAI_USAGE = {
+        "prompt_tokens": 20,
+        "completion_tokens": 50,
+        "total_tokens": 85,
+        "thoughts_token_count": 15,
+        "cached_content_token_count": 0,
+    }
+
+    @pytest.mark.parametrize(
+        "usage, expected",
+        [
+            (OPENAI_CHAT_USAGE, 1163),
+            (OPENAI_RESPONSES_USAGE, 1261),
+            (ANTHROPIC_USAGE, 2598),
+            (BEDROCK_USAGE, 432),
+            (GOOGLE_GENAI_USAGE, 70),  # 20 + 50, deliberately not the 85 total (which includes 15 thoughts tokens)
+            ({"prompt_tokens": 10}, 10),  # only one side reported -> partial count
+            ({"completion_tokens": 7}, 7),
+            ({}, 0),  # no usage reported
+            ({"foo": 5, "bar": 9}, 0),  # no recognized keys
+        ],
+    )
+    def test_normalizes_provider_shapes(self, usage, expected):
+        assert _context_tokens_from_usage(usage) == expected
+
+    def test_bool_values_are_not_counted_as_tokens(self):
+        # bool is an int subclass; True/False under a token key must be skipped, not summed.
+        assert _context_tokens_from_usage({"prompt_tokens": True, "completion_tokens": 5}) == 5
+
+
+class TestRecordContextTokens:
+    """`_record_context_tokens` replaces the value with the latest reply's input+output, only when usage is reported."""
+
+    def _state(self) -> State:
+        state = State(schema={"context_tokens": {"type": int, "handler": replace_values}})
+        state.set("context_tokens", 0)
+        return state
+
+    def test_records_latest_reply_usage(self):
+        state = self._state()
+        _record_context_tokens(
+            state, [_assistant_with_usage("Hi", usage={"prompt_tokens": 12, "completion_tokens": 3})]
+        )
+        assert state.get("context_tokens") == 15
+
+    def test_replaces_rather_than_accumulates(self):
+        state = self._state()
+        state.set("context_tokens", 999)
+        _record_context_tokens(state, [_assistant_with_usage("Hi", usage={"prompt_tokens": 4, "completion_tokens": 1})])
+        assert state.get("context_tokens") == 5
+
+    def test_no_messages_leaves_value_untouched(self):
+        state = self._state()
+        state.set("context_tokens", 42)
+        _record_context_tokens(state, [])
+        assert state.get("context_tokens") == 42
+
+    def test_missing_or_empty_usage_leaves_value_untouched(self):
+        # A reply without usage (or with empty usage) must not clobber the previous value, including the initial 0.
+        state = self._state()
+        _record_context_tokens(state, [ChatMessage.from_assistant("no usage here")])
+        _record_context_tokens(state, [_assistant_with_usage("empty", usage={})])
+        assert state.get("context_tokens") == 0
+
+
+class TestAgentContextTokens:
+    """The Agent refreshes the internal `context_tokens` after each LLM call so a hook can read the current
+    context-window size (e.g. to trigger compaction). It is a per-call snapshot, not accumulated."""
+
+    def test_before_llm_hook_reads_refreshed_context_tokens(self, weather_tool):
+        # Step 1: a tool call (prompt 10 + completion 5 = 15). Step 2: the final text answer.
+        first_step = [
+            _assistant_with_usage(
+                tool_calls=[ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})],
+                usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            )
+        ]
+        second_step = [_assistant_with_usage("Done.", usage={"prompt_tokens": 20, "completion_tokens": 8})]
+
+        seen: list[int] = []
+
+        @hook
+        def capture(state: State) -> None:
+            seen.append(state.get("context_tokens"))
+
+        agent = Agent(
+            chat_generator=MockChatGenerator(first_step + second_step),
+            tools=[weather_tool],
+            hooks={"before_llm": [capture]},
+        )
+        agent.run([ChatMessage.from_user("Weather in Berlin?")])
+
+        # Before the first call there is no usage yet (0); before the second call it reflects the first call (15),
+        # confirming the recorder runs in the loop and the value is refreshed per call rather than accumulated.
+        assert seen == [0, 15]
+
+
+class TestAgentContextTokensAsync:
+    @pytest.mark.asyncio
+    async def test_before_llm_hook_reads_refreshed_context_tokens_async(self, weather_tool):
+        first_step = [
+            _assistant_with_usage(
+                tool_calls=[ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})],
+                usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            )
+        ]
+        second_step = [_assistant_with_usage("Done.", usage={"prompt_tokens": 20, "completion_tokens": 8})]
+
+        seen: list[int] = []
+
+        @hook
+        def capture(state: State) -> None:
+            seen.append(state.get("context_tokens"))
+
+        agent = Agent(
+            chat_generator=MockChatGenerator(first_step + second_step),
+            tools=[weather_tool],
+            hooks={"before_llm": [capture]},
+        )
+        await agent.run_async([ChatMessage.from_user("Weather in Berlin?")])
+        assert seen == [0, 15]
 
 
 class TestAgentExitReason:
@@ -1434,7 +1619,7 @@ class TestAgentTracing:
             "haystack.agent.max_steps": 100,
             "haystack.agent.tools": '[{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]',  # noqa: E501
             "haystack.agent.exit_conditions": '["text"]',
-            "haystack.agent.state_schema": '{"messages": {"type": "list[haystack.dataclasses.chat_message.ChatMessage]", "handler": "haystack.components.agents.state.state_utils.merge_lists"}, "step_count": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "token_usage": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tool_call_counts": {"type": "dict[str, int]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "exit_reason": {"type": "str", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "continue_run": {"type": "bool", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tools": {"type": "list", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "hook_context": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}}',  # noqa: E501
+            "haystack.agent.state_schema": '{"messages": {"type": "list[haystack.dataclasses.chat_message.ChatMessage]", "handler": "haystack.components.agents.state.state_utils.merge_lists"}, "step_count": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "token_usage": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tool_call_counts": {"type": "dict[str, int]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "exit_reason": {"type": "str", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "continue_run": {"type": "bool", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tools": {"type": "list", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "hook_context": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "context_tokens": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}}',  # noqa: E501
             "haystack.agent.input": '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}], "streaming_callback": null}',  # noqa: E501
             "haystack.agent.output": '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}, {"role": "assistant", "meta": {}, "name": null, "content": [{"text": "Hello"}]}], "step_count": 1, "token_usage": {}, "tool_call_counts": {"weather_tool": 0}, "exit_reason": "text", "last_message": {"role": "assistant", "meta": {}, "name": null, "content": [{"text": "Hello"}]}}',  # noqa: E501
             "haystack.agent.steps_taken": 1,
@@ -1601,7 +1786,7 @@ class TestAgentTracing:
             "haystack.agent.max_steps": 100,
             "haystack.agent.tools": '[{"type": "haystack.tools.tool.Tool", "data": {"name": "weather_tool", "description": "Provides weather information for a given location.", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}, "function": "test_agent.weather_function", "outputs_to_string": null, "inputs_from_state": null, "outputs_to_state": null, "async_function": null}}]',  # noqa: E501
             "haystack.agent.exit_conditions": '["text"]',
-            "haystack.agent.state_schema": '{"messages": {"type": "list[haystack.dataclasses.chat_message.ChatMessage]", "handler": "haystack.components.agents.state.state_utils.merge_lists"}, "step_count": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "token_usage": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tool_call_counts": {"type": "dict[str, int]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "exit_reason": {"type": "str", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "continue_run": {"type": "bool", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tools": {"type": "list", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "hook_context": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}}',  # noqa: E501
+            "haystack.agent.state_schema": '{"messages": {"type": "list[haystack.dataclasses.chat_message.ChatMessage]", "handler": "haystack.components.agents.state.state_utils.merge_lists"}, "step_count": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "token_usage": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tool_call_counts": {"type": "dict[str, int]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "exit_reason": {"type": "str", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "continue_run": {"type": "bool", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "tools": {"type": "list", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "hook_context": {"type": "dict[str, typing.Any]", "handler": "haystack.components.agents.state.state_utils.replace_values"}, "context_tokens": {"type": "int", "handler": "haystack.components.agents.state.state_utils.replace_values"}}',  # noqa: E501
             "haystack.agent.input": '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}], "streaming_callback": null}',  # noqa: E501
             "haystack.agent.output": '{"messages": [{"role": "user", "meta": {}, "name": null, "content": [{"text": "What\'s the weather in Paris?"}]}, {"role": "assistant", "meta": {"model": "mock-model", "index": 0, "finish_reason": "stop", "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}}, "name": null, "content": [{"text": "Hello"}]}], "step_count": 1, "token_usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}, "tool_call_counts": {"weather_tool": 0}, "exit_reason": "text", "last_message": {"role": "assistant", "meta": {"model": "mock-model", "index": 0, "finish_reason": "stop", "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}}, "name": null, "content": [{"text": "Hello"}]}}',  # noqa: E501
             "haystack.agent.steps_taken": 1,

--- a/test/components/agents/test_agent_hitl.py
+++ b/test/components/agents/test_agent_hitl.py
@@ -103,7 +103,7 @@ class TestAgent:
                                 "required": ["a", "b"],
                                 "type": "object",
                             },
-                            "function": "test_agent_hitl.addition_tool",
+                            "function": "agents.test_agent_hitl.addition_tool",
                             "async_function": None,
                             "outputs_to_string": None,
                             "inputs_from_state": None,

--- a/test/components/agents/test_state_class.py
+++ b/test/components/agents/test_state_class.py
@@ -351,7 +351,7 @@ class TestState:
 
     def test_schema_to_dict_with_handlers(self, complex_schema):
         expected_dict = {
-            "numbers": {"type": "list", "handler": "test_state_class.numbers_handler"},
+            "numbers": {"type": "list", "handler": "agents.test_state_class.numbers_handler"},
             "metadata": {"type": "dict"},
             "name": {"type": "str"},
         }
@@ -365,7 +365,7 @@ class TestState:
 
     def test_schema_from_dict_with_handlers(self, complex_schema):
         schema_dict = {
-            "numbers": {"type": "list", "handler": "test_state_class.numbers_handler"},
+            "numbers": {"type": "list", "handler": "agents.test_state_class.numbers_handler"},
             "metadata": {"type": "dict"},
             "name": {"type": "str"},
         }

--- a/test/components/agents/test_utils.py
+++ b/test/components/agents/test_utils.py
@@ -12,35 +12,40 @@ from haystack.dataclasses import ChatMessage
 class TestContextTokensFromUsage:
     """`_context_tokens_from_usage` normalizes real provider `meta["usage"]` shapes to input + output tokens."""
 
-    # OpenAI Chat Completions (core repo): `_serialize_object(completion.usage)` -> the full CompletionUsage dump.
+    # OpenAI Chat Completions (core repo): reasoning_tokens is a subset of completion_tokens (64 of 74), so
+    # context_tokens includes reasoning.
     OPENAI_CHAT_USAGE = {
-        "prompt_tokens": 1117,
-        "completion_tokens": 46,
-        "total_tokens": 1163,
-        "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+        "completion_tokens": 74,
+        "prompt_tokens": 19,
+        "total_tokens": 93,
         "completion_tokens_details": {
-            "reasoning_tokens": 0,
-            "audio_tokens": 0,
             "accepted_prediction_tokens": 0,
+            "audio_tokens": 0,
+            "reasoning_tokens": 64,
             "rejected_prediction_tokens": 0,
         },
+        "prompt_tokens_details": {"audio_tokens": 0, "cached_tokens": 0},
     }
-    # OpenAI Responses API (core repo).
+    # OpenAI Responses API (core repo): the only Haystack generator using input/output keys.
     OPENAI_RESPONSES_USAGE = {
-        "input_tokens": 75,
-        "input_tokens_details": {"cached_tokens": 0},
-        "output_tokens": 1186,
-        "output_tokens_details": {"reasoning_tokens": 1024},
-        "total_tokens": 1261,
+        "input_tokens": 19,
+        "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0},
+        "output_tokens": 58,
+        "output_tokens_details": {"reasoning_tokens": 0},
+        "total_tokens": 77,
     }
-    # Anthropic chat generator (integration): remaps input/output -> prompt/completion.
+    # Anthropic chat generator (integration): no total_tokens, and thinking_tokens is a subset of completion_tokens
+    # (57 of 63).
     ANTHROPIC_USAGE = {
-        "prompt_tokens": 2095,
-        "completion_tokens": 503,
+        "cache_creation": {"ephemeral_1h_input_tokens": 0, "ephemeral_5m_input_tokens": 0},
         "cache_creation_input_tokens": 0,
-        "cache_read_input_tokens": 1024,
-        "cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 0},
+        "cache_read_input_tokens": 0,
+        "inference_geo": "not_available",
+        "output_tokens_details": {"thinking_tokens": 57},
+        "server_tool_use": None,
         "service_tier": "standard",
+        "prompt_tokens": 49,
+        "completion_tokens": 63,
     }
     # Amazon Bedrock chat generator (integration).
     BEDROCK_USAGE = {
@@ -51,24 +56,47 @@ class TestContextTokensFromUsage:
         "cache_write_input_tokens": 0,
         "cache_details": {},
     }
-    # Google GenAI chat generator (integration): total_tokens folds in thoughts, so it exceeds prompt + completion.
-    # We deliberately use prompt+completion, so thoughts are excluded.
+    # Cohere chat generator (integration): bare prompt/completion pair, no total_tokens.
+    COHERE_USAGE = {"prompt_tokens": 63, "completion_tokens": 118}
+    # Mistral chat generator (integration).
+    MISTRAL_USAGE = {
+        "prompt_tokens": 30,
+        "total_tokens": 34,
+        "completion_tokens": 4,
+        "prompt_tokens_details": {"cached_tokens": 0},
+    }
+    # Nvidia chat generator (integration).
+    NVIDIA_USAGE = {
+        "completion_tokens": 2,
+        "prompt_tokens": 48,
+        "total_tokens": 50,
+        "completion_tokens_details": None,
+        "prompt_tokens_details": {"audio_tokens": None, "cached_tokens": 16},
+    }
+    # Google GenAI chat generator (integration): thoughts_token_count (281) is NOT part of completion_tokens;
+    # total_tokens (300) includes it, so context_tokens (19) excludes thoughts.
     GOOGLE_GENAI_USAGE = {
-        "prompt_tokens": 20,
-        "completion_tokens": 50,
-        "total_tokens": 85,
-        "thoughts_token_count": 15,
-        "cached_content_token_count": 0,
+        "prompt_tokens": 16,
+        "completion_tokens": 3,
+        "total_tokens": 300,
+        "thoughts_token_count": 281,
+        "prompt_token_count": 16,
+        "candidates_token_count": 3,
+        "total_token_count": 300,
+        "prompt_tokens_details": [{"modality": "TEXT", "token_count": 16}],
     }
 
     @pytest.mark.parametrize(
         "usage, expected",
         [
-            (OPENAI_CHAT_USAGE, 1163),
-            (OPENAI_RESPONSES_USAGE, 1261),
-            (ANTHROPIC_USAGE, 2598),
+            (OPENAI_CHAT_USAGE, 93),
+            (OPENAI_RESPONSES_USAGE, 77),
+            (ANTHROPIC_USAGE, 112),
             (BEDROCK_USAGE, 432),
-            (GOOGLE_GENAI_USAGE, 70),  # 20 + 50, deliberately not the 85 total (which includes 15 thoughts tokens)
+            (COHERE_USAGE, 181),
+            (MISTRAL_USAGE, 34),
+            (NVIDIA_USAGE, 50),
+            (GOOGLE_GENAI_USAGE, 19),  # 16 + 3, deliberately not the 300 total (which includes 281 thoughts tokens)
             ({"prompt_tokens": 10}, 10),  # only one side reported -> partial count
             ({"completion_tokens": 7}, 7),
             ({}, 0),  # no usage reported

--- a/test/components/agents/test_utils.py
+++ b/test/components/agents/test_utils.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack.components.agents.state import State, replace_values
+from haystack.components.agents.utils import _context_tokens_from_usage, _record_context_tokens
+from haystack.dataclasses import ChatMessage
+
+
+class TestContextTokensFromUsage:
+    """`_context_tokens_from_usage` normalizes real provider `meta["usage"]` shapes to input + output tokens.
+
+    Fixtures below are the actual shapes these providers report (nested detail dicts and all), so the test pins
+    the normalization against reality rather than a simplified stand-in.
+    """
+
+    # OpenAI Chat Completions (core repo): `_serialize_object(completion.usage)` -> the full CompletionUsage dump.
+    OPENAI_CHAT_USAGE = {
+        "prompt_tokens": 1117,
+        "completion_tokens": 46,
+        "total_tokens": 1163,
+        "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+        "completion_tokens_details": {
+            "reasoning_tokens": 0,
+            "audio_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0,
+        },
+    }
+    # OpenAI Responses API (core repo): the only Haystack generator that uses input/output keys, each with a
+    # details dict.
+    OPENAI_RESPONSES_USAGE = {
+        "input_tokens": 75,
+        "input_tokens_details": {"cached_tokens": 0},
+        "output_tokens": 1186,
+        "output_tokens_details": {"reasoning_tokens": 1024},
+        "total_tokens": 1261,
+    }
+    # Anthropic chat generator (integration): remaps input/output -> prompt/completion and keeps the cache
+    # accounting (incl. the nested cache_creation breakdown).
+    ANTHROPIC_USAGE = {
+        "prompt_tokens": 2095,
+        "completion_tokens": 503,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 1024,
+        "cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 0},
+        "service_tier": "standard",
+    }
+    # Amazon Bedrock chat generator (integration): prompt/completion/total plus cache accounting.
+    BEDROCK_USAGE = {
+        "prompt_tokens": 340,
+        "completion_tokens": 92,
+        "total_tokens": 432,
+        "cache_read_input_tokens": 0,
+        "cache_write_input_tokens": 0,
+        "cache_details": {},
+    }
+    # Google GenAI chat generator (integration): total_tokens folds in thoughts, so it exceeds prompt + completion.
+    # We deliberately use prompt+completion, so thoughts are excluded.
+    GOOGLE_GENAI_USAGE = {
+        "prompt_tokens": 20,
+        "completion_tokens": 50,
+        "total_tokens": 85,
+        "thoughts_token_count": 15,
+        "cached_content_token_count": 0,
+    }
+
+    @pytest.mark.parametrize(
+        "usage, expected",
+        [
+            (OPENAI_CHAT_USAGE, 1163),
+            (OPENAI_RESPONSES_USAGE, 1261),
+            (ANTHROPIC_USAGE, 2598),
+            (BEDROCK_USAGE, 432),
+            (GOOGLE_GENAI_USAGE, 70),  # 20 + 50, deliberately not the 85 total (which includes 15 thoughts tokens)
+            ({"prompt_tokens": 10}, 10),  # only one side reported -> partial count
+            ({"completion_tokens": 7}, 7),
+            ({}, 0),  # no usage reported
+            ({"foo": 5, "bar": 9}, 0),  # no recognized keys
+        ],
+    )
+    def test_normalizes_provider_shapes(self, usage, expected):
+        assert _context_tokens_from_usage(usage) == expected
+
+    def test_bool_values_are_not_counted_as_tokens(self):
+        # bool is an int subclass; True/False under a token key must be skipped, not summed.
+        assert _context_tokens_from_usage({"prompt_tokens": True, "completion_tokens": 5}) == 5
+
+
+class TestRecordContextTokens:
+    """`_record_context_tokens` replaces the value with the latest reply's input+output, only when usage is reported."""
+
+    def _state(self) -> State:
+        state = State(schema={"context_tokens": {"type": int, "handler": replace_values}})
+        state.set("context_tokens", 0)
+        return state
+
+    def test_records_latest_reply_usage(self):
+        state = self._state()
+        _record_context_tokens(
+            state, [ChatMessage.from_assistant("Hi", meta={"usage": {"prompt_tokens": 12, "completion_tokens": 3}})]
+        )
+        assert state.get("context_tokens") == 15
+
+    def test_replaces_rather_than_accumulates(self):
+        state = self._state()
+        state.set("context_tokens", 999)
+        _record_context_tokens(
+            state, [ChatMessage.from_assistant("Hi", meta={"usage": {"prompt_tokens": 4, "completion_tokens": 1}})]
+        )
+        assert state.get("context_tokens") == 5
+
+    def test_no_messages_leaves_value_untouched(self):
+        state = self._state()
+        state.set("context_tokens", 42)
+        _record_context_tokens(state, [])
+        assert state.get("context_tokens") == 42
+
+    def test_missing_or_empty_usage_leaves_value_untouched(self):
+        # A reply without usage (or with empty usage) must not clobber the previous value, including the initial 0.
+        state = self._state()
+        _record_context_tokens(state, [ChatMessage.from_assistant("no usage here")])
+        _record_context_tokens(state, [ChatMessage.from_assistant("empty", meta={"usage": {}})])
+        assert state.get("context_tokens") == 0

--- a/test/components/agents/test_utils.py
+++ b/test/components/agents/test_utils.py
@@ -10,11 +10,7 @@ from haystack.dataclasses import ChatMessage
 
 
 class TestContextTokensFromUsage:
-    """`_context_tokens_from_usage` normalizes real provider `meta["usage"]` shapes to input + output tokens.
-
-    Fixtures below are the actual shapes these providers report (nested detail dicts and all), so the test pins
-    the normalization against reality rather than a simplified stand-in.
-    """
+    """`_context_tokens_from_usage` normalizes real provider `meta["usage"]` shapes to input + output tokens."""
 
     # OpenAI Chat Completions (core repo): `_serialize_object(completion.usage)` -> the full CompletionUsage dump.
     OPENAI_CHAT_USAGE = {
@@ -29,8 +25,7 @@ class TestContextTokensFromUsage:
             "rejected_prediction_tokens": 0,
         },
     }
-    # OpenAI Responses API (core repo): the only Haystack generator that uses input/output keys, each with a
-    # details dict.
+    # OpenAI Responses API (core repo).
     OPENAI_RESPONSES_USAGE = {
         "input_tokens": 75,
         "input_tokens_details": {"cached_tokens": 0},
@@ -38,8 +33,7 @@ class TestContextTokensFromUsage:
         "output_tokens_details": {"reasoning_tokens": 1024},
         "total_tokens": 1261,
     }
-    # Anthropic chat generator (integration): remaps input/output -> prompt/completion and keeps the cache
-    # accounting (incl. the nested cache_creation breakdown).
+    # Anthropic chat generator (integration): remaps input/output -> prompt/completion.
     ANTHROPIC_USAGE = {
         "prompt_tokens": 2095,
         "completion_tokens": 503,
@@ -48,7 +42,7 @@ class TestContextTokensFromUsage:
         "cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 0},
         "service_tier": "standard",
     }
-    # Amazon Bedrock chat generator (integration): prompt/completion/total plus cache accounting.
+    # Amazon Bedrock chat generator (integration).
     BEDROCK_USAGE = {
         "prompt_tokens": 340,
         "completion_tokens": 92,
@@ -97,20 +91,13 @@ class TestRecordContextTokens:
         state.set("context_tokens", 0)
         return state
 
-    def test_records_latest_reply_usage(self):
+    def test_records_latest_reply_usage_replacing_previous_value(self):
         state = self._state()
+        state.set("context_tokens", 999)
         _record_context_tokens(
             state, [ChatMessage.from_assistant("Hi", meta={"usage": {"prompt_tokens": 12, "completion_tokens": 3}})]
         )
         assert state.get("context_tokens") == 15
-
-    def test_replaces_rather_than_accumulates(self):
-        state = self._state()
-        state.set("context_tokens", 999)
-        _record_context_tokens(
-            state, [ChatMessage.from_assistant("Hi", meta={"usage": {"prompt_tokens": 4, "completion_tokens": 1}})]
-        )
-        assert state.get("context_tokens") == 5
 
     def test_no_messages_leaves_value_untouched(self):
         state = self._state()
@@ -119,7 +106,6 @@ class TestRecordContextTokens:
         assert state.get("context_tokens") == 42
 
     def test_missing_or_empty_usage_leaves_value_untouched(self):
-        # A reply without usage (or with empty usage) must not clobber the previous value, including the initial 0.
         state = self._state()
         _record_context_tokens(state, [ChatMessage.from_assistant("no usage here")])
         _record_context_tokens(state, [ChatMessage.from_assistant("empty", meta={"usage": {}})])

--- a/test/components/agents/test_utils.py
+++ b/test/components/agents/test_utils.py
@@ -26,7 +26,7 @@ class TestContextTokensFromUsage:
         },
         "prompt_tokens_details": {"audio_tokens": 0, "cached_tokens": 0},
     }
-    # OpenAI Responses API (core repo): the only Haystack generator using input/output keys.
+    # OpenAI Responses API (core repo).
     OPENAI_RESPONSES_USAGE = {
         "input_tokens": 19,
         "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0},
@@ -49,15 +49,15 @@ class TestContextTokensFromUsage:
     }
     # Amazon Bedrock chat generator (integration).
     BEDROCK_USAGE = {
-        "prompt_tokens": 340,
-        "completion_tokens": 92,
-        "total_tokens": 432,
+        "prompt_tokens": 20,
+        "completion_tokens": 5,
+        "total_tokens": 25,
         "cache_read_input_tokens": 0,
         "cache_write_input_tokens": 0,
         "cache_details": {},
     }
-    # Cohere chat generator (integration): bare prompt/completion pair, no total_tokens.
-    COHERE_USAGE = {"prompt_tokens": 63, "completion_tokens": 118}
+    # Cohere chat generator (integration).
+    COHERE_USAGE = {"prompt_tokens": 15.0, "completion_tokens": 3.0}
     # Mistral chat generator (integration).
     MISTRAL_USAGE = {
         "prompt_tokens": 30,
@@ -92,8 +92,8 @@ class TestContextTokensFromUsage:
             (OPENAI_CHAT_USAGE, 93),
             (OPENAI_RESPONSES_USAGE, 77),
             (ANTHROPIC_USAGE, 112),
-            (BEDROCK_USAGE, 432),
-            (COHERE_USAGE, 181),
+            (BEDROCK_USAGE, 25),
+            (COHERE_USAGE, 18),
             (MISTRAL_USAGE, 34),
             (NVIDIA_USAGE, 50),
             (GOOGLE_GENAI_USAGE, 19),  # 16 + 3, deliberately not the 300 total (which includes 281 thoughts tokens)


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack/issues/10866

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

The ``Agent`` now tracks an approximate current context-window size in its internal ``State`` under ``context_tokens``, refreshed after every LLM call with that reply's prompt-plus-completion tokens (normalized across the ``prompt_tokens``/``completion_tokens`` and ``input_tokens``/``output_tokens`` key conventions). Unlike ``token_usage``, which accumulates across the whole run, ``context_tokens`` is replaced each call. Hooks can read it via ``state.get("context_tokens")`` — for example, a ``before_llm`` hook that triggers context compaction once the value crosses a threshold. It is a best-effort snapshot: it is ``0`` when the generator does not report usage, and does not count messages appended after the latest call until the next call refreshes it.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

I decided to add a new utils file `agent/utils.py` to start collecting these util functions that are crowding the top of the `agent.py` file. After this PR I will open a new one to move more util functionality into that file. This is not a breaking change since all util functions being moved are private. 

I also ran live runs against different model providers APIs using our chat generators to see what usage looks like and confirm that the agent's util methods works for our most popular providers. I've collected them in `test_normalizes_provider_shapes`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
