### PR TITLE
fix(preprocessors): stop CSVDocumentSplitter recursing forever on multi-block CSVs (#12190)

### DIFF
--- a/haystack/components/preprocessors/csv_document_splitter.py
+++ b/haystack/components/preprocessors/csv_document_splitter.py
@@ -175,10 +175,16 @@ class CSVDocumentSplitter:
         :param axis: Axis along which to find empty elements. Either "row" or "column".
         :return: List of indices where consecutive empty rows or columns start.
         """
+        # Use positional indices here rather than index/column labels so the split points stay
+        # consistent with the positional ``.iloc`` slicing done in ``_split_dataframe``. On a
+        # sub-table produced by an earlier split the labels no longer match their positions;
+        # feeding those labels back into ``.iloc`` failed to actually remove the empty row/column,
+        # so ``_recursive_split`` kept re-detecting it and recursed forever (RecursionError).
         if axis == "row":
-            empty_elements = df[df.isnull().all(axis=1)].index.tolist()
+            empty_mask = df.isnull().all(axis=1).to_numpy()
         else:
-            empty_elements = df.columns[df.isnull().all(axis=0)].tolist()
+            empty_mask = df.isnull().all(axis=0).to_numpy()
+        empty_elements = [pos for pos, is_empty in enumerate(empty_mask) if is_empty]
 
         # If no empty elements found, return empty list
         if len(empty_elements) == 0:

--- a/releasenotes/notes/fix-csv-splitter-recursionerror-73d0529a7c516440.yaml
+++ b/releasenotes/notes/fix-csv-splitter-recursionerror-73d0529a7c516440.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a `RecursionError` in `CSVDocumentSplitter` that could occur when both
+    `row_split_threshold` and `column_split_threshold` were set and a later row block
+    still required a column split. Empty rows/columns are now detected by position
+    instead of by index/column label, keeping the detection consistent with the
+    positional slicing used to actually split the sub-tables.

--- a/test/components/preprocessors/test_csv_document_splitter.py
+++ b/test/components/preprocessors/test_csv_document_splitter.py
@@ -211,6 +211,26 @@ P,Q,,,,
             assert table.content == expected_tables[i]
             assert table.meta == expected_meta[i]
 
+    def test_recursive_split_later_block_needs_column_split(self, splitter: CSVDocumentSplitter) -> None:
+        # Regression test: a later row block that itself needs a column split used to make
+        # ``_recursive_split`` recurse forever (RecursionError), because the empty row/column
+        # detection returned index/column labels while the actual slicing was positional. On a
+        # sub-table those no longer match, so the empty section was never removed.
+        csv_content = "A,B,C,D,E,F\n1,2,3,4,5,6\n,,,,,\nP,Q,,,X,Y\n1,2,,,7,8\n,,,,M,N\n,,,,9,10\nR,S,,,,\n3,4,,,,\n"
+        splitter = CSVDocumentSplitter(row_split_threshold=1, column_split_threshold=1)
+        result = splitter.run([Document(content=csv_content, id="test_id")])["documents"]
+        expected_tables = ["A,B,C,D,E,F\n1,2,3,4,5,6\n", "P,Q\n1,2\n", "X,Y\n7,8\nM,N\n9,10\n", "R,S\n3,4\n"]
+        expected_meta = [
+            {"source_id": "test_id", "row_idx_start": 0, "col_idx_start": 0, "split_id": 0},
+            {"source_id": "test_id", "row_idx_start": 3, "col_idx_start": 0, "split_id": 1},
+            {"source_id": "test_id", "row_idx_start": 3, "col_idx_start": 4, "split_id": 2},
+            {"source_id": "test_id", "row_idx_start": 7, "col_idx_start": 0, "split_id": 3},
+        ]
+        assert len(result) == len(expected_tables)
+        for i, table in enumerate(result):
+            assert table.content == expected_tables[i]
+            assert table.meta == expected_meta[i]
+
     def test_csv_with_blank_lines(self, splitter: CSVDocumentSplitter) -> None:
         csv_data = """ID,LeftVal,,,RightVal,Extra
 1,Hello,,,World,Joined


### PR DESCRIPTION
### Related Issues

Fixes #12190

### Proposed Changes

`CSVDocumentSplitter.run()` could raise `RecursionError` when both `row_split_threshold` and `column_split_threshold` are set and a *later* row block still needs a column split.

**Root cause:** `_find_split_indices` reports empty rows/columns using pandas **index/column labels**, while `_split_dataframe` removes them with **positional** `.iloc` slicing. For the top-level DataFrame the labels happen to equal the positions (a `RangeIndex`), so it works. But on a sub-table produced by an earlier split, the labels no longer match positions — e.g. an empty row at label `6` sits at position `1` in a 3-row sub-table. `df.iloc[0:6]` then returns the whole table unchanged, the empty row is never removed, and `_recursive_split` keeps re-detecting it and recurses until the interpreter's recursion limit is hit.

The fix detects empty rows/columns **by position** (`enumerate` over the boolean mask) so the split points stay consistent with the positional `.iloc` slicing. Sub-table index/column labels are left untouched, so the `row_idx_start` / `col_idx_start` metadata (read from `split_df.index[0]` / `split_df.columns[0]`) is unchanged. For the top-level DataFrame, positions equal labels, so existing behavior — including the `_find_split_indices` unit tests — is preserved.

### How did you test it?

- Added a regression test (`test_recursive_split_later_block_needs_column_split`) using the exact CSV from the issue; it previously hit `RecursionError` and now returns 4 sub-tables with the correct content and metadata.
- Verified the existing `TestFindSplitIndices`, `test_recursive_split_one_level`, and `test_recursive_split_two_levels` cases still produce identical results.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
