### PR TITLE
fix: set source_id on RecursiveDocumentSplitter chunks

### DIFF
--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -426,9 +426,6 @@ class RecursiveDocumentSplitter:
 
         for split_nr, chunk in enumerate(chunks):
             meta = deepcopy(doc.meta)
-            # `source_id` is the key every other splitter writes, and the one components
-            # like SentenceWindowRetriever look for by default. `parent_id` carries the
-            # same value and is kept for callers already reading it.
             meta["source_id"] = doc.id
             meta["parent_id"] = doc.id
             meta["split_id"] = split_nr

--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -38,7 +38,7 @@ class RecursiveDocumentSplitter:
     from haystack import Document
     from haystack.components.preprocessors import RecursiveDocumentSplitter
 
-    chunker = RecursiveDocumentSplitter(split_length=260, split_overlap=0, separators=["\\n\\n", "\\n", ".", " "])
+    chunker = RecursiveDocumentSplitter(split_length=15, split_overlap=0, separators=["\\n\\n", "\\n", ".", " "])
     text = ('''Artificial intelligence (AI) - Introduction
 
     AI, in its broadest sense, is intelligence exhibited by machines, particularly computer systems.
@@ -47,10 +47,11 @@ class RecursiveDocumentSplitter:
     doc_chunks = chunker.run([doc])
     print(doc_chunks["documents"])
     # [
-    # Document(id=..., content: 'Artificial intelligence (AI) - Introduction\\n\\n', meta: {'original_id': '...', 'split_id': 0, 'split_idx_start': 0, '_split_overlap': []})
-    # Document(id=..., content: 'AI, in its broadest sense, is intelligence exhibited by machines, particularly computer systems.\\n', meta: {'original_id': '...', 'split_id': 1, 'split_idx_start': 45, '_split_overlap': []})
-    # Document(id=..., content: 'AI technology is widely used throughout industry, government, and science.', meta: {'original_id': '...', 'split_id': 2, 'split_idx_start': 142, '_split_overlap': []})
-    # Document(id=..., content: ' Some high-profile applications include advanced web search engines; recommendation systems; interac...', meta: {'original_id': '...', 'split_id': 3, 'split_idx_start': 216, '_split_overlap': []})
+    # Document(id=..., content: 'Artificial intelligence (AI) - Introduction\\n\\n', meta: {'source_id': '...', 'parent_id': '...', 'split_id': 0, 'split_idx_start': 0, '_split_overlap': None, 'page_number': 1})
+    # Document(id=..., content: 'AI, in its broadest sense, is intelligence exhibited by machines, particularly computer systems.\\n', meta: {'source_id': '...', 'parent_id': '...', 'split_id': 1, 'split_idx_start': 45, '_split_overlap': None, 'page_number': 1})
+    # Document(id=..., content: 'AI technology is widely used throughout industry, government, and science.', meta: {'source_id': '...', 'parent_id': '...', 'split_id': 2, 'split_idx_start': 142, '_split_overlap': None, 'page_number': 1})
+    # Document(id=..., content: ' Some high-profile applications include advanced web search engines; recommendation systems; interac...', meta: {'source_id': '...', 'parent_id': '...', 'split_id': 3, 'split_idx_start': 216, '_split_overlap': None, 'page_number': 1})
+    # Document(id=..., content: 'vehicles; generative and creative tools; and superhuman play and analysis in strategy games.', meta: {'source_id': '...', 'parent_id': '...', 'split_id': 4, 'split_idx_start': 350, '_split_overlap': None, 'page_number': 1})
     # ]
     ```
     """  # noqa: E501
@@ -425,6 +426,10 @@ class RecursiveDocumentSplitter:
 
         for split_nr, chunk in enumerate(chunks):
             meta = deepcopy(doc.meta)
+            # `source_id` is the key every other splitter writes, and the one components
+            # like SentenceWindowRetriever look for by default. `parent_id` carries the
+            # same value and is kept for callers already reading it.
+            meta["source_id"] = doc.id
             meta["parent_id"] = doc.id
             meta["split_id"] = split_nr
             meta["split_idx_start"] = current_position

--- a/releasenotes/notes/recursive-splitter-source-id-4efff9b9344f57e4.yaml
+++ b/releasenotes/notes/recursive-splitter-source-id-4efff9b9344f57e4.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fixed ``RecursiveDocumentSplitter`` not setting the ``source_id`` meta field on the chunks
+    it produces. It wrote only ``parent_id``, while every other splitter in the library
+    (``DocumentSplitter``, ``CSVDocumentSplitter``, ``EmbeddingBasedDocumentSplitter``,
+    ``HierarchicalDocumentSplitter``, ``MarkdownHeaderSplitter`` and ``PythonCodeSplitter``)
+    writes ``source_id``. Components that follow that convention therefore rejected its output:
+    ``SentenceWindowRetriever`` reads ``source_id`` by default and raises when it is absent, so
+    it failed with "The retrieved documents must have 'source_id' in their metadata." on a
+    pipeline that worked with any other splitter. Chunks now carry ``source_id`` as well as
+    ``parent_id``, which keeps its previous value for callers already reading it.

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -11,6 +11,8 @@ from pytest import LogCaptureFixture
 from haystack import Document, Pipeline
 from haystack.components.preprocessors.recursive_splitter import RecursiveDocumentSplitter
 from haystack.components.preprocessors.sentence_tokenizer import SentenceSplitter
+from haystack.components.retrievers.sentence_window_retriever import SentenceWindowRetriever
+from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 
 def test_get_custom_sentence_tokenizer_success():
@@ -1053,6 +1055,36 @@ def test_recursive_splitter_generates_unique_ids_and_correct_meta():
     for idx, chunk in enumerate(chunks):
         assert chunk.meta["parent_id"] == source_doc.id
         assert chunk.meta["split_id"] == idx
+
+
+def test_recursive_splitter_sets_source_id():
+    """`source_id` is the key the rest of the library uses to tie a chunk back to its document."""
+    source_doc = Document(content="Haystack is awesome. " * 5)
+
+    chunks = RecursiveDocumentSplitter(split_length=3).run([source_doc])["documents"]
+
+    assert chunks
+    for chunk in chunks:
+        assert chunk.meta["source_id"] == source_doc.id
+        # parent_id carried the same value before source_id existed, so it stays.
+        assert chunk.meta["parent_id"] == source_doc.id
+
+
+def test_recursive_splitter_output_works_with_sentence_window_retriever():
+    """SentenceWindowRetriever looks up `source_id` by default and raises when it is
+    absent, so chunks from this splitter used to be unusable with it."""
+    source_doc = Document(content="Haystack is awesome. " * 10)
+    chunks = RecursiveDocumentSplitter(split_length=3).run([source_doc])["documents"]
+    assert len(chunks) > 2
+
+    store = InMemoryDocumentStore()
+    store.write_documents(chunks)
+
+    result = SentenceWindowRetriever(document_store=store, window_size=1).run(retrieved_documents=[chunks[1]])
+
+    # The middle chunk plus one neighbour on each side.
+    assert len(result["context_documents"]) == 3
+    assert result["context_windows"]
 
 
 def test_warm_up_is_idempotent_sentence(monkeypatch):

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -1051,28 +1051,16 @@ def test_recursive_splitter_generates_unique_ids_and_correct_meta():
     # IDs must be unique
     assert len({c.id for c in chunks}) == len(chunks)
 
-    # parent_id and split_id checks
+    # source_id, parent_id and split_id checks
     for idx, chunk in enumerate(chunks):
+        assert chunk.meta["source_id"] == source_doc.id
         assert chunk.meta["parent_id"] == source_doc.id
         assert chunk.meta["split_id"] == idx
 
 
-def test_recursive_splitter_sets_source_id():
-    """`source_id` is the key the rest of the library uses to tie a chunk back to its document."""
-    source_doc = Document(content="Haystack is awesome. " * 5)
-
-    chunks = RecursiveDocumentSplitter(split_length=3).run([source_doc])["documents"]
-
-    assert chunks
-    for chunk in chunks:
-        assert chunk.meta["source_id"] == source_doc.id
-        # parent_id carried the same value before source_id existed, so it stays.
-        assert chunk.meta["parent_id"] == source_doc.id
-
-
 def test_recursive_splitter_output_works_with_sentence_window_retriever():
     """SentenceWindowRetriever looks up `source_id` by default and raises when it is
-    absent, so chunks from this splitter used to be unusable with it."""
+    absent"""
     source_doc = Document(content="Haystack is awesome. " * 10)
     chunks = RecursiveDocumentSplitter(split_length=3).run([source_doc])["documents"]
     assert len(chunks) > 2


### PR DESCRIPTION
### Related Issues

- fixes #12154

### Proposed Changes:

`RecursiveDocumentSplitter` wrote only `parent_id` on its chunks. Every other splitter writes `source_id`, and that is the key the rest of Haystack reads to tie a chunk back to its document, so the output did not compose with components that follow the convention. `SentenceWindowRetriever` reads `source_id` by default and raises when it is absent, so the same pipeline worked with `DocumentSplitter` and failed with this one.

Chunks now set `source_id` alongside `parent_id`. `parent_id` keeps its previous value, so anything already reading it is unaffected, and this is additive for anyone reading the meta dict.

I went with adding the key rather than renaming it, or teaching the retriever about `parent_id`. Renaming would break existing readers, and teaching one consumer about the alias would leave the underlying inconsistency in place for the next one.

The class docstring also needed a correction. It showed a meta key named `original_id`, which the code has never written, so the documented key, the emitted key and the key consumers read were three different names. Its output block did not match the example either: it was generated with a different `split_length` than the one in the snippet (260 produces a single chunk, the four shown come out at 15) and reported `_split_overlap` as `[]` where a run with `split_overlap=0` gives `None`. I regenerated the block by running the example so it now reproduces what it claims.

### How did you test it?

Two new unit tests in `test/components/preprocessors/test_recursive_splitter.py`:

- `test_recursive_splitter_sets_source_id` — chunks carry `source_id`, and `parent_id` still holds the same value.
- `test_recursive_splitter_output_works_with_sentence_window_retriever` — the actual reported failure, end to end through `InMemoryDocumentStore` and `SentenceWindowRetriever`.

Both fail on `main`, with `KeyError: 'source_id'` and `ValueError: The retrieved documents must have 'source_id' in their metadata.` respectively.

```
hatch run test:unit test/components/preprocessors/ test/components/retrievers/
526 passed, 49 deselected
```

`hatch run fmt-check` reports the same two `PLR0917` errors before and after my change, both in `azure_document_embedder.py` and `openai_document_embedder.py`, which this PR does not touch.

### Notes for the reviewer

The interesting line is the one added in `_run_one`. Everything else is the docstring and the tests.

Worth deciding explicitly: `parent_id` is now redundant. I kept it because removing it would be a breaking change and is not needed to fix the issue, but if you would rather deprecate it, that is a natural follow-up and I am happy to do it.

`HierarchicalDocumentSplitter` already emits both keys, so this brings `RecursiveDocumentSplitter` in line with it.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

<sub>I used AI assistance while investigating this and preparing the change. I reviewed and verified it myself.</sub>