### PR TITLE
fix: preserve explicit runtime retriever overrides

### DIFF
--- a/haystack/components/retrievers/filter_retriever.py
+++ b/haystack/components/retrievers/filter_retriever.py
@@ -29,7 +29,8 @@ class FilterRetriever:
     doc_store.write_documents(docs)
     retriever = FilterRetriever(doc_store, filters={"field": "lang", "operator": "==", "value": "en"})
 
-    # if passed in the run method, filters override those provided at initialization
+    # If passed in the run method, filters override those provided at initialization.
+    # Passing an empty dictionary explicitly clears the initialization filters.
     result = retriever.run(filters={"field": "lang", "operator": "==", "value": "de"})
 
     print(result["documents"])
@@ -44,6 +45,7 @@ class FilterRetriever:
             An instance of a Document Store to use with the Retriever.
         :param filters:
             A dictionary with filters to narrow down the search space.
+            Passing an empty dictionary explicitly clears filters provided at initialization.
         """
         self.document_store = document_store
         self.filters = filters
@@ -82,11 +84,12 @@ class FilterRetriever:
 
         :param filters:
             A dictionary with filters to narrow down the search space.
+            Passing an empty dictionary explicitly clears filters provided at initialization.
             If not specified, the FilterRetriever uses the values provided at initialization.
         :returns:
             A list of retrieved documents.
         """
-        return {"documents": self.document_store.filter_documents(filters=filters or self.filters)}
+        return {"documents": self.document_store.filter_documents(filters=self.filters if filters is None else filters)}
 
     @component.output_types(documents=list[Document])
     async def run_async(self, filters: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -100,7 +103,9 @@ class FilterRetriever:
             A list of retrieved documents.
         """
         # 'ignore' since filter_documents_async is not defined in the Protocol but exists in the implementations
-        out_documents = await self.document_store.filter_documents_async(filters=filters or self.filters)  # type: ignore[attr-defined]
+        out_documents = await self.document_store.filter_documents_async(  # type: ignore[attr-defined]
+            filters=self.filters if filters is None else filters
+        )
         return {"documents": out_documents}
 
     def close(self) -> None:

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -104,8 +104,7 @@ class SentenceWindowRetriever:
             metadata fields. If False, it will skip retrieving the context for documents that are missing
             the required metadata fields, but will still include the original document in the results.
         """
-        if window_size < 1:
-            raise ValueError("The window_size parameter must be greater than 0.")
+        self._validate_window_size(window_size)
 
         self.window_size = window_size
         self.document_store = document_store
@@ -197,8 +196,8 @@ class SentenceWindowRetriever:
                                       meta field.
 
         """
-        window_size = window_size or self.window_size
-        SentenceWindowRetriever._raise_if_windows_size_is_negative(window_size)
+        window_size = self.window_size if window_size is None else window_size
+        self._validate_window_size(window_size)
         self._raise_if_documents_do_not_have_expected_metadata(retrieved_documents)
 
         context_text = []
@@ -230,8 +229,8 @@ class SentenceWindowRetriever:
                                       meta field.
 
         """
-        window_size = window_size or self.window_size
-        SentenceWindowRetriever._raise_if_windows_size_is_negative(window_size)
+        window_size = self.window_size if window_size is None else window_size
+        self._validate_window_size(window_size)
         self._raise_if_documents_do_not_have_expected_metadata(retrieved_documents)
 
         context_text = []
@@ -244,7 +243,7 @@ class SentenceWindowRetriever:
         return {"context_windows": context_text, "context_documents": context_documents}
 
     @staticmethod
-    def _raise_if_windows_size_is_negative(window_size: int) -> None:
+    def _validate_window_size(window_size: int) -> None:
         if window_size < 1:
             raise ValueError("The window_size parameter must be greater than 0.")
 

--- a/releasenotes/notes/fix-runtime-empty-retriever-overrides.yaml
+++ b/releasenotes/notes/fix-runtime-empty-retriever-overrides.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    FilterRetriever now treats an explicitly provided empty runtime filter as an override
+    of initialization filters in both synchronous and asynchronous execution.

--- a/releasenotes/notes/fix-sentence-window-runtime-window-size-zero.yaml
+++ b/releasenotes/notes/fix-sentence-window-runtime-window-size-zero.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    SentenceWindowRetriever now validates an explicitly provided runtime `window_size=0`
+    SentenceWindowRetriever now validates an explicitly provided runtime ``window_size=0``
     instead of silently falling back to the constructor value.

--- a/releasenotes/notes/fix-sentence-window-runtime-window-size-zero.yaml
+++ b/releasenotes/notes/fix-sentence-window-runtime-window-size-zero.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    SentenceWindowRetriever now validates an explicitly provided runtime `window_size=0`
+    instead of silently falling back to the constructor value.

--- a/test/components/retrievers/test_filter_retriever.py
+++ b/test/components/retrievers/test_filter_retriever.py
@@ -122,6 +122,13 @@ class TestFilterRetriever:
         assert len(result["documents"]) == 2
         assert TestFilterRetriever._documents_equal(result["documents"], sample_docs["de_docs"])
 
+    def test_retriever_runtime_empty_filter_clears_init_filter(self, sample_document_store, sample_docs):
+        retriever = FilterRetriever(sample_document_store, filters={"field": "lang", "operator": "==", "value": "en"})
+        result = retriever.run(filters={})
+
+        assert len(result["documents"]) == len(sample_docs["all_docs"])
+        assert TestFilterRetriever._documents_equal(result["documents"], sample_docs["all_docs"])
+
     @pytest.mark.integration
     def test_run_with_pipeline(self, sample_document_store, sample_docs):
         retriever = FilterRetriever(sample_document_store, filters={"field": "lang", "operator": "==", "value": "de"})
@@ -145,6 +152,12 @@ class TestFilterRetriever:
         results_docs = result["retriever"]["documents"]
         assert results_docs
         assert TestFilterRetriever._documents_equal(results_docs, sample_docs["en_docs"])
+
+        result: dict[str, Any] = pipeline.run(data={"retriever": {"filters": {}}})
+
+        results_docs = result["retriever"]["documents"]
+        assert len(results_docs) == len(sample_docs["all_docs"])
+        assert TestFilterRetriever._documents_equal(results_docs, sample_docs["all_docs"])
 
     def test_close(self):
         closable_document_store = Mock(spec=["close"])

--- a/test/components/retrievers/test_filter_retriever_async.py
+++ b/test/components/retrievers/test_filter_retriever_async.py
@@ -72,6 +72,14 @@ class TestFilterRetrieverAsync:
         assert TestFilterRetrieverAsync._documents_equal(result["documents"], sample_docs["de_docs"])
 
     @pytest.mark.asyncio
+    async def test_retriever_runtime_empty_filter_clears_init_filter(self, sample_document_store, sample_docs):
+        retriever = FilterRetriever(sample_document_store, filters={"field": "lang", "operator": "==", "value": "en"})
+        result = await retriever.run_async(filters={})
+
+        assert len(result["documents"]) == len(sample_docs["all_docs"])
+        assert TestFilterRetrieverAsync._documents_equal(result["documents"], sample_docs["all_docs"])
+
+    @pytest.mark.asyncio
     @pytest.mark.integration
     async def test_run_with_pipeline(self, sample_document_store, sample_docs):
         retriever = FilterRetriever(sample_document_store, filters={"field": "lang", "operator": "==", "value": "de"})
@@ -95,6 +103,12 @@ class TestFilterRetrieverAsync:
         results_docs = result["retriever"]["documents"]
         assert results_docs
         assert TestFilterRetrieverAsync._documents_equal(results_docs, sample_docs["en_docs"])
+
+        result: dict[str, Any] = await pipeline.run_async(data={"retriever": {"filters": {}}})
+
+        results_docs = result["retriever"]["documents"]
+        assert len(results_docs) == len(sample_docs["all_docs"])
+        assert TestFilterRetrieverAsync._documents_equal(results_docs, sample_docs["all_docs"])
 
     @pytest.mark.asyncio
     async def test_close_async(self):

--- a/test/components/retrievers/test_sentence_window_retriever.py
+++ b/test/components/retrievers/test_sentence_window_retriever.py
@@ -24,7 +24,7 @@ class TestSentenceWindowRetriever:
         retriever = SentenceWindowRetriever(in_memory_doc_store, window_size=5)
         assert retriever.window_size == 5
 
-    def test_init_with_invalid_window_size_parameter(self, in_memory_doc_store):
+    def test_init_invalid_window_size(self, in_memory_doc_store):
         with pytest.raises(ValueError):
             SentenceWindowRetriever(in_memory_doc_store, window_size=-2)
 
@@ -174,11 +174,20 @@ class TestSentenceWindowRetriever:
             )
             retriever.run(retrieved_documents=docs)
 
-    def test_run_invalid_window_size(self, in_memory_doc_store):
+    def test_init_rejects_zero_window_size(self, in_memory_doc_store):
         docs = [Document(content="This is a text with some words. There is a ", meta={"id": "doc_0", "split_id": 0})]
         with pytest.raises(ValueError):
             retriever = SentenceWindowRetriever(document_store=in_memory_doc_store, window_size=0)
             retriever.run(retrieved_documents=docs)
+
+    def test_run_rejects_zero_runtime_window_size(self, in_memory_doc_store):
+        retriever = SentenceWindowRetriever(document_store=in_memory_doc_store, window_size=3)
+
+        with pytest.raises(ValueError, match="window_size parameter must be greater than 0"):
+            retriever.run(retrieved_documents=[], window_size=0)
+
+        with pytest.raises(ValueError, match="window_size parameter must be greater than 0"):
+            retriever.run(retrieved_documents=[], window_size=-1)
 
     def test_constructor_parameter_does_not_change(self, in_memory_doc_store):
         retriever = SentenceWindowRetriever(in_memory_doc_store, window_size=5)

--- a/test/components/retrievers/test_sentence_window_retriever_async.py
+++ b/test/components/retrievers/test_sentence_window_retriever_async.py
@@ -15,6 +15,7 @@ from haystack.components.retrievers.sentence_window_retriever import SentenceWin
 
 
 class TestSentenceWindowRetrieverAsync:
+    @pytest.mark.asyncio
     async def test_document_without_split_id(self, in_memory_doc_store):
         docs = [
             Document(content="This is a text with some words. There is a ", meta={"id": "doc_0"}),
@@ -67,6 +68,16 @@ class TestSentenceWindowRetrieverAsync:
         with pytest.raises(ValueError):
             retriever = SentenceWindowRetriever(document_store=in_memory_doc_store, window_size=0)
             await retriever.run_async(retrieved_documents=docs)
+
+    @pytest.mark.asyncio
+    async def test_run_async_rejects_zero_runtime_window_size(self, in_memory_doc_store):
+        retriever = SentenceWindowRetriever(document_store=in_memory_doc_store, window_size=3)
+
+        with pytest.raises(ValueError, match="window_size parameter must be greater than 0"):
+            await retriever.run_async(retrieved_documents=[], window_size=0)
+
+        with pytest.raises(ValueError, match="window_size parameter must be greater than 0"):
+            await retriever.run_async(retrieved_documents=[], window_size=-1)
 
     @pytest.mark.asyncio
     async def test_constructor_parameter_does_not_change(self, in_memory_doc_store):


### PR DESCRIPTION
## Summary

- Preserve an explicitly provided empty ilters={} in FilterRetriever, including synchronous, asynchronous, and Pipeline execution.
- Validate runtime window_size values in SentenceWindowRetriever consistently across constructor, sync, and async paths.
- Add regression tests and release notes.

## Tests

- python -m py_compile passed for all changed Python files.
- Hatch/pytest were not run in the available environment: Hatch is not installed and the available Python is 3.8.6, below Haystack's supported range.
