### PR TITLE
fix: preserve BreakpointException and PipelineRuntimeError in _run_component_async

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -566,6 +566,16 @@ class Pipeline(PipelineBase):
                 # For sync-only components, _run_component_async dispatches to a thread via asyncio.to_thread,
                 # which copies the current contextvars context — preserving e.g. the active tracing span.
                 outputs = await _execute_component_async(instance, **component_inputs_copy)
+            except BreakpointException:
+                # Re-raise BreakpointException to preserve the original exception context.
+                # This is important when Agent components internally use Pipeline._run_component
+                # and trigger breakpoints that need to bubble up to the main pipeline.
+                raise
+            except PipelineRuntimeError:
+                # Any components that internally use Pipeline._run_component could raise a PipelineRuntimeError
+                # with additional context (e.g. Agent raises an agent snapshot) so we re-raise here instead of
+                # wrapping it in another PipelineRuntimeError.
+                raise
             except Exception as error:
                 raise PipelineRuntimeError.from_exception(component_name, instance.__class__, error) from error
 

--- a/releasenotes/notes/fix-async-breakpoint-exception-980c389b99a94039.yaml
+++ b/releasenotes/notes/fix-async-breakpoint-exception-980c389b99a94039.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed ``_run_component_async`` swallowing ``BreakpointException`` and ``PipelineRuntimeError``
+    instead of re-raising them. Previously, a bare ``except Exception`` clause wrapped both
+    exception types in a new ``PipelineRuntimeError``, which silently broke breakpoints in the
+    async pipeline path (``run_async``, ``run_async_generator``, ``stream``) and caused nested
+    pipeline errors from Agent components to lose their original context. The async path now
+    mirrors the sync ``_run_component`` behavior: ``BreakpointException`` and
+    ``PipelineRuntimeError`` are re-raised as-is, and only unknown exceptions are wrapped.

--- a/test/core/pipeline/test_async_pipeline.py
+++ b/test/core/pipeline/test_async_pipeline.py
@@ -602,9 +602,7 @@ async def test_run_component_async_does_not_rewrap_pipeline_runtime_error():
     """
 
     original_error = PipelineRuntimeError(
-        component_name="inner_comp",
-        component_type=type(None),
-        message="original detailed message",
+        component_name="inner_comp", component_type=type(None), message="original detailed message"
     )
 
     @component

--- a/test/core/pipeline/test_async_pipeline.py
+++ b/test/core/pipeline/test_async_pipeline.py
@@ -558,10 +558,10 @@ async def test_run_component_async_propagates_breakpoint_exception():
     """
     Regression test: _run_component_async must re-raise BreakpointException as-is.
 
-    Before the fix, a bare ``except Exception`` in _run_component_async would catch the
-    BreakpointException raised at the start of that method (before _execute_component_async
-    is even called) and wrap it in a PipelineRuntimeError, silently breaking the breakpoint
-    feature for the async path.
+    Before the fix, a ``BreakpointException`` raised during component execution (or by a nested pipeline)
+    was caught by the generic ``except Exception`` handler in _run_component_async and wrapped in a
+    new ``PipelineRuntimeError``, preventing callers from handling breakpoints correctly in the
+    async pipeline path.
     """
 
     @component

--- a/test/core/pipeline/test_async_pipeline.py
+++ b/test/core/pipeline/test_async_pipeline.py
@@ -11,7 +11,8 @@ import pytest
 
 from haystack import Document, Pipeline, component
 from haystack.components.joiners import BranchJoiner
-from haystack.core.errors import PipelineRuntimeError
+from haystack.core.errors import BreakpointException, PipelineRuntimeError
+from haystack.dataclasses.breakpoints import Breakpoint
 
 _test_context_var: contextvars.ContextVar[str] = contextvars.ContextVar("_test_context_var", default="unset")
 
@@ -550,3 +551,73 @@ async def test_run_async_raises_when_multi_element_list_is_unwrapped_at_runtime(
 
     with pytest.raises(PipelineRuntimeError, match="Cannot unwrap a list of 3 items"):
         await pipe.run_async({})
+
+
+@pytest.mark.asyncio
+async def test_run_component_async_propagates_breakpoint_exception():
+    """
+    Regression test: _run_component_async must re-raise BreakpointException as-is.
+
+    Before the fix, a bare ``except Exception`` in _run_component_async would catch the
+    BreakpointException raised at the start of that method (before _execute_component_async
+    is even called) and wrap it in a PipelineRuntimeError, silently breaking the breakpoint
+    feature for the async path.
+    """
+
+    @component
+    class SimpleComponent:
+        @component.output_types(result=str)
+        def run(self, value: str) -> dict[str, str]:
+            return {"result": f"{value}_processed"}
+
+    pipeline = Pipeline()
+    pipeline.add_component("comp", SimpleComponent())
+
+    break_point = Breakpoint(component_name="comp", visit_count=0)
+    component_visits = {"comp": 0}
+    comp = pipeline._get_component_with_graph_metadata_and_visits("comp", 0)
+
+    # _run_component_async must raise BreakpointException, not wrap it in PipelineRuntimeError.
+    with pytest.raises(BreakpointException) as exc_info:
+        await pipeline._run_component_async(
+            component_name="comp",
+            component=comp,
+            component_inputs={"value": "hello"},
+            component_visits=component_visits,
+            break_point=break_point,
+        )
+
+    # The exception must carry the break_point back to the caller.
+    assert exc_info.value.break_point.component_name == "comp"
+
+
+@pytest.mark.asyncio
+async def test_run_component_async_does_not_rewrap_pipeline_runtime_error():
+    """
+    Regression test: _run_component_async must re-raise PipelineRuntimeError without wrapping it.
+
+    Components such as Agent internally call Pipeline._run_component and may raise a
+    PipelineRuntimeError that already contains a full snapshot / context. The async path must
+    not swallow that and replace it with a freshly constructed PipelineRuntimeError.
+    """
+
+    original_error = PipelineRuntimeError(
+        component_name="inner_comp",
+        component_type=type(None),
+        message="original detailed message",
+    )
+
+    @component
+    class ErroringComponent:
+        @component.output_types(result=str)
+        def run(self, value: str) -> dict[str, str]:
+            raise original_error
+
+    pipeline = Pipeline()
+    pipeline.add_component("erroring", ErroringComponent())
+
+    with pytest.raises(PipelineRuntimeError) as exc_info:
+        await pipeline.run_async({"erroring": {"value": "x"}})
+
+    # Must be the exact same instance — not a freshly constructed wrapper.
+    assert exc_info.value is original_error


### PR DESCRIPTION
## Related Issues

* Fixes #12173

## Proposed Changes

* Added `except BreakpointException: raise` and `except PipelineRuntimeError: raise` clauses to `_run_component_async` in `pipeline.py`, before the general `except Exception` handler, mirroring the existing logic in the synchronous `_run_component`.
* Added regression test `test_run_component_async_propagates_breakpoint_exception`, which calls `_run_component_async` directly with a `break_point` and asserts that `BreakpointException` is propagated instead of being wrapped.
* Added regression test `test_run_component_async_does_not_rewrap_pipeline_runtime_error`, using a component that raises `PipelineRuntimeError` directly and asserting that the same exception instance propagates through `run_async`.
* Added a release note.

## How did you test it?

```bash
hatch run test:unit test/core/pipeline/test_async_pipeline.py
hatch run test:unit test/core/pipeline/test_breakpoint.py
hatch run test:types haystack/core/pipeline/pipeline.py
```

All 21 async pipeline tests and 32 breakpoint tests pass. `mypy` reports no issues.

## Notes for the reviewer

* The change is strictly additive: two new `except` clauses are inserted before the existing generic exception handler. The normal execution path is unchanged.
* `BreakpointException` is raised before `_execute_component_async` is called, so the previous `except Exception` block always intercepted it and wrapped it in a new `PipelineRuntimeError`, preventing callers from handling breakpoints correctly.
* Preserving `PipelineRuntimeError` also maintains parity with the synchronous implementation and avoids unnecessary double-wrapping for nested pipelines (for example, `Agent` components), preserving the original exception context.

## Checklist

* [x] I have read the [[contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md)](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [[code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
* [x] I have updated the related issue with new insights and changes.
* [x] I have added unit tests and updated the docstrings.
* [x] I've used one of the [[conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/)](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
* [x] I have documented my code.
* [x] I have added a release note file, following the [[contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes)](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
* [x] I have run the pre-commit hooks and fixed any issues.