### PR TITLE
ci: group CodeQL dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: 'daily'
     cooldown:
       default-days: 1
+    groups:
+      codeql:
+        patterns:
+          - 'github/codeql-action/*'
 
   - package-ecosystem: 'pip'
     directory: '/'


### PR DESCRIPTION
### Related Issues
- dependabot generally opens 3 separate PRs for updating CodeQL GitHub Actions: the problem is that they are interdependent, so tests sometimes fail in the update PRs. https://github.com/deepset-ai/haystack/actions/runs/30015914878/job/89235744744?pr=12135

### Proposed Changes:
- create a group in dependabot to group CodeQL updates: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
