### PR TITLE
ci: fix the release process for the 2.31.x maintenance line

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -50,14 +50,10 @@ jobs:
         with:
           images: $DOCKER_REPO_NAME
 
-      - name: Detect stable version
-        run: |
-          if [[ "${{ steps.meta.outputs.version }}" =~ ^v2\.[0-9]+\.[0-9]+$ ]]; then
-            echo "IS_STABLE=true" >> "$GITHUB_ENV"
-            echo "Stable version detected"
-          else
-            echo "Not a stable version"
-          fi
+      # 2.31.x maintenance line change
+      # The 2.31.x maintenance line must never move the ":stable" Docker tag:
+      # skip stable detection and leave IS_STABLE at its default ("false")
+
       - name: Build base images
         uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,9 @@ jobs:
           token: ${{ secrets.HAYSTACK_BOT_TOKEN }}
 
       - name: Update haystack pin
-        run: sed -i "s/haystack-ai>=.*/haystack-ai>=${VERSION}/" requirements-test.txt
+        # 2.31.x maintenance line change
+        # Pin the exact version. ">=${VERSION}" might lead to use the latest 3.x version.
+        run: sed -i "s/haystack-ai>=.*/haystack-ai==${VERSION}/" requirements-test.txt
 
       - name: Create Pull Request
         id: create-pr


### PR DESCRIPTION
### Related Issues

part of https://github.com/deepset-ai/haystack-private/issues/469

I expected bugfix versions like 2.31.1 to be released with the following commands (to be documented)
```bash
gh workflow run release.yml -R deepset-ai/haystack -r v2.31.x -f version=v2.31.1-rc1
gh workflow run release.yml -R deepset-ai/haystack -r v2.31.x -f version=v2.31.1
```

I investigated and discovered that when specifying `-r/--ref`, the workflow from the specified branch is executed (should also have a matching workflow in main, with the same name and inputs).
Other workflows triggered by release tags (eg v2.31.1) use the workflow present at the tagged commit (same as v2.31.x in this case).

I read this in the docs but also tried it in [my fork](https://github.com/anakin87/haystack/actions).

This means we need to edit the workflow on v2.31.x branch.


### Proposed Changes:
- avoid tagging a Docker image as `stable`: the tag must stay in more recent 3.x images
- use exact pin instead of >= to bump `dc-pipeline-templates`: this avoids installing 3.x versions 

### How did you test it?
Haven't tested the changed workflow but a similar one in my fork.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
