### PR TITLE
Fix/pipeline mid loop resume

### DIFF
--- a/haystack/core/pipeline/breakpoint.py
+++ b/haystack/core/pipeline/breakpoint.py
@@ -13,7 +13,9 @@ from networkx import MultiDiGraph
 
 from haystack import logging
 from haystack.core.errors import PipelineInvalidPipelineSnapshotError
+from haystack.core.pipeline.component_checks import _NO_OUTPUT_PRODUCED
 from haystack.dataclasses.breakpoints import Breakpoint, PipelineSnapshot, PipelineState
+from haystack.utils import _deserialize_value_with_schema
 from haystack.utils.base_serialization import _serialize_with_field_fallback
 
 logger = logging.getLogger(__name__)
@@ -24,6 +26,9 @@ HAYSTACK_PIPELINE_SNAPSHOT_SAVE_ENABLED = "HAYSTACK_PIPELINE_SNAPSHOT_SAVE_ENABL
 # Type alias for snapshot callback function
 # The callback receives a PipelineSnapshot and optionally returns a file path string
 SnapshotCallback = Callable[[PipelineSnapshot], str | None]
+
+_INTERNAL_PIPELINE_INPUTS_MARKER = "__haystack_internal_inputs__"
+_NO_OUTPUT_PRODUCED_MARKER = "__haystack_no_output_produced__"
 
 
 def _is_snapshot_save_enabled() -> bool:
@@ -211,10 +216,91 @@ def _save_pipeline_snapshot(
     return str(full_path)
 
 
+def _wrap_pipeline_snapshot_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
+    """
+    Wrap pipeline-internal inputs so snapshot restore can distinguish them from legacy flattened inputs.
+
+    Legacy snapshots stored plain component input values, which are ambiguous with user payloads containing
+    `sender`/`value` keys. The wrapper keeps restore logic explicit and backward-compatible.
+    """
+
+    return {_INTERNAL_PIPELINE_INPUTS_MARKER: True, **_serialize_snapshot_input_values(inputs)}
+
+
+def _serialize_snapshot_input_values(data: Any) -> Any:
+    """
+    Replace non-serializable internal sentinels in pipeline inputs with serializable markers.
+    """
+
+    if isinstance(data, dict):
+        if "sender" in data and "value" in data and data["value"] is _NO_OUTPUT_PRODUCED:
+            return {"sender": data["sender"], "value": {_NO_OUTPUT_PRODUCED_MARKER: True}}
+        return {key: _serialize_snapshot_input_values(value) for key, value in data.items()}
+
+    if isinstance(data, list):
+        return [_serialize_snapshot_input_values(item) for item in data]
+
+    return data
+
+
+def _restore_snapshot_input_values(data: Any) -> Any:
+    """
+    Restore serializable snapshot markers back to the pipeline's internal sentinels.
+    """
+
+    if isinstance(data, dict):
+        if data == {_NO_OUTPUT_PRODUCED_MARKER: True}:
+            return _NO_OUTPUT_PRODUCED
+        return {key: _restore_snapshot_input_values(value) for key, value in data.items()}
+
+    if isinstance(data, list):
+        return [_restore_snapshot_input_values(item) for item in data]
+
+    return data
+
+
+def _pipeline_snapshot_inputs_use_internal_format(serialized_inputs: dict[str, Any]) -> bool:
+    """
+    Check whether snapshot inputs were stored in the sender-preserving internal format.
+    """
+
+    serialized_data = serialized_inputs.get("serialized_data", {})
+    return isinstance(serialized_data, dict) and serialized_data.get(_INTERNAL_PIPELINE_INPUTS_MARKER) is True
+
+
+def _restore_pipeline_snapshot_inputs(serialized_inputs: dict[str, Any]) -> dict[str, Any]:
+    """
+    Restore snapshot inputs to the pipeline-internal `[{sender, value}]` shape.
+
+    New snapshots preserve sender metadata under an explicit wrapper. Legacy snapshots only stored flattened
+    values, so we conservatively re-wrap those as `sender=None` user inputs.
+    """
+
+    deserialized_inputs = _restore_snapshot_input_values(_deserialize_value_with_schema(serialized_inputs))
+    if isinstance(deserialized_inputs, dict) and deserialized_inputs.get(_INTERNAL_PIPELINE_INPUTS_MARKER) is True:
+        return {
+            component_name: socket_dict
+            for component_name, socket_dict in deserialized_inputs.items()
+            if component_name != _INTERNAL_PIPELINE_INPUTS_MARKER
+        }
+
+    restored_inputs: dict[str, Any] = {}
+    for component_name, socket_dict in deserialized_inputs.items():
+        if not isinstance(socket_dict, dict):
+            restored_inputs[component_name] = socket_dict
+            continue
+
+        restored_inputs[component_name] = {
+            socket_name: [{"sender": None, "value": value}] for socket_name, value in socket_dict.items()
+        }
+
+    return restored_inputs
+
+
 def _create_pipeline_snapshot(
     *,
     inputs: dict[str, Any],
-    component_inputs: dict[str, Any],
+    component_snapshot_inputs: dict[str, Any],
     break_point: Breakpoint,
     component_visits: dict[str, int],
     original_input_data: dict[str, Any],
@@ -226,7 +312,7 @@ def _create_pipeline_snapshot(
     Create a snapshot of the pipeline at the point where the breakpoint was triggered.
 
     :param inputs: The current pipeline snapshot inputs.
-    :param component_inputs: The inputs to the component that triggered the breakpoint.
+    :param component_snapshot_inputs: The pre-consume inputs for the component that triggered the breakpoint.
     :param break_point: The breakpoint that triggered the snapshot.
     :param component_visits: The visit count of the component that triggered the breakpoint.
     :param original_input_data: The original input data.
@@ -239,10 +325,10 @@ def _create_pipeline_snapshot(
     component_name = break_point.component_name
 
     transformed_original_input_data = _transform_json_structure(original_input_data)
-    transformed_inputs = _transform_json_structure({**inputs, component_name: component_inputs})
+    snapshot_inputs = _wrap_pipeline_snapshot_inputs({**inputs, component_name: component_snapshot_inputs})
 
     serialized_inputs = _serialize_with_field_fallback(
-        transformed_inputs, description="the inputs of the current pipeline state"
+        snapshot_inputs, description="the inputs of the current pipeline state"
     )
     serialized_original_input_data = _serialize_with_field_fallback(
         transformed_original_input_data, description="original input data for `pipeline.run`"

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -9,7 +9,12 @@ from typing import Any, ClassVar, cast
 
 from haystack import logging, tracing
 from haystack.core.component import Component
-from haystack.core.errors import BreakpointException, PipelineInvalidPipelineSnapshotError, PipelineRuntimeError
+from haystack.core.errors import (
+    BreakpointException,
+    PipelineInvalidPipelineSnapshotError,
+    PipelineMaxComponentRuns,
+    PipelineRuntimeError,
+)
 from haystack.core.pipeline.base import (
     _COMPONENT_INPUT,
     _COMPONENT_OUTPUT,
@@ -21,6 +26,8 @@ from haystack.core.pipeline.base import (
 from haystack.core.pipeline.breakpoint import (
     SnapshotCallback,
     _create_pipeline_snapshot,
+    _pipeline_snapshot_inputs_use_internal_format,
+    _restore_pipeline_snapshot_inputs,
     _save_pipeline_snapshot,
     _validate_break_point_against_pipeline,
     _validate_pipeline_snapshot_against_pipeline,
@@ -347,10 +354,14 @@ class Pipeline(PipelineBase):
             include_outputs_from = set()
 
         pipeline_outputs: dict[str, Any] = {}
+        original_input_data: dict[str, Any]
+        force_legacy_resume_component_name: str | None = None
+        snapshot_inputs_use_internal_format = False
 
         if not pipeline_snapshot:
             # normalize `data`
             data = self._prepare_component_input_data(data)
+            original_input_data = data
 
             # Raise ValueError if input is malformed in some way
             self.validate_input(data)
@@ -369,7 +380,18 @@ class Pipeline(PipelineBase):
             # Handle resuming the pipeline from a snapshot
             component_visits = pipeline_snapshot.pipeline_state.component_visits
             ordered_component_names = pipeline_snapshot.ordered_component_names
-            data = _deserialize_value_with_schema(pipeline_snapshot.pipeline_state.inputs)
+            original_input_data = _deserialize_value_with_schema(pipeline_snapshot.original_input_data)
+            data = original_input_data
+            snapshot_inputs_use_internal_format = _pipeline_snapshot_inputs_use_internal_format(
+                pipeline_snapshot.pipeline_state.inputs
+            )
+            if (
+                not snapshot_inputs_use_internal_format
+                and component_visits[pipeline_snapshot.break_point.component_name] > 0
+            ):
+                # Legacy snapshots lost sender provenance for the paused component, so they can fail the
+                # pre-loop blocked check before resume has a chance to consume the already-paused inputs once.
+                force_legacy_resume_component_name = pipeline_snapshot.break_point.component_name
 
             # include_outputs_from from the snapshot when resuming
             include_outputs_from = pipeline_snapshot.include_outputs_from
@@ -391,14 +413,33 @@ class Pipeline(PipelineBase):
                 "haystack.pipeline.execution_mode": "sync",
             },
         ) as span:
-            inputs = self._convert_to_internal_format(pipeline_inputs=data)
+            if pipeline_snapshot:
+                inputs = _restore_pipeline_snapshot_inputs(pipeline_snapshot.pipeline_state.inputs)
+            else:
+                inputs = self._convert_to_internal_format(pipeline_inputs=data)
             priority_queue = self._fill_queue(ordered_component_names, inputs, component_visits)
 
             # check if pipeline is blocked before execution
-            self.validate_pipeline(priority_queue)
+            if force_legacy_resume_component_name is None:
+                self.validate_pipeline(priority_queue)
 
             while True:
-                candidate = self._get_next_runnable_component(priority_queue, component_visits)
+                candidate: tuple[ComponentPriority, str, dict[str, Any]] | None
+                if force_legacy_resume_component_name is not None:
+                    component_name = force_legacy_resume_component_name
+                    component = self._get_component_with_graph_metadata_and_visits(
+                        component_name, component_visits[component_name]
+                    )
+                    if component["visits"] >= self._max_runs_per_component:
+                        msg = (
+                            f"Maximum run count {self._max_runs_per_component} reached for component '{component_name}'"
+                        )
+                        raise PipelineMaxComponentRuns(msg)
+                    priority = ComponentPriority.READY
+                    force_legacy_resume_component_name = None
+                    candidate = (priority, component_name, component)
+                else:
+                    candidate = self._get_next_runnable_component(priority_queue, component_visits)
 
                 # If there are no runnable components left, we can exit the loop.
                 # In practice this rarely happens because the queue is constantly refilled even with components that
@@ -431,10 +472,11 @@ class Pipeline(PipelineBase):
                         component_name, component_visits[component_name]
                     )
 
-                if pipeline_snapshot:
+                if pipeline_snapshot and not snapshot_inputs_use_internal_format:
                     is_resume = pipeline_snapshot.break_point.component_name == component_name
                 else:
                     is_resume = False
+                component_snapshot_inputs = inputs.get(component_name, {})
                 component_inputs = self._consume_component_inputs(
                     component_name=component_name, component=component, inputs=inputs, is_resume=is_resume
                 )
@@ -443,13 +485,6 @@ class Pipeline(PipelineBase):
                 # might not provide these defaults for components with inputs defined dynamically upon component
                 # initialization
                 component_inputs = self._add_missing_input_defaults(component_inputs, component["input_sockets"])
-
-                # Scenario 1: Pipeline snapshot is provided to resume the pipeline at a specific component
-                # Deserialize the component_inputs if they are passed in the pipeline_snapshot.
-                # this check will prevent other component_inputs generated at runtime from being deserialized
-                if pipeline_snapshot and component_name in pipeline_snapshot.pipeline_state.inputs.keys():
-                    for key, value in component_inputs.items():
-                        component_inputs[key] = _deserialize_value_with_schema(value)
 
                 try:
                     component_outputs = self._run_component(
@@ -474,10 +509,10 @@ class Pipeline(PipelineBase):
                     # Create a snapshot of the state of the pipeline before the error occurred.
                     pipeline_snapshot = _create_pipeline_snapshot(
                         inputs=_deepcopy_with_exceptions(inputs),
-                        component_inputs=_deepcopy_with_exceptions(component_inputs),
+                        component_snapshot_inputs=_deepcopy_with_exceptions(component_snapshot_inputs),
                         break_point=saved_break_point,
                         component_visits=component_visits,
-                        original_input_data=data,
+                        original_input_data=original_input_data,
                         ordered_component_names=ordered_component_names,
                         include_outputs_from=include_outputs_from,
                         pipeline_outputs=pipeline_outputs,
@@ -492,6 +527,11 @@ class Pipeline(PipelineBase):
                     )
                     error.pipeline_snapshot_file_path = full_file_path
                     raise error
+
+                if is_resume:
+                    # Resume-specific input handling only applies to the first resumed execution of the
+                    # breakpoint component. Later loop visits must use the normal consume path.
+                    pipeline_snapshot = None
 
                 # Updates global input state with component outputs and returns outputs that should go to
                 # pipeline outputs.

--- a/releasenotes/notes/pipeline-snapshot-resume-10c030aa144175d1.yaml
+++ b/releasenotes/notes/pipeline-snapshot-resume-10c030aa144175d1.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed pipeline snapshot resume for breakpoints hit after the first visit of
+    a looping component. Resumed pipelines now preserve the internal input
+    metadata needed to continue the paused component correctly, and they stop
+    applying resume-only input handling after that component has resumed.
+    Older snapshots remain supported on a best-effort basis, but they may still
+    be limited by missing provenance data in the original snapshot format.

--- a/test/core/pipeline/test_breakpoint.py
+++ b/test/core/pipeline/test_breakpoint.py
@@ -8,21 +8,23 @@ import logging
 import pytest
 
 from haystack import component
+from haystack.components.joiners import BranchJoiner
 from haystack.core.errors import BreakpointException, PipelineInvalidPipelineSnapshotError
 from haystack.core.pipeline import Pipeline
 from haystack.core.pipeline.breakpoint import (
     HAYSTACK_PIPELINE_SNAPSHOT_SAVE_ENABLED,
     _create_pipeline_snapshot,
     _is_snapshot_save_enabled,
+    _restore_pipeline_snapshot_inputs,
     _save_pipeline_snapshot,
     _transform_json_structure,
     load_pipeline_snapshot,
 )
+from haystack.core.pipeline.component_checks import _NO_OUTPUT_PRODUCED
 from haystack.dataclasses import ChatMessage
 from haystack.dataclasses.breakpoints import Breakpoint, PipelineSnapshot, PipelineState
 from haystack.utils import _deserialize_value_with_schema
-
-_EMPTY_OBJECT_PAYLOAD = {"serialization_schema": {"type": "object", "properties": {}}, "serialized_data": {}}
+from haystack.utils.base_serialization import _serialize_with_field_fallback
 
 
 def test_transform_json_structure_unwraps_sender_value():
@@ -80,6 +82,26 @@ def test_load_state_handles_invalid_state(tmp_path):
 
     with pytest.raises(ValueError, match="Invalid pipeline snapshot from"):
         load_pipeline_snapshot(pipeline_snapshot_file)
+
+
+def test_restore_pipeline_snapshot_inputs_wraps_legacy_flattened_inputs():
+    legacy_inputs = {
+        "serialization_schema": {
+            "type": "object",
+            "properties": {
+                "comp1": {"type": "object", "properties": {"input_value": {"type": "string"}}},
+                "comp2": {"type": "object", "properties": {"values": {"type": "array", "items": {"type": "integer"}}}},
+            },
+        },
+        "serialized_data": {"comp1": {"input_value": "test"}, "comp2": {"values": [1, 2]}},
+    }
+
+    restored_inputs = _restore_pipeline_snapshot_inputs(legacy_inputs)
+
+    assert restored_inputs == {
+        "comp1": {"input_value": [{"sender": None, "value": "test"}]},
+        "comp2": {"values": [{"sender": None, "value": [1, 2]}]},
+    }
 
 
 def test_breakpoint_saves_intermediate_outputs(tmp_path, monkeypatch):
@@ -152,6 +174,24 @@ def _three_component_pipeline() -> Pipeline:
     return pipeline
 
 
+@component
+class _LoopOrDone:
+    @component.output_types(retry=str, done=str)
+    def run(self, value: str) -> dict[str, str]:
+        if value == "start":
+            return {"retry": "start-retry"}
+        return {"done": value}
+
+
+def _branch_joiner_loop_pipeline() -> Pipeline:
+    pipeline = Pipeline(max_runs_per_component=5)
+    pipeline.add_component("joiner", BranchJoiner(str))
+    pipeline.add_component("loop", _LoopOrDone())
+    pipeline.connect("joiner.value", "loop.value")
+    pipeline.connect("loop.retry", "joiner.value")
+    return pipeline
+
+
 def test_break_point_with_pipeline_snapshot_steps_through_pipeline():
     pipeline = _three_component_pipeline()
 
@@ -198,6 +238,101 @@ def test_break_point_matching_pipeline_snapshot_break_point_raises():
         pipeline.run(data={}, pipeline_snapshot=snapshot, break_point=Breakpoint(component_name="comp2", visit_count=0))
 
 
+def test_break_point_with_pipeline_snapshot_resumes_mid_loop_visit():
+    pipeline = _branch_joiner_loop_pipeline()
+
+    with pytest.raises(BreakpointException) as exc_info:
+        pipeline.run(
+            data={"joiner": {"value": "start"}}, break_point=Breakpoint(component_name="joiner", visit_count=1)
+        )
+    snapshot = exc_info.value.pipeline_snapshot
+    assert snapshot is not None
+    assert snapshot.pipeline_state.component_visits == {"joiner": 1, "loop": 1}
+    assert _restore_pipeline_snapshot_inputs(snapshot.pipeline_state.inputs)["joiner"] == {
+        "value": [{"sender": "loop", "value": "start-retry"}]
+    }
+
+    result = pipeline.run(data={}, pipeline_snapshot=snapshot)
+    assert result["loop"]["done"] == "start-retry"
+
+
+def test_legacy_pipeline_snapshot_resumes_mid_loop_visit():
+    pipeline = _branch_joiner_loop_pipeline()
+
+    with pytest.raises(BreakpointException) as exc_info:
+        pipeline.run(
+            data={"joiner": {"value": "start"}}, break_point=Breakpoint(component_name="joiner", visit_count=1)
+        )
+    snapshot = exc_info.value.pipeline_snapshot
+    assert snapshot is not None
+
+    legacy_snapshot = PipelineSnapshot(
+        pipeline_state=PipelineState(
+            inputs=_serialize_with_field_fallback(
+                {"joiner": {"value": ["start-retry"]}, "loop": {}}, description="legacy pipeline snapshot inputs"
+            ),
+            component_visits=snapshot.pipeline_state.component_visits,
+            pipeline_outputs=snapshot.pipeline_state.pipeline_outputs,
+        ),
+        timestamp=snapshot.timestamp,
+        break_point=snapshot.break_point,
+        original_input_data=snapshot.original_input_data,
+        ordered_component_names=snapshot.ordered_component_names,
+        include_outputs_from=snapshot.include_outputs_from,
+    )
+
+    result = pipeline.run(data={}, pipeline_snapshot=legacy_snapshot)
+    assert result["loop"]["done"] == "start-retry"
+
+
+def test_break_point_resume_only_uses_resume_mode_once():
+    pipeline = _branch_joiner_loop_pipeline()
+
+    with pytest.raises(BreakpointException) as exc_info:
+        pipeline.run(
+            data={"joiner": {"value": "start"}}, break_point=Breakpoint(component_name="joiner", visit_count=0)
+        )
+    snapshot = exc_info.value.pipeline_snapshot
+    assert snapshot is not None
+
+    result = pipeline.run(data={}, pipeline_snapshot=snapshot)
+    assert result["loop"]["done"] == "start-retry"
+
+
+def test_break_point_with_pipeline_snapshot_preserves_no_output_sentinels():
+    @component
+    class Router:
+        @component.output_types(path1=str, path2=str)
+        def run(self, value: str) -> dict[str, str]:
+            return {"path2": value}
+
+    @component
+    class Sink:
+        @component.output_types(result=str)
+        def run(self, mandatory: str, optional: str | None = None) -> dict[str, str]:
+            return {"result": f"{mandatory}-{optional}"}
+
+    pipeline = Pipeline()
+    pipeline.add_component("router", Router())
+    pipeline.add_component("sink", Sink())
+    pipeline.connect("router.path1", "sink.optional")
+
+    with pytest.raises(BreakpointException) as exc_info:
+        pipeline.run(
+            data={"router": {"value": "hello"}, "sink": {"mandatory": "world"}},
+            break_point=Breakpoint(component_name="sink", visit_count=0),
+        )
+    snapshot = exc_info.value.pipeline_snapshot
+    assert snapshot is not None
+    assert _restore_pipeline_snapshot_inputs(snapshot.pipeline_state.inputs)["sink"] == {
+        "mandatory": [{"sender": None, "value": "world"}],
+        "optional": [{"sender": "router", "value": _NO_OUTPUT_PRODUCED}],
+    }
+
+    result = pipeline.run(data={}, pipeline_snapshot=snapshot)
+    assert result == {"router": {"path2": "hello"}, "sink": {"result": "world-None"}}
+
+
 class TestCreatePipelineSnapshot:
     def test_create_pipeline_snapshot_all_fields(self):
         break_point = Breakpoint(component_name="comp2")
@@ -206,7 +341,7 @@ class TestCreatePipelineSnapshot:
 
         snapshot = _create_pipeline_snapshot(
             inputs={"comp1": {"input_value": [{"sender": None, "value": "test"}]}, "comp2": {}},
-            component_inputs={"input_value": "processed_test"},
+            component_snapshot_inputs={"input_value": [{"sender": "comp1", "value": "processed_test"}]},
             break_point=break_point,
             component_visits={"comp1": 1, "comp2": 0},
             original_input_data={"comp1": {"input_value": "test"}},
@@ -225,31 +360,24 @@ class TestCreatePipelineSnapshot:
         assert snapshot.ordered_component_names == ordered_component_names
         assert snapshot.break_point == break_point
         assert snapshot.include_outputs_from == include_outputs_from
-        assert snapshot.pipeline_state == PipelineState(
-            inputs={
-                "serialization_schema": {
-                    "type": "object",
-                    "properties": {
-                        "comp1": {"type": "object", "properties": {"input_value": {"type": "string"}}},
-                        "comp2": {"type": "object", "properties": {"input_value": {"type": "string"}}},
-                    },
-                },
-                "serialized_data": {"comp1": {"input_value": "test"}, "comp2": {"input_value": "processed_test"}},
+        assert snapshot.pipeline_state.inputs["serialized_data"]["__haystack_internal_inputs__"] is True
+        assert _restore_pipeline_snapshot_inputs(snapshot.pipeline_state.inputs) == {
+            "comp1": {"input_value": [{"sender": None, "value": "test"}]},
+            "comp2": {"input_value": [{"sender": "comp1", "value": "processed_test"}]},
+        }
+        assert snapshot.pipeline_state.component_visits == {"comp1": 1, "comp2": 0}
+        assert snapshot.pipeline_state.pipeline_outputs == {
+            "serialization_schema": {
+                "type": "object",
+                "properties": {"comp1": {"type": "object", "properties": {"result": {"type": "string"}}}},
             },
-            component_visits={"comp1": 1, "comp2": 0},
-            pipeline_outputs={
-                "serialization_schema": {
-                    "type": "object",
-                    "properties": {"comp1": {"type": "object", "properties": {"result": {"type": "string"}}}},
-                },
-                "serialized_data": {"comp1": {"result": "processed_test"}},
-            },
-        )
+            "serialized_data": {"comp1": {"result": "processed_test"}},
+        }
 
     def test_create_pipeline_snapshot_with_dataclasses_in_pipeline_outputs(self):
         snapshot = _create_pipeline_snapshot(
             inputs={},
-            component_inputs={},
+            component_snapshot_inputs={},
             break_point=Breakpoint(component_name="comp2"),
             component_visits={"comp1": 1, "comp2": 0},
             original_input_data={},
@@ -258,30 +386,22 @@ class TestCreatePipelineSnapshot:
             pipeline_outputs={"comp1": {"result": ChatMessage.from_user("hello")}},
         )
 
-        assert snapshot.pipeline_state == PipelineState(
-            inputs={
-                "serialization_schema": {
-                    "type": "object",
-                    "properties": {"comp2": {"type": "object", "properties": {}}},
-                },
-                "serialized_data": {"comp2": {}},
-            },
-            component_visits={"comp1": 1, "comp2": 0},
-            pipeline_outputs={
-                "serialization_schema": {
-                    "type": "object",
-                    "properties": {
-                        "comp1": {
-                            "type": "object",
-                            "properties": {"result": {"type": "haystack.dataclasses.chat_message.ChatMessage"}},
-                        }
-                    },
-                },
-                "serialized_data": {
-                    "comp1": {"result": {"role": "user", "meta": {}, "name": None, "content": [{"text": "hello"}]}}
+        assert _restore_pipeline_snapshot_inputs(snapshot.pipeline_state.inputs) == {"comp2": {}}
+        assert snapshot.pipeline_state.component_visits == {"comp1": 1, "comp2": 0}
+        assert snapshot.pipeline_state.pipeline_outputs == {
+            "serialization_schema": {
+                "type": "object",
+                "properties": {
+                    "comp1": {
+                        "type": "object",
+                        "properties": {"result": {"type": "haystack.dataclasses.chat_message.ChatMessage"}},
+                    }
                 },
             },
-        )
+            "serialized_data": {
+                "comp1": {"result": {"role": "user", "meta": {}, "name": None, "content": [{"text": "hello"}]}}
+            },
+        }
 
     def test_create_pipeline_snapshot_non_serializable_inputs(self, caplog):
         class NonSerializable:
@@ -291,7 +411,7 @@ class TestCreatePipelineSnapshot:
         with caplog.at_level(logging.WARNING):
             _create_pipeline_snapshot(
                 inputs={"comp1": {"input_value": [{"sender": None, "value": NonSerializable()}]}, "comp2": {}},
-                component_inputs={},
+                component_snapshot_inputs={},
                 break_point=Breakpoint(component_name="comp2"),
                 component_visits={"comp1": 1, "comp2": 0},
                 original_input_data={"comp1": {"input_value": NonSerializable()}},
@@ -321,7 +441,7 @@ class TestCreatePipelineSnapshot:
                     "comp1": {"input_value": [{"sender": None, "value": NonSerializable()}]},
                     "comp2": {"input_value": [{"sender": None, "value": "keep me"}]},
                 },
-                component_inputs={},
+                component_snapshot_inputs={},
                 break_point=Breakpoint(component_name="comp3"),
                 component_visits={"comp1": 1, "comp2": 1, "comp3": 0},
                 original_input_data={"comp1": {"input_value": NonSerializable()}},
@@ -331,13 +451,13 @@ class TestCreatePipelineSnapshot:
             )
 
         # No DeserializationError on any of the three pipeline-level payloads.
-        deserialized_inputs = _deserialize_value_with_schema(snapshot.pipeline_state.inputs)
+        deserialized_inputs = _restore_pipeline_snapshot_inputs(snapshot.pipeline_state.inputs)
         deserialized_original_input_data = _deserialize_value_with_schema(snapshot.original_input_data)
         deserialized_outputs = _deserialize_value_with_schema(snapshot.pipeline_state.pipeline_outputs)
 
         # The non-serializable comp1 field is omitted while the serializable siblings are preserved.
         assert "comp1" not in deserialized_inputs
-        assert deserialized_inputs["comp2"] == {"input_value": "keep me"}
+        assert deserialized_inputs["comp2"] == {"input_value": [{"sender": None, "value": "keep me"}]}
         assert deserialized_inputs["comp3"] == {}
         # original_input_data and pipeline_outputs degrade to empty-but-valid payloads.
         assert deserialized_original_input_data == {}
@@ -357,7 +477,7 @@ def test_save_pipeline_snapshot_raises_on_failure(tmp_path, caplog, monkeypatch)
 
     snapshot = _create_pipeline_snapshot(
         inputs={},
-        component_inputs={},
+        component_snapshot_inputs={},
         break_point=Breakpoint(component_name="comp2", snapshot_file_path=str(snapshot_path)),
         component_visits={"comp1": 1, "comp2": 0},
         original_input_data={},
@@ -384,7 +504,7 @@ class TestSnapshotCallback:
 
         snapshot = _create_pipeline_snapshot(
             inputs={},
-            component_inputs={},
+            component_snapshot_inputs={},
             break_point=Breakpoint(component_name="comp2", snapshot_file_path=str(tmp_path)),
             component_visits={"comp1": 1, "comp2": 0},
             original_input_data={},
@@ -411,7 +531,7 @@ class TestSnapshotCallback:
 
         snapshot = _create_pipeline_snapshot(
             inputs={},
-            component_inputs={},
+            component_snapshot_inputs={},
             break_point=Breakpoint(component_name="comp2", snapshot_file_path=str(tmp_path)),
             component_visits={"comp1": 1, "comp2": 0},
             original_input_data={},
@@ -433,7 +553,7 @@ class TestSnapshotCallback:
 
         snapshot = _create_pipeline_snapshot(
             inputs={},
-            component_inputs={},
+            component_snapshot_inputs={},
             break_point=Breakpoint(component_name="comp2", snapshot_file_path=str(tmp_path)),
             component_visits={"comp1": 1, "comp2": 0},
             original_input_data={},
@@ -462,7 +582,7 @@ class TestSnapshotCallback:
 
         snapshot = _create_pipeline_snapshot(
             inputs={},
-            component_inputs={},
+            component_snapshot_inputs={},
             break_point=Breakpoint(component_name="comp2", snapshot_file_path=str(tmp_path)),
             component_visits={"comp1": 1, "comp2": 0},
             original_input_data={},
@@ -571,7 +691,7 @@ class TestSnapshotSaveEnabled:
 
         snapshot = _create_pipeline_snapshot(
             inputs={},
-            component_inputs={},
+            component_snapshot_inputs={},
             break_point=Breakpoint(component_name="comp2", snapshot_file_path=str(tmp_path)),
             component_visits={"comp1": 1, "comp2": 0},
             original_input_data={},
@@ -591,7 +711,7 @@ class TestSnapshotSaveEnabled:
 
         snapshot = _create_pipeline_snapshot(
             inputs={},
-            component_inputs={},
+            component_snapshot_inputs={},
             break_point=Breakpoint(component_name="comp2", snapshot_file_path=str(tmp_path)),
             component_visits={"comp1": 1, "comp2": 0},
             original_input_data={},
@@ -622,7 +742,7 @@ class TestSnapshotSaveEnabled:
 
         snapshot = _create_pipeline_snapshot(
             inputs={},
-            component_inputs={},
+            component_snapshot_inputs={},
             break_point=Breakpoint(component_name="comp2", snapshot_file_path=str(tmp_path)),
             component_visits={"comp1": 1, "comp2": 0},
             original_input_data={},


### PR DESCRIPTION
### Related Issues

- fixes #12145

### Proposed Changes:

Resuming a pipeline snapshot could fail when the breakpoint hit a component on its second visit (or later) in a loop. The root cause was that the snapshot lost the input provenance needed to know that the paused component should run again.

This PR preserves that provenance in new snapshots, keeps a best-effort compatibility path for older snapshots, and fixes the optional-socket sentinel case so resume does not silently drop paused inputs.

### How did you test it?

- `hatch run test:unit test/core/pipeline`
- `hatch run test:integration test/core/pipeline/breakpoints`
- `hatch run test:types`
- `hatch run fmt haystack/core/pipeline/breakpoint.py haystack/core/pipeline/pipeline.py test/core/pipeline/test_breakpoint.py`
- Reproduced the original blocked-resume case and the optional-socket regression locally

### Notes for the reviewer

- Suggested review order:
  1. `haystack/core/pipeline/breakpoint.py`
  2. `haystack/core/pipeline/pipeline.py`
  3. `test/core/pipeline/test_breakpoint.py`

- If you only look at one test first, please start with `test_break_point_with_pipeline_snapshot_resumes_mid_loop_visit`, because it captures the core failure this PR fixes.

- The main cases covered by tests are:
  - new-format mid-loop resume
  - legacy snapshot compatibility
  - one-shot legacy resume behavior
  - optional socket / `_NO_OUTPUT_PRODUCED` handling

- One intentional tradeoff: raw saved snapshot inputs are now more internal-looking because they preserve sender metadata needed for correct resume behavior.

- Legacy snapshots are supported on a best-effort basis; older files may still be limited by missing provenance in the original snapshot format.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
