### PR TITLE
feat: Add compaction hook

### DIFF
--- a/haystack/hooks/compaction/__init__.py
+++ b/haystack/hooks/compaction/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from typing import TYPE_CHECKING
+
+from lazy_imports import LazyImporter
+
+_import_structure = {
+    "hooks": ["ContextCompactionHook"],
+    "sliding_window": ["SlidingWindowCompactor"],
+    "types": ["Compactor"],
+}
+
+if TYPE_CHECKING:
+    from .hooks import ContextCompactionHook as ContextCompactionHook
+    from .sliding_window import SlidingWindowCompactor as SlidingWindowCompactor
+    from .types import Compactor as Compactor
+else:
+    sys.modules[__name__] = LazyImporter(name=__name__, module_file=__file__, import_structure=_import_structure)

--- a/haystack/hooks/compaction/hooks.py
+++ b/haystack/hooks/compaction/hooks.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 from typing import Any
 
 from haystack import logging
@@ -11,41 +10,18 @@ from haystack.components.agents.state.state_utils import replace_values
 from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction.types import Compactor
-from haystack.hooks.compaction.utils import _tool_result_text
 from haystack.utils.deserialization import deserialize_component_inplace
 
 logger = logging.getLogger(__name__)
-
-
-def _conversation_chars(messages: list[ChatMessage]) -> int:
-    """
-    Return the approximate size of a conversation in characters.
-
-    Counts message text, tool-call names and arguments, and tool-result content - everything that grows the prompt. It
-    is measured in characters rather than messages so that a strategy which rewrites messages in place, rather than
-    removing them, still registers as having shrunk the conversation. As a rough guide one token is about four
-    characters, though the ratio varies by tokenizer and content.
-
-    :param messages: The conversation to measure.
-    :returns: The total number of characters.
-    """
-    total = 0
-    for message in messages:
-        total += sum(len(text) for text in message.texts)
-        for call in message.tool_calls:
-            total += len(call.tool_name) + len(json.dumps(call.arguments, default=str, sort_keys=True))
-        for result in message.tool_call_results:
-            total += len(_tool_result_text(result.result))
-    return total
 
 
 class ContextCompactionHook:
     """
     Compacts an Agent's conversation once it grows past a threshold, so a long run does not exhaust the context window.
 
-    This `before_llm` Agent hook checks the size of the conversation before each chat-generator call and, when it is
-    over the threshold, hands it to a `Compactor` to rewrite. Register it on an `Agent` under the `before_llm` hook
-    point:
+    This `before_llm` Agent hook compares the `context_tokens` state key against `threshold_tokens` before each
+    chat-generator call and, when it is over, hands the conversation to a `Compactor` to rewrite. Register it on an
+    `Agent` under the `before_llm` hook point:
 
     ```python
     from haystack.components.agents import Agent
@@ -53,9 +29,7 @@ class ContextCompactionHook:
     from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
 
     hook = ContextCompactionHook(
-        compactor=SlidingWindowCompactor(keep_last_n_messages=20),
-        threshold_tokens=100_000,
-        threshold_chars=400_000,
+        compactor=SlidingWindowCompactor(keep_last_n_messages=20), threshold_tokens=100_000
     )
     agent = Agent(
         chat_generator=OpenAIChatGenerator(model="gpt-5.4-nano"),
@@ -65,8 +39,13 @@ class ContextCompactionHook:
     )
     ```
 
-    Set the threshold well below the model's context window: it is checked before the call rather than after, and the
-    reply plus the tool results it triggers are added on top of what was measured.
+    **The Agent's Chat Generator must report token usage.** `context_tokens` is refreshed after each call from the
+    reply's `meta["usage"]`, and stays at `0` for a generator that does not report it - in which case the threshold is
+    never reached and the hook never compacts. The hook logs a warning once per run when it detects this. Most Chat
+    Generators report usage; a custom or mock one may not.
+
+    Set the threshold well below the model's context window: it is checked before the call rather than after, so the
+    reply and the tool results it triggers are added on top of what was measured.
 
     Compaction is lossy by nature, so the Agent works from a shorter record of the run afterwards. What survives is up
     to the compactor.
@@ -74,40 +53,30 @@ class ContextCompactionHook:
 
     allowed_hook_points = ("before_llm",)
 
-    def __init__(
-        self, compactor: Compactor, *, threshold_tokens: int | None = None, threshold_chars: int | None = None
-    ) -> None:
+    def __init__(self, compactor: Compactor, *, threshold_tokens: int) -> None:
         """
-        Initialize the hook with a compactor and the thresholds that trigger it.
+        Initialize the hook with a compactor and the context size that triggers it.
 
-        At least one threshold must be set. Setting both is the most robust configuration: they measure different
-        things and are checked independently, so whichever crosses first triggers compaction.
-
-        :param compactor: The `Compactor` that rewrites the conversation, for example a `SummarizationCompactor`.
-        :param threshold_tokens: Compact once the `context_tokens` state key reaches this value. That key is refreshed
-            after each chat-generator call from the reply's reported token usage, so it is the more accurate trigger -
-            but it stays at `0` for Chat Generators that do not report usage, in which case this threshold never fires.
-            Pair it with `threshold_chars` unless you know your generator reports usage.
-        :param threshold_chars: Compact once the conversation reaches this many characters. Counted from the messages
-            themselves, so it works with any Chat Generator and accounts for content added since the last call. As a
-            rough guide one token is about four characters.
-        :raises ValueError: If neither threshold is set, since the hook would then never compact.
+        :param compactor: The `Compactor` that rewrites the conversation, for example a `SlidingWindowCompactor`.
+        :param threshold_tokens: Compact once the `context_tokens` state key reaches this value. The Agent refreshes
+            that key after each chat-generator call from the reply's reported token usage, so the Agent's Chat
+            Generator must report usage for this to ever fire.
+        :raises ValueError: If `threshold_tokens` is less than 1, which would compact on every step.
         """
-        if threshold_tokens is None and threshold_chars is None:
+        if threshold_tokens < 1:
             raise ValueError(
-                "`ContextCompactionHook` requires at least one of `threshold_tokens` or `threshold_chars` to be set, "
-                "otherwise it would never compact."
+                f"`threshold_tokens` must be at least 1, got {threshold_tokens}. A threshold of 0 is reached before "
+                f"the Agent has done anything, so every step would attempt compaction."
             )
         self.compactor = compactor
         self.threshold_tokens = threshold_tokens
-        self.threshold_chars = threshold_chars
 
     def run(self, state: State) -> None:
         """
-        Compact `state.data["messages"]` if the conversation is over the threshold.
+        Compact `state.data["messages"]` if the context is over the threshold.
 
         :param state: The Agent's live `State`. Read to decide whether to compact, and rewritten in place when the
-            compactor returns a shorter conversation.
+            compactor returns a compacted conversation.
         :returns: None. The hook mutates `state` in place.
         """
         if not self._over_threshold(state):
@@ -116,10 +85,10 @@ class ContextCompactionHook:
 
     async def run_async(self, state: State) -> None:
         """
-        Asynchronously compact `state.data["messages"]` if the conversation is over the threshold.
+        Asynchronously compact `state.data["messages"]` if the context is over the threshold.
 
         :param state: The Agent's live `State`. Read to decide whether to compact, and rewritten in place when the
-            compactor returns a shorter conversation.
+            compactor returns a compacted conversation.
         :returns: None. The hook mutates `state` in place.
         """
         if not self._over_threshold(state):
@@ -128,24 +97,49 @@ class ContextCompactionHook:
 
     def _over_threshold(self, state: State) -> bool:
         """
-        Return whether the conversation has reached either configured threshold.
+        Return whether the context has reached `threshold_tokens`.
 
         :param state: The Agent's `State`.
         :returns: True when compaction should be attempted.
         """
-        if self.threshold_tokens is not None and state.data.get("context_tokens", 0) >= self.threshold_tokens:
-            return True
-        if self.threshold_chars is not None:
-            return _conversation_chars(state.data.get("messages") or []) >= self.threshold_chars
-        return False
+        context_tokens = state.data.get("context_tokens", 0)
+        if context_tokens == 0:
+            self._warn_if_usage_is_never_reported(state)
+            return False
+        return context_tokens >= self.threshold_tokens
+
+    def _warn_if_usage_is_never_reported(self, state: State) -> None:
+        """
+        Warn when `context_tokens` is still unset after the Agent's first chat-generator call.
+
+        `context_tokens` is legitimately `0` before the first call. Still being `0` afterwards means the Chat Generator
+        does not report token usage, so the threshold can never be reached and this hook will silently do nothing for
+        the whole run.
+
+        `step_count` equals 1 at exactly one `before_llm` call per run, so warning only then logs once without the hook
+        having to remember anything - which keeps it safe to share across concurrent runs.
+
+        :param state: The Agent's `State`.
+        :returns: None.
+        """
+        if state.data.get("step_count") != 1:
+            return
+        logger.warning(
+            "The Agent's `context_tokens` is still 0 after the first chat-generator call, which means the Chat "
+            "Generator does not report token usage. `ContextCompactionHook` triggers on `context_tokens`, so it will "
+            "never compact this run. Use a Chat Generator that reports usage in `meta['usage']`."
+        )
 
     def _apply(self, state: State, compacted: list[ChatMessage] | None) -> None:
         """
-        Write a compacted conversation back into `State`, if the compactor actually shrank it.
+        Write a compacted conversation back into `State`.
+
+        A compactor returns None when it has nothing worth changing, so there is no second-guessing here: whatever it
+        returns is applied.
 
         `context_tokens` is reset to `0`, its "not yet measured" value: the count it held describes the conversation
         that was just replaced, and the next chat-generator call refreshes it from real usage. Leaving the old value in
-        place would re-trigger compaction on the next step whenever that call reports no usage.
+        place would re-trigger compaction on the next step.
 
         The cumulative run metadata (`token_usage`, `tool_call_counts`) is deliberately left alone - it records what
         the run has spent and done, which compaction does not change.
@@ -156,35 +150,14 @@ class ContextCompactionHook:
         """
         if compacted is None:
             return
-        messages = state.data.get("messages") or []
-        size_before = _conversation_chars(messages)
-        size_after = _conversation_chars(compacted)
-        if size_after >= size_before:
-            return
-
+        messages_before = len(state.data.get("messages") or [])
         state.set("messages", compacted, handler_override=replace_values)
         state.set("context_tokens", 0)
         logger.debug(
-            "Compacted the Agent's conversation from {before} to {after} characters ({messages_before} to "
-            "{messages_after} messages).",
-            before=size_before,
-            after=size_after,
-            messages_before=len(messages),
-            messages_after=len(compacted),
+            "Compacted the Agent's conversation from {before} to {after} messages.",
+            before=messages_before,
+            after=len(compacted),
         )
-
-        # Only `threshold_chars` can be re-checked here: `context_tokens` was just reset and is not measured again
-        # until the next chat-generator call.
-        if self.threshold_chars is not None and size_after >= self.threshold_chars:
-            logger.warning(
-                "The Agent's conversation is still {after} characters after compaction, at or above the "
-                "`threshold_chars` of {threshold}. The threshold is likely below the size the compactor can reach - "
-                "for example, smaller than the recent messages it keeps verbatim - so compaction will keep being "
-                "attempted without ever getting under it. Raise `threshold_chars` or configure the compactor to "
-                "retain less.",
-                after=size_after,
-                threshold=self.threshold_chars,
-            )
 
     def warm_up(self) -> None:
         """Warm up the compactor, which may hold resources such as a Chat Generator."""
@@ -222,7 +195,6 @@ class ContextCompactionHook:
             self,
             compactor=component_to_dict(obj=self.compactor, name="compactor"),
             threshold_tokens=self.threshold_tokens,
-            threshold_chars=self.threshold_chars,
         )
 
     @classmethod

--- a/haystack/hooks/compaction/hooks.py
+++ b/haystack/hooks/compaction/hooks.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from typing import Any
 
 from haystack import logging
@@ -10,10 +11,32 @@ from haystack.components.agents.state.state_utils import replace_values
 from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction.types import Compactor
-from haystack.hooks.compaction.utils import _conversation_chars
+from haystack.hooks.compaction.utils import _tool_result_text
 from haystack.utils.deserialization import deserialize_component_inplace
 
 logger = logging.getLogger(__name__)
+
+
+def _conversation_chars(messages: list[ChatMessage]) -> int:
+    """
+    Return the approximate size of a conversation in characters.
+
+    Counts message text, tool-call names and arguments, and tool-result content - everything that grows the prompt. It
+    is measured in characters rather than messages so that a strategy which rewrites messages in place, rather than
+    removing them, still registers as having shrunk the conversation. As a rough guide one token is about four
+    characters, though the ratio varies by tokenizer and content.
+
+    :param messages: The conversation to measure.
+    :returns: The total number of characters.
+    """
+    total = 0
+    for message in messages:
+        total += sum(len(text) for text in message.texts)
+        for call in message.tool_calls:
+            total += len(call.tool_name) + len(json.dumps(call.arguments, default=str, sort_keys=True))
+        for result in message.tool_call_results:
+            total += len(_tool_result_text(result.result))
+    return total
 
 
 class ContextCompactionHook:
@@ -24,7 +47,6 @@ class ContextCompactionHook:
     over the threshold, hands it to a `Compactor` to rewrite. Register it on an `Agent` under the `before_llm` hook
     point:
 
-    <!-- test-concept -->
     ```python
     from haystack.components.agents import Agent
     from haystack.components.generators.chat import OpenAIChatGenerator
@@ -143,8 +165,8 @@ class ContextCompactionHook:
         state.set("messages", compacted, handler_override=replace_values)
         state.set("context_tokens", 0)
         logger.debug(
-            "Compacted the Agent's conversation from {before} to {after} characters "
-            "({messages_before} to {messages_after} messages).",
+            "Compacted the Agent's conversation from {before} to {after} characters ({messages_before} to "
+            "{messages_after} messages).",
             before=size_before,
             after=size_after,
             messages_before=len(messages),
@@ -152,7 +174,7 @@ class ContextCompactionHook:
         )
 
         # Only `threshold_chars` can be re-checked here: `context_tokens` was just reset and is not measured again
-        # until the next chat-generator call, so a token-only configuration cannot detect this.
+        # until the next chat-generator call.
         if self.threshold_chars is not None and size_after >= self.threshold_chars:
             logger.warning(
                 "The Agent's conversation is still {after} characters after compaction, at or above the "

--- a/haystack/hooks/compaction/hooks.py
+++ b/haystack/hooks/compaction/hooks.py
@@ -79,7 +79,7 @@ class ContextCompactionHook:
         """
         if not self._over_threshold(state):
             return
-        self._apply(state, self.compactor.compact(state))
+        self._apply(state, self.compactor.compact(state.data.get("messages") or []))
 
     async def run_async(self, state: State) -> None:
         """
@@ -91,7 +91,7 @@ class ContextCompactionHook:
         """
         if not self._over_threshold(state):
             return
-        self._apply(state, await self.compactor.compact_async(state))
+        self._apply(state, await self.compactor.compact_async(state.data.get("messages") or []))
 
     def _over_threshold(self, state: State) -> bool:
         """
@@ -139,7 +139,8 @@ class ContextCompactionHook:
         # Reset to "not yet measured" so the next chat-generator call refreshes it from real usage.
         state.set("context_tokens", 0)
         logger.debug(
-            "Compacted the Agent's conversation from {before} to {after} messages.",
+            "Compacted the Agent's conversation at step {step} from {before} to {after} messages.",
+            step=state.data.get("step_count", 0),
             before=messages_before,
             after=len(compacted),
         )

--- a/haystack/hooks/compaction/hooks.py
+++ b/haystack/hooks/compaction/hooks.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack import logging
+from haystack.components.agents.state.state import State
+from haystack.components.agents.state.state_utils import replace_values
+from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
+from haystack.dataclasses import ChatMessage
+from haystack.hooks.compaction.types import Compactor
+from haystack.hooks.compaction.utils import _conversation_chars
+from haystack.utils.deserialization import deserialize_component_inplace
+
+logger = logging.getLogger(__name__)
+
+
+class ContextCompactionHook:
+    """
+    Compacts an Agent's conversation once it grows past a threshold, so a long run does not exhaust the context window.
+
+    This `before_llm` Agent hook checks the size of the conversation before each chat-generator call and, when it is
+    over the threshold, hands it to a `Compactor` to rewrite. Register it on an `Agent` under the `before_llm` hook
+    point:
+
+    <!-- test-concept -->
+    ```python
+    from haystack.components.agents import Agent
+    from haystack.components.generators.chat import OpenAIChatGenerator
+    from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+
+    hook = ContextCompactionHook(
+        compactor=SlidingWindowCompactor(keep_last_n_messages=20),
+        threshold_tokens=100_000,
+        threshold_chars=400_000,
+    )
+    agent = Agent(
+        chat_generator=OpenAIChatGenerator(model="gpt-5.4-nano"),
+        tools=[web_search],
+        hooks={"before_llm": [hook]},
+        max_agent_steps=50,
+    )
+    ```
+
+    Set the threshold well below the model's context window: it is checked before the call rather than after, and the
+    reply plus the tool results it triggers are added on top of what was measured.
+
+    Compaction is lossy by nature, so the Agent works from a shorter record of the run afterwards. What survives is up
+    to the compactor.
+    """
+
+    allowed_hook_points = ("before_llm",)
+
+    def __init__(
+        self, compactor: Compactor, *, threshold_tokens: int | None = None, threshold_chars: int | None = None
+    ) -> None:
+        """
+        Initialize the hook with a compactor and the thresholds that trigger it.
+
+        At least one threshold must be set. Setting both is the most robust configuration: they measure different
+        things and are checked independently, so whichever crosses first triggers compaction.
+
+        :param compactor: The `Compactor` that rewrites the conversation, for example a `SummarizationCompactor`.
+        :param threshold_tokens: Compact once the `context_tokens` state key reaches this value. That key is refreshed
+            after each chat-generator call from the reply's reported token usage, so it is the more accurate trigger -
+            but it stays at `0` for Chat Generators that do not report usage, in which case this threshold never fires.
+            Pair it with `threshold_chars` unless you know your generator reports usage.
+        :param threshold_chars: Compact once the conversation reaches this many characters. Counted from the messages
+            themselves, so it works with any Chat Generator and accounts for content added since the last call. As a
+            rough guide one token is about four characters.
+        :raises ValueError: If neither threshold is set, since the hook would then never compact.
+        """
+        if threshold_tokens is None and threshold_chars is None:
+            raise ValueError(
+                "`ContextCompactionHook` requires at least one of `threshold_tokens` or `threshold_chars` to be set, "
+                "otherwise it would never compact."
+            )
+        self.compactor = compactor
+        self.threshold_tokens = threshold_tokens
+        self.threshold_chars = threshold_chars
+
+    def run(self, state: State) -> None:
+        """
+        Compact `state.data["messages"]` if the conversation is over the threshold.
+
+        :param state: The Agent's live `State`. Read to decide whether to compact, and rewritten in place when the
+            compactor returns a shorter conversation.
+        :returns: None. The hook mutates `state` in place.
+        """
+        if not self._over_threshold(state):
+            return
+        self._apply(state, self.compactor.compact(state))
+
+    async def run_async(self, state: State) -> None:
+        """
+        Asynchronously compact `state.data["messages"]` if the conversation is over the threshold.
+
+        :param state: The Agent's live `State`. Read to decide whether to compact, and rewritten in place when the
+            compactor returns a shorter conversation.
+        :returns: None. The hook mutates `state` in place.
+        """
+        if not self._over_threshold(state):
+            return
+        self._apply(state, await self.compactor.compact_async(state))
+
+    def _over_threshold(self, state: State) -> bool:
+        """
+        Return whether the conversation has reached either configured threshold.
+
+        :param state: The Agent's `State`.
+        :returns: True when compaction should be attempted.
+        """
+        if self.threshold_tokens is not None and state.data.get("context_tokens", 0) >= self.threshold_tokens:
+            return True
+        if self.threshold_chars is not None:
+            return _conversation_chars(state.data.get("messages") or []) >= self.threshold_chars
+        return False
+
+    def _apply(self, state: State, compacted: list[ChatMessage] | None) -> None:
+        """
+        Write a compacted conversation back into `State`, if the compactor actually shrank it.
+
+        `context_tokens` is reset to `0`, its "not yet measured" value: the count it held describes the conversation
+        that was just replaced, and the next chat-generator call refreshes it from real usage. Leaving the old value in
+        place would re-trigger compaction on the next step whenever that call reports no usage.
+
+        The cumulative run metadata (`token_usage`, `tool_call_counts`) is deliberately left alone - it records what
+        the run has spent and done, which compaction does not change.
+
+        :param state: The Agent's live `State`.
+        :param compacted: The compactor's result, or None when it had nothing to change.
+        :returns: None.
+        """
+        if compacted is None:
+            return
+        messages = state.data.get("messages") or []
+        size_before = _conversation_chars(messages)
+        size_after = _conversation_chars(compacted)
+        if size_after >= size_before:
+            return
+
+        state.set("messages", compacted, handler_override=replace_values)
+        state.set("context_tokens", 0)
+        logger.debug(
+            "Compacted the Agent's conversation from {before} to {after} characters "
+            "({messages_before} to {messages_after} messages).",
+            before=size_before,
+            after=size_after,
+            messages_before=len(messages),
+            messages_after=len(compacted),
+        )
+
+        # Only `threshold_chars` can be re-checked here: `context_tokens` was just reset and is not measured again
+        # until the next chat-generator call, so a token-only configuration cannot detect this.
+        if self.threshold_chars is not None and size_after >= self.threshold_chars:
+            logger.warning(
+                "The Agent's conversation is still {after} characters after compaction, at or above the "
+                "`threshold_chars` of {threshold}. The threshold is likely below the size the compactor can reach - "
+                "for example, smaller than the recent messages it keeps verbatim - so compaction will keep being "
+                "attempted without ever getting under it. Raise `threshold_chars` or configure the compactor to "
+                "retain less.",
+                after=size_after,
+                threshold=self.threshold_chars,
+            )
+
+    def warm_up(self) -> None:
+        """Warm up the compactor, which may hold resources such as a Chat Generator."""
+        if hasattr(self.compactor, "warm_up"):
+            self.compactor.warm_up()
+
+    async def warm_up_async(self) -> None:
+        """Warm up the compactor on the serving event loop."""
+        warm_up_async = getattr(self.compactor, "warm_up_async", None)
+        if warm_up_async is not None:
+            await warm_up_async()
+        elif hasattr(self.compactor, "warm_up"):
+            self.compactor.warm_up()
+
+    def close(self) -> None:
+        """Release the compactor's resources."""
+        if hasattr(self.compactor, "close"):
+            self.compactor.close()
+
+    async def close_async(self) -> None:
+        """Release the compactor's async resources."""
+        close_async = getattr(self.compactor, "close_async", None)
+        if close_async is not None:
+            await close_async()
+        elif hasattr(self.compactor, "close"):
+            self.compactor.close()
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize the hook, including its compactor.
+
+        :returns: A dictionary representation of the hook.
+        """
+        return default_to_dict(
+            self,
+            compactor=component_to_dict(obj=self.compactor, name="compactor"),
+            threshold_tokens=self.threshold_tokens,
+            threshold_chars=self.threshold_chars,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ContextCompactionHook":
+        """
+        Deserialize the hook, reconstructing its compactor.
+
+        :param data: A dictionary representation produced by `to_dict`.
+        :returns: The deserialized `ContextCompactionHook`.
+        """
+        init_params = data.get("init_parameters", {})
+        if init_params.get("compactor") is not None:
+            deserialize_component_inplace(init_params, key="compactor")
+        return default_from_dict(cls, data)

--- a/haystack/hooks/compaction/hooks.py
+++ b/haystack/hooks/compaction/hooks.py
@@ -57,10 +57,8 @@ class ContextCompactionHook:
         """
         Initialize the hook with a compactor and the context size that triggers it.
 
-        :param compactor: The `Compactor` that rewrites the conversation, for example a `SlidingWindowCompactor`.
-        :param threshold_tokens: Compact once the `context_tokens` state key reaches this value. The Agent refreshes
-            that key after each chat-generator call from the reply's reported token usage, so the Agent's Chat
-            Generator must report usage for this to ever fire.
+        :param compactor: The `Compactor` that rewrites the conversation.
+        :param threshold_tokens: Compact once the `context_tokens` state key reaches this value.
         :raises ValueError: If `threshold_tokens` is less than 1, which would compact on every step.
         """
         if threshold_tokens < 1:
@@ -112,12 +110,8 @@ class ContextCompactionHook:
         """
         Warn when `context_tokens` is still unset after the Agent's first chat-generator call.
 
-        `context_tokens` is legitimately `0` before the first call. Still being `0` afterwards means the Chat Generator
-        does not report token usage, so the threshold can never be reached and this hook will silently do nothing for
-        the whole run.
-
-        `step_count` equals 1 at exactly one `before_llm` call per run, so warning only then logs once without the hook
-        having to remember anything - which keeps it safe to share across concurrent runs.
+        `context_tokens` still being `0` after the first step (i.e. `step_count=0`) means the Chat Generator does not
+        report token usage, so we warn the user that the hook will never compact this run.
 
         :param state: The Agent's `State`.
         :returns: None.
@@ -127,31 +121,22 @@ class ContextCompactionHook:
         logger.warning(
             "The Agent's `context_tokens` is still 0 after the first chat-generator call, which means the Chat "
             "Generator does not report token usage. `ContextCompactionHook` triggers on `context_tokens`, so it will "
-            "never compact this run. Use a Chat Generator that reports usage in `meta['usage']`."
+            "never compact this run. Use a Chat Generator that reports usage in `replies[0].meta['usage']`."
         )
 
     def _apply(self, state: State, compacted: list[ChatMessage] | None) -> None:
         """
         Write a compacted conversation back into `State`.
 
-        A compactor returns None when it has nothing worth changing, so there is no second-guessing here: whatever it
-        returns is applied.
-
-        `context_tokens` is reset to `0`, its "not yet measured" value: the count it held describes the conversation
-        that was just replaced, and the next chat-generator call refreshes it from real usage. Leaving the old value in
-        place would re-trigger compaction on the next step.
-
-        The cumulative run metadata (`token_usage`, `tool_call_counts`) is deliberately left alone - it records what
-        the run has spent and done, which compaction does not change.
-
         :param state: The Agent's live `State`.
         :param compacted: The compactor's result, or None when it had nothing to change.
-        :returns: None.
+        :returns: None
         """
         if compacted is None:
             return
         messages_before = len(state.data.get("messages") or [])
         state.set("messages", compacted, handler_override=replace_values)
+        # Reset to "not yet measured" so the next chat-generator call refreshes it from real usage.
         state.set("context_tokens", 0)
         logger.debug(
             "Compacted the Agent's conversation from {before} to {after} messages.",

--- a/haystack/hooks/compaction/hooks.py
+++ b/haystack/hooks/compaction/hooks.py
@@ -44,8 +44,8 @@ class ContextCompactionHook:
     never reached and the hook never compacts. The hook logs a warning once per run when it detects this. Most Chat
     Generators report usage; a custom or mock one may not.
 
-    Set the threshold well below the model's context window: it is checked before the call rather than after, so the
-    reply and the tool results it triggers are added on top of what was measured.
+    Leave headroom between the threshold and the model's context window: `context_tokens` was measured at the previous
+    call, so the tool results appended since and the upcoming reply must still fit within the window.
 
     Compaction is lossy by nature, so the Agent works from a shorter record of the run afterwards. What survives is up
     to the compactor.

--- a/haystack/hooks/compaction/sliding_window.py
+++ b/haystack/hooks/compaction/sliding_window.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack.components.agents.state.state import State
+from haystack.core.serialization import default_to_dict
+from haystack.dataclasses import ChatMessage
+from haystack.hooks.compaction.types import Compactor
+from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _preserved_prefix_end, _safe_cut_index
+
+
+class SlidingWindowCompactor(Compactor):
+    """
+    Keeps the leading system messages and the most recent messages, dropping everything in between.
+
+    The cheapest strategy and the most lossy: nothing is written in place of what it removes, so anything the Agent
+    learned outside the retained window is simply gone. It suits runs whose turns are largely independent, or as a
+    last resort behind a strategy that preserves more.
+
+    <!-- test-concept -->
+    ```python
+    from haystack.components.agents import Agent
+    from haystack.components.generators.chat import OpenAIChatGenerator
+    from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+
+    hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=20), threshold_chars=400_000)
+    agent = Agent(
+        chat_generator=OpenAIChatGenerator(model="gpt-5.4-nano"),
+        tools=[web_search],
+        hooks={"before_llm": [hook]},
+    )
+    ```
+    """
+
+    def __init__(self, *, keep_last_n_messages: int = 20, omission_note: bool = True) -> None:
+        """
+        Initialize the compactor with the size of the window it retains.
+
+        :param keep_last_n_messages: How many of the most recent messages to keep. The boundary is moved further back
+            when it would otherwise split a tool call from its results, so slightly more may be kept. Must be at least
+            1: the Agent may be mid-step with a pending tool call whose result is appended right after compaction, and
+            dropping the message holding that call would leave the result orphaned.
+        :param omission_note: Whether to leave a short system message in place of what was removed. Keep it on unless
+            you have a reason not to - without it the conversation reads as though the removed turns never happened,
+            and the model may repeat work or answer as if it had context it no longer has.
+        :raises ValueError: If `keep_last_n_messages` is less than 1.
+        """
+        if keep_last_n_messages < 1:
+            raise ValueError(
+                f"`keep_last_n_messages` must be at least 1, got {keep_last_n_messages}. Keeping no messages would "
+                f"drop a pending tool call whose result the Agent appends after compaction, leaving it orphaned."
+            )
+        self.keep_last_n_messages = keep_last_n_messages
+        self.omission_note = omission_note
+
+    def compact(self, state: State) -> list[ChatMessage] | None:
+        """
+        Drop the messages between the leading system block and the retained window.
+
+        :param state: The Agent's `State`, read only. The conversation is `state.data["messages"]`.
+        :returns: The leading system messages, an optional omission note, and the retained window; or None when the
+            conversation already fits in the window.
+        """
+        messages = state.data.get("messages") or []
+        prefix_end = _preserved_prefix_end(messages)
+        cut = _safe_cut_index(messages, prefix_end, self.keep_last_n_messages)
+        if cut <= prefix_end:
+            return None
+
+        compacted = list(messages[:prefix_end])
+        if self.omission_note:
+            removed = cut - prefix_end
+            subject = "1 earlier message was" if removed == 1 else f"{removed} earlier messages were"
+            compacted.append(
+                ChatMessage.from_system(
+                    f"[{subject} removed from this conversation to free up context and cannot be recovered.]",
+                    meta={
+                        _COMPACTION_META_KEY: {
+                            "step": state.data.get("step_count", 0),
+                            "strategy": "sliding_window",
+                            "removed_messages": removed,
+                            "kept_messages": len(messages) - cut,
+                        }
+                    },
+                )
+            )
+        compacted.extend(messages[cut:])
+        return compacted
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize the compactor.
+
+        :returns: A dictionary representation of the compactor.
+        """
+        return default_to_dict(self, keep_last_n_messages=self.keep_last_n_messages, omission_note=self.omission_note)

--- a/haystack/hooks/compaction/sliding_window.py
+++ b/haystack/hooks/compaction/sliding_window.py
@@ -19,7 +19,6 @@ class SlidingWindowCompactor(Compactor):
     learned outside the retained window is simply gone. It suits runs whose turns are largely independent, or as a
     last resort behind a strategy that preserves more.
 
-    <!-- test-concept -->
     ```python
     from haystack.components.agents import Agent
     from haystack.components.generators.chat import OpenAIChatGenerator

--- a/haystack/hooks/compaction/sliding_window.py
+++ b/haystack/hooks/compaction/sliding_window.py
@@ -8,7 +8,7 @@ from haystack.components.agents.state.state import State
 from haystack.core.serialization import default_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction.types import Compactor
-from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _preserved_prefix_end, _safe_cut_index
+from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _compaction_bounds
 
 
 class SlidingWindowCompactor(Compactor):
@@ -63,18 +63,15 @@ class SlidingWindowCompactor(Compactor):
             conversation already fits in the window, or when the omission note would cost as much as it saves.
         """
         messages = state.data.get("messages") or []
-        prefix_end = _preserved_prefix_end(messages)
-        cut = _safe_cut_index(messages, prefix_end, self.keep_last_n_messages)
-        if cut <= prefix_end:
-            return None
-        # Dropping a single message only to add a note in its place gains nothing, and would then repeat every step,
-        # replacing one note with the next.
-        if self.omission_note and cut - prefix_end < 2:
+        start, end = _compaction_bounds(messages, self.keep_last_n_messages)
+        removed = end - start
+        # With a note, removing a single message only swaps it for the note and would repeat every step, replacing one
+        # note with the next.
+        if removed < (2 if self.omission_note else 1):
             return None
 
-        compacted = list(messages[:prefix_end])
+        compacted = list(messages[:start])
         if self.omission_note:
-            removed = cut - prefix_end
             subject = "1 earlier message was" if removed == 1 else f"{removed} earlier messages were"
             compacted.append(
                 ChatMessage.from_system(
@@ -84,12 +81,12 @@ class SlidingWindowCompactor(Compactor):
                             "step": state.data.get("step_count", 0),
                             "strategy": "sliding_window",
                             "removed_messages": removed,
-                            "kept_messages": len(messages) - cut,
+                            "kept_messages": len(messages) - end,
                         }
                     },
                 )
             )
-        compacted.extend(messages[cut:])
+        compacted.extend(messages[end:])
         return compacted
 
     def to_dict(self) -> dict[str, Any]:

--- a/haystack/hooks/compaction/sliding_window.py
+++ b/haystack/hooks/compaction/sliding_window.py
@@ -4,7 +4,6 @@
 
 from typing import Any
 
-from haystack.components.agents.state.state import State
 from haystack.core.serialization import default_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction.types import Compactor
@@ -46,7 +45,7 @@ class SlidingWindowCompactor(Compactor):
 
         :param keep_last_n_messages: How many of the most recent messages to keep. Slightly more may be kept when the
             boundary would otherwise split a tool call from its results.
-        :param omission_note: The system message left in place of what was removed, or None to remove the messages
+        :param omission_note: The user message left in place of what was removed, or None to remove the messages
             silently. Include `{num_removed}` to have the number of removed messages substituted in.
         :raises ValueError: If `keep_last_n_messages` is less than 1, which would drop a pending tool call whose result
             the Agent appends right after compaction.
@@ -59,15 +58,14 @@ class SlidingWindowCompactor(Compactor):
         self.keep_last_n_messages = keep_last_n_messages
         self.omission_note = omission_note
 
-    def compact(self, state: State) -> list[ChatMessage] | None:
+    def compact(self, messages: list[ChatMessage]) -> list[ChatMessage] | None:
         """
         Drop the messages between the leading system block and the retained window.
 
-        :param state: The Agent's `State`, read only. The conversation is `state.data["messages"]`.
+        :param messages: The conversation to compact, oldest to newest.
         :returns: The system messages, an omission note if one is configured, and the retained window; or None when
             there is nothing worth removing.
         """
-        messages = state.data.get("messages") or []
         start, end = _compaction_bounds(messages, self.keep_last_n_messages)
         removed = end - start
         # With a note, removing a single message just swaps it for the note.
@@ -77,12 +75,13 @@ class SlidingWindowCompactor(Compactor):
         compacted = list(messages[:start])
         if self.omission_note:
             compacted.append(
-                ChatMessage.from_system(
+                # A user message rather than a system one: providers that hoist system messages into a separate
+                # top-level field would move the note away from the point in the conversation it describes.
+                ChatMessage.from_user(
                     # `replace` rather than `format`, so a note carrying braces of its own cannot raise.
                     self.omission_note.replace(_NUM_REMOVED_PLACEHOLDER, str(removed)),
                     meta={
                         _COMPACTION_META_KEY: {
-                            "step": state.data.get("step_count", 0),
                             "strategy": "sliding_window",
                             "removed_messages": removed,
                             "kept_messages": len(messages) - end,

--- a/haystack/hooks/compaction/sliding_window.py
+++ b/haystack/hooks/compaction/sliding_window.py
@@ -10,14 +10,21 @@ from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction.types import Compactor
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _compaction_bounds
 
+# Placeholder a custom omission note may include to have the number of removed messages substituted in.
+_NUM_REMOVED_PLACEHOLDER = "{num_removed}"
+
+_DEFAULT_OMISSION_NOTE = (
+    f"[{_NUM_REMOVED_PLACEHOLDER} earlier messages were removed from this conversation to free up context and cannot "
+    f"be recovered.]"
+)
+
 
 class SlidingWindowCompactor(Compactor):
     """
     Keeps the leading system messages and the most recent messages, dropping everything in between.
 
-    The cheapest strategy and the most lossy: nothing is written in place of what it removes, so anything the Agent
-    learned outside the retained window is simply gone. It suits runs whose turns are largely independent, or as a
-    last resort behind a strategy that preserves more.
+    An `omission_note` is left in place of what was removed. Cheap but lossy: whatever the Agent learned outside the
+    retained window is gone, so it suits runs whose turns are largely independent.
 
     ```python
     from haystack.components.agents import Agent
@@ -33,18 +40,16 @@ class SlidingWindowCompactor(Compactor):
     ```
     """
 
-    def __init__(self, *, keep_last_n_messages: int = 20, omission_note: bool = True) -> None:
+    def __init__(self, *, keep_last_n_messages: int = 20, omission_note: str | None = _DEFAULT_OMISSION_NOTE) -> None:
         """
         Initialize the compactor with the size of the window it retains.
 
-        :param keep_last_n_messages: How many of the most recent messages to keep. The boundary is moved further back
-            when it would otherwise split a tool call from its results, so slightly more may be kept. Must be at least
-            1: the Agent may be mid-step with a pending tool call whose result is appended right after compaction, and
-            dropping the message holding that call would leave the result orphaned.
-        :param omission_note: Whether to leave a short system message in place of what was removed. Keep it on unless
-            you have a reason not to - without it the conversation reads as though the removed turns never happened,
-            and the model may repeat work or answer as if it had context it no longer has.
-        :raises ValueError: If `keep_last_n_messages` is less than 1.
+        :param keep_last_n_messages: How many of the most recent messages to keep. Slightly more may be kept when the
+            boundary would otherwise split a tool call from its results.
+        :param omission_note: The system message left in place of what was removed, or None to remove the messages
+            silently. Include `{num_removed}` to have the number of removed messages substituted in.
+        :raises ValueError: If `keep_last_n_messages` is less than 1, which would drop a pending tool call whose result
+            the Agent appends right after compaction.
         """
         if keep_last_n_messages < 1:
             raise ValueError(
@@ -59,23 +64,22 @@ class SlidingWindowCompactor(Compactor):
         Drop the messages between the leading system block and the retained window.
 
         :param state: The Agent's `State`, read only. The conversation is `state.data["messages"]`.
-        :returns: The leading system messages, an optional omission note, and the retained window; or None when the
-            conversation already fits in the window, or when the omission note would cost as much as it saves.
+        :returns: The system messages, an omission note if one is configured, and the retained window; or None when
+            there is nothing worth removing.
         """
         messages = state.data.get("messages") or []
         start, end = _compaction_bounds(messages, self.keep_last_n_messages)
         removed = end - start
-        # With a note, removing a single message only swaps it for the note and would repeat every step, replacing one
-        # note with the next.
+        # With a note, removing a single message just swaps it for the note.
         if removed < (2 if self.omission_note else 1):
             return None
 
         compacted = list(messages[:start])
         if self.omission_note:
-            subject = "1 earlier message was" if removed == 1 else f"{removed} earlier messages were"
             compacted.append(
                 ChatMessage.from_system(
-                    f"[{subject} removed from this conversation to free up context and cannot be recovered.]",
+                    # `replace` rather than `format`, so a note carrying braces of its own cannot raise.
+                    self.omission_note.replace(_NUM_REMOVED_PLACEHOLDER, str(removed)),
                     meta={
                         _COMPACTION_META_KEY: {
                             "step": state.data.get("step_count", 0),

--- a/haystack/hooks/compaction/sliding_window.py
+++ b/haystack/hooks/compaction/sliding_window.py
@@ -24,7 +24,7 @@ class SlidingWindowCompactor(Compactor):
     from haystack.components.generators.chat import OpenAIChatGenerator
     from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
 
-    hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=20), threshold_chars=400_000)
+    hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=20), threshold_tokens=100_000)
     agent = Agent(
         chat_generator=OpenAIChatGenerator(model="gpt-5.4-nano"),
         tools=[web_search],
@@ -60,12 +60,16 @@ class SlidingWindowCompactor(Compactor):
 
         :param state: The Agent's `State`, read only. The conversation is `state.data["messages"]`.
         :returns: The leading system messages, an optional omission note, and the retained window; or None when the
-            conversation already fits in the window.
+            conversation already fits in the window, or when the omission note would cost as much as it saves.
         """
         messages = state.data.get("messages") or []
         prefix_end = _preserved_prefix_end(messages)
         cut = _safe_cut_index(messages, prefix_end, self.keep_last_n_messages)
         if cut <= prefix_end:
+            return None
+        # Dropping a single message only to add a note in its place gains nothing, and would then repeat every step,
+        # replacing one note with the next.
+        if self.omission_note and cut - prefix_end < 2:
             return None
 
         compacted = list(messages[:prefix_end])

--- a/haystack/hooks/compaction/types/__init__.py
+++ b/haystack/hooks/compaction/types/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .protocol import Compactor
+
+__all__ = ["Compactor"]

--- a/haystack/hooks/compaction/types/protocol.py
+++ b/haystack/hooks/compaction/types/protocol.py
@@ -20,8 +20,10 @@ class Compactor(Protocol):
 
     Implementations must honor three rules:
 
-    1. **Return `None` when there is nothing to do.** Callers leave the conversation untouched in that case, so a
-       compactor that cannot shrink the conversation any further costs nothing to call repeatedly.
+    1. **Return `None` unless the conversation actually gets smaller.** Callers apply whatever else is returned without
+       second-guessing it, so judging whether compacting was worthwhile is the compactor's job - it is the only party
+       that knows what its own output costs. Returning `None` also makes a compactor free to call repeatedly once it
+       has nothing left to give.
     2. **Do not mutate `state`.** It is read-only context: `messages` to compact, plus `step_count`,
        `context_tokens`, `tools`, and `hook_context` for strategies that want them. The caller writes the returned
        list back into `State`.

--- a/haystack/hooks/compaction/types/protocol.py
+++ b/haystack/hooks/compaction/types/protocol.py
@@ -4,7 +4,6 @@
 
 from typing import Any, Protocol
 
-from haystack.components.agents.state.state import State
 from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses import ChatMessage
 
@@ -21,8 +20,7 @@ class Compactor(Protocol):
 
     1. **Return `None` unless the conversation actually gets smaller.** Callers apply whatever else is returned, so
        judging whether compacting was worthwhile is the compactor's job.
-    2. **Do not mutate `state`.** It is read-only context: `messages` to compact, plus `step_count`, `context_tokens`,
-       `tools`, and `hook_context` for strategies that want them. The caller writes the returned list back into `State`.
+    2. **Return a new list; leave `messages` as it is.** The caller owns that list and writes the returned one back.
     3. **Never drop the final message.** The Agent may be mid-step with a pending tool call whose result is appended
        right after compaction returns, and dropping the assistant message holding that call leaves the result orphaned,
        which chat-completion APIs reject.
@@ -31,26 +29,26 @@ class Compactor(Protocol):
     below cover compactors whose constructor takes no arguments.
     """
 
-    def compact(self, state: State) -> list[ChatMessage] | None:
+    def compact(self, messages: list[ChatMessage]) -> list[ChatMessage] | None:
         """
-        Return a compacted replacement for `state.data["messages"]`, or None to leave it unchanged.
+        Return a shorter replacement for `messages`, or None to leave it unchanged.
 
-        :param state: The Agent's `State`, read-only. The conversation to compact is `state.data["messages"]`.
+        :param messages: The conversation to compact, oldest to newest.
         :returns: The replacement conversation, or None when this compactor has nothing to change.
         """
         ...
 
-    async def compact_async(self, state: State) -> list[ChatMessage] | None:
+    async def compact_async(self, messages: list[ChatMessage]) -> list[ChatMessage] | None:
         """
-        Asynchronously return a compacted replacement for `state.data["messages"]`, or None to leave it unchanged.
+        Asynchronously return a shorter replacement for `messages`, or None to leave it unchanged.
 
         The default implementation calls `compact` directly. Override it when compaction does I/O, so the event loop is
         not blocked.
 
-        :param state: The Agent's `State`, read-only. The conversation to compact is `state.data["messages"]`.
+        :param messages: The conversation to compact, oldest to newest.
         :returns: The replacement conversation, or None when this compactor has nothing to change.
         """
-        return self.compact(state)
+        return self.compact(messages)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the compactor to a dictionary."""

--- a/haystack/hooks/compaction/types/protocol.py
+++ b/haystack/hooks/compaction/types/protocol.py
@@ -13,24 +13,19 @@ class Compactor(Protocol):
     """
     Rewrites an Agent's conversation into a shorter one that carries the same working context.
 
-    A compactor is the *how* of context compaction; deciding *when* to compact is the caller's job (the
-    `ContextCompactionHook` compares the context size against a threshold, and `ContextCompactionTool` lets the model
-    ask for it). Strategies differ widely in cost and fidelity: summarizing the older turns with an LLM, replacing
-    stale tool results with a placeholder, or dropping the oldest messages outright.
+    A compactor is the *how* of context compaction; deciding *when* to compact is the caller's job, which
+    `ContextCompactionHook` does by comparing the context size against a threshold. Strategies differ widely in cost
+    and fidelity, from dropping the oldest messages outright to condensing them with an LLM.
 
     Implementations must honor three rules:
 
-    1. **Return `None` unless the conversation actually gets smaller.** Callers apply whatever else is returned without
-       second-guessing it, so judging whether compacting was worthwhile is the compactor's job - it is the only party
-       that knows what its own output costs. Returning `None` also makes a compactor free to call repeatedly once it
-       has nothing left to give.
-    2. **Do not mutate `state`.** It is read-only context: `messages` to compact, plus `step_count`,
-       `context_tokens`, `tools`, and `hook_context` for strategies that want them. The caller writes the returned
-       list back into `State`.
+    1. **Return `None` unless the conversation actually gets smaller.** Callers apply whatever else is returned, so
+       judging whether compacting was worthwhile is the compactor's job.
+    2. **Do not mutate `state`.** It is read-only context: `messages` to compact, plus `step_count`, `context_tokens`,
+       `tools`, and `hook_context` for strategies that want them. The caller writes the returned list back into `State`.
     3. **Never drop the final message.** The Agent may be mid-step with a pending tool call whose result is appended
-       right after compaction returns; dropping the assistant message that holds that call leaves the result orphaned,
-       which chat-completion APIs reject. Keeping a non-empty tail of recent messages, or rewriting messages in place,
-       satisfies this.
+       right after compaction returns, and dropping the assistant message holding that call leaves the result orphaned,
+       which chat-completion APIs reject.
 
     Implement both `to_dict` and `from_dict` to make a custom compactor serializable; the default implementations
     below cover compactors whose constructor takes no arguments.
@@ -49,9 +44,8 @@ class Compactor(Protocol):
         """
         Asynchronously return a compacted replacement for `state.data["messages"]`, or None to leave it unchanged.
 
-        The default implementation calls `compact` directly, which is correct for a strategy that only rearranges
-        messages. Override it when compaction does I/O — for example, calling a Chat Generator to write a summary —
-        so the event loop is not blocked.
+        The default implementation calls `compact` directly. Override it when compaction does I/O, so the event loop is
+        not blocked.
 
         :param state: The Agent's `State`, read-only. The conversation to compact is `state.data["messages"]`.
         :returns: The replacement conversation, or None when this compactor has nothing to change.

--- a/haystack/hooks/compaction/types/protocol.py
+++ b/haystack/hooks/compaction/types/protocol.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Protocol
+
+from haystack.components.agents.state.state import State
+from haystack.core.serialization import default_from_dict, default_to_dict
+from haystack.dataclasses import ChatMessage
+
+
+class Compactor(Protocol):
+    """
+    Rewrites an Agent's conversation into a shorter one that carries the same working context.
+
+    A compactor is the *how* of context compaction; deciding *when* to compact is the caller's job (the
+    `ContextCompactionHook` compares the context size against a threshold, and `ContextCompactionTool` lets the model
+    ask for it). Strategies differ widely in cost and fidelity: summarizing the older turns with an LLM, replacing
+    stale tool results with a placeholder, or dropping the oldest messages outright.
+
+    Implementations must honor three rules:
+
+    1. **Return `None` when there is nothing to do.** Callers leave the conversation untouched in that case, so a
+       compactor that cannot shrink the conversation any further costs nothing to call repeatedly.
+    2. **Do not mutate `state`.** It is read-only context: `messages` to compact, plus `step_count`,
+       `context_tokens`, `tools`, and `hook_context` for strategies that want them. The caller writes the returned
+       list back into `State`.
+    3. **Never drop the final message.** The Agent may be mid-step with a pending tool call whose result is appended
+       right after compaction returns; dropping the assistant message that holds that call leaves the result orphaned,
+       which chat-completion APIs reject. Keeping a non-empty tail of recent messages, or rewriting messages in place,
+       satisfies this.
+
+    Implement both `to_dict` and `from_dict` to make a custom compactor serializable; the default implementations
+    below cover compactors whose constructor takes no arguments.
+    """
+
+    def compact(self, state: State) -> list[ChatMessage] | None:
+        """
+        Return a compacted replacement for `state.data["messages"]`, or None to leave it unchanged.
+
+        :param state: The Agent's `State`, read-only. The conversation to compact is `state.data["messages"]`.
+        :returns: The replacement conversation, or None when this compactor has nothing to change.
+        """
+        ...
+
+    async def compact_async(self, state: State) -> list[ChatMessage] | None:
+        """
+        Asynchronously return a compacted replacement for `state.data["messages"]`, or None to leave it unchanged.
+
+        The default implementation calls `compact` directly, which is correct for a strategy that only rearranges
+        messages. Override it when compaction does I/O — for example, calling a Chat Generator to write a summary —
+        so the event loop is not blocked.
+
+        :param state: The Agent's `State`, read-only. The conversation to compact is `state.data["messages"]`.
+        :returns: The replacement conversation, or None when this compactor has nothing to change.
+        """
+        return self.compact(state)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the compactor to a dictionary."""
+        return default_to_dict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Compactor":
+        """Deserialize the compactor from a dictionary."""
+        return default_from_dict(cls, data)

--- a/haystack/hooks/compaction/utils.py
+++ b/haystack/hooks/compaction/utils.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from haystack.dataclasses import ChatMessage, ChatRole, FileContent, ImageContent, TextContent
+from haystack.dataclasses.chat_message import ChatMessageContentT, ToolCallResultContentT
+
+# Meta key marking a message that a compactor produced (a summary, an omission note, or a rewritten tool result). Its
+# value records which strategy ran and at which step. Compactors both write and read it: it keeps a rewritten message
+# from being rewritten again, and it tells `_preserved_prefix_end` that a leading system message is a previous summary
+# rather than part of the conversation's permanent system prefix.
+_COMPACTION_META_KEY = "context_compaction"
+
+
+def _preserved_prefix_end(messages: list[ChatMessage]) -> int:
+    """
+    Return the length of the leading block of system messages that compaction must never touch.
+
+    These are the Agent's standing instructions, so they stay in context however often the conversation is compacted.
+    A leading system message carrying `_COMPACTION_META_KEY` is excluded: it is a summary an earlier compaction
+    inserted, and treating it as permanent prefix would leave one summary behind per compaction instead of folding
+    each into the next.
+
+    :param messages: The conversation, oldest to newest.
+    :returns: The index of the first message that may be compacted.
+    """
+    index = 0
+    while (
+        index < len(messages)
+        and messages[index].is_from(ChatRole.SYSTEM)
+        and _COMPACTION_META_KEY not in messages[index].meta
+    ):
+        index += 1
+    return index
+
+
+def _safe_cut_index(messages: list[ChatMessage], prefix_end: int, keep_last_n: int) -> int:
+    """
+    Return the index where the retained tail starts, moved to a boundary that leaves a valid conversation.
+
+    The tail must not begin with a tool-result message: its matching tool call lives in the assistant message before
+    it, which compaction is about to remove, and a tool result whose call is missing is rejected by chat-completion
+    APIs. Walking the boundary backwards onto that assistant message retains more than `keep_last_n` rather than
+    fewer, and steps over a whole batch of parallel tool results in one pass.
+
+    Nothing is checked about the messages before the boundary, because they are removed as a block rather than
+    reconnected to anything.
+
+    :param messages: The conversation, oldest to newest.
+    :param prefix_end: The index the compactable region starts at, from `_preserved_prefix_end`. The boundary is never
+        moved before it.
+    :param keep_last_n: How many trailing messages to retain, before the adjustment.
+    :returns: The index of the first retained message. Equal to `prefix_end` when there is nothing to remove.
+    """
+    cut = max(len(messages) - keep_last_n, prefix_end)
+    while cut > prefix_end and messages[cut].tool_call_result is not None:
+        cut -= 1
+    return cut
+
+
+def _non_text_placeholder(content: ChatMessageContentT) -> str:
+    """
+    Return a short stand-in for a piece of message content that has no text form.
+
+    :param content: The content block to describe.
+    :returns: A placeholder such as `<image>`, naming the content so a reader can see something was there.
+    """
+    if isinstance(content, ImageContent):
+        return "<image>"
+    if isinstance(content, FileContent):
+        return f"<file: {content.filename or 'unnamed'}>"
+    return f"<{type(content).__name__}>"
+
+
+def _tool_result_text(result: ToolCallResultContentT) -> str:
+    """
+    Render a tool result as text, substituting placeholders for any non-text parts.
+
+    :param result: The tool result content, either a plain string or a sequence of content blocks.
+    :returns: The result as a single string.
+    """
+    if isinstance(result, str):
+        return result
+    return "".join(block.text if isinstance(block, TextContent) else _non_text_placeholder(block) for block in result)
+
+
+def _conversation_chars(messages: list[ChatMessage]) -> int:
+    """
+    Return the approximate size of a conversation in characters.
+
+    Counts message text, tool-call names and arguments, and tool-result content - everything that grows the prompt. It
+    is measured in characters rather than messages so that a strategy which rewrites messages in place, rather than
+    removing them, still registers as having shrunk the conversation. As a rough guide one token is about four
+    characters, though the ratio varies by tokenizer and content.
+
+    :param messages: The conversation to measure.
+    :returns: The total number of characters.
+    """
+    total = 0
+    for message in messages:
+        total += sum(len(text) for text in message.texts)
+        for call in message.tool_calls:
+            total += len(call.tool_name) + len(json.dumps(call.arguments, default=str, sort_keys=True))
+        for result in message.tool_call_results:
+            total += len(_tool_result_text(result.result))
+    return total

--- a/haystack/hooks/compaction/utils.py
+++ b/haystack/hooks/compaction/utils.py
@@ -32,6 +32,8 @@ def _compaction_bounds(messages: list[ChatMessage], keep_last_n: int) -> tuple[i
     ):
         start += 1
 
+    # We assume that tool calls and their results are always adjacent, so we can step back over a batch of results in
+    # one pass.
     end = max(len(messages) - keep_last_n, start)
     while end > start and messages[end].tool_call_result is not None:
         end -= 1

--- a/haystack/hooks/compaction/utils.py
+++ b/haystack/hooks/compaction/utils.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import json
-
 from haystack.dataclasses import ChatMessage, ChatRole, FileContent, ImageContent, TextContent
 from haystack.dataclasses.chat_message import ChatMessageContentT, ToolCallResultContentT
 
@@ -84,25 +82,3 @@ def _tool_result_text(result: ToolCallResultContentT) -> str:
     if isinstance(result, str):
         return result
     return "".join(block.text if isinstance(block, TextContent) else _non_text_placeholder(block) for block in result)
-
-
-def _conversation_chars(messages: list[ChatMessage]) -> int:
-    """
-    Return the approximate size of a conversation in characters.
-
-    Counts message text, tool-call names and arguments, and tool-result content - everything that grows the prompt. It
-    is measured in characters rather than messages so that a strategy which rewrites messages in place, rather than
-    removing them, still registers as having shrunk the conversation. As a rough guide one token is about four
-    characters, though the ratio varies by tokenizer and content.
-
-    :param messages: The conversation to measure.
-    :returns: The total number of characters.
-    """
-    total = 0
-    for message in messages:
-        total += sum(len(text) for text in message.texts)
-        for call in message.tool_calls:
-            total += len(call.tool_name) + len(json.dumps(call.arguments, default=str, sort_keys=True))
-        for result in message.tool_call_results:
-            total += len(_tool_result_text(result.result))
-    return total

--- a/haystack/hooks/compaction/utils.py
+++ b/haystack/hooks/compaction/utils.py
@@ -12,21 +12,17 @@ def _compaction_bounds(messages: list[ChatMessage], keep_last_n: int) -> tuple[i
     """
     Return the half-open range of messages that compaction may remove.
 
-    Before the range sits the leading block of system messages: the Agent's standing instructions, which stay in context
-    however often the conversation is compacted. That block ends at the first system message carrying
-    `_COMPACTION_META_KEY`, because an earlier compaction produced that one and the next compaction replaces it instead
-    of accumulating beside it.
+    The range starts after the leading block of system messages, the Agent's standing instructions, which stay in
+    context however often the conversation is compacted. That block ends at the first system message carrying
+    `_COMPACTION_META_KEY`, since an earlier compaction produced that one and the next compaction replaces it.
 
-    After the range sits the tail of `keep_last_n` recent messages. The tail's start is moved backwards off any
-    tool-result message: the matching tool call lives in the assistant message before it, which compaction is about to
-    remove, and a tool result whose call is missing is rejected by chat-completion APIs. Moving backwards retains more
-    than `keep_last_n` rather than fewer, and steps over a whole batch of parallel tool results in one pass. Nothing is
-    checked inside the range itself, since it is removed as a block rather than reconnected to anything.
+    The range ends before the tail of `keep_last_n` recent messages, moved back off any tool-result message so that the
+    tail keeps the assistant message holding the matching call - a tool result whose call is missing is rejected by
+    chat-completion APIs. Moving back also steps over a whole batch of parallel tool results in one pass.
 
     :param messages: The conversation, oldest to newest.
     :param keep_last_n: How many trailing messages to retain, before the adjustment described above.
-    :returns: The `(start, end)` indices of the removable range, where `end - start` is how many messages it covers and
-        `0` means there is nothing to remove.
+    :returns: The `(start, end)` indices of the removable range; `end - start` is `0` when there is nothing to remove.
     """
     start = 0
     while (

--- a/haystack/hooks/compaction/utils.py
+++ b/haystack/hooks/compaction/utils.py
@@ -12,15 +12,16 @@ def _compaction_bounds(messages: list[ChatMessage], keep_last_n: int) -> tuple[i
     """
     Return where the block of messages that compaction may remove starts and ends.
 
-    The block runs from `start` up to but not including `end`, so `messages[start:end]` is what may go. Before it are
-    the Agent's standing instructions and after it is the recent window, both of which are kept.
+    The block runs from `start` up to but not including `end`, so `messages[start:end]` is what may go. Before it is the
+    leading run of system messages and after it is the recent window, both of which are kept.
 
     :param messages: The conversation, oldest to newest.
     :param keep_last_n: How many trailing messages to retain, before the adjustment made below.
     :returns: The `(start, end)` indices of the removable block; `end - start` is `0` when there is nothing to remove.
     """
-    # Skip the Agent's user-defined system prompt. The marker check guards against a compactor configured to write
-    # system messages of its own - those are removable, so they end the block instead of extending it.
+    # Protect only the *leading* run of system messages: the Agent's system prompt and anything a hook prepended. A
+    # system message further along is removed like any other. The marker check ends the run at a message a compactor
+    # produced, since that is removable.
     start = 0
     while (
         start < len(messages)

--- a/haystack/hooks/compaction/utils.py
+++ b/haystack/hooks/compaction/utils.py
@@ -4,26 +4,23 @@
 
 from haystack.dataclasses import ChatMessage, ChatRole
 
-# Meta key marking a message that a compactor produced. Its value records which strategy ran and at which step.
+# Meta key marking a message that a compactor produced. Its value records which strategy ran.
 _COMPACTION_META_KEY = "context_compaction"
 
 
 def _compaction_bounds(messages: list[ChatMessage], keep_last_n: int) -> tuple[int, int]:
     """
-    Return the half-open range of messages that compaction may remove.
+    Return where the block of messages that compaction may remove starts and ends.
 
-    The range starts after the leading block of system messages, the Agent's standing instructions, which stay in
-    context however often the conversation is compacted. That block ends at the first system message carrying
-    `_COMPACTION_META_KEY`, since an earlier compaction produced that one and the next compaction replaces it.
-
-    The range ends before the tail of `keep_last_n` recent messages, moved back off any tool-result message so that the
-    tail keeps the assistant message holding the matching call - a tool result whose call is missing is rejected by
-    chat-completion APIs. Moving back also steps over a whole batch of parallel tool results in one pass.
+    The block runs from `start` up to but not including `end`, so `messages[start:end]` is what may go. Before it are
+    the Agent's standing instructions and after it is the recent window, both of which are kept.
 
     :param messages: The conversation, oldest to newest.
-    :param keep_last_n: How many trailing messages to retain, before the adjustment described above.
-    :returns: The `(start, end)` indices of the removable range; `end - start` is `0` when there is nothing to remove.
+    :param keep_last_n: How many trailing messages to retain, before the adjustment made below.
+    :returns: The `(start, end)` indices of the removable block; `end - start` is `0` when there is nothing to remove.
     """
+    # Skip the Agent's user-defined system prompt. The marker check guards against a compactor configured to write
+    # system messages of its own - those are removable, so they end the block instead of extending it.
     start = 0
     while (
         start < len(messages)
@@ -32,8 +29,8 @@ def _compaction_bounds(messages: list[ChatMessage], keep_last_n: int) -> tuple[i
     ):
         start += 1
 
-    # We assume that tool calls and their results are always adjacent, so we can step back over a batch of results in
-    # one pass.
+    # Walk the tail's start back off any tool result, so the tail keeps the assistant message holding the matching call:
+    # chat-completion APIs reject a tool result whose call is missing. One pass steps over a whole parallel batch.
     end = max(len(messages) - keep_last_n, start)
     while end > start and messages[end].tool_call_result is not None:
         end -= 1

--- a/haystack/hooks/compaction/utils.py
+++ b/haystack/hooks/compaction/utils.py
@@ -2,8 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from haystack.dataclasses import ChatMessage, ChatRole, FileContent, ImageContent, TextContent
-from haystack.dataclasses.chat_message import ChatMessageContentT, ToolCallResultContentT
+from haystack.dataclasses import ChatMessage, ChatRole
 
 # Meta key marking a message that a compactor produced (a summary, an omission note, or a rewritten tool result). Its
 # value records which strategy ran and at which step. Compactors both write and read it: it keeps a rewritten message
@@ -56,29 +55,3 @@ def _safe_cut_index(messages: list[ChatMessage], prefix_end: int, keep_last_n: i
     while cut > prefix_end and messages[cut].tool_call_result is not None:
         cut -= 1
     return cut
-
-
-def _non_text_placeholder(content: ChatMessageContentT) -> str:
-    """
-    Return a short stand-in for a piece of message content that has no text form.
-
-    :param content: The content block to describe.
-    :returns: A placeholder such as `<image>`, naming the content so a reader can see something was there.
-    """
-    if isinstance(content, ImageContent):
-        return "<image>"
-    if isinstance(content, FileContent):
-        return f"<file: {content.filename or 'unnamed'}>"
-    return f"<{type(content).__name__}>"
-
-
-def _tool_result_text(result: ToolCallResultContentT) -> str:
-    """
-    Render a tool result as text, substituting placeholders for any non-text parts.
-
-    :param result: The tool result content, either a plain string or a sequence of content blocks.
-    :returns: The result as a single string.
-    """
-    if isinstance(result, str):
-        return result
-    return "".join(block.text if isinstance(block, TextContent) else _non_text_placeholder(block) for block in result)

--- a/haystack/hooks/compaction/utils.py
+++ b/haystack/hooks/compaction/utils.py
@@ -4,54 +4,39 @@
 
 from haystack.dataclasses import ChatMessage, ChatRole
 
-# Meta key marking a message that a compactor produced (a summary, an omission note, or a rewritten tool result). Its
-# value records which strategy ran and at which step. Compactors both write and read it: it keeps a rewritten message
-# from being rewritten again, and it tells `_preserved_prefix_end` that a leading system message is a previous summary
-# rather than part of the conversation's permanent system prefix.
+# Meta key marking a message that a compactor produced. Its value records which strategy ran and at which step.
 _COMPACTION_META_KEY = "context_compaction"
 
 
-def _preserved_prefix_end(messages: list[ChatMessage]) -> int:
+def _compaction_bounds(messages: list[ChatMessage], keep_last_n: int) -> tuple[int, int]:
     """
-    Return the length of the leading block of system messages that compaction must never touch.
+    Return the half-open range of messages that compaction may remove.
 
-    These are the Agent's standing instructions, so they stay in context however often the conversation is compacted.
-    A leading system message carrying `_COMPACTION_META_KEY` is excluded: it is a summary an earlier compaction
-    inserted, and treating it as permanent prefix would leave one summary behind per compaction instead of folding
-    each into the next.
+    Before the range sits the leading block of system messages: the Agent's standing instructions, which stay in context
+    however often the conversation is compacted. That block ends at the first system message carrying
+    `_COMPACTION_META_KEY`, because an earlier compaction produced that one and the next compaction replaces it instead
+    of accumulating beside it.
+
+    After the range sits the tail of `keep_last_n` recent messages. The tail's start is moved backwards off any
+    tool-result message: the matching tool call lives in the assistant message before it, which compaction is about to
+    remove, and a tool result whose call is missing is rejected by chat-completion APIs. Moving backwards retains more
+    than `keep_last_n` rather than fewer, and steps over a whole batch of parallel tool results in one pass. Nothing is
+    checked inside the range itself, since it is removed as a block rather than reconnected to anything.
 
     :param messages: The conversation, oldest to newest.
-    :returns: The index of the first message that may be compacted.
+    :param keep_last_n: How many trailing messages to retain, before the adjustment described above.
+    :returns: The `(start, end)` indices of the removable range, where `end - start` is how many messages it covers and
+        `0` means there is nothing to remove.
     """
-    index = 0
+    start = 0
     while (
-        index < len(messages)
-        and messages[index].is_from(ChatRole.SYSTEM)
-        and _COMPACTION_META_KEY not in messages[index].meta
+        start < len(messages)
+        and messages[start].is_from(ChatRole.SYSTEM)
+        and _COMPACTION_META_KEY not in messages[start].meta
     ):
-        index += 1
-    return index
+        start += 1
 
-
-def _safe_cut_index(messages: list[ChatMessage], prefix_end: int, keep_last_n: int) -> int:
-    """
-    Return the index where the retained tail starts, moved to a boundary that leaves a valid conversation.
-
-    The tail must not begin with a tool-result message: its matching tool call lives in the assistant message before
-    it, which compaction is about to remove, and a tool result whose call is missing is rejected by chat-completion
-    APIs. Walking the boundary backwards onto that assistant message retains more than `keep_last_n` rather than
-    fewer, and steps over a whole batch of parallel tool results in one pass.
-
-    Nothing is checked about the messages before the boundary, because they are removed as a block rather than
-    reconnected to anything.
-
-    :param messages: The conversation, oldest to newest.
-    :param prefix_end: The index the compactable region starts at, from `_preserved_prefix_end`. The boundary is never
-        moved before it.
-    :param keep_last_n: How many trailing messages to retain, before the adjustment.
-    :returns: The index of the first retained message. Equal to `prefix_end` when there is nothing to remove.
-    """
-    cut = max(len(messages) - keep_last_n, prefix_end)
-    while cut > prefix_end and messages[cut].tool_call_result is not None:
-        cut -= 1
-    return cut
+    end = max(len(messages) - keep_last_n, start)
+    while end > start and messages[end].tool_call_result is not None:
+        end -= 1
+    return start, end

--- a/pydoc/hooks_api.yml
+++ b/pydoc/hooks_api.yml
@@ -1,6 +1,7 @@
 loaders:
   - search_path: [../haystack/hooks]
-    modules: ["protocol", "from_function", "human_in_the_loop/dataclasses", "human_in_the_loop/hooks",
+    modules: ["protocol", "from_function", "compaction/hooks", "compaction/sliding_window",
+      "compaction/types/protocol", "human_in_the_loop/dataclasses", "human_in_the_loop/hooks",
       "human_in_the_loop/policies", "human_in_the_loop/strategies", "human_in_the_loop/user_interfaces",
       "tool_result_offloading/hooks", "tool_result_offloading/policies", "tool_result_offloading/stores",
       "tool_result_offloading/types/protocol"]
@@ -12,5 +13,5 @@ renderer:
   title: Hooks
   id: hooks-api
   description: Hooks that run at points in the Agent's run loop and influence it by mutating State, including
-    built-in tool result offloading and Human-in-the-Loop tool confirmation.
+    built-in context compaction, tool result offloading, and Human-in-the-Loop tool confirmation.
   filename: hooks_api.md

--- a/releasenotes/notes/add-agent-context-compaction-3258c08dec9d2b34.yaml
+++ b/releasenotes/notes/add-agent-context-compaction-3258c08dec9d2b34.yaml
@@ -1,0 +1,40 @@
+---
+features:
+  - |
+    Added context compaction for the ``Agent``: a ``ContextCompactionHook`` that shortens the conversation once it
+    grows past a threshold, and a ``Compactor`` protocol defining how the shortening is done. The first built-in
+    strategy is ``SlidingWindowCompactor``, which keeps the leading system messages and the most recent messages and
+    drops what is in between, leaving a short note in their place. Register the hook under the ``before_llm`` hook
+    point:
+
+    .. code-block:: python
+
+        from haystack.components.agents import Agent
+        from haystack.components.generators.chat import OpenAIChatGenerator
+        from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+
+        hook = ContextCompactionHook(
+            compactor=SlidingWindowCompactor(keep_last_n_messages=20),
+            threshold_tokens=100_000,
+            threshold_chars=400_000,
+        )
+        agent = Agent(
+            chat_generator=OpenAIChatGenerator(model="gpt-5.4-nano"),
+            tools=[web_search],
+            hooks={"before_llm": [hook]},
+        )
+
+    At least one threshold must be set, and setting both is the most robust configuration. ``threshold_tokens`` reads
+    the ``context_tokens`` state key, which is the more accurate signal but stays at ``0`` for Chat Generators that do
+    not report token usage - in which case that threshold never fires. ``threshold_chars`` is measured from the
+    messages themselves, so it works with any Chat Generator and accounts for content added since the last call.
+
+    Compaction never leaves a tool result whose originating tool call was removed, which chat-completion APIs reject:
+    the boundary of the retained window is moved backwards onto the assistant message holding the call, so slightly
+    more may be kept than ``keep_last_n_messages`` asks for. Implement the ``Compactor`` protocol to define your own
+    strategy; the conversation it returns must keep the final message, because the Agent may be mid-step with a pending
+    tool call whose result is appended right after compaction.
+
+    Note that compaction is lossy. After it runs the Agent works from a shorter record of the run, and with
+    ``SlidingWindowCompactor`` anything outside the retained window is gone rather than summarized. Set the threshold
+    well below the model's context window, since it is checked before the chat-generator call rather than after.

--- a/releasenotes/notes/add-agent-context-compaction-3258c08dec9d2b34.yaml
+++ b/releasenotes/notes/add-agent-context-compaction-3258c08dec9d2b34.yaml
@@ -32,8 +32,9 @@ features:
     Compaction never leaves a tool result whose originating tool call was removed, which chat-completion APIs reject:
     the boundary of the retained window is moved backwards onto the assistant message holding the call, so slightly
     more may be kept than ``keep_last_n_messages`` asks for. Implement the ``Compactor`` protocol to define your own
-    strategy. Return ``None`` unless the conversation actually gets smaller, and never drop the final message, because
-    the Agent may be mid-step with a pending tool call whose result is appended right after compaction.
+    strategy: it takes the conversation as a plain list of ``ChatMessage`` and returns a shorter one. Return ``None``
+    unless the conversation actually gets smaller, and never drop the final message, because the Agent may be mid-step
+    with a pending tool call whose result is appended right after compaction.
 
     Note that compaction is lossy. After it runs the Agent works from a shorter record of the run, and with
     ``SlidingWindowCompactor`` anything outside the retained window is gone rather than summarized.

--- a/releasenotes/notes/add-agent-context-compaction-3258c08dec9d2b34.yaml
+++ b/releasenotes/notes/add-agent-context-compaction-3258c08dec9d2b34.yaml
@@ -25,9 +25,9 @@ features:
     The trigger is the ``context_tokens`` state key, which the Agent refreshes after each chat-generator call from the
     reply's reported token usage. **The Agent's Chat Generator must report usage** in ``meta["usage"]``, otherwise
     ``context_tokens`` stays at ``0``, the threshold is never reached, and the hook never compacts. The hook logs a
-    warning once per run when it detects this. Set the threshold well below the model's context window, since it is
-    checked before the call rather than after, so the reply and the tool results it triggers are added on top of what
-    was measured.
+    warning once per run when it detects this. Leave headroom between the threshold and the model's context window:
+    ``context_tokens`` was measured at the previous call, so the tool results appended since and the upcoming reply must
+    still fit within the window.
 
     Compaction never leaves a tool result whose originating tool call was removed, which chat-completion APIs reject:
     the boundary of the retained window is moved backwards onto the assistant message holding the call, so slightly

--- a/releasenotes/notes/add-agent-context-compaction-3258c08dec9d2b34.yaml
+++ b/releasenotes/notes/add-agent-context-compaction-3258c08dec9d2b34.yaml
@@ -14,9 +14,7 @@ features:
         from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
 
         hook = ContextCompactionHook(
-            compactor=SlidingWindowCompactor(keep_last_n_messages=20),
-            threshold_tokens=100_000,
-            threshold_chars=400_000,
+            compactor=SlidingWindowCompactor(keep_last_n_messages=20), threshold_tokens=100_000
         )
         agent = Agent(
             chat_generator=OpenAIChatGenerator(model="gpt-5.4-nano"),
@@ -24,17 +22,18 @@ features:
             hooks={"before_llm": [hook]},
         )
 
-    At least one threshold must be set, and setting both is the most robust configuration. ``threshold_tokens`` reads
-    the ``context_tokens`` state key, which is the more accurate signal but stays at ``0`` for Chat Generators that do
-    not report token usage - in which case that threshold never fires. ``threshold_chars`` is measured from the
-    messages themselves, so it works with any Chat Generator and accounts for content added since the last call.
+    The trigger is the ``context_tokens`` state key, which the Agent refreshes after each chat-generator call from the
+    reply's reported token usage. **The Agent's Chat Generator must report usage** in ``meta["usage"]``, otherwise
+    ``context_tokens`` stays at ``0``, the threshold is never reached, and the hook never compacts. The hook logs a
+    warning once per run when it detects this. Set the threshold well below the model's context window, since it is
+    checked before the call rather than after, so the reply and the tool results it triggers are added on top of what
+    was measured.
 
     Compaction never leaves a tool result whose originating tool call was removed, which chat-completion APIs reject:
     the boundary of the retained window is moved backwards onto the assistant message holding the call, so slightly
     more may be kept than ``keep_last_n_messages`` asks for. Implement the ``Compactor`` protocol to define your own
-    strategy; the conversation it returns must keep the final message, because the Agent may be mid-step with a pending
-    tool call whose result is appended right after compaction.
+    strategy. Return ``None`` unless the conversation actually gets smaller, and never drop the final message, because
+    the Agent may be mid-step with a pending tool call whose result is appended right after compaction.
 
     Note that compaction is lossy. After it runs the Agent works from a shorter record of the run, and with
-    ``SlidingWindowCompactor`` anything outside the retained window is gone rather than summarized. Set the threshold
-    well below the model's context window, since it is checked before the chat-generator call rather than after.
+    ``SlidingWindowCompactor`` anything outside the retained window is gone rather than summarized.

--- a/test/hooks/compaction/__init__.py
+++ b/test/hooks/compaction/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/hooks/compaction/helpers.py
+++ b/test/hooks/compaction/helpers.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack.components.agents.state.state import State
+from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
+
+# The keys of the Agent's State that compaction reads or writes.
+_SCHEMA = {
+    "messages": {"type": list[ChatMessage]},
+    "step_count": {"type": int},
+    "context_tokens": {"type": int},
+    "token_usage": {"type": dict},
+    "tool_call_counts": {"type": dict},
+}
+
+
+def tool_call(*call_ids: str, name: str = "search", arguments: dict[str, Any] | None = None) -> ChatMessage:
+    """An assistant message requesting one tool call per given id, so several ids give a parallel batch."""
+    return ChatMessage.from_assistant(
+        tool_calls=[ToolCall(tool_name=name, arguments=arguments or {}, id=call_id) for call_id in call_ids]
+    )
+
+
+def tool_result(result: str, *, call_id: str = "c1", name: str = "search", error: bool = False) -> ChatMessage:
+    """A tool-result message answering the call with the given id."""
+    return ChatMessage.from_tool(
+        tool_result=result, origin=ToolCall(tool_name=name, arguments={}, id=call_id), error=error
+    )
+
+
+def make_state(messages: list[ChatMessage], **data: Any) -> State:
+    """A State shaped like the Agent's, holding `messages` and whatever run metadata a test overrides."""
+    base = {"messages": messages, "step_count": 2, "context_tokens": 900, "token_usage": {}, "tool_call_counts": {}}
+    return State(schema=_SCHEMA, data={**base, **data})
+
+
+def long_conversation() -> list[ChatMessage]:
+    """Six messages: a system prefix, a user turn, then two tool round-trips."""
+    return [
+        ChatMessage.from_system("rules"),
+        ChatMessage.from_user("start"),
+        tool_call("c1"),
+        tool_result("first result", call_id="c1"),
+        tool_call("c2"),
+        tool_result("second result", call_id="c2"),
+    ]
+
+
+def count_markers(messages: list[ChatMessage]) -> int:
+    """How many messages carry a compaction marker."""
+    return sum(_COMPACTION_META_KEY in message.meta for message in messages)

--- a/test/hooks/compaction/test_hooks.py
+++ b/test/hooks/compaction/test_hooks.py
@@ -16,17 +16,6 @@ from haystack.hooks.compaction.sliding_window import _DEFAULT_OMISSION_NOTE
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
 from haystack.tools import tool
 
-SCHEMA = {
-    "messages": {"type": list[ChatMessage]},
-    "step_count": {"type": int},
-    "context_tokens": {"type": int},
-    "token_usage": {"type": dict},
-    "tool_call_counts": {"type": dict},
-}
-
-# `_record_context_tokens` sums the prompt and completion tokens, so every reply reports a context of 1000 tokens.
-USAGE_META = {"usage": {"prompt_tokens": 900, "completion_tokens": 100}}
-
 
 @tool
 def fetch(topic: Annotated[str, "the topic to fetch"]) -> str:
@@ -85,13 +74,23 @@ def _long_conversation() -> list[ChatMessage]:
 
 def _state(messages: list[ChatMessage], **data) -> State:
     base = {"messages": messages, "step_count": 2, "context_tokens": 900, "token_usage": {}, "tool_call_counts": {}}
-    return State(schema=SCHEMA, data={**base, **data})
+    return State(
+        schema={
+            "messages": {"type": list[ChatMessage]},
+            "step_count": {"type": int},
+            "context_tokens": {"type": int},
+            "token_usage": {"type": dict},
+            "tool_call_counts": {"type": dict},
+        },
+        data={**base, **data},
+    )
 
 
 def _agent(hooks) -> Agent:
     return Agent(
         chat_generator=MockChatGenerator(
-            responses=[_tool_call("c1"), _tool_call("c2"), _tool_call("c3"), "done"], meta=USAGE_META
+            responses=[_tool_call("c1"), _tool_call("c2"), _tool_call("c3"), "done"],
+            meta={"usage": {"prompt_tokens": 900, "completion_tokens": 100}},
         ),
         tools=[fetch],
         system_prompt="rules",
@@ -127,9 +126,7 @@ class TestContextCompactionHook:
     def test_trigger(self, context_tokens, should_compact):
         compactor = _RecordingCompactor()
         hook = ContextCompactionHook(compactor=compactor, threshold_tokens=100)
-
         hook.run(_state(_long_conversation(), context_tokens=context_tokens))
-
         assert compactor.calls == (["compact"] if should_compact else [])
 
     def test_rewrites_messages_and_resets_context_tokens(self):
@@ -137,15 +134,13 @@ class TestContextCompactionHook:
         state = _state(
             _long_conversation(), context_tokens=900, token_usage={"prompt_tokens": 12}, tool_call_counts={"fetch": 2}
         )
-
         hook.run(state)
-
         messages = state.data["messages"]
         assert len(messages) == 4
         assert _COMPACTION_META_KEY in messages[1].meta
-        # Reset to its "not yet measured" value; the next chat-generator call refreshes it from real usage.
         assert state.data["context_tokens"] == 0
         # Cumulative run metadata records what the run spent and did, which compaction does not change.
+        # TODO You could technically argue that compaction if using a chat generator should increment the token usage
         assert state.data["token_usage"] == {"prompt_tokens": 12}
         assert state.data["tool_call_counts"] == {"fetch": 2}
 
@@ -153,31 +148,17 @@ class TestContextCompactionHook:
         messages = _long_conversation()
         hook = ContextCompactionHook(compactor=_RecordingCompactor(result=None), threshold_tokens=100)
         state = _state(messages, context_tokens=900)
-
         hook.run(state)
-
         assert state.data["messages"] == messages
         assert state.data["context_tokens"] == 900
-
-    def test_warns_when_usage_is_never_reported(self, caplog):
-        # `context_tokens` still 0 after the first call means the Chat Generator reports no usage, so this hook can
-        # never fire. `step_count == 1` happens once per run, so the warning is not repeated every step.
-        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=100)
-
-        with caplog.at_level(logging.WARNING):
-            hook.run(_state(_long_conversation(), step_count=1, context_tokens=0))
-
-        assert "does not report token usage" in caplog.text
 
     def test_warns_only_once_across_a_run(self, caplog):
         # The `step_count` values a `before_llm` hook actually observes over a four-step run, confirmed against the
         # Agent loop. Only one of them is 1, which is what keeps the warning from repeating every step.
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=100)
-
         with caplog.at_level(logging.WARNING):
             for step_count in (0, 1, 2, 3):
                 hook.run(_state(_long_conversation(), step_count=step_count, context_tokens=0))
-
         assert caplog.text.count("does not report token usage") == 1
 
     @pytest.mark.parametrize(
@@ -190,31 +171,25 @@ class TestContextCompactionHook:
     )
     def test_does_not_warn_about_usage(self, caplog, step_count, context_tokens):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=100)
-
         with caplog.at_level(logging.WARNING):
             hook.run(_state(_long_conversation(), step_count=step_count, context_tokens=context_tokens))
-
         assert "does not report token usage" not in caplog.text
 
     def test_lifecycle_delegates_to_the_compactor(self):
         compactor = _RecordingCompactor()
         hook = ContextCompactionHook(compactor=compactor, threshold_tokens=100)
-
         hook.warm_up()
         hook.close()
-
         assert compactor.calls == ["warm_up", "close"]
 
     def test_cannot_be_registered_at_another_hook_point(self):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=100)
-
         with pytest.raises(ValueError, match="before_llm"):
             Agent(chat_generator=MockChatGenerator(), tools=[fetch], hooks={"after_tool": [hook]})
 
     def test_serde_round_trip(self):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=4), threshold_tokens=100_000)
         data = hook.to_dict()
-
         assert data == {
             "type": "haystack.hooks.compaction.hooks.ContextCompactionHook",
             "init_parameters": {
@@ -230,32 +205,12 @@ class TestContextCompactionHook:
         assert restored.compactor.keep_last_n_messages == 4
         assert restored.threshold_tokens == 100_000
 
-    def test_survives_an_agent_serde_round_trip(self):
-        agent = _agent(
-            {
-                "before_llm": [
-                    ContextCompactionHook(
-                        compactor=SlidingWindowCompactor(keep_last_n_messages=3), threshold_tokens=100
-                    )
-                ]
-            }
-        )
-
-        restored = Agent.from_dict(agent.to_dict())
-
-        hook = restored.hooks["before_llm"][0]
-        assert isinstance(hook, ContextCompactionHook)
-        assert isinstance(hook.compactor, SlidingWindowCompactor)
-        assert hook.compactor.keep_last_n_messages == 3
-
 
 class TestContextCompactionHookInAgent:
     def test_compacts_a_multi_step_run(self):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_tokens=1000)
-
         compacted = _agent({"before_llm": [hook]}).run(messages=[ChatMessage.from_user("start")])
         uncompacted = _agent(None).run(messages=[ChatMessage.from_user("start")])
-
         messages = compacted["messages"]
         assert len(messages) < len(uncompacted["messages"])
         # Exactly one omission note: each compaction folds the previous one into the block it drops.
@@ -266,9 +221,7 @@ class TestContextCompactionHookInAgent:
 
     def test_does_not_compact_below_the_threshold(self):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=1_000_000)
-
         result = _agent({"before_llm": [hook]}).run(messages=[ChatMessage.from_user("start")])
-
         assert not any(_COMPACTION_META_KEY in message.meta for message in result["messages"])
 
 
@@ -277,18 +230,14 @@ class TestContextCompactionHookAsync:
     async def test_run_async_uses_the_async_compaction_path(self):
         compactor = _RecordingCompactor()
         hook = ContextCompactionHook(compactor=compactor, threshold_tokens=100)
-
         await hook.run_async(_state(_long_conversation()))
-
         assert compactor.calls == ["compact_async"]
 
     @pytest.mark.asyncio
     async def test_run_async_rewrites_messages(self):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_tokens=100)
         state = _state(_long_conversation(), context_tokens=900)
-
         await hook.run_async(state)
-
         assert len(state.data["messages"]) == 4
         assert state.data["context_tokens"] == 0
 
@@ -296,17 +245,13 @@ class TestContextCompactionHookAsync:
     async def test_lifecycle_prefers_the_async_methods(self):
         compactor = _RecordingCompactor()
         hook = ContextCompactionHook(compactor=compactor, threshold_tokens=100)
-
         await hook.warm_up_async()
         await hook.close_async()
-
         assert compactor.calls == ["warm_up_async", "close_async"]
 
     @pytest.mark.asyncio
     async def test_compacts_a_multi_step_async_run(self):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_tokens=1000)
-
         result = await _agent({"before_llm": [hook]}).run_async(messages=[ChatMessage.from_user("start")])
-
         assert sum(_COMPACTION_META_KEY in message.meta for message in result["messages"]) == 1
         _assert_every_tool_result_is_answered(result["messages"])

--- a/test/hooks/compaction/test_hooks.py
+++ b/test/hooks/compaction/test_hooks.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from typing import Annotated
+
+import pytest
+
+from haystack.components.agents import Agent
+from haystack.components.agents.state.state import State
+from haystack.components.generators.chat import MockChatGenerator
+from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.hooks.compaction import Compactor, ContextCompactionHook, SlidingWindowCompactor
+from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
+from haystack.tools import tool
+
+SCHEMA = {
+    "messages": {"type": list[ChatMessage]},
+    "step_count": {"type": int},
+    "context_tokens": {"type": int},
+    "token_usage": {"type": dict},
+    "tool_call_counts": {"type": dict},
+}
+
+
+@tool
+def fetch(topic: Annotated[str, "the topic to fetch"]) -> str:
+    """Fetch a document about a topic."""
+    return "DATA " * 200
+
+
+class _RecordingCompactor(Compactor):
+    """A compactor that returns a preset result and records every call made to it."""
+
+    def __init__(self, result: list[ChatMessage] | None = None) -> None:
+        self.result = result
+        self.calls: list[str] = []
+
+    def compact(self, state: State) -> list[ChatMessage] | None:
+        self.calls.append("compact")
+        return self.result
+
+    async def compact_async(self, state: State) -> list[ChatMessage] | None:
+        self.calls.append("compact_async")
+        return self.result
+
+    def warm_up(self) -> None:
+        self.calls.append("warm_up")
+
+    async def warm_up_async(self) -> None:
+        self.calls.append("warm_up_async")
+
+    def close(self) -> None:
+        self.calls.append("close")
+
+    async def close_async(self) -> None:
+        self.calls.append("close_async")
+
+
+def _tool_result(result: str, *, call_id: str = "c1") -> ChatMessage:
+    return ChatMessage.from_tool(tool_result=result, origin=ToolCall(tool_name="fetch", arguments={}, id=call_id))
+
+
+def _tool_call(call_id: str = "c1") -> ChatMessage:
+    return ChatMessage.from_assistant(
+        tool_calls=[ToolCall(tool_name="fetch", arguments={"topic": "haystack"}, id=call_id)]
+    )
+
+
+def _long_conversation() -> list[ChatMessage]:
+    return [
+        ChatMessage.from_system("rules"),
+        ChatMessage.from_user("start"),
+        _tool_call("c1"),
+        _tool_result("R" * 400, call_id="c1"),
+        _tool_call("c2"),
+        _tool_result("R" * 400, call_id="c2"),
+    ]
+
+
+def _state(messages: list[ChatMessage], **data) -> State:
+    base = {"messages": messages, "step_count": 2, "context_tokens": 0, "token_usage": {}, "tool_call_counts": {}}
+    return State(schema=SCHEMA, data={**base, **data})
+
+
+def _assert_every_tool_result_is_answered(messages: list[ChatMessage]) -> None:
+    """A tool result whose originating call is missing from the history is rejected by chat-completion APIs."""
+    offered_call_ids: set[str | None] = set()
+    for message in messages:
+        for call in message.tool_calls:
+            offered_call_ids.add(call.id)
+        for result in message.tool_call_results:
+            assert result.origin.id in offered_call_ids, f"orphaned tool result: {result.origin}"
+
+
+class TestContextCompactionHook:
+    def test_requires_at_least_one_threshold(self):
+        with pytest.raises(ValueError, match="at least one of `threshold_tokens` or `threshold_chars`"):
+            ContextCompactionHook(compactor=SlidingWindowCompactor())
+
+    @pytest.mark.parametrize(
+        ("thresholds", "context_tokens", "should_compact"),
+        [
+            pytest.param({"threshold_tokens": 100}, 150, True, id="tokens-over"),
+            pytest.param({"threshold_tokens": 100}, 100, True, id="tokens-at-threshold"),
+            pytest.param({"threshold_tokens": 100}, 50, False, id="tokens-under"),
+            # A Chat Generator that reports no usage leaves `context_tokens` at 0, so a token threshold never fires.
+            pytest.param({"threshold_tokens": 100}, 0, False, id="tokens-never-reported"),
+            pytest.param({"threshold_chars": 500}, 0, True, id="chars-over-without-usage"),
+            pytest.param({"threshold_chars": 100_000}, 0, False, id="chars-under"),
+            pytest.param({"threshold_tokens": 100, "threshold_chars": 100_000}, 150, True, id="either-fires"),
+            pytest.param({"threshold_tokens": 100_000, "threshold_chars": 500}, 5, True, id="chars-fires-alone"),
+        ],
+    )
+    def test_trigger(self, thresholds, context_tokens, should_compact):
+        compactor = _RecordingCompactor()
+        hook = ContextCompactionHook(compactor=compactor, **thresholds)
+
+        hook.run(_state(_long_conversation(), context_tokens=context_tokens))
+
+        assert compactor.calls == (["compact"] if should_compact else [])
+
+    def test_rewrites_messages_and_resets_context_tokens(self):
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_chars=500)
+        state = _state(
+            _long_conversation(), context_tokens=900, token_usage={"prompt_tokens": 12}, tool_call_counts={"fetch": 2}
+        )
+
+        hook.run(state)
+
+        messages = state.data["messages"]
+        assert len(messages) == 4
+        assert _COMPACTION_META_KEY in messages[1].meta
+        # Reset to its "not yet measured" value; the next chat-generator call refreshes it from real usage.
+        assert state.data["context_tokens"] == 0
+        # Cumulative run metadata records what the run spent and did, which compaction does not change.
+        assert state.data["token_usage"] == {"prompt_tokens": 12}
+        assert state.data["tool_call_counts"] == {"fetch": 2}
+
+    @pytest.mark.parametrize(
+        "result",
+        [pytest.param(None, id="compactor-declined"), pytest.param("unchanged", id="compactor-did-not-shrink")],
+    )
+    def test_leaves_the_conversation_alone_when_nothing_was_gained(self, result):
+        messages = _long_conversation()
+        compactor = _RecordingCompactor(result=list(messages) if result == "unchanged" else None)
+        hook = ContextCompactionHook(compactor=compactor, threshold_chars=500)
+        state = _state(messages, context_tokens=900)
+
+        hook.run(state)
+
+        assert state.data["messages"] == messages
+        assert state.data["context_tokens"] == 900
+
+    def test_warns_when_the_threshold_cannot_be_reached(self, caplog):
+        # `threshold_chars` is below what the retained window costs, so compaction can never get under it.
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_chars=100)
+
+        with caplog.at_level(logging.WARNING):
+            hook.run(_state(_long_conversation()))
+
+        assert "still" in caplog.text
+        assert "`threshold_chars`" in caplog.text
+
+    def test_lifecycle_delegates_to_the_compactor(self):
+        compactor = _RecordingCompactor()
+        hook = ContextCompactionHook(compactor=compactor, threshold_chars=500)
+
+        hook.warm_up()
+        hook.close()
+
+        assert compactor.calls == ["warm_up", "close"]
+
+    def test_cannot_be_registered_at_another_hook_point(self):
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_chars=500)
+
+        with pytest.raises(ValueError, match="before_llm"):
+            Agent(chat_generator=MockChatGenerator(), tools=[fetch], hooks={"after_tool": [hook]})
+
+    def test_serde_round_trip(self):
+        hook = ContextCompactionHook(
+            compactor=SlidingWindowCompactor(keep_last_n_messages=4), threshold_tokens=100, threshold_chars=500
+        )
+        data = hook.to_dict()
+
+        assert data == {
+            "type": "haystack.hooks.compaction.hooks.ContextCompactionHook",
+            "init_parameters": {
+                "compactor": {
+                    "type": "haystack.hooks.compaction.sliding_window.SlidingWindowCompactor",
+                    "init_parameters": {"keep_last_n_messages": 4, "omission_note": True},
+                },
+                "threshold_tokens": 100,
+                "threshold_chars": 500,
+            },
+        }
+        restored = ContextCompactionHook.from_dict(data)
+        assert isinstance(restored.compactor, SlidingWindowCompactor)
+        assert restored.compactor.keep_last_n_messages == 4
+        assert restored.threshold_tokens == 100
+
+    def test_survives_an_agent_serde_round_trip(self):
+        agent = Agent(
+            chat_generator=MockChatGenerator(),
+            tools=[fetch],
+            hooks={
+                "before_llm": [
+                    ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=3), threshold_chars=500)
+                ]
+            },
+        )
+
+        restored = Agent.from_dict(agent.to_dict())
+
+        hook = restored.hooks["before_llm"][0]
+        assert isinstance(hook, ContextCompactionHook)
+        assert isinstance(hook.compactor, SlidingWindowCompactor)
+        assert hook.compactor.keep_last_n_messages == 3
+
+
+class TestContextCompactionHookInAgent:
+    def _agent(self, hooks) -> Agent:
+        return Agent(
+            chat_generator=MockChatGenerator(responses=[_tool_call("c1"), _tool_call("c2"), _tool_call("c3"), "done"]),
+            tools=[fetch],
+            system_prompt="rules",
+            hooks=hooks,
+        )
+
+    def test_compacts_a_multi_step_run(self):
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_chars=1500)
+
+        compacted = self._agent({"before_llm": [hook]}).run(messages=[ChatMessage.from_user("start")])
+        uncompacted = self._agent(None).run(messages=[ChatMessage.from_user("start")])
+
+        compacted_messages = compacted["messages"]
+        assert len(compacted_messages) < len(uncompacted["messages"])
+        # Exactly one omission note: each compaction folds the previous one into the block it drops.
+        assert sum(_COMPACTION_META_KEY in message.meta for message in compacted_messages) == 1
+        assert compacted_messages[0].text == "rules"
+        assert compacted["last_message"].text == "done"
+        _assert_every_tool_result_is_answered(compacted_messages)
+
+    def test_does_not_compact_a_run_that_stays_small(self):
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_chars=1_000_000)
+
+        result = self._agent({"before_llm": [hook]}).run(messages=[ChatMessage.from_user("start")])
+
+        assert not any(_COMPACTION_META_KEY in message.meta for message in result["messages"])
+
+
+class TestContextCompactionHookAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_uses_the_async_compaction_path(self):
+        compactor = _RecordingCompactor()
+        hook = ContextCompactionHook(compactor=compactor, threshold_chars=500)
+
+        await hook.run_async(_state(_long_conversation()))
+
+        assert compactor.calls == ["compact_async"]
+
+    @pytest.mark.asyncio
+    async def test_run_async_rewrites_messages(self):
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_chars=500)
+        state = _state(_long_conversation(), context_tokens=900)
+
+        await hook.run_async(state)
+
+        assert len(state.data["messages"]) == 4
+        assert state.data["context_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_prefers_the_async_methods(self):
+        compactor = _RecordingCompactor()
+        hook = ContextCompactionHook(compactor=compactor, threshold_chars=500)
+
+        await hook.warm_up_async()
+        await hook.close_async()
+
+        assert compactor.calls == ["warm_up_async", "close_async"]
+
+    @pytest.mark.asyncio
+    async def test_compacts_a_multi_step_async_run(self):
+        agent = Agent(
+            chat_generator=MockChatGenerator(responses=[_tool_call("c1"), _tool_call("c2"), _tool_call("c3"), "done"]),
+            tools=[fetch],
+            system_prompt="rules",
+            hooks={
+                "before_llm": [
+                    ContextCompactionHook(
+                        compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_chars=1500
+                    )
+                ]
+            },
+        )
+
+        result = await agent.run_async(messages=[ChatMessage.from_user("start")])
+
+        assert sum(_COMPACTION_META_KEY in message.meta for message in result["messages"]) == 1
+        _assert_every_tool_result_is_answered(result["messages"])

--- a/test/hooks/compaction/test_hooks.py
+++ b/test/hooks/compaction/test_hooks.py
@@ -8,7 +8,6 @@ from typing import Annotated
 import pytest
 
 from haystack.components.agents import Agent
-from haystack.components.agents.state.state import State
 from haystack.components.generators.chat import MockChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction import Compactor, ContextCompactionHook, SlidingWindowCompactor
@@ -30,11 +29,11 @@ class _RecordingCompactor(Compactor):
         self.result = result
         self.calls: list[str] = []
 
-    def compact(self, state: State) -> list[ChatMessage] | None:
+    def compact(self, messages: list[ChatMessage]) -> list[ChatMessage] | None:
         self.calls.append("compact")
         return self.result
 
-    async def compact_async(self, state: State) -> list[ChatMessage] | None:
+    async def compact_async(self, messages: list[ChatMessage]) -> list[ChatMessage] | None:
         self.calls.append("compact_async")
         return self.result
 

--- a/test/hooks/compaction/test_hooks.py
+++ b/test/hooks/compaction/test_hooks.py
@@ -10,11 +10,11 @@ import pytest
 from haystack.components.agents import Agent
 from haystack.components.agents.state.state import State
 from haystack.components.generators.chat import MockChatGenerator
-from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction import Compactor, ContextCompactionHook, SlidingWindowCompactor
 from haystack.hooks.compaction.sliding_window import _DEFAULT_OMISSION_NOTE
-from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
 from haystack.tools import tool
+from test.hooks.compaction.helpers import count_markers, long_conversation, make_state, tool_call
 
 
 @tool
@@ -51,45 +51,15 @@ class _RecordingCompactor(Compactor):
         self.calls.append("close_async")
 
 
-def _tool_result(result: str, *, call_id: str = "c1") -> ChatMessage:
-    return ChatMessage.from_tool(tool_result=result, origin=ToolCall(tool_name="fetch", arguments={}, id=call_id))
-
-
-def _tool_call(call_id: str = "c1") -> ChatMessage:
-    return ChatMessage.from_assistant(
-        tool_calls=[ToolCall(tool_name="fetch", arguments={"topic": "haystack"}, id=call_id)]
-    )
-
-
-def _long_conversation() -> list[ChatMessage]:
-    return [
-        ChatMessage.from_system("rules"),
-        ChatMessage.from_user("start"),
-        _tool_call("c1"),
-        _tool_result("R" * 400, call_id="c1"),
-        _tool_call("c2"),
-        _tool_result("R" * 400, call_id="c2"),
-    ]
-
-
-def _state(messages: list[ChatMessage], **data) -> State:
-    base = {"messages": messages, "step_count": 2, "context_tokens": 900, "token_usage": {}, "tool_call_counts": {}}
-    return State(
-        schema={
-            "messages": {"type": list[ChatMessage]},
-            "step_count": {"type": int},
-            "context_tokens": {"type": int},
-            "token_usage": {"type": dict},
-            "tool_call_counts": {"type": dict},
-        },
-        data={**base, **data},
-    )
+def _fetch_call(call_id: str) -> ChatMessage:
+    """A call to the `fetch` tool, which the Agent-level tests actually have registered."""
+    return tool_call(call_id, name="fetch", arguments={"topic": "haystack"})
 
 
 def _agent(hooks) -> Agent:
     return Agent(
         chat_generator=MockChatGenerator(
-            responses=[_tool_call("c1"), _tool_call("c2"), _tool_call("c3"), "done"],
+            responses=[_fetch_call("c1"), _fetch_call("c2"), _fetch_call("c3"), "done"],
             meta={"usage": {"prompt_tokens": 900, "completion_tokens": 100}},
         ),
         tools=[fetch],
@@ -109,7 +79,7 @@ def _assert_every_tool_result_is_answered(messages: list[ChatMessage]) -> None:
 
 
 class TestContextCompactionHook:
-    def test_rejects_a_threshold_that_is_always_met(self):
+    def test_rejects_invalid_threshold(self):
         with pytest.raises(ValueError, match="`threshold_tokens` must be at least 1"):
             ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=0)
 
@@ -126,28 +96,27 @@ class TestContextCompactionHook:
     def test_trigger(self, context_tokens, should_compact):
         compactor = _RecordingCompactor()
         hook = ContextCompactionHook(compactor=compactor, threshold_tokens=100)
-        hook.run(_state(_long_conversation(), context_tokens=context_tokens))
+        hook.run(make_state(long_conversation(), context_tokens=context_tokens))
         assert compactor.calls == (["compact"] if should_compact else [])
 
     def test_rewrites_messages_and_resets_context_tokens(self):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_tokens=100)
-        state = _state(
-            _long_conversation(), context_tokens=900, token_usage={"prompt_tokens": 12}, tool_call_counts={"fetch": 2}
+        state = make_state(
+            long_conversation(), context_tokens=900, token_usage={"prompt_tokens": 12}, tool_call_counts={"fetch": 2}
         )
         hook.run(state)
         messages = state.data["messages"]
         assert len(messages) == 4
-        assert _COMPACTION_META_KEY in messages[1].meta
+        assert count_markers(messages) == 1
         assert state.data["context_tokens"] == 0
         # Cumulative run metadata records what the run spent and did, which compaction does not change.
-        # TODO You could technically argue that compaction if using a chat generator should increment the token usage
         assert state.data["token_usage"] == {"prompt_tokens": 12}
         assert state.data["tool_call_counts"] == {"fetch": 2}
 
     def test_leaves_the_conversation_alone_when_the_compactor_declines(self):
-        messages = _long_conversation()
+        messages = long_conversation()
         hook = ContextCompactionHook(compactor=_RecordingCompactor(result=None), threshold_tokens=100)
-        state = _state(messages, context_tokens=900)
+        state = make_state(messages, context_tokens=900)
         hook.run(state)
         assert state.data["messages"] == messages
         assert state.data["context_tokens"] == 900
@@ -158,7 +127,7 @@ class TestContextCompactionHook:
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=100)
         with caplog.at_level(logging.WARNING):
             for step_count in (0, 1, 2, 3):
-                hook.run(_state(_long_conversation(), step_count=step_count, context_tokens=0))
+                hook.run(make_state(long_conversation(), step_count=step_count, context_tokens=0))
         assert caplog.text.count("does not report token usage") == 1
 
     @pytest.mark.parametrize(
@@ -172,7 +141,7 @@ class TestContextCompactionHook:
     def test_does_not_warn_about_usage(self, caplog, step_count, context_tokens):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=100)
         with caplog.at_level(logging.WARNING):
-            hook.run(_state(_long_conversation(), step_count=step_count, context_tokens=context_tokens))
+            hook.run(make_state(long_conversation(), step_count=step_count, context_tokens=context_tokens))
         assert "does not report token usage" not in caplog.text
 
     def test_lifecycle_delegates_to_the_compactor(self):
@@ -214,7 +183,7 @@ class TestContextCompactionHookInAgent:
         messages = compacted["messages"]
         assert len(messages) < len(uncompacted["messages"])
         # Exactly one omission note: each compaction folds the previous one into the block it drops.
-        assert sum(_COMPACTION_META_KEY in message.meta for message in messages) == 1
+        assert count_markers(messages) == 1
         assert messages[0].text == "rules"
         assert compacted["last_message"].text == "done"
         _assert_every_tool_result_is_answered(messages)
@@ -222,7 +191,7 @@ class TestContextCompactionHookInAgent:
     def test_does_not_compact_below_the_threshold(self):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=1_000_000)
         result = _agent({"before_llm": [hook]}).run(messages=[ChatMessage.from_user("start")])
-        assert not any(_COMPACTION_META_KEY in message.meta for message in result["messages"])
+        assert count_markers(result["messages"]) == 0
 
 
 class TestContextCompactionHookAsync:
@@ -230,13 +199,13 @@ class TestContextCompactionHookAsync:
     async def test_run_async_uses_the_async_compaction_path(self):
         compactor = _RecordingCompactor()
         hook = ContextCompactionHook(compactor=compactor, threshold_tokens=100)
-        await hook.run_async(_state(_long_conversation()))
+        await hook.run_async(make_state(long_conversation()))
         assert compactor.calls == ["compact_async"]
 
     @pytest.mark.asyncio
     async def test_run_async_rewrites_messages(self):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_tokens=100)
-        state = _state(_long_conversation(), context_tokens=900)
+        state = make_state(long_conversation(), context_tokens=900)
         await hook.run_async(state)
         assert len(state.data["messages"]) == 4
         assert state.data["context_tokens"] == 0
@@ -253,5 +222,5 @@ class TestContextCompactionHookAsync:
     async def test_compacts_a_multi_step_async_run(self):
         hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_tokens=1000)
         result = await _agent({"before_llm": [hook]}).run_async(messages=[ChatMessage.from_user("start")])
-        assert sum(_COMPACTION_META_KEY in message.meta for message in result["messages"]) == 1
+        assert count_markers(result["messages"]) == 1
         _assert_every_tool_result_is_answered(result["messages"])

--- a/test/hooks/compaction/test_hooks.py
+++ b/test/hooks/compaction/test_hooks.py
@@ -12,6 +12,7 @@ from haystack.components.agents.state.state import State
 from haystack.components.generators.chat import MockChatGenerator
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.hooks.compaction import Compactor, ContextCompactionHook, SlidingWindowCompactor
+from haystack.hooks.compaction.hooks import _conversation_chars
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
 from haystack.tools import tool
 
@@ -92,6 +93,30 @@ def _assert_every_tool_result_is_answered(messages: list[ChatMessage]) -> None:
             offered_call_ids.add(call.id)
         for result in message.tool_call_results:
             assert result.origin.id in offered_call_ids, f"orphaned tool result: {result.origin}"
+
+
+class TestConversationChars:
+    @pytest.mark.parametrize(
+        ("messages", "expected"),
+        [
+            pytest.param([], 0, id="empty"),
+            pytest.param([ChatMessage.from_user("12345")], 5, id="message-text"),
+            pytest.param(
+                [_tool_call("c1")], len("fetch") + len('{"topic": "haystack"}'), id="tool-call-name-and-arguments"
+            ),
+            pytest.param([_tool_result("R" * 40)], 40, id="tool-result-content"),
+        ],
+    )
+    def test_size(self, messages, expected):
+        assert _conversation_chars(messages) == expected
+
+    def test_shrinks_when_a_result_is_rewritten_in_place(self):
+        # A strategy that replaces a result's content without removing the message must still register as a shrink,
+        # which is why size is measured in characters rather than in messages.
+        before = [_tool_call("c1"), _tool_result("R" * 500)]
+        after = [_tool_call("c1"), _tool_result("[removed]")]
+        assert len(after) == len(before)
+        assert _conversation_chars(after) < _conversation_chars(before)
 
 
 class TestContextCompactionHook:

--- a/test/hooks/compaction/test_hooks.py
+++ b/test/hooks/compaction/test_hooks.py
@@ -12,7 +12,6 @@ from haystack.components.agents.state.state import State
 from haystack.components.generators.chat import MockChatGenerator
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.hooks.compaction import Compactor, ContextCompactionHook, SlidingWindowCompactor
-from haystack.hooks.compaction.hooks import _conversation_chars
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
 from haystack.tools import tool
 
@@ -23,6 +22,9 @@ SCHEMA = {
     "token_usage": {"type": dict},
     "tool_call_counts": {"type": dict},
 }
+
+# `_record_context_tokens` sums the prompt and completion tokens, so every reply reports a context of 1000 tokens.
+USAGE_META = {"usage": {"prompt_tokens": 900, "completion_tokens": 100}}
 
 
 @tool
@@ -81,8 +83,19 @@ def _long_conversation() -> list[ChatMessage]:
 
 
 def _state(messages: list[ChatMessage], **data) -> State:
-    base = {"messages": messages, "step_count": 2, "context_tokens": 0, "token_usage": {}, "tool_call_counts": {}}
+    base = {"messages": messages, "step_count": 2, "context_tokens": 900, "token_usage": {}, "tool_call_counts": {}}
     return State(schema=SCHEMA, data={**base, **data})
+
+
+def _agent(hooks) -> Agent:
+    return Agent(
+        chat_generator=MockChatGenerator(
+            responses=[_tool_call("c1"), _tool_call("c2"), _tool_call("c3"), "done"], meta=USAGE_META
+        ),
+        tools=[fetch],
+        system_prompt="rules",
+        hooks=hooks,
+    )
 
 
 def _assert_every_tool_result_is_answered(messages: list[ChatMessage]) -> None:
@@ -95,59 +108,31 @@ def _assert_every_tool_result_is_answered(messages: list[ChatMessage]) -> None:
             assert result.origin.id in offered_call_ids, f"orphaned tool result: {result.origin}"
 
 
-class TestConversationChars:
-    @pytest.mark.parametrize(
-        ("messages", "expected"),
-        [
-            pytest.param([], 0, id="empty"),
-            pytest.param([ChatMessage.from_user("12345")], 5, id="message-text"),
-            pytest.param(
-                [_tool_call("c1")], len("fetch") + len('{"topic": "haystack"}'), id="tool-call-name-and-arguments"
-            ),
-            pytest.param([_tool_result("R" * 40)], 40, id="tool-result-content"),
-        ],
-    )
-    def test_size(self, messages, expected):
-        assert _conversation_chars(messages) == expected
-
-    def test_shrinks_when_a_result_is_rewritten_in_place(self):
-        # A strategy that replaces a result's content without removing the message must still register as a shrink,
-        # which is why size is measured in characters rather than in messages.
-        before = [_tool_call("c1"), _tool_result("R" * 500)]
-        after = [_tool_call("c1"), _tool_result("[removed]")]
-        assert len(after) == len(before)
-        assert _conversation_chars(after) < _conversation_chars(before)
-
-
 class TestContextCompactionHook:
-    def test_requires_at_least_one_threshold(self):
-        with pytest.raises(ValueError, match="at least one of `threshold_tokens` or `threshold_chars`"):
-            ContextCompactionHook(compactor=SlidingWindowCompactor())
+    def test_rejects_a_threshold_that_is_always_met(self):
+        with pytest.raises(ValueError, match="`threshold_tokens` must be at least 1"):
+            ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=0)
 
     @pytest.mark.parametrize(
-        ("thresholds", "context_tokens", "should_compact"),
+        ("context_tokens", "should_compact"),
         [
-            pytest.param({"threshold_tokens": 100}, 150, True, id="tokens-over"),
-            pytest.param({"threshold_tokens": 100}, 100, True, id="tokens-at-threshold"),
-            pytest.param({"threshold_tokens": 100}, 50, False, id="tokens-under"),
-            # A Chat Generator that reports no usage leaves `context_tokens` at 0, so a token threshold never fires.
-            pytest.param({"threshold_tokens": 100}, 0, False, id="tokens-never-reported"),
-            pytest.param({"threshold_chars": 500}, 0, True, id="chars-over-without-usage"),
-            pytest.param({"threshold_chars": 100_000}, 0, False, id="chars-under"),
-            pytest.param({"threshold_tokens": 100, "threshold_chars": 100_000}, 150, True, id="either-fires"),
-            pytest.param({"threshold_tokens": 100_000, "threshold_chars": 500}, 5, True, id="chars-fires-alone"),
+            pytest.param(150, True, id="over"),
+            pytest.param(100, True, id="at-threshold"),
+            pytest.param(50, False, id="under"),
+            # A Chat Generator that reports no usage leaves `context_tokens` at 0, so the threshold is never reached.
+            pytest.param(0, False, id="usage-never-reported"),
         ],
     )
-    def test_trigger(self, thresholds, context_tokens, should_compact):
+    def test_trigger(self, context_tokens, should_compact):
         compactor = _RecordingCompactor()
-        hook = ContextCompactionHook(compactor=compactor, **thresholds)
+        hook = ContextCompactionHook(compactor=compactor, threshold_tokens=100)
 
         hook.run(_state(_long_conversation(), context_tokens=context_tokens))
 
         assert compactor.calls == (["compact"] if should_compact else [])
 
     def test_rewrites_messages_and_resets_context_tokens(self):
-        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_chars=500)
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_tokens=100)
         state = _state(
             _long_conversation(), context_tokens=900, token_usage={"prompt_tokens": 12}, tool_call_counts={"fetch": 2}
         )
@@ -163,14 +148,9 @@ class TestContextCompactionHook:
         assert state.data["token_usage"] == {"prompt_tokens": 12}
         assert state.data["tool_call_counts"] == {"fetch": 2}
 
-    @pytest.mark.parametrize(
-        "result",
-        [pytest.param(None, id="compactor-declined"), pytest.param("unchanged", id="compactor-did-not-shrink")],
-    )
-    def test_leaves_the_conversation_alone_when_nothing_was_gained(self, result):
+    def test_leaves_the_conversation_alone_when_the_compactor_declines(self):
         messages = _long_conversation()
-        compactor = _RecordingCompactor(result=list(messages) if result == "unchanged" else None)
-        hook = ContextCompactionHook(compactor=compactor, threshold_chars=500)
+        hook = ContextCompactionHook(compactor=_RecordingCompactor(result=None), threshold_tokens=100)
         state = _state(messages, context_tokens=900)
 
         hook.run(state)
@@ -178,19 +158,46 @@ class TestContextCompactionHook:
         assert state.data["messages"] == messages
         assert state.data["context_tokens"] == 900
 
-    def test_warns_when_the_threshold_cannot_be_reached(self, caplog):
-        # `threshold_chars` is below what the retained window costs, so compaction can never get under it.
-        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_chars=100)
+    def test_warns_when_usage_is_never_reported(self, caplog):
+        # `context_tokens` still 0 after the first call means the Chat Generator reports no usage, so this hook can
+        # never fire. `step_count == 1` happens once per run, so the warning is not repeated every step.
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=100)
 
         with caplog.at_level(logging.WARNING):
-            hook.run(_state(_long_conversation()))
+            hook.run(_state(_long_conversation(), step_count=1, context_tokens=0))
 
-        assert "still" in caplog.text
-        assert "`threshold_chars`" in caplog.text
+        assert "does not report token usage" in caplog.text
+
+    def test_warns_only_once_across_a_run(self, caplog):
+        # The `step_count` values a `before_llm` hook actually observes over a four-step run, confirmed against the
+        # Agent loop. Only one of them is 1, which is what keeps the warning from repeating every step.
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=100)
+
+        with caplog.at_level(logging.WARNING):
+            for step_count in (0, 1, 2, 3):
+                hook.run(_state(_long_conversation(), step_count=step_count, context_tokens=0))
+
+        assert caplog.text.count("does not report token usage") == 1
+
+    @pytest.mark.parametrize(
+        ("step_count", "context_tokens"),
+        [
+            pytest.param(0, 0, id="before-the-first-call"),
+            pytest.param(1, 50, id="usage-reported-but-under-threshold"),
+            pytest.param(2, 0, id="not-the-first-step"),
+        ],
+    )
+    def test_does_not_warn_about_usage(self, caplog, step_count, context_tokens):
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=100)
+
+        with caplog.at_level(logging.WARNING):
+            hook.run(_state(_long_conversation(), step_count=step_count, context_tokens=context_tokens))
+
+        assert "does not report token usage" not in caplog.text
 
     def test_lifecycle_delegates_to_the_compactor(self):
         compactor = _RecordingCompactor()
-        hook = ContextCompactionHook(compactor=compactor, threshold_chars=500)
+        hook = ContextCompactionHook(compactor=compactor, threshold_tokens=100)
 
         hook.warm_up()
         hook.close()
@@ -198,15 +205,13 @@ class TestContextCompactionHook:
         assert compactor.calls == ["warm_up", "close"]
 
     def test_cannot_be_registered_at_another_hook_point(self):
-        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_chars=500)
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=100)
 
         with pytest.raises(ValueError, match="before_llm"):
             Agent(chat_generator=MockChatGenerator(), tools=[fetch], hooks={"after_tool": [hook]})
 
     def test_serde_round_trip(self):
-        hook = ContextCompactionHook(
-            compactor=SlidingWindowCompactor(keep_last_n_messages=4), threshold_tokens=100, threshold_chars=500
-        )
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=4), threshold_tokens=100_000)
         data = hook.to_dict()
 
         assert data == {
@@ -216,24 +221,23 @@ class TestContextCompactionHook:
                     "type": "haystack.hooks.compaction.sliding_window.SlidingWindowCompactor",
                     "init_parameters": {"keep_last_n_messages": 4, "omission_note": True},
                 },
-                "threshold_tokens": 100,
-                "threshold_chars": 500,
+                "threshold_tokens": 100_000,
             },
         }
         restored = ContextCompactionHook.from_dict(data)
         assert isinstance(restored.compactor, SlidingWindowCompactor)
         assert restored.compactor.keep_last_n_messages == 4
-        assert restored.threshold_tokens == 100
+        assert restored.threshold_tokens == 100_000
 
     def test_survives_an_agent_serde_round_trip(self):
-        agent = Agent(
-            chat_generator=MockChatGenerator(),
-            tools=[fetch],
-            hooks={
+        agent = _agent(
+            {
                 "before_llm": [
-                    ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=3), threshold_chars=500)
+                    ContextCompactionHook(
+                        compactor=SlidingWindowCompactor(keep_last_n_messages=3), threshold_tokens=100
+                    )
                 ]
-            },
+            }
         )
 
         restored = Agent.from_dict(agent.to_dict())
@@ -245,32 +249,24 @@ class TestContextCompactionHook:
 
 
 class TestContextCompactionHookInAgent:
-    def _agent(self, hooks) -> Agent:
-        return Agent(
-            chat_generator=MockChatGenerator(responses=[_tool_call("c1"), _tool_call("c2"), _tool_call("c3"), "done"]),
-            tools=[fetch],
-            system_prompt="rules",
-            hooks=hooks,
-        )
-
     def test_compacts_a_multi_step_run(self):
-        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_chars=1500)
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_tokens=1000)
 
-        compacted = self._agent({"before_llm": [hook]}).run(messages=[ChatMessage.from_user("start")])
-        uncompacted = self._agent(None).run(messages=[ChatMessage.from_user("start")])
+        compacted = _agent({"before_llm": [hook]}).run(messages=[ChatMessage.from_user("start")])
+        uncompacted = _agent(None).run(messages=[ChatMessage.from_user("start")])
 
-        compacted_messages = compacted["messages"]
-        assert len(compacted_messages) < len(uncompacted["messages"])
+        messages = compacted["messages"]
+        assert len(messages) < len(uncompacted["messages"])
         # Exactly one omission note: each compaction folds the previous one into the block it drops.
-        assert sum(_COMPACTION_META_KEY in message.meta for message in compacted_messages) == 1
-        assert compacted_messages[0].text == "rules"
+        assert sum(_COMPACTION_META_KEY in message.meta for message in messages) == 1
+        assert messages[0].text == "rules"
         assert compacted["last_message"].text == "done"
-        _assert_every_tool_result_is_answered(compacted_messages)
+        _assert_every_tool_result_is_answered(messages)
 
-    def test_does_not_compact_a_run_that_stays_small(self):
-        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_chars=1_000_000)
+    def test_does_not_compact_below_the_threshold(self):
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), threshold_tokens=1_000_000)
 
-        result = self._agent({"before_llm": [hook]}).run(messages=[ChatMessage.from_user("start")])
+        result = _agent({"before_llm": [hook]}).run(messages=[ChatMessage.from_user("start")])
 
         assert not any(_COMPACTION_META_KEY in message.meta for message in result["messages"])
 
@@ -279,7 +275,7 @@ class TestContextCompactionHookAsync:
     @pytest.mark.asyncio
     async def test_run_async_uses_the_async_compaction_path(self):
         compactor = _RecordingCompactor()
-        hook = ContextCompactionHook(compactor=compactor, threshold_chars=500)
+        hook = ContextCompactionHook(compactor=compactor, threshold_tokens=100)
 
         await hook.run_async(_state(_long_conversation()))
 
@@ -287,7 +283,7 @@ class TestContextCompactionHookAsync:
 
     @pytest.mark.asyncio
     async def test_run_async_rewrites_messages(self):
-        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_chars=500)
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_tokens=100)
         state = _state(_long_conversation(), context_tokens=900)
 
         await hook.run_async(state)
@@ -298,7 +294,7 @@ class TestContextCompactionHookAsync:
     @pytest.mark.asyncio
     async def test_lifecycle_prefers_the_async_methods(self):
         compactor = _RecordingCompactor()
-        hook = ContextCompactionHook(compactor=compactor, threshold_chars=500)
+        hook = ContextCompactionHook(compactor=compactor, threshold_tokens=100)
 
         await hook.warm_up_async()
         await hook.close_async()
@@ -307,20 +303,9 @@ class TestContextCompactionHookAsync:
 
     @pytest.mark.asyncio
     async def test_compacts_a_multi_step_async_run(self):
-        agent = Agent(
-            chat_generator=MockChatGenerator(responses=[_tool_call("c1"), _tool_call("c2"), _tool_call("c3"), "done"]),
-            tools=[fetch],
-            system_prompt="rules",
-            hooks={
-                "before_llm": [
-                    ContextCompactionHook(
-                        compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_chars=1500
-                    )
-                ]
-            },
-        )
+        hook = ContextCompactionHook(compactor=SlidingWindowCompactor(keep_last_n_messages=2), threshold_tokens=1000)
 
-        result = await agent.run_async(messages=[ChatMessage.from_user("start")])
+        result = await _agent({"before_llm": [hook]}).run_async(messages=[ChatMessage.from_user("start")])
 
         assert sum(_COMPACTION_META_KEY in message.meta for message in result["messages"]) == 1
         _assert_every_tool_result_is_answered(result["messages"])

--- a/test/hooks/compaction/test_hooks.py
+++ b/test/hooks/compaction/test_hooks.py
@@ -12,6 +12,7 @@ from haystack.components.agents.state.state import State
 from haystack.components.generators.chat import MockChatGenerator
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.hooks.compaction import Compactor, ContextCompactionHook, SlidingWindowCompactor
+from haystack.hooks.compaction.sliding_window import _DEFAULT_OMISSION_NOTE
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
 from haystack.tools import tool
 
@@ -219,7 +220,7 @@ class TestContextCompactionHook:
             "init_parameters": {
                 "compactor": {
                     "type": "haystack.hooks.compaction.sliding_window.SlidingWindowCompactor",
-                    "init_parameters": {"keep_last_n_messages": 4, "omission_note": True},
+                    "init_parameters": {"keep_last_n_messages": 4, "omission_note": _DEFAULT_OMISSION_NOTE},
                 },
                 "threshold_tokens": 100_000,
             },

--- a/test/hooks/compaction/test_sliding_window.py
+++ b/test/hooks/compaction/test_sliding_window.py
@@ -6,11 +6,11 @@ from typing import Any
 
 import pytest
 
-from haystack.dataclasses import ChatMessage
+from haystack.dataclasses import ChatMessage, ChatRole
 from haystack.hooks.compaction import SlidingWindowCompactor
 from haystack.hooks.compaction.sliding_window import _DEFAULT_OMISSION_NOTE
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
-from test.hooks.compaction.helpers import count_markers, long_conversation, make_state, tool_call, tool_result
+from test.hooks.compaction.helpers import count_markers, long_conversation, tool_call, tool_result
 
 
 def _marker(message: ChatMessage) -> dict[str, Any]:
@@ -20,22 +20,19 @@ def _marker(message: ChatMessage) -> dict[str, Any]:
 class TestSlidingWindowCompactor:
     def test_replaces_the_middle_with_an_omission_note(self):
         messages = long_conversation()
-        compacted = SlidingWindowCompactor(keep_last_n_messages=2).compact(make_state(messages))
+        compacted = SlidingWindowCompactor(keep_last_n_messages=2).compact(messages)
         assert compacted is not None
         # The system prefix survives, the note stands in for what was dropped, and the window is kept verbatim.
         assert compacted[0] is messages[0]
         assert compacted[2:] == messages[4:]
-        assert _marker(compacted[1]) == {
-            "step": 2,
-            "strategy": "sliding_window",
-            "removed_messages": 3,
-            "kept_messages": 2,
-        }
+        assert _marker(compacted[1]) == {"strategy": "sliding_window", "removed_messages": 3, "kept_messages": 2}
         assert compacted[1].text == _DEFAULT_OMISSION_NOTE.replace("{num_removed}", "3")
+        # A user message, not a system one, so providers that hoist system messages cannot move it out of position.
+        assert compacted[1].is_from(ChatRole.USER)
 
     def test_omission_note_can_be_turned_off(self):
         messages = long_conversation()
-        compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(make_state(messages))
+        compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(messages)
         assert compacted == [messages[0], *messages[4:]]
 
     @pytest.mark.parametrize(
@@ -48,9 +45,7 @@ class TestSlidingWindowCompactor:
         ],
     )
     def test_omission_note_can_be_customized(self, note, expected):
-        compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=note).compact(
-            make_state(long_conversation())
-        )
+        compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=note).compact(long_conversation())
         assert compacted is not None
         assert compacted[1].text == expected
 
@@ -63,11 +58,11 @@ class TestSlidingWindowCompactor:
         ],
     )
     def test_returns_none_when_there_is_nothing_to_remove(self, messages):
-        assert SlidingWindowCompactor(keep_last_n_messages=20).compact(make_state(messages)) is None
+        assert SlidingWindowCompactor(keep_last_n_messages=20).compact(messages) is None
 
     def test_keeps_a_tool_call_together_with_its_results(self):
         messages = long_conversation()
-        compacted = SlidingWindowCompactor(keep_last_n_messages=1).compact(make_state(messages))
+        compacted = SlidingWindowCompactor(keep_last_n_messages=1).compact(messages)
         # 1 system, 1 note, 2 tool messages: the call and its result are kept together.
         assert len(compacted) == 4
         assert compacted[-2:] == messages[4:]
@@ -77,16 +72,16 @@ class TestSlidingWindowCompactor:
     def test_never_drops_the_final_message(self, keep_last_n_messages):
         # The Agent may be mid-step with a pending tool call whose result is appended right after compaction returns.
         messages = long_conversation()
-        compacted = SlidingWindowCompactor(keep_last_n_messages=keep_last_n_messages).compact(make_state(messages))
+        compacted = SlidingWindowCompactor(keep_last_n_messages=keep_last_n_messages).compact(messages)
         assert (compacted or messages)[-1] is messages[-1]
 
     def test_repeated_compaction_folds_the_previous_note(self):
         compactor = SlidingWindowCompactor(keep_last_n_messages=2)
-        first = compactor.compact(make_state(long_conversation()))
+        first = compactor.compact(long_conversation())
         assert first is not None
         # Simulate two more turns arriving on top of the already-compacted conversation.
         grown = [*first, tool_call("c3"), tool_result("third result", call_id="c3")]
-        second = compactor.compact(make_state(grown))
+        second = compactor.compact(grown)
         assert second is not None
         # Exactly one note: the earlier one is inside the block that was dropped, not carried along beside the new one.
         assert count_markers(second) == 1
@@ -101,9 +96,9 @@ class TestSlidingWindowCompactor:
             ChatMessage.from_user("b"),
             ChatMessage.from_user("c"),
         ]
-        assert SlidingWindowCompactor(keep_last_n_messages=2).compact(make_state(messages)) is None
+        assert SlidingWindowCompactor(keep_last_n_messages=2).compact(messages) is None
         # Without a note there is a real saving, so the same cut is worth making.
-        assert SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(make_state(messages)) == [
+        assert SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(messages) == [
             messages[0],
             *messages[2:],
         ]
@@ -130,9 +125,9 @@ class TestSlidingWindowCompactorAsync:
         # `SlidingWindowCompactor` does no I/O, so it relies on the protocol's default `compact_async`.
         compactor = SlidingWindowCompactor(keep_last_n_messages=2)
         messages = long_conversation()
-        assert await compactor.compact_async(make_state(messages)) == compactor.compact(make_state(messages))
+        assert await compactor.compact_async(messages) == compactor.compact(messages)
 
     @pytest.mark.asyncio
     async def test_compact_async_returns_none_when_nothing_to_remove(self):
         compactor = SlidingWindowCompactor(keep_last_n_messages=20)
-        assert await compactor.compact_async(make_state([ChatMessage.from_user("hi")])) is None
+        assert await compactor.compact_async([ChatMessage.from_user("hi")]) is None

--- a/test/hooks/compaction/test_sliding_window.py
+++ b/test/hooks/compaction/test_sliding_window.py
@@ -105,6 +105,24 @@ class TestSlidingWindowCompactor:
         assert sum(_COMPACTION_META_KEY in message.meta for message in second) == 1
         assert second[0].text == "rules"
 
+    def test_returns_none_when_the_note_would_cost_what_it_saves(self):
+        # Dropping one message to add a note in its place gains nothing, and repeating it every step would just swap
+        # one note for the next.
+        # Four messages with a one-message system prefix: keeping the last two leaves exactly one to remove.
+        messages = [
+            ChatMessage.from_system("rules"),
+            ChatMessage.from_user("a"),
+            ChatMessage.from_user("b"),
+            ChatMessage.from_user("c"),
+        ]
+
+        assert SlidingWindowCompactor(keep_last_n_messages=2).compact(_state(messages)) is None
+        # Without a note there is a real saving, so the same cut is worth making.
+        assert SlidingWindowCompactor(keep_last_n_messages=2, omission_note=False).compact(_state(messages)) == [
+            messages[0],
+            *messages[2:],
+        ]
+
     def test_rejects_keeping_no_messages(self):
         with pytest.raises(ValueError, match="`keep_last_n_messages` must be at least 1"):
             SlidingWindowCompactor(keep_last_n_messages=0)

--- a/test/hooks/compaction/test_sliding_window.py
+++ b/test/hooks/compaction/test_sliding_window.py
@@ -7,6 +7,7 @@ import pytest
 from haystack.components.agents.state.state import State
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.hooks.compaction import SlidingWindowCompactor
+from haystack.hooks.compaction.sliding_window import _DEFAULT_OMISSION_NOTE
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
 
 SCHEMA = {"messages": {"type": list[ChatMessage]}, "step_count": {"type": int}}
@@ -54,13 +55,30 @@ class TestSlidingWindowCompactor:
             "removed_messages": 3,
             "kept_messages": 2,
         }
-        assert "3 earlier messages" in compacted[1].text
+        assert compacted[1].text == _DEFAULT_OMISSION_NOTE.replace("{num_removed}", "3")
 
     def test_omission_note_can_be_turned_off(self):
         messages = _long_conversation()
-        compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=False).compact(_state(messages))
+        compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(_state(messages))
 
         assert compacted == [messages[0], *messages[4:]]
+
+    @pytest.mark.parametrize(
+        ("note", "expected"),
+        [
+            pytest.param("Dropped {num_removed} messages.", "Dropped 3 messages.", id="placeholder-substituted"),
+            pytest.param("Some history is missing.", "Some history is missing.", id="no-placeholder-used-as-written"),
+            # A note is arbitrary user text, so braces of its own must not be treated as placeholders.
+            pytest.param("Gone: {other} x{num_removed}", "Gone: {other} x3", id="other-braces-left-alone"),
+        ],
+    )
+    def test_omission_note_can_be_customized(self, note, expected):
+        compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=note).compact(
+            _state(_long_conversation())
+        )
+
+        assert compacted is not None
+        assert compacted[1].text == expected
 
     @pytest.mark.parametrize(
         "messages",
@@ -118,7 +136,7 @@ class TestSlidingWindowCompactor:
 
         assert SlidingWindowCompactor(keep_last_n_messages=2).compact(_state(messages)) is None
         # Without a note there is a real saving, so the same cut is worth making.
-        assert SlidingWindowCompactor(keep_last_n_messages=2, omission_note=False).compact(_state(messages)) == [
+        assert SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(_state(messages)) == [
             messages[0],
             *messages[2:],
         ]
@@ -128,16 +146,16 @@ class TestSlidingWindowCompactor:
             SlidingWindowCompactor(keep_last_n_messages=0)
 
     def test_serde_round_trip(self):
-        compactor = SlidingWindowCompactor(keep_last_n_messages=7, omission_note=False)
+        compactor = SlidingWindowCompactor(keep_last_n_messages=7, omission_note="Dropped {num_removed}.")
         data = compactor.to_dict()
 
         assert data == {
             "type": "haystack.hooks.compaction.sliding_window.SlidingWindowCompactor",
-            "init_parameters": {"keep_last_n_messages": 7, "omission_note": False},
+            "init_parameters": {"keep_last_n_messages": 7, "omission_note": "Dropped {num_removed}."},
         }
         restored = SlidingWindowCompactor.from_dict(data)
         assert restored.keep_last_n_messages == 7
-        assert restored.omission_note is False
+        assert restored.omission_note == "Dropped {num_removed}."
 
 
 class TestSlidingWindowCompactorAsync:

--- a/test/hooks/compaction/test_sliding_window.py
+++ b/test/hooks/compaction/test_sliding_window.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack.components.agents.state.state import State
+from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.hooks.compaction import SlidingWindowCompactor
+from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
+
+SCHEMA = {"messages": {"type": list[ChatMessage]}, "step_count": {"type": int}}
+
+
+def _tool_result(name: str, result: str, *, call_id: str = "c1") -> ChatMessage:
+    return ChatMessage.from_tool(tool_result=result, origin=ToolCall(tool_name=name, arguments={}, id=call_id))
+
+
+def _tool_call(name: str, *, call_id: str = "c1") -> ChatMessage:
+    return ChatMessage.from_assistant(tool_calls=[ToolCall(tool_name=name, arguments={}, id=call_id)])
+
+
+def _state(messages: list[ChatMessage], *, step_count: int = 3) -> State:
+    return State(schema=SCHEMA, data={"messages": messages, "step_count": step_count})
+
+
+def _long_conversation() -> list[ChatMessage]:
+    return [
+        ChatMessage.from_system("rules"),
+        ChatMessage.from_user("start"),
+        _tool_call("search", call_id="c1"),
+        _tool_result("search", "first", call_id="c1"),
+        _tool_call("search", call_id="c2"),
+        _tool_result("search", "second", call_id="c2"),
+    ]
+
+
+def _marker(message: ChatMessage) -> dict:
+    return message.meta[_COMPACTION_META_KEY]
+
+
+class TestSlidingWindowCompactor:
+    def test_replaces_the_middle_with_an_omission_note(self):
+        messages = _long_conversation()
+        compacted = SlidingWindowCompactor(keep_last_n_messages=2).compact(_state(messages))
+
+        assert compacted is not None
+        # The system prefix survives, the note stands in for what was dropped, and the window is kept verbatim.
+        assert compacted[0] is messages[0]
+        assert compacted[2:] == messages[4:]
+        assert _marker(compacted[1]) == {
+            "step": 3,
+            "strategy": "sliding_window",
+            "removed_messages": 3,
+            "kept_messages": 2,
+        }
+        assert "3 earlier messages" in compacted[1].text
+
+    def test_omission_note_can_be_turned_off(self):
+        messages = _long_conversation()
+        compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=False).compact(_state(messages))
+
+        assert compacted == [messages[0], *messages[4:]]
+
+    @pytest.mark.parametrize(
+        "messages",
+        [
+            pytest.param([], id="empty"),
+            pytest.param([ChatMessage.from_system("a"), ChatMessage.from_system("b")], id="only-system"),
+            pytest.param([ChatMessage.from_system("rules"), ChatMessage.from_user("hi")], id="already-fits"),
+        ],
+    )
+    def test_returns_none_when_there_is_nothing_to_remove(self, messages):
+        assert SlidingWindowCompactor(keep_last_n_messages=20).compact(_state(messages)) is None
+
+    def test_keeps_a_tool_call_together_with_its_results(self):
+        # Keeping exactly one message would start the window at a tool result whose call had been dropped, which
+        # chat-completion APIs reject. The window grows instead.
+        messages = _long_conversation()
+        compacted = SlidingWindowCompactor(keep_last_n_messages=1).compact(_state(messages))
+
+        assert compacted is not None
+        assert compacted[-2:] == messages[4:]
+        assert compacted[-2].tool_calls[0].id == compacted[-1].tool_call_result.origin.id
+
+    @pytest.mark.parametrize("keep_last_n_messages", [1, 2, 3, 20])
+    def test_never_drops_the_final_message(self, keep_last_n_messages):
+        # The Agent may be mid-step with a pending tool call whose result is appended right after compaction returns.
+        messages = _long_conversation()
+        compacted = SlidingWindowCompactor(keep_last_n_messages=keep_last_n_messages).compact(_state(messages))
+
+        assert (compacted or messages)[-1] is messages[-1]
+
+    def test_repeated_compaction_folds_the_previous_note(self):
+        compactor = SlidingWindowCompactor(keep_last_n_messages=2)
+        first = compactor.compact(_state(_long_conversation()))
+        assert first is not None
+
+        # Simulate two more turns arriving on top of the already-compacted conversation.
+        grown = [*first, _tool_call("search", call_id="c3"), _tool_result("search", "third", call_id="c3")]
+        second = compactor.compact(_state(grown))
+
+        assert second is not None
+        # Exactly one note: the earlier one is inside the block that was dropped, not carried along beside the new one.
+        assert sum(_COMPACTION_META_KEY in message.meta for message in second) == 1
+        assert second[0].text == "rules"
+
+    def test_rejects_keeping_no_messages(self):
+        with pytest.raises(ValueError, match="`keep_last_n_messages` must be at least 1"):
+            SlidingWindowCompactor(keep_last_n_messages=0)
+
+    def test_serde_round_trip(self):
+        compactor = SlidingWindowCompactor(keep_last_n_messages=7, omission_note=False)
+        data = compactor.to_dict()
+
+        assert data == {
+            "type": "haystack.hooks.compaction.sliding_window.SlidingWindowCompactor",
+            "init_parameters": {"keep_last_n_messages": 7, "omission_note": False},
+        }
+        restored = SlidingWindowCompactor.from_dict(data)
+        assert restored.keep_last_n_messages == 7
+        assert restored.omission_note is False
+
+
+class TestSlidingWindowCompactorAsync:
+    @pytest.mark.asyncio
+    async def test_compact_async_matches_compact(self):
+        # `SlidingWindowCompactor` does no I/O, so it relies on the protocol's default `compact_async`.
+        compactor = SlidingWindowCompactor(keep_last_n_messages=2)
+        messages = _long_conversation()
+
+        assert await compactor.compact_async(_state(messages)) == compactor.compact(_state(messages))
+
+    @pytest.mark.asyncio
+    async def test_compact_async_returns_none_when_nothing_to_remove(self):
+        compactor = SlidingWindowCompactor(keep_last_n_messages=20)
+        assert await compactor.compact_async(_state([ChatMessage.from_user("hi")])) is None

--- a/test/hooks/compaction/test_sliding_window.py
+++ b/test/hooks/compaction/test_sliding_window.py
@@ -21,7 +21,6 @@ class TestSlidingWindowCompactor:
     def test_replaces_the_middle_with_an_omission_note(self):
         messages = long_conversation()
         compacted = SlidingWindowCompactor(keep_last_n_messages=2).compact(make_state(messages))
-
         assert compacted is not None
         # The system prefix survives, the note stands in for what was dropped, and the window is kept verbatim.
         assert compacted[0] is messages[0]
@@ -37,7 +36,6 @@ class TestSlidingWindowCompactor:
     def test_omission_note_can_be_turned_off(self):
         messages = long_conversation()
         compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(make_state(messages))
-
         assert compacted == [messages[0], *messages[4:]]
 
     @pytest.mark.parametrize(
@@ -53,7 +51,6 @@ class TestSlidingWindowCompactor:
         compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=note).compact(
             make_state(long_conversation())
         )
-
         assert compacted is not None
         assert compacted[1].text == expected
 
@@ -69,12 +66,10 @@ class TestSlidingWindowCompactor:
         assert SlidingWindowCompactor(keep_last_n_messages=20).compact(make_state(messages)) is None
 
     def test_keeps_a_tool_call_together_with_its_results(self):
-        # Keeping exactly one message would start the window at a tool result whose call had been dropped, which
-        # chat-completion APIs reject. The window grows instead.
         messages = long_conversation()
         compacted = SlidingWindowCompactor(keep_last_n_messages=1).compact(make_state(messages))
-
-        assert compacted is not None
+        # 1 system, 1 note, 2 tool messages: the call and its result are kept together.
+        assert len(compacted) == 4
         assert compacted[-2:] == messages[4:]
         assert compacted[-2].tool_calls[0].id == compacted[-1].tool_call_result.origin.id
 
@@ -83,18 +78,15 @@ class TestSlidingWindowCompactor:
         # The Agent may be mid-step with a pending tool call whose result is appended right after compaction returns.
         messages = long_conversation()
         compacted = SlidingWindowCompactor(keep_last_n_messages=keep_last_n_messages).compact(make_state(messages))
-
         assert (compacted or messages)[-1] is messages[-1]
 
     def test_repeated_compaction_folds_the_previous_note(self):
         compactor = SlidingWindowCompactor(keep_last_n_messages=2)
         first = compactor.compact(make_state(long_conversation()))
         assert first is not None
-
         # Simulate two more turns arriving on top of the already-compacted conversation.
         grown = [*first, tool_call("c3"), tool_result("third result", call_id="c3")]
         second = compactor.compact(make_state(grown))
-
         assert second is not None
         # Exactly one note: the earlier one is inside the block that was dropped, not carried along beside the new one.
         assert count_markers(second) == 1
@@ -109,7 +101,6 @@ class TestSlidingWindowCompactor:
             ChatMessage.from_user("b"),
             ChatMessage.from_user("c"),
         ]
-
         assert SlidingWindowCompactor(keep_last_n_messages=2).compact(make_state(messages)) is None
         # Without a note there is a real saving, so the same cut is worth making.
         assert SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(make_state(messages)) == [
@@ -124,7 +115,6 @@ class TestSlidingWindowCompactor:
     def test_serde_round_trip(self):
         compactor = SlidingWindowCompactor(keep_last_n_messages=7, omission_note="Dropped {num_removed}.")
         data = compactor.to_dict()
-
         assert data == {
             "type": "haystack.hooks.compaction.sliding_window.SlidingWindowCompactor",
             "init_parameters": {"keep_last_n_messages": 7, "omission_note": "Dropped {num_removed}."},
@@ -140,7 +130,6 @@ class TestSlidingWindowCompactorAsync:
         # `SlidingWindowCompactor` does no I/O, so it relies on the protocol's default `compact_async`.
         compactor = SlidingWindowCompactor(keep_last_n_messages=2)
         messages = long_conversation()
-
         assert await compactor.compact_async(make_state(messages)) == compactor.compact(make_state(messages))
 
     @pytest.mark.asyncio

--- a/test/hooks/compaction/test_sliding_window.py
+++ b/test/hooks/compaction/test_sliding_window.py
@@ -2,55 +2,32 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any
+
 import pytest
 
-from haystack.components.agents.state.state import State
-from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction import SlidingWindowCompactor
 from haystack.hooks.compaction.sliding_window import _DEFAULT_OMISSION_NOTE
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
-
-SCHEMA = {"messages": {"type": list[ChatMessage]}, "step_count": {"type": int}}
-
-
-def _tool_result(name: str, result: str, *, call_id: str = "c1") -> ChatMessage:
-    return ChatMessage.from_tool(tool_result=result, origin=ToolCall(tool_name=name, arguments={}, id=call_id))
+from test.hooks.compaction.helpers import count_markers, long_conversation, make_state, tool_call, tool_result
 
 
-def _tool_call(name: str, *, call_id: str = "c1") -> ChatMessage:
-    return ChatMessage.from_assistant(tool_calls=[ToolCall(tool_name=name, arguments={}, id=call_id)])
-
-
-def _state(messages: list[ChatMessage], *, step_count: int = 3) -> State:
-    return State(schema=SCHEMA, data={"messages": messages, "step_count": step_count})
-
-
-def _long_conversation() -> list[ChatMessage]:
-    return [
-        ChatMessage.from_system("rules"),
-        ChatMessage.from_user("start"),
-        _tool_call("search", call_id="c1"),
-        _tool_result("search", "first", call_id="c1"),
-        _tool_call("search", call_id="c2"),
-        _tool_result("search", "second", call_id="c2"),
-    ]
-
-
-def _marker(message: ChatMessage) -> dict:
+def _marker(message: ChatMessage) -> dict[str, Any]:
     return message.meta[_COMPACTION_META_KEY]
 
 
 class TestSlidingWindowCompactor:
     def test_replaces_the_middle_with_an_omission_note(self):
-        messages = _long_conversation()
-        compacted = SlidingWindowCompactor(keep_last_n_messages=2).compact(_state(messages))
+        messages = long_conversation()
+        compacted = SlidingWindowCompactor(keep_last_n_messages=2).compact(make_state(messages))
 
         assert compacted is not None
         # The system prefix survives, the note stands in for what was dropped, and the window is kept verbatim.
         assert compacted[0] is messages[0]
         assert compacted[2:] == messages[4:]
         assert _marker(compacted[1]) == {
-            "step": 3,
+            "step": 2,
             "strategy": "sliding_window",
             "removed_messages": 3,
             "kept_messages": 2,
@@ -58,8 +35,8 @@ class TestSlidingWindowCompactor:
         assert compacted[1].text == _DEFAULT_OMISSION_NOTE.replace("{num_removed}", "3")
 
     def test_omission_note_can_be_turned_off(self):
-        messages = _long_conversation()
-        compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(_state(messages))
+        messages = long_conversation()
+        compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(make_state(messages))
 
         assert compacted == [messages[0], *messages[4:]]
 
@@ -74,7 +51,7 @@ class TestSlidingWindowCompactor:
     )
     def test_omission_note_can_be_customized(self, note, expected):
         compacted = SlidingWindowCompactor(keep_last_n_messages=2, omission_note=note).compact(
-            _state(_long_conversation())
+            make_state(long_conversation())
         )
 
         assert compacted is not None
@@ -89,13 +66,13 @@ class TestSlidingWindowCompactor:
         ],
     )
     def test_returns_none_when_there_is_nothing_to_remove(self, messages):
-        assert SlidingWindowCompactor(keep_last_n_messages=20).compact(_state(messages)) is None
+        assert SlidingWindowCompactor(keep_last_n_messages=20).compact(make_state(messages)) is None
 
     def test_keeps_a_tool_call_together_with_its_results(self):
         # Keeping exactly one message would start the window at a tool result whose call had been dropped, which
         # chat-completion APIs reject. The window grows instead.
-        messages = _long_conversation()
-        compacted = SlidingWindowCompactor(keep_last_n_messages=1).compact(_state(messages))
+        messages = long_conversation()
+        compacted = SlidingWindowCompactor(keep_last_n_messages=1).compact(make_state(messages))
 
         assert compacted is not None
         assert compacted[-2:] == messages[4:]
@@ -104,29 +81,28 @@ class TestSlidingWindowCompactor:
     @pytest.mark.parametrize("keep_last_n_messages", [1, 2, 3, 20])
     def test_never_drops_the_final_message(self, keep_last_n_messages):
         # The Agent may be mid-step with a pending tool call whose result is appended right after compaction returns.
-        messages = _long_conversation()
-        compacted = SlidingWindowCompactor(keep_last_n_messages=keep_last_n_messages).compact(_state(messages))
+        messages = long_conversation()
+        compacted = SlidingWindowCompactor(keep_last_n_messages=keep_last_n_messages).compact(make_state(messages))
 
         assert (compacted or messages)[-1] is messages[-1]
 
     def test_repeated_compaction_folds_the_previous_note(self):
         compactor = SlidingWindowCompactor(keep_last_n_messages=2)
-        first = compactor.compact(_state(_long_conversation()))
+        first = compactor.compact(make_state(long_conversation()))
         assert first is not None
 
         # Simulate two more turns arriving on top of the already-compacted conversation.
-        grown = [*first, _tool_call("search", call_id="c3"), _tool_result("search", "third", call_id="c3")]
-        second = compactor.compact(_state(grown))
+        grown = [*first, tool_call("c3"), tool_result("third result", call_id="c3")]
+        second = compactor.compact(make_state(grown))
 
         assert second is not None
         # Exactly one note: the earlier one is inside the block that was dropped, not carried along beside the new one.
-        assert sum(_COMPACTION_META_KEY in message.meta for message in second) == 1
+        assert count_markers(second) == 1
         assert second[0].text == "rules"
 
     def test_returns_none_when_the_note_would_cost_what_it_saves(self):
-        # Dropping one message to add a note in its place gains nothing, and repeating it every step would just swap
-        # one note for the next.
-        # Four messages with a one-message system prefix: keeping the last two leaves exactly one to remove.
+        # Four messages with a one-message system prefix: keeping the last two leaves exactly one to remove, which a
+        # note would merely replace.
         messages = [
             ChatMessage.from_system("rules"),
             ChatMessage.from_user("a"),
@@ -134,9 +110,9 @@ class TestSlidingWindowCompactor:
             ChatMessage.from_user("c"),
         ]
 
-        assert SlidingWindowCompactor(keep_last_n_messages=2).compact(_state(messages)) is None
+        assert SlidingWindowCompactor(keep_last_n_messages=2).compact(make_state(messages)) is None
         # Without a note there is a real saving, so the same cut is worth making.
-        assert SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(_state(messages)) == [
+        assert SlidingWindowCompactor(keep_last_n_messages=2, omission_note=None).compact(make_state(messages)) == [
             messages[0],
             *messages[2:],
         ]
@@ -163,11 +139,11 @@ class TestSlidingWindowCompactorAsync:
     async def test_compact_async_matches_compact(self):
         # `SlidingWindowCompactor` does no I/O, so it relies on the protocol's default `compact_async`.
         compactor = SlidingWindowCompactor(keep_last_n_messages=2)
-        messages = _long_conversation()
+        messages = long_conversation()
 
-        assert await compactor.compact_async(_state(messages)) == compactor.compact(_state(messages))
+        assert await compactor.compact_async(make_state(messages)) == compactor.compact(make_state(messages))
 
     @pytest.mark.asyncio
     async def test_compact_async_returns_none_when_nothing_to_remove(self):
         compactor = SlidingWindowCompactor(keep_last_n_messages=20)
-        assert await compactor.compact_async(_state([ChatMessage.from_user("hi")])) is None
+        assert await compactor.compact_async(make_state([ChatMessage.from_user("hi")])) is None

--- a/test/hooks/compaction/test_utils.py
+++ b/test/hooks/compaction/test_utils.py
@@ -30,7 +30,21 @@ class TestCompactionBounds:
                 [ChatMessage.from_user("hi"), ChatMessage.from_system("late rules")],
                 1,
                 (0, 1),
-                id="system-not-leading-is-removable",
+                id="system-not-leading-does-not-extend-the-protected-run",
+            ),
+            # Only the leading run of system messages is protected. One injected mid-conversation, such as a per-step
+            # nudge from a hook, is removable like anything else - keeping every one would pile them up.
+            pytest.param(
+                [
+                    ChatMessage.from_system("rules"),
+                    ChatMessage.from_user("a"),
+                    ChatMessage.from_system("nudge"),
+                    ChatMessage.from_user("b"),
+                    ChatMessage.from_user("c"),
+                ],
+                2,
+                (1, 3),
+                id="mid-conversation-system-is-removable",
             ),
             # A note or summary an earlier compaction produced is removable, so the next one replaces it.
             pytest.param(

--- a/test/hooks/compaction/test_utils.py
+++ b/test/hooks/compaction/test_utils.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack.dataclasses import ChatMessage, ImageContent, TextContent, ToolCall
+from haystack.hooks.compaction.utils import (
+    _COMPACTION_META_KEY,
+    _conversation_chars,
+    _preserved_prefix_end,
+    _safe_cut_index,
+    _tool_result_text,
+)
+
+IMAGE = ImageContent(base64_image="Zm9v", mime_type="image/png")
+COMPACTED_META = {_COMPACTION_META_KEY: {"strategy": "sliding_window"}}
+
+
+def _tool_result(name: str, result: str, *, error: bool = False, call_id: str = "c1") -> ChatMessage:
+    return ChatMessage.from_tool(
+        tool_result=result, origin=ToolCall(tool_name=name, arguments={}, id=call_id), error=error
+    )
+
+
+def _tool_call(name: str, *, call_id: str = "c1", **arguments) -> ChatMessage:
+    return ChatMessage.from_assistant(tool_calls=[ToolCall(tool_name=name, arguments=arguments, id=call_id)])
+
+
+class TestPreservedPrefixEnd:
+    @pytest.mark.parametrize(
+        ("messages", "expected"),
+        [
+            pytest.param([], 0, id="empty"),
+            pytest.param([ChatMessage.from_user("hi")], 0, id="no-leading-system"),
+            pytest.param([ChatMessage.from_system("a"), ChatMessage.from_system("b")], 2, id="only-system"),
+            pytest.param(
+                [ChatMessage.from_system("a"), ChatMessage.from_system("b"), ChatMessage.from_user("hi")],
+                2,
+                id="leading-system-block",
+            ),
+            pytest.param(
+                [ChatMessage.from_user("hi"), ChatMessage.from_system("late rules")], 0, id="system-not-leading"
+            ),
+            # A previous summary sits right after the real system prompt. Counting it as prefix would leave it behind on
+            # every future compaction instead of folding it into the next one.
+            pytest.param(
+                [
+                    ChatMessage.from_system("rules"),
+                    ChatMessage.from_system("summary", meta=COMPACTED_META),
+                    ChatMessage.from_user("hi"),
+                ],
+                1,
+                id="stops-at-previous-summary",
+            ),
+        ],
+    )
+    def test_prefix_end(self, messages, expected):
+        assert _preserved_prefix_end(messages) == expected
+
+
+class TestSafeCutIndex:
+    @pytest.mark.parametrize(
+        ("messages", "prefix_end", "keep_last_n", "expected"),
+        [
+            pytest.param([], 0, 5, 0, id="empty"),
+            pytest.param([ChatMessage.from_user(f"m{i}") for i in range(6)], 0, 2, 4, id="keeps-requested-count"),
+            # Cutting at index 2 would start the tail with a tool result whose call had been removed, so the boundary
+            # walks back onto the assistant message holding that call.
+            pytest.param(
+                [ChatMessage.from_user("hi"), _tool_call("search"), _tool_result("search", "found")],
+                0,
+                1,
+                1,
+                id="walks-back-off-tool-result",
+            ),
+            pytest.param(
+                [
+                    ChatMessage.from_user("hi"),
+                    ChatMessage.from_assistant(
+                        tool_calls=[ToolCall(tool_name="search", arguments={}, id=f"c{i}") for i in range(3)]
+                    ),
+                    _tool_result("search", "a", call_id="c0"),
+                    _tool_result("search", "b", call_id="c1"),
+                    _tool_result("search", "c", call_id="c2"),
+                ],
+                0,
+                1,
+                1,
+                id="walks-back-over-parallel-batch",
+            ),
+            pytest.param(
+                [ChatMessage.from_system("rules"), _tool_result("search", "orphan")],
+                1,
+                1,
+                1,
+                id="never-moves-before-prefix",
+            ),
+            pytest.param(
+                [ChatMessage.from_system("rules"), ChatMessage.from_user("hi")], 1, 50, 1, id="clamps-to-prefix"
+            ),
+        ],
+    )
+    def test_cut_index(self, messages, prefix_end, keep_last_n, expected):
+        assert _safe_cut_index(messages, prefix_end=prefix_end, keep_last_n=keep_last_n) == expected
+
+
+class TestToolResultText:
+    @pytest.mark.parametrize(
+        ("result", "expected"),
+        [
+            pytest.param("hello", "hello", id="plain-string"),
+            pytest.param([TextContent(text="a"), TextContent(text="b")], "ab", id="text-blocks-concatenated"),
+            pytest.param([TextContent(text="see "), IMAGE], "see <image>", id="non-text-placeholder"),
+        ],
+    )
+    def test_tool_result_text(self, result, expected):
+        assert _tool_result_text(result) == expected
+
+
+class TestConversationChars:
+    @pytest.mark.parametrize(
+        ("messages", "expected"),
+        [
+            pytest.param([], 0, id="empty"),
+            pytest.param([ChatMessage.from_user("12345")], 5, id="message-text"),
+            pytest.param(
+                [_tool_call("search", query="haystack")],
+                len("search") + len('{"query": "haystack"}'),
+                id="tool-call-name-and-arguments",
+            ),
+            pytest.param([_tool_result("search", "R" * 40)], 40, id="tool-result-content"),
+        ],
+    )
+    def test_size(self, messages, expected):
+        assert _conversation_chars(messages) == expected
+
+    def test_shrinks_when_a_result_is_rewritten_in_place(self):
+        # A strategy that replaces a result's content without removing the message must still register as a shrink,
+        # which is why size is measured in characters rather than in messages.
+        before = [_tool_call("search"), _tool_result("search", "R" * 500)]
+        after = [_tool_call("search"), _tool_result("search", "[removed]")]
+        assert len(after) == len(before)
+        assert _conversation_chars(after) < _conversation_chars(before)

--- a/test/hooks/compaction/test_utils.py
+++ b/test/hooks/compaction/test_utils.py
@@ -4,26 +4,18 @@
 
 import pytest
 
-from haystack.dataclasses import ChatMessage, ImageContent, TextContent, ToolCall
-from haystack.hooks.compaction.utils import (
-    _COMPACTION_META_KEY,
-    _preserved_prefix_end,
-    _safe_cut_index,
-    _tool_result_text,
-)
+from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _preserved_prefix_end, _safe_cut_index
 
-IMAGE = ImageContent(base64_image="Zm9v", mime_type="image/png")
 COMPACTED_META = {_COMPACTION_META_KEY: {"strategy": "sliding_window"}}
 
 
-def _tool_result(name: str, result: str, *, error: bool = False, call_id: str = "c1") -> ChatMessage:
-    return ChatMessage.from_tool(
-        tool_result=result, origin=ToolCall(tool_name=name, arguments={}, id=call_id), error=error
-    )
+def _tool_result(name: str, result: str, *, call_id: str = "c1") -> ChatMessage:
+    return ChatMessage.from_tool(tool_result=result, origin=ToolCall(tool_name=name, arguments={}, id=call_id))
 
 
-def _tool_call(name: str, *, call_id: str = "c1", **arguments) -> ChatMessage:
-    return ChatMessage.from_assistant(tool_calls=[ToolCall(tool_name=name, arguments=arguments, id=call_id)])
+def _tool_call(name: str, *, call_id: str = "c1") -> ChatMessage:
+    return ChatMessage.from_assistant(tool_calls=[ToolCall(tool_name=name, arguments={}, id=call_id)])
 
 
 class TestPreservedPrefixEnd:
@@ -102,16 +94,3 @@ class TestSafeCutIndex:
     )
     def test_cut_index(self, messages, prefix_end, keep_last_n, expected):
         assert _safe_cut_index(messages, prefix_end=prefix_end, keep_last_n=keep_last_n) == expected
-
-
-class TestToolResultText:
-    @pytest.mark.parametrize(
-        ("result", "expected"),
-        [
-            pytest.param("hello", "hello", id="plain-string"),
-            pytest.param([TextContent(text="a"), TextContent(text="b")], "ab", id="text-blocks-concatenated"),
-            pytest.param([TextContent(text="see "), IMAGE], "see <image>", id="non-text-placeholder"),
-        ],
-    )
-    def test_tool_result_text(self, result, expected):
-        assert _tool_result_text(result) == expected

--- a/test/hooks/compaction/test_utils.py
+++ b/test/hooks/compaction/test_utils.py
@@ -5,92 +5,86 @@
 import pytest
 
 from haystack.dataclasses import ChatMessage, ToolCall
-from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _preserved_prefix_end, _safe_cut_index
+from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _compaction_bounds
 
 COMPACTED_META = {_COMPACTION_META_KEY: {"strategy": "sliding_window"}}
 
 
-def _tool_result(name: str, result: str, *, call_id: str = "c1") -> ChatMessage:
-    return ChatMessage.from_tool(tool_result=result, origin=ToolCall(tool_name=name, arguments={}, id=call_id))
+def _tool_result(result: str, *, call_id: str = "c1") -> ChatMessage:
+    return ChatMessage.from_tool(tool_result=result, origin=ToolCall(tool_name="search", arguments={}, id=call_id))
 
 
-def _tool_call(name: str, *, call_id: str = "c1") -> ChatMessage:
-    return ChatMessage.from_assistant(tool_calls=[ToolCall(tool_name=name, arguments={}, id=call_id)])
+def _tool_call(*call_ids: str) -> ChatMessage:
+    return ChatMessage.from_assistant(
+        tool_calls=[ToolCall(tool_name="search", arguments={}, id=call_id) for call_id in call_ids]
+    )
 
 
-class TestPreservedPrefixEnd:
+class TestCompactionBounds:
     @pytest.mark.parametrize(
-        ("messages", "expected"),
+        ("messages", "keep_last_n", "expected"),
         [
-            pytest.param([], 0, id="empty"),
-            pytest.param([ChatMessage.from_user("hi")], 0, id="no-leading-system"),
-            pytest.param([ChatMessage.from_system("a"), ChatMessage.from_system("b")], 2, id="only-system"),
+            pytest.param([], 5, (0, 0), id="empty"),
+            pytest.param([ChatMessage.from_user(f"m{i}") for i in range(6)], 2, (0, 4), id="keeps-requested-count"),
+            pytest.param([ChatMessage.from_user("hi")], 1, (0, 0), id="nothing-to-remove"),
+            # The Agent's standing instructions are never removable.
+            pytest.param([ChatMessage.from_system("a"), ChatMessage.from_system("b")], 1, (2, 2), id="only-system"),
             pytest.param(
                 [ChatMessage.from_system("a"), ChatMessage.from_system("b"), ChatMessage.from_user("hi")],
-                2,
+                1,
+                (2, 2),
                 id="leading-system-block",
             ),
             pytest.param(
-                [ChatMessage.from_user("hi"), ChatMessage.from_system("late rules")], 0, id="system-not-leading"
+                [ChatMessage.from_user("hi"), ChatMessage.from_system("late rules")],
+                1,
+                (0, 1),
+                id="system-not-leading-is-removable",
             ),
-            # A previous summary sits right after the real system prompt. Counting it as prefix would leave it behind on
-            # every future compaction instead of folding it into the next one.
+            # A note or summary an earlier compaction produced is removable, so the next one replaces it.
             pytest.param(
                 [
                     ChatMessage.from_system("rules"),
-                    ChatMessage.from_system("summary", meta=COMPACTED_META),
+                    ChatMessage.from_system("earlier note", meta=COMPACTED_META),
                     ChatMessage.from_user("hi"),
                 ],
                 1,
-                id="stops-at-previous-summary",
+                (1, 2),
+                id="previous-compaction-is-removable",
             ),
-        ],
-    )
-    def test_prefix_end(self, messages, expected):
-        assert _preserved_prefix_end(messages) == expected
-
-
-class TestSafeCutIndex:
-    @pytest.mark.parametrize(
-        ("messages", "prefix_end", "keep_last_n", "expected"),
-        [
-            pytest.param([], 0, 5, 0, id="empty"),
-            pytest.param([ChatMessage.from_user(f"m{i}") for i in range(6)], 0, 2, 4, id="keeps-requested-count"),
-            # Cutting at index 2 would start the tail with a tool result whose call had been removed, so the boundary
-            # walks back onto the assistant message holding that call.
+            # The tail may not start on a tool result whose call is about to be removed, so it grows to include the
+            # assistant message holding the call.
             pytest.param(
-                [ChatMessage.from_user("hi"), _tool_call("search"), _tool_result("search", "found")],
-                0,
+                [ChatMessage.from_user("hi"), _tool_call("c1"), _tool_result("found", call_id="c1")],
                 1,
-                1,
-                id="walks-back-off-tool-result",
+                (0, 1),
+                id="tail-grows-past-tool-result",
             ),
             pytest.param(
                 [
                     ChatMessage.from_user("hi"),
-                    ChatMessage.from_assistant(
-                        tool_calls=[ToolCall(tool_name="search", arguments={}, id=f"c{i}") for i in range(3)]
-                    ),
-                    _tool_result("search", "a", call_id="c0"),
-                    _tool_result("search", "b", call_id="c1"),
-                    _tool_result("search", "c", call_id="c2"),
+                    _tool_call("c0", "c1", "c2"),
+                    _tool_result("a", call_id="c0"),
+                    _tool_result("b", call_id="c1"),
+                    _tool_result("c", call_id="c2"),
                 ],
-                0,
                 1,
-                1,
-                id="walks-back-over-parallel-batch",
+                (0, 1),
+                id="tail-grows-past-parallel-batch",
             ),
             pytest.param(
-                [ChatMessage.from_system("rules"), _tool_result("search", "orphan")],
+                [ChatMessage.from_system("rules"), _tool_result("orphan")],
                 1,
-                1,
-                1,
-                id="never-moves-before-prefix",
+                (1, 1),
+                id="tail-never-grows-into-the-system-block",
             ),
             pytest.param(
-                [ChatMessage.from_system("rules"), ChatMessage.from_user("hi")], 1, 50, 1, id="clamps-to-prefix"
+                [ChatMessage.from_system("rules"), ChatMessage.from_user("hi")],
+                50,
+                (1, 1),
+                id="keeps-more-than-there-is",
             ),
         ],
     )
-    def test_cut_index(self, messages, prefix_end, keep_last_n, expected):
-        assert _safe_cut_index(messages, prefix_end=prefix_end, keep_last_n=keep_last_n) == expected
+    def test_bounds(self, messages, keep_last_n, expected):
+        assert _compaction_bounds(messages, keep_last_n) == expected

--- a/test/hooks/compaction/test_utils.py
+++ b/test/hooks/compaction/test_utils.py
@@ -7,7 +7,6 @@ import pytest
 from haystack.dataclasses import ChatMessage, ImageContent, TextContent, ToolCall
 from haystack.hooks.compaction.utils import (
     _COMPACTION_META_KEY,
-    _conversation_chars,
     _preserved_prefix_end,
     _safe_cut_index,
     _tool_result_text,
@@ -116,29 +115,3 @@ class TestToolResultText:
     )
     def test_tool_result_text(self, result, expected):
         assert _tool_result_text(result) == expected
-
-
-class TestConversationChars:
-    @pytest.mark.parametrize(
-        ("messages", "expected"),
-        [
-            pytest.param([], 0, id="empty"),
-            pytest.param([ChatMessage.from_user("12345")], 5, id="message-text"),
-            pytest.param(
-                [_tool_call("search", query="haystack")],
-                len("search") + len('{"query": "haystack"}'),
-                id="tool-call-name-and-arguments",
-            ),
-            pytest.param([_tool_result("search", "R" * 40)], 40, id="tool-result-content"),
-        ],
-    )
-    def test_size(self, messages, expected):
-        assert _conversation_chars(messages) == expected
-
-    def test_shrinks_when_a_result_is_rewritten_in_place(self):
-        # A strategy that replaces a result's content without removing the message must still register as a shrink,
-        # which is why size is measured in characters rather than in messages.
-        before = [_tool_call("search"), _tool_result("search", "R" * 500)]
-        after = [_tool_call("search"), _tool_result("search", "[removed]")]
-        assert len(after) == len(before)
-        assert _conversation_chars(after) < _conversation_chars(before)

--- a/test/hooks/compaction/test_utils.py
+++ b/test/hooks/compaction/test_utils.py
@@ -4,20 +4,11 @@
 
 import pytest
 
-from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _compaction_bounds
+from test.hooks.compaction.helpers import tool_call, tool_result
 
 COMPACTED_META = {_COMPACTION_META_KEY: {"strategy": "sliding_window"}}
-
-
-def _tool_result(result: str, *, call_id: str = "c1") -> ChatMessage:
-    return ChatMessage.from_tool(tool_result=result, origin=ToolCall(tool_name="search", arguments={}, id=call_id))
-
-
-def _tool_call(*call_ids: str) -> ChatMessage:
-    return ChatMessage.from_assistant(
-        tool_calls=[ToolCall(tool_name="search", arguments={}, id=call_id) for call_id in call_ids]
-    )
 
 
 class TestCompactionBounds:
@@ -55,7 +46,7 @@ class TestCompactionBounds:
             # The tail may not start on a tool result whose call is about to be removed, so it grows to include the
             # assistant message holding the call.
             pytest.param(
-                [ChatMessage.from_user("hi"), _tool_call("c1"), _tool_result("found", call_id="c1")],
+                [ChatMessage.from_user("hi"), tool_call("c1"), tool_result("found", call_id="c1")],
                 1,
                 (0, 1),
                 id="tail-grows-past-tool-result",
@@ -63,17 +54,17 @@ class TestCompactionBounds:
             pytest.param(
                 [
                     ChatMessage.from_user("hi"),
-                    _tool_call("c0", "c1", "c2"),
-                    _tool_result("a", call_id="c0"),
-                    _tool_result("b", call_id="c1"),
-                    _tool_result("c", call_id="c2"),
+                    tool_call("c0", "c1", "c2"),
+                    tool_result("a", call_id="c0"),
+                    tool_result("b", call_id="c1"),
+                    tool_result("c", call_id="c2"),
                 ],
                 1,
                 (0, 1),
                 id="tail-grows-past-parallel-batch",
             ),
             pytest.param(
-                [ChatMessage.from_system("rules"), _tool_result("orphan")],
+                [ChatMessage.from_system("rules"), tool_result("orphan")],
                 1,
                 (1, 1),
                 id="tail-never-grows-into-the-system-block",


### PR DESCRIPTION
### Related Issues

- part 1 of https://github.com/deepset-ai/haystack/issues/10866

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Added context compaction for the ``Agent``: a ``ContextCompactionHook`` that shortens the conversation once it
grows past a threshold, and a ``Compactor`` protocol defining how the shortening is done. The first built-in
compactor is ``SlidingWindowCompactor``, which keeps the leading system messages and the most recent messages and drops what is in between, leaving a short note in their place. Register the hook under the ``before_llm`` hook point:

```python
from haystack.components.agents import Agent
from haystack.components.generators.chat import OpenAIChatGenerator
from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor

hook = ContextCompactionHook(
    compactor=SlidingWindowCompactor(keep_last_n_messages=20), threshold_tokens=100_000
)
agent = Agent(
    chat_generator=OpenAIChatGenerator(model="gpt-5.4-nano"),
    tools=[web_search],
    hooks={"before_llm": [hook]},
)
```

The trigger is the ``context_tokens`` state key, which the Agent refreshes after each chat-generator call from the
reply's reported token usage. **The Agent's Chat Generator must report usage** in ``meta["usage"]``, otherwise ``context_tokens`` stays at ``0``, the threshold is never reached, and the hook never compacts. The hook logs a
warning once per run when it detects this. Leave headroom between the threshold and the model's context window: ``context_tokens`` was measured at the previous call, so the tool results appended since and the upcoming reply must still fit within the window.

Compaction never leaves a tool result whose originating tool call was removed, which chat-completion APIs reject: the boundary of the retained window is moved backwards onto the assistant message holding the call, so slightly more may be kept than ``keep_last_n_messages`` asks for. Implement the ``Compactor`` protocol to define your own strategy. Return ``None`` unless the conversation actually gets smaller, and never drop the final message, because the Agent may be mid-step with a pending tool call whose result is appended right after compaction.

Note that compaction is lossy. After it runs the Agent works from a shorter record of the run, and with ``SlidingWindowCompactor`` anything outside the retained window is gone rather than summarized.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added new tests.

Also tried it out locally with
[compaction_live_check.py](https://github.com/user-attachments/files/30463730/compaction_live_check.py)

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

This one a few PRs.
1. I'll add proper docs pages in a separate PR.
2. I plan on adding more Compactor types (e.g. summarization, tool result pruning) in a separate PR.
3. The Compaction Tool (which will reuse the introduced Compactor type) will be a separate PR.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
