### PR TITLE
refactor(components): accept Iterable[Document] instead of List[Document] in run() inputs

### DIFF
--- a/haystack/components/preprocessors/document_cleaner.py
+++ b/haystack/components/preprocessors/document_cleaner.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from copy import deepcopy
 from functools import partial, reduce
 from itertools import chain
@@ -101,19 +101,20 @@ class DocumentCleaner:
             raise ValueError("unicode_normalization must be one of 'NFC', 'NFKC', 'NFD', 'NFKD'.")
 
     @component.output_types(documents=list[Document])
-    def run(self, documents: list[Document]) -> dict[str, list[Document]]:
+    def run(self, documents: Iterable[Document]) -> dict[str, list[Document]]:
         """
         Cleans up the documents.
 
-        :param documents: List of Documents to clean.
+        :param documents: Iterable of Documents to clean.
 
         :returns: A dictionary with the following key:
             - `documents`: List of cleaned Documents.
 
-        :raises TypeError: if documents is not a list of Documents.
+        :raises TypeError: if documents is not an iterable of Documents.
         """
-        if not isinstance(documents, list) or documents and not isinstance(documents[0], Document):
-            raise TypeError("DocumentCleaner expects a List of Documents as input.")
+        documents = list(documents)
+        if documents and not isinstance(documents[0], Document):
+            raise TypeError("DocumentCleaner expects an Iterable of Documents as input.")
 
         cleaned_docs = []
         for doc in documents:

--- a/haystack/components/routers/document_length_router.py
+++ b/haystack/components/routers/document_length_router.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from collections.abc import Iterable
+
 from haystack import component
 from haystack.dataclasses import Document
 
@@ -52,12 +54,12 @@ class DocumentLengthRouter:
         self.threshold = threshold
 
     @component.output_types(short_documents=list[Document], long_documents=list[Document])
-    def run(self, documents: list[Document]) -> dict[str, list[Document]]:
+    def run(self, documents: Iterable[Document]) -> dict[str, list[Document]]:
         """
         Categorize input documents into groups based on the length of the `content` field.
 
         :param documents:
-            A list of documents to be categorized.
+            An iterable of documents to be categorized.
 
         :returns: A dictionary with the following keys:
             - `short_documents`: A list of documents where `content` is None or the length of `content` is less than or

--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Iterable
 from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
@@ -77,12 +78,12 @@ class DocumentWriter:
         return default_from_dict(cls, data)
 
     @component.output_types(documents_written=int)
-    def run(self, documents: list[Document], policy: DuplicatePolicy | None = None) -> dict[str, int]:
+    def run(self, documents: Iterable[Document], policy: DuplicatePolicy | None = None) -> dict[str, int]:
         """
         Run the DocumentWriter on the given input data.
 
         :param documents:
-            A list of documents to write to the document store.
+            An iterable of documents to write to the document store.
         :param policy:
             The policy to use when encountering duplicate documents.
         :returns:
@@ -94,11 +95,11 @@ class DocumentWriter:
         if policy is None:
             policy = self.policy
 
-        documents_written = self.document_store.write_documents(documents=documents, policy=policy)
+        documents_written = self.document_store.write_documents(documents=list(documents), policy=policy)
         return {"documents_written": documents_written}
 
     @component.output_types(documents_written=int)
-    async def run_async(self, documents: list[Document], policy: DuplicatePolicy | None = None) -> dict[str, int]:
+    async def run_async(self, documents: Iterable[Document], policy: DuplicatePolicy | None = None) -> dict[str, int]:
         """
         Asynchronously run the DocumentWriter on the given input data.
 
@@ -106,7 +107,7 @@ class DocumentWriter:
         but can be used with `await` in async code.
 
         :param documents:
-            A list of documents to write to the document store.
+            An iterable of documents to write to the document store.
         :param policy:
             The policy to use when encountering duplicate documents.
         :returns:
@@ -123,5 +124,5 @@ class DocumentWriter:
         if not hasattr(self.document_store, "write_documents_async"):
             raise TypeError(f"Document store {type(self.document_store).__name__} does not provide async support.")
 
-        documents_written = await self.document_store.write_documents_async(documents=documents, policy=policy)
+        documents_written = await self.document_store.write_documents_async(documents=list(documents), policy=policy)
         return {"documents_written": documents_written}

--- a/releasenotes/notes/list-to-iterable-document-inputs-2fc70736148a4d43.yaml
+++ b/releasenotes/notes/list-to-iterable-document-inputs-2fc70736148a4d43.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Changed the ``documents`` parameter type from ``list[Document]`` to ``Iterable[Document]`` in the ``run()``
+    and ``run_async()`` methods of ``DocumentWriter``, ``DocumentCleaner``, and ``DocumentLengthRouter``.
+    This allows callers to pass generators or other lazy sequences directly without first materialising them
+    into a list. Components that require list operations internally convert the input with ``list(documents)``.


### PR DESCRIPTION
### Related Issues
- fixes #8494

### Proposed Changes:
Changed `List[Document]` to `Iterable[Document]` in the `run()` method of `DocumentWriter`, `DocumentCleaner`, and `DocumentLengthRouter`. Internal code that required list operations converts the input with `list(documents)`.

- **`DocumentWriter`**: `run()` and `run_async()` — passes `list(documents)` to `document_store.write_documents()`.
- **`DocumentCleaner`**: `run()` — converts to list at the top of the method (needed because the body uses index access for the type-guard check).
- **`DocumentLengthRouter`**: `run()` — pure iteration, no list conversion needed.

### How did you test it?
Existing unit tests pass. No behavior change — `list` satisfies `Iterable`.

### Notes for the reviewer

### Checklist
- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] PR title uses a conventional commit type.
- [x] I have documented my code.
- [x] I have added a release note file.
- [x] I have run pre-commit hooks and fixed any issue.

---

Note: This PR was developed with AI assistance.