### PR TITLE
feat: add closing methods to components that hold Document Stores

### DIFF
--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -121,3 +121,17 @@ class CacheChecker:
             else:
                 misses.append(item)
         return {"hits": found_documents, "misses": misses}
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        if hasattr(self.document_store, "close"):
+            self.document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        if hasattr(self.document_store, "close_async"):
+            await self.document_store.close_async()

--- a/haystack/components/retrievers/auto_merging_retriever.py
+++ b/haystack/components/retrievers/auto_merging_retriever.py
@@ -224,3 +224,17 @@ class AutoMergingRetriever:
             return await _try_merge_level(merged_docs, docs_to_return)
 
         return {"documents": await _try_merge_level(documents, [])}
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        if hasattr(self.document_store, "close"):
+            self.document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        if hasattr(self.document_store, "close_async"):
+            await self.document_store.close_async()

--- a/haystack/components/retrievers/filter_retriever.py
+++ b/haystack/components/retrievers/filter_retriever.py
@@ -102,3 +102,17 @@ class FilterRetriever:
         # 'ignore' since filter_documents_async is not defined in the Protocol but exists in the implementations
         out_documents = await self.document_store.filter_documents_async(filters=filters or self.filters)  # type: ignore[attr-defined]
         return {"documents": out_documents}
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        if hasattr(self.document_store, "close"):
+            self.document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        if hasattr(self.document_store, "close_async"):
+            await self.document_store.close_async()

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -319,3 +319,17 @@ class SentenceWindowRetriever:
             *source_id_filters,
         ]
         return {"operator": "AND", "conditions": conditions}
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        if hasattr(self.document_store, "close"):
+            self.document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        if hasattr(self.document_store, "close_async"):
+            await self.document_store.close_async()

--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -125,3 +125,17 @@ class DocumentWriter:
 
         documents_written = await self.document_store.write_documents_async(documents=documents, policy=policy)
         return {"documents_written": documents_written}
+
+    def close(self) -> None:
+        """
+        Release the synchronous resources of the underlying Document Store.
+        """
+        if hasattr(self.document_store, "close"):
+            self.document_store.close()
+
+    async def close_async(self) -> None:
+        """
+        Release the asynchronous resources of the underlying Document Store.
+        """
+        if hasattr(self.document_store, "close_async"):
+            await self.document_store.close_async()

--- a/releasenotes/notes/closing-methods-for-ds-holding-comps-e2dcfc4e5afddd0f.yaml
+++ b/releasenotes/notes/closing-methods-for-ds-holding-comps-e2dcfc4e5afddd0f.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Haystack components that use a document store now provide ``close`` and ``close_async`` methods for releasing
+    resources. These methods are available on: ``AutoMergingRetriever``, ``CacheChecker``, ``DocumentWriter``,
+    ``FilterRetriever``, and ``SentenceWindowRetriever``. If the underlying Document Store does not implement the
+    corresponding method, calling ``close`` or ``close_async`` has no effect.

--- a/test/components/caching/test_cache_checker.py
+++ b/test/components/caching/test_cache_checker.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -92,3 +92,14 @@ class TestCacheChecker:
         checker.run(items=["https://example.com/1"])
         valid_filters_syntax = {"field": "url", "operator": "==", "value": "https://example.com/1"}
         mocked_docstore_class.filter_documents.assert_any_call(filters=valid_filters_syntax)
+
+    def test_close(self):
+        closable_document_store = Mock(spec=["close"])
+        checker = CacheChecker(document_store=closable_document_store, cache_field="url")
+        checker.close()
+        closable_document_store.close.assert_called_once_with()
+
+        nonclosable_document_store = Mock(spec=[])
+        checker = CacheChecker(document_store=nonclosable_document_store, cache_field="url")
+        checker.close()
+        assert nonclosable_document_store.mock_calls == []

--- a/test/components/caching/test_cache_checker_async.py
+++ b/test/components/caching/test_cache_checker_async.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
@@ -60,3 +60,16 @@ class TestCacheCheckerAsync:
         await checker.run_async(items=["https://example.com/1"])
         expected_filters = {"field": "url", "operator": "==", "value": "https://example.com/1"}
         mock_store.filter_documents_async.assert_awaited_once_with(filters=expected_filters)
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        closable_document_store = Mock(spec=["close_async"])
+        closable_document_store.close_async = AsyncMock()
+        checker = CacheChecker(document_store=closable_document_store, cache_field="url")
+        await checker.close_async()
+        closable_document_store.close_async.assert_awaited_once_with()
+
+        nonclosable_document_store = Mock(spec=[])
+        checker = CacheChecker(document_store=nonclosable_document_store, cache_field="url")
+        await checker.close_async()
+        assert nonclosable_document_store.mock_calls == []

--- a/test/components/retrievers/test_auto_merging_retriever.py
+++ b/test/components/retrievers/test_auto_merging_retriever.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import Mock
+
 import pytest
 
 from haystack import Document, Pipeline
@@ -252,3 +254,14 @@ class TestAutoMergingRetriever:
 
         assert len(result["documents"]) == 1
         assert result["documents"][0].meta["__level"] == 0  # hit root document
+
+    def test_close(self):
+        closable_document_store = Mock(spec=["close"])
+        retriever = AutoMergingRetriever(document_store=closable_document_store)
+        retriever.close()
+        closable_document_store.close.assert_called_once_with()
+
+        nonclosable_document_store = Mock(spec=[])
+        retriever = AutoMergingRetriever(document_store=nonclosable_document_store)
+        retriever.close()
+        assert nonclosable_document_store.mock_calls == []

--- a/test/components/retrievers/test_auto_merging_retriever_async.py
+++ b/test/components/retrievers/test_auto_merging_retriever_async.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import AsyncMock, Mock
+
 import pytest
 
 from haystack import Document
@@ -206,3 +208,16 @@ class TestAutoMergingRetrieverAsync:
 
         assert len(result["documents"]) == 1
         assert result["documents"][0].meta["__level"] == 0  # hit root document
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        closable_document_store = Mock(spec=["close_async"])
+        closable_document_store.close_async = AsyncMock()
+        retriever = AutoMergingRetriever(document_store=closable_document_store)
+        await retriever.close_async()
+        closable_document_store.close_async.assert_awaited_once_with()
+
+        nonclosable_document_store = Mock(spec=[])
+        retriever = AutoMergingRetriever(document_store=nonclosable_document_store)
+        await retriever.close_async()
+        assert nonclosable_document_store.mock_calls == []

--- a/test/components/retrievers/test_filter_retriever.py
+++ b/test/components/retrievers/test_filter_retriever.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
@@ -144,3 +145,14 @@ class TestFilterRetriever:
         results_docs = result["retriever"]["documents"]
         assert results_docs
         assert TestFilterRetriever._documents_equal(results_docs, sample_docs["en_docs"])
+
+    def test_close(self):
+        closable_document_store = Mock(spec=["close"])
+        retriever = FilterRetriever(document_store=closable_document_store)
+        retriever.close()
+        closable_document_store.close.assert_called_once_with()
+
+        nonclosable_document_store = Mock(spec=[])
+        retriever = FilterRetriever(document_store=nonclosable_document_store)
+        retriever.close()
+        assert nonclosable_document_store.mock_calls == []

--- a/test/components/retrievers/test_filter_retriever_async.py
+++ b/test/components/retrievers/test_filter_retriever_async.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -94,3 +95,16 @@ class TestFilterRetrieverAsync:
         results_docs = result["retriever"]["documents"]
         assert results_docs
         assert TestFilterRetrieverAsync._documents_equal(results_docs, sample_docs["en_docs"])
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        closable_document_store = Mock(spec=["close_async"])
+        closable_document_store.close_async = AsyncMock()
+        retriever = FilterRetriever(document_store=closable_document_store)
+        await retriever.close_async()
+        closable_document_store.close_async.assert_awaited_once_with()
+
+        nonclosable_document_store = Mock(spec=[])
+        retriever = FilterRetriever(document_store=nonclosable_document_store)
+        await retriever.close_async()
+        assert nonclosable_document_store.mock_calls == []

--- a/test/components/retrievers/test_sentence_window_retriever.py
+++ b/test/components/retrievers/test_sentence_window_retriever.py
@@ -4,7 +4,7 @@
 
 import random
 import re
-from unittest.mock import ANY
+from unittest.mock import ANY, Mock
 
 import pytest
 
@@ -329,3 +329,14 @@ class TestSentenceWindowRetriever:
         deserialized = Pipeline.from_dict(serialized)
 
         assert deserialized == pipe
+
+    def test_close(self):
+        closable_document_store = Mock(spec=["close"])
+        retriever = SentenceWindowRetriever(document_store=closable_document_store)
+        retriever.close()
+        closable_document_store.close.assert_called_once_with()
+
+        nonclosable_document_store = Mock(spec=[])
+        retriever = SentenceWindowRetriever(document_store=nonclosable_document_store)
+        retriever.close()
+        assert nonclosable_document_store.mock_calls == []

--- a/test/components/retrievers/test_sentence_window_retriever_async.py
+++ b/test/components/retrievers/test_sentence_window_retriever_async.py
@@ -4,6 +4,7 @@
 
 import random
 import re
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -224,3 +225,16 @@ class TestSentenceWindowRetrieverAsync:
         deserialized = Pipeline.from_dict(serialized)
 
         assert deserialized == pipe
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        closable_document_store = Mock(spec=["close_async"])
+        closable_document_store.close_async = AsyncMock()
+        retriever = SentenceWindowRetriever(document_store=closable_document_store)
+        await retriever.close_async()
+        closable_document_store.close_async.assert_awaited_once_with()
+
+        nonclosable_document_store = Mock(spec=[])
+        retriever = SentenceWindowRetriever(document_store=nonclosable_document_store)
+        await retriever.close_async()
+        assert nonclosable_document_store.mock_calls == []

--- a/test/components/writers/test_document_writer.py
+++ b/test/components/writers/test_document_writer.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import AsyncMock, Mock
+
 import pytest
 
 from haystack import Document
@@ -107,6 +109,17 @@ class TestDocumentWriter:
         result = writer.run(documents=documents)
         assert result["documents_written"] == 0
 
+    def test_close(self):
+        closable_document_store = Mock(spec=["close"])
+        writer = DocumentWriter(document_store=closable_document_store)
+        writer.close()
+        closable_document_store.close.assert_called_once_with()
+
+        nonclosable_document_store = Mock(spec=[])
+        writer = DocumentWriter(document_store=nonclosable_document_store)
+        writer.close()
+        assert nonclosable_document_store.mock_calls == []
+
     @pytest.mark.asyncio
     async def test_run_async_invalid_docstore(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
@@ -144,3 +157,16 @@ class TestDocumentWriter:
 
         result = await writer.run_async(documents=documents)
         assert result["documents_written"] == 0
+
+    @pytest.mark.asyncio
+    async def test_close_async(self):
+        closable_document_store = Mock(spec=["close_async"])
+        closable_document_store.close_async = AsyncMock()
+        writer = DocumentWriter(document_store=closable_document_store)
+        await writer.close_async()
+        closable_document_store.close_async.assert_awaited_once_with()
+
+        nonclosable_document_store = Mock(spec=[])
+        writer = DocumentWriter(document_store=nonclosable_document_store)
+        await writer.close_async()
+        assert nonclosable_document_store.mock_calls == []


### PR DESCRIPTION
### Related Issues
- related to https://github.com/deepset-ai/haystack-core-integrations/issues/1628: we have been adding closing methods to Document Stores (and specific retrievers).

### Proposed Changes:
- Implement closing methods for components that support multiple Document Stores
  - they delegate to the Document Store if it has closing methods
  - otherwise, they do nothing

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
