### PR TITLE
feat: add token counters

### DIFF
--- a/haystack/token_counters/__init__.py
+++ b/haystack/token_counters/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from typing import TYPE_CHECKING
+
+from lazy_imports import LazyImporter
+
+_import_structure = {
+    "approximate_counter": ["ApproximateTokenCounter"],
+    "types": ["TokenCounter"],
+    "tiktoken_counter": ["TiktokenCounter"],
+}
+
+if TYPE_CHECKING:
+    from .approximate_counter import ApproximateTokenCounter as ApproximateTokenCounter
+    from .tiktoken_counter import TiktokenCounter as TiktokenCounter
+    from .types import TokenCounter as TokenCounter
+else:
+    sys.modules[__name__] = LazyImporter(name=__name__, module_file=__file__, import_structure=_import_structure)

--- a/haystack/token_counters/approximate_counter.py
+++ b/haystack/token_counters/approximate_counter.py
@@ -7,7 +7,8 @@ from typing import Any
 from haystack.core.serialization import default_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.token_counters.types import TokenCounter
-from haystack.token_counters.utils import _non_text_tokens, _rendered_conversation
+from haystack.token_counters.utils import _non_text_tokens, _rendered_conversation, _rendered_tools
+from haystack.tools import ToolsType
 
 
 class ApproximateTokenCounter(TokenCounter):
@@ -46,17 +47,21 @@ class ApproximateTokenCounter(TokenCounter):
         self.tokens_per_image = tokens_per_image
         self.tokens_per_file = tokens_per_file
 
-    def count(self, messages: list[ChatMessage]) -> int:
+    def count(self, messages: list[ChatMessage], tools: ToolsType | None = None) -> int:
         """
         Return the estimated number of tokens the given messages occupy.
 
         :param messages: The messages to measure.
-        :returns: The estimated token count, or `0` for an empty list.
+        :param tools: Tools whose schemas are sent alongside the messages, and so consume tokens too.
+        :returns: The estimated token count, or `0` when there is nothing to measure.
         """
-        if not messages:
+        if not messages and not tools:
             return 0
-        text_tokens = int(len(_rendered_conversation(messages)) / self.chars_per_token)
-        return text_tokens + _non_text_tokens(messages, self.tokens_per_image, self.tokens_per_file)
+        text = _rendered_conversation(messages) + _rendered_tools(tools)
+        text_tokens = int(len(text) / self.chars_per_token)
+        return text_tokens + _non_text_tokens(
+            messages, tokens_per_image=self.tokens_per_image, tokens_per_file=self.tokens_per_file
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/haystack/token_counters/approximate_counter.py
+++ b/haystack/token_counters/approximate_counter.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack.core.serialization import default_to_dict
+from haystack.dataclasses import ChatMessage
+from haystack.token_counters.types import TokenCounter
+from haystack.token_counters.utils import _non_text_tokens, _rendered_conversation
+
+
+class ApproximateTokenCounter(TokenCounter):
+    """
+    Estimates tokens from text length using a flat ratio of characters to tokens.
+
+    ## Usage Example:
+    ```python
+    from haystack.dataclasses import ChatMessage
+    from haystack.token_counters import ApproximateTokenCounter
+
+    counter = ApproximateTokenCounter(chars_per_token=4.0)
+    messages = [
+        ChatMessage.from_user("Hello, how are you?"),
+        ChatMessage.from_assistant("I'm good, thank you! How can I assist you today?")
+    ]
+    token_count = counter.count(messages)
+    print(f"Estimated token count: {token_count}")
+    ```
+    """
+
+    def __init__(self, chars_per_token: float = 4.0, tokens_per_image: int = 85, tokens_per_file: int = 1000) -> None:
+        """
+        Initialize the counter.
+
+        :param chars_per_token: How many characters to treat as one token.
+        :param tokens_per_image: Tokens to charge per image, which has no text to measure. The default is what
+            OpenAI charges for a small image; raise it if you send large ones.
+        :param tokens_per_file: Tokens to charge per file. A rough stand-in for a short document, since the real
+            cost depends on the page count; raise it if you send long ones.
+        :raises ValueError: If `chars_per_token` is not positive.
+        """
+        if chars_per_token <= 0:
+            raise ValueError(f"`chars_per_token` must be greater than 0, got {chars_per_token}.")
+        self.chars_per_token = chars_per_token
+        self.tokens_per_image = tokens_per_image
+        self.tokens_per_file = tokens_per_file
+
+    def count(self, messages: list[ChatMessage]) -> int:
+        """
+        Return the estimated number of tokens the given messages occupy.
+
+        :param messages: The messages to measure.
+        :returns: The estimated token count, or `0` for an empty list.
+        """
+        if not messages:
+            return 0
+        text_tokens = int(len(_rendered_conversation(messages)) / self.chars_per_token)
+        return text_tokens + _non_text_tokens(messages, self.tokens_per_image, self.tokens_per_file)
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize the counter.
+
+        :returns: A dictionary representation of the counter.
+        """
+        return default_to_dict(
+            self,
+            chars_per_token=self.chars_per_token,
+            tokens_per_image=self.tokens_per_image,
+            tokens_per_file=self.tokens_per_file,
+        )

--- a/haystack/token_counters/approximate_counter.py
+++ b/haystack/token_counters/approximate_counter.py
@@ -60,7 +60,7 @@ class ApproximateTokenCounter(TokenCounter):
         text = _rendered_conversation(messages) + _rendered_tools(tools)
         text_tokens = int(len(text) / self.chars_per_token)
         return text_tokens + _non_text_tokens(
-            messages, tokens_per_image=self.tokens_per_image, tokens_per_file=self.tokens_per_file
+            messages=messages, tokens_per_image=self.tokens_per_image, tokens_per_file=self.tokens_per_file
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/haystack/token_counters/tiktoken_counter.py
+++ b/haystack/token_counters/tiktoken_counter.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack.core.serialization import default_to_dict
+from haystack.dataclasses import ChatMessage
+from haystack.lazy_imports import LazyImport
+from haystack.token_counters.types import TokenCounter
+from haystack.token_counters.utils import _non_text_tokens, _rendered_conversation
+
+with LazyImport("Run 'pip install tiktoken'") as tiktoken_imports:
+    import tiktoken
+
+
+class TiktokenCounter(TokenCounter):
+    """
+    Counts tokens locally with `tiktoken`, OpenAI's byte-pair encoder.
+
+    Counting is an estimate, and two limits are worth knowing before relying on it:
+    - **It is text-only**, so images and files get the flat `tokens_per_image` / `tokens_per_file` estimate rather
+      than a real count.
+    - **It is OpenAI's encoder.** Other providers tokenize differently, so expect the count to drift on them.
+
+    ## Usage Example:
+    ```python
+    from haystack.dataclasses import ChatMessage
+    from haystack.token_counters import TiktokenCounter
+
+    counter = TiktokenCounter(encoding="o200k_base")
+    messages = [
+        ChatMessage.from_user("Hello, how are you?"),
+        ChatMessage.from_assistant("I'm good, thank you! How can I assist you today?")
+    ]
+    token_count = counter.count(messages)
+    print(f"Token count: {token_count}")
+    ```
+    """
+
+    def __init__(self, encoding: str = "o200k_base", tokens_per_image: int = 85, tokens_per_file: int = 1000) -> None:
+        """
+        Initialize the counter.
+
+        :param encoding: The `tiktoken` encoding to count with. The default, `o200k_base`, is what current OpenAI
+            models use.
+        :param tokens_per_image: Tokens to charge per image, which the tokenizer cannot measure. The default is what
+            OpenAI charges for a small image; raise it if you send large ones.
+        :param tokens_per_file: Tokens to charge per file. A rough stand-in for a short document, since the real
+            cost depends on the page count; raise it if you send long ones.
+        :raises ImportError: If `tiktoken` is not installed.
+        """
+        tiktoken_imports.check()
+        self.encoding = encoding
+        self.tokens_per_image = tokens_per_image
+        self.tokens_per_file = tokens_per_file
+        self._encoder: Any = None
+
+    def warm_up(self) -> None:
+        """Load the encoder, downloading its vocabulary if it is not already cached."""
+        if self._encoder is not None:
+            return
+        self._encoder = tiktoken.get_encoding(self.encoding)
+
+    def count(self, messages: list[ChatMessage]) -> int:
+        """
+        Return the estimated number of tokens used by the given messages.
+
+        :param messages: The messages to measure.
+        :returns: The estimated token count, or `0` for an empty list.
+        """
+        if not messages:
+            return 0
+        self.warm_up()
+        text_tokens = len(self._encoder.encode(_rendered_conversation(messages)))
+        return text_tokens + _non_text_tokens(messages, self.tokens_per_image, self.tokens_per_file)
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize the counter.
+
+        :returns: A dictionary representation of the counter.
+        """
+        return default_to_dict(
+            self, encoding=self.encoding, tokens_per_image=self.tokens_per_image, tokens_per_file=self.tokens_per_file
+        )

--- a/haystack/token_counters/tiktoken_counter.py
+++ b/haystack/token_counters/tiktoken_counter.py
@@ -8,7 +8,8 @@ from haystack.core.serialization import default_to_dict
 from haystack.dataclasses import ChatMessage
 from haystack.lazy_imports import LazyImport
 from haystack.token_counters.types import TokenCounter
-from haystack.token_counters.utils import _non_text_tokens, _rendered_conversation
+from haystack.token_counters.utils import _non_text_tokens, _rendered_conversation, _rendered_tools
+from haystack.tools import ToolsType
 
 with LazyImport("Run 'pip install tiktoken'") as tiktoken_imports:
     import tiktoken
@@ -62,18 +63,21 @@ class TiktokenCounter(TokenCounter):
             return
         self._encoder = tiktoken.get_encoding(self.encoding)
 
-    def count(self, messages: list[ChatMessage]) -> int:
+    def count(self, messages: list[ChatMessage], tools: ToolsType | None = None) -> int:
         """
         Return the estimated number of tokens used by the given messages.
 
         :param messages: The messages to measure.
-        :returns: The estimated token count, or `0` for an empty list.
+        :param tools: Tools whose schemas are sent alongside the messages, and so consume tokens too.
+        :returns: The estimated token count, or `0` when there is nothing to measure.
         """
-        if not messages:
+        if not messages and not tools:
             return 0
         self.warm_up()
-        text_tokens = len(self._encoder.encode(_rendered_conversation(messages)))
-        return text_tokens + _non_text_tokens(messages, self.tokens_per_image, self.tokens_per_file)
+        text_tokens = len(self._encoder.encode(_rendered_conversation(messages) + _rendered_tools(tools)))
+        return text_tokens + _non_text_tokens(
+            messages, tokens_per_image=self.tokens_per_image, tokens_per_file=self.tokens_per_file
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/haystack/token_counters/types/__init__.py
+++ b/haystack/token_counters/types/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .protocol import TokenCounter
+
+__all__ = ["TokenCounter"]

--- a/haystack/token_counters/types/protocol.py
+++ b/haystack/token_counters/types/protocol.py
@@ -4,30 +4,34 @@
 
 from typing import Any, Protocol
 
-from haystack.core.serialization import default_from_dict, default_to_dict
+from haystack.core.serialization import default_from_dict
 from haystack.dataclasses import ChatMessage
+from haystack.tools import ToolsType
 
 
 class TokenCounter(Protocol):
     """
     Estimates the number tokens used by a list of messages.
 
-    Override `to_dict` when the counter takes constructor arguments, so that they are serialized; the default emits
-    none. `from_dict` rebuilds the counter from whatever `to_dict` emitted and rarely needs overriding.
+    Implement `to_dict` so the counter's settings survive serialization. The default `from_dict` passes them straight
+    back to the constructor, which is enough for plain values; override it when `to_dict` emitted something that has to
+    be rebuilt first, such as a `Secret` or a nested component.
     """
 
-    def count(self, messages: list[ChatMessage]) -> int:
+    def count(self, messages: list[ChatMessage], tools: ToolsType | None = None) -> int:
         """
         Return the estimated number of tokens in the given messages.
 
         :param messages: The messages to measure.
+        :param tools: Tools whose schemas are sent alongside the messages, and so consume tokens too. Pass them to have
+            them counted; leave as None to measure the messages alone.
         :returns: The estimated token count.
         """
         ...
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the counter to a dictionary."""
-        return default_to_dict(self)
+        ...
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "TokenCounter":

--- a/haystack/token_counters/types/protocol.py
+++ b/haystack/token_counters/types/protocol.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Protocol
+
+from haystack.core.serialization import default_from_dict, default_to_dict
+from haystack.dataclasses import ChatMessage
+
+
+class TokenCounter(Protocol):
+    """
+    Estimates the number tokens used by a list of messages.
+
+    Override `to_dict` when the counter takes constructor arguments, so that they are serialized; the default emits
+    none. `from_dict` rebuilds the counter from whatever `to_dict` emitted and rarely needs overriding.
+    """
+
+    def count(self, messages: list[ChatMessage]) -> int:
+        """
+        Return the estimated number of tokens in the given messages.
+
+        :param messages: The messages to measure.
+        :returns: The estimated token count.
+        """
+        ...
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the counter to a dictionary."""
+        return default_to_dict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TokenCounter":
+        """Deserialize the counter from a dictionary."""
+        return default_from_dict(cls, data)

--- a/haystack/token_counters/utils.py
+++ b/haystack/token_counters/utils.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from haystack.dataclasses import ChatMessage, FileContent, ImageContent, TextContent
+from haystack.dataclasses.chat_message import ChatMessageContentT, ToolCallResultContentT
+
+
+def _non_text_placeholder(content: ChatMessageContentT) -> str:
+    """A short stand-in, such as `<image>`, for message content that has no text form."""
+    if isinstance(content, ImageContent):
+        return "<image>"
+    if isinstance(content, FileContent):
+        return f"<file: {content.filename or 'unnamed'}>"
+    return f"<{type(content).__name__}>"
+
+
+def _tool_result_text(result: ToolCallResultContentT) -> str:
+    """A tool result as a single string, with placeholders standing in for any non-text parts."""
+    if isinstance(result, str):
+        return result
+    return "".join(block.text if isinstance(block, TextContent) else _non_text_placeholder(block) for block in result)
+
+
+def _render_message(message: ChatMessage) -> str:
+    """
+    One message as one or more lines of plain text.
+
+    Reasoning content is deliberately left out: providers discard it between turns, so it is not part of the context
+    being measured.
+    """
+    role = message.role.value
+    # A tool-result msg only carries tool_call_results, so it is rendered on its own and labelled with the tool that
+    # produced it.
+    if results := message.tool_call_results:
+        return "\n".join(
+            f"[tool:{result.origin.tool_name}{' (error)' if result.error else ''}] {_tool_result_text(result.result)}"
+            for result in results
+        )
+
+    lines: list[str] = []
+    if texts := message.texts:
+        lines.append(f"[{role}] " + "\n".join(texts))
+    for call in message.tool_calls:
+        arguments = json.dumps(call.arguments, default=str, sort_keys=True)
+        lines.append(f"[{role} -> tool_call] {call.tool_name}({arguments})")
+    # Images and files cost tokens too, so they need a stand-in rather than being skipped.
+    non_text: list[ChatMessageContentT] = [*message.images, *message.files]
+    for content in non_text:
+        lines.append(f"[{role}] {_non_text_placeholder(content)}")
+    return "\n".join(lines) if lines else f"[{role}] <no content>"
+
+
+def _rendered_conversation(messages: list[ChatMessage]) -> str:
+    """The whole conversation as one plain-text block, which is what a counter measures."""
+    return "\n".join(_render_message(message) for message in messages)
+
+
+def _non_text_tokens(messages: list[ChatMessage], tokens_per_image: int, tokens_per_file: int) -> int:
+    """
+    A flat estimate for the images and files in a conversation, which have no text to measure.
+
+    :param messages: The conversation to measure.
+    :param tokens_per_image: Tokens to charge per image.
+    :param tokens_per_file: Tokens to charge per file.
+    :returns: The estimated token count for the non-text content.
+    """
+    images = 0
+    files = 0
+    for message in messages:
+        images += len(message.images)
+        files += len(message.files)
+        # Images and files returned by a tool are nested inside the tool result
+        for result in message.tool_call_results:
+            if isinstance(result.result, str):
+                continue
+            images += sum(isinstance(block, ImageContent) for block in result.result)
+            files += sum(isinstance(block, FileContent) for block in result.result)
+    return images * tokens_per_image + files * tokens_per_file

--- a/haystack/token_counters/utils.py
+++ b/haystack/token_counters/utils.py
@@ -6,6 +6,7 @@ import json
 
 from haystack.dataclasses import ChatMessage, FileContent, ImageContent, TextContent
 from haystack.dataclasses.chat_message import ChatMessageContentT, ToolCallResultContentT
+from haystack.tools import ToolsType, flatten_tools_or_toolsets
 
 
 def _non_text_placeholder(content: ChatMessageContentT) -> str:
@@ -58,7 +59,19 @@ def _rendered_conversation(messages: list[ChatMessage]) -> str:
     return "\n".join(_render_message(message) for message in messages)
 
 
-def _non_text_tokens(messages: list[ChatMessage], tokens_per_image: int, tokens_per_file: int) -> int:
+def _rendered_tools(tools: ToolsType | None) -> str:
+    """
+    Tool schemas as one JSON block, standing in for what a provider sends alongside the messages.
+
+    :param tools: The tools to render, or None.
+    :returns: The rendered schemas, or an empty string when there are none.
+    """
+    if not tools:
+        return ""
+    return json.dumps([tool.tool_spec for tool in flatten_tools_or_toolsets(tools)], default=str, sort_keys=True)
+
+
+def _non_text_tokens(messages: list[ChatMessage], *, tokens_per_image: int, tokens_per_file: int) -> int:
     """
     A flat estimate for the images and files in a conversation, which have no text to measure.
 

--- a/pydoc/token_counters_api.yml
+++ b/pydoc/token_counters_api.yml
@@ -1,0 +1,13 @@
+loaders:
+  - search_path: [../haystack/token_counters]
+    modules: ["types/protocol", "approximate_counter", "tiktoken_counter"]
+processors:
+  - type: filter
+    documented_only: true
+    skip_empty_modules: true
+renderer:
+  title: Token Counters
+  id: token-counters-api
+  description: Estimate how many tokens a conversation occupies, for features that need a size before sending it to a
+    model.
+  filename: token_counters_api.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ dependencies = [
   "python-oxmsg",                     # MSGToDocument
 
   "nltk>=3.9.1", # NLTKDocumentSplitter, RecursiveDocumentSplitter
-  "tiktoken", # RecursiveDocumentSplitter
+  "tiktoken", # RecursiveDocumentSplitter, TiktokenCounter
 
   # Human in the Loop
   "rich",                 # Console rendering for HITL

--- a/releasenotes/notes/add-token-counters-f2685e989bff106e.yaml
+++ b/releasenotes/notes/add-token-counters-f2685e989bff106e.yaml
@@ -1,0 +1,35 @@
+---
+features:
+  - |
+    Added ``haystack.token_counters``: a ``TokenCounter`` protocol for estimating how many tokens a list of
+    ``ChatMessage`` objects occupies, with two implementations.
+
+    Providers report token usage only after a call, and only for the call as a whole, so anything that needs a size
+    beforehand - deciding whether a conversation still fits a model's context window, or how much of it to drop - has to
+    estimate one.
+
+    .. code-block:: python
+
+        from haystack.dataclasses import ChatMessage
+        from haystack.token_counters import ApproximateTokenCounter, TiktokenCounter
+
+        messages = [ChatMessage.from_user("Hello, how are you?")]
+
+        # No dependencies: estimates from text length.
+        ApproximateTokenCounter(chars_per_token=4.0).count(messages)
+
+        # Closer for OpenAI models; needs: pip install tiktoken
+        TiktokenCounter(encoding="o200k_base").count(messages)
+
+    ``ApproximateTokenCounter`` needs nothing installed and estimates from text length at a configurable
+    ``chars_per_token``. ``TiktokenCounter`` counts with OpenAI's byte-pair encoder, which is closer for OpenAI models
+    but requires ``tiktoken`` and drifts on other providers; it raises at construction when the dependency is missing,
+    and loads its encoding on first use.
+
+    Neither can measure an image or a file, since a tokenizer only sees text and providers derive an image's cost from
+    its dimensions. Both charge a flat ``tokens_per_image`` and ``tokens_per_file`` instead, counting images a tool
+    returned inside its result as well as those a message carries directly. Raise those values if you send large images
+    or long documents.
+
+    Implement ``TokenCounter`` to count differently - for instance against a provider's own token-counting endpoint,
+    which is the only way to have images counted exactly.

--- a/releasenotes/notes/add-token-counters-f2685e989bff106e.yaml
+++ b/releasenotes/notes/add-token-counters-f2685e989bff106e.yaml
@@ -31,5 +31,12 @@ features:
     returned inside its result as well as those a message carries directly. Raise those values if you send large images
     or long documents.
 
+    Tool schemas are sent alongside the messages and consume tokens too, so ``count`` takes an optional ``tools``
+    argument to have them included:
+
+    .. code-block:: python
+
+        counter.count(messages, tools=[my_tool])
+
     Implement ``TokenCounter`` to count differently - for instance against a provider's own token-counting endpoint,
     which is the only way to have images counted exactly.

--- a/test/token_counters/__init__.py
+++ b/test/token_counters/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/token_counters/test_approximate_counter.py
+++ b/test/token_counters/test_approximate_counter.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack.dataclasses import ChatMessage, FileContent, ImageContent, TextContent, ToolCall
+from haystack.token_counters import ApproximateTokenCounter
+from haystack.token_counters.utils import _rendered_conversation
+
+IMAGE = ImageContent(base64_image="Zm9v", mime_type="image/png")
+FILE = FileContent(base64_data="Zm9v", mime_type="application/pdf", filename="report.pdf")
+
+
+class TestApproximateTokenCounter:
+    def test_counts_an_empty_conversation_as_zero(self):
+        assert ApproximateTokenCounter().count([]) == 0
+
+    def test_counts_at_the_configured_ratio(self):
+        messages = [ChatMessage.from_user("x" * 400)]
+        rendered = len(_rendered_conversation(messages))
+
+        assert ApproximateTokenCounter().count(messages) == rendered // 4
+        assert ApproximateTokenCounter(chars_per_token=2).count(messages) == rendered // 2
+
+    def test_needs_no_dependency_or_warm_up(self):
+        # The whole point of this counter: it works straight away, with nothing installed and nothing loaded.
+        assert ApproximateTokenCounter().count([ChatMessage.from_user("hi")]) > 0
+
+    def test_counts_grow_with_content(self):
+        counter = ApproximateTokenCounter()
+
+        assert counter.count([ChatMessage.from_user("hi")]) < counter.count([ChatMessage.from_user("hi " * 500)])
+
+    @pytest.mark.parametrize(
+        ("content_parts", "expected_flat"),
+        [
+            pytest.param([IMAGE], 85, id="image"),
+            pytest.param([FILE], 1000, id="file"),
+            pytest.param([IMAGE, IMAGE, FILE], 85 * 2 + 1000, id="several"),
+        ],
+    )
+    def test_non_text_content_is_charged_at_a_flat_rate(self, content_parts, expected_flat):
+        # Neither has text to measure, so each gets a flat estimate on top of whatever its placeholder renders to.
+        count = ApproximateTokenCounter().count([ChatMessage.from_user(content_parts=content_parts)])
+
+        assert count > expected_flat
+
+    def test_an_image_inside_a_tool_result_is_counted(self):
+        # `ChatMessage.images` does not see these, but a tool returning a screenshot puts them here, so a counter
+        # looking only at a message's own content would miss them entirely.
+        counter = ApproximateTokenCounter()
+        nested = ChatMessage.from_tool(
+            tool_result=[TextContent(text="shot:"), IMAGE], origin=ToolCall(tool_name="shot", arguments={}, id="c1")
+        )
+
+        assert nested.images == []
+        assert counter.count([nested]) > 85
+
+    def test_the_flat_rates_are_configurable(self):
+        messages = [ChatMessage.from_user(content_parts=[IMAGE])]
+
+        cheap = ApproximateTokenCounter(tokens_per_image=10).count(messages)
+        dear = ApproximateTokenCounter(tokens_per_image=500).count(messages)
+
+        assert dear - cheap == 490
+
+    def test_rejects_a_non_positive_ratio(self):
+        with pytest.raises(ValueError, match="`chars_per_token` must be greater than 0"):
+            ApproximateTokenCounter(chars_per_token=0)
+
+    def test_serde_round_trip(self):
+        data = ApproximateTokenCounter(chars_per_token=3.5, tokens_per_image=200, tokens_per_file=3000).to_dict()
+
+        assert data == {
+            "type": "haystack.token_counters.approximate_counter.ApproximateTokenCounter",
+            "init_parameters": {"chars_per_token": 3.5, "tokens_per_image": 200, "tokens_per_file": 3000},
+        }
+        restored = ApproximateTokenCounter.from_dict(data)
+        assert restored.chars_per_token == 3.5
+        assert restored.tokens_per_file == 3000

--- a/test/token_counters/test_approximate_counter.py
+++ b/test/token_counters/test_approximate_counter.py
@@ -2,11 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Annotated
+
 import pytest
 
 from haystack.dataclasses import ChatMessage, FileContent, ImageContent, TextContent, ToolCall
 from haystack.token_counters import ApproximateTokenCounter
 from haystack.token_counters.utils import _rendered_conversation
+from haystack.tools import tool
 
 IMAGE = ImageContent(base64_image="Zm9v", mime_type="image/png")
 FILE = FileContent(base64_data="Zm9v", mime_type="application/pdf", filename="report.pdf")
@@ -79,3 +82,25 @@ class TestApproximateTokenCounter:
         restored = ApproximateTokenCounter.from_dict(data)
         assert restored.chars_per_token == 3.5
         assert restored.tokens_per_file == 3000
+
+
+@tool
+def search(query: Annotated[str, "the search query"]) -> str:
+    """Search the web for a query and return the top results."""
+    return "result"
+
+
+class TestApproximateTokenCounterTools:
+    def test_tool_schemas_add_to_the_count(self):
+        # A provider is sent the schemas alongside the messages, so they consume tokens too.
+        counter = ApproximateTokenCounter()
+        messages = [ChatMessage.from_user("hi")]
+
+        assert counter.count(messages, tools=[search]) > counter.count(messages)
+
+    def test_tools_can_be_counted_without_messages(self):
+        assert ApproximateTokenCounter().count([], tools=[search]) > 0
+
+    def test_nothing_to_measure_is_zero(self):
+        assert ApproximateTokenCounter().count([]) == 0
+        assert ApproximateTokenCounter().count([], tools=None) == 0

--- a/test/token_counters/test_tiktoken_counter.py
+++ b/test/token_counters/test_tiktoken_counter.py
@@ -109,6 +109,28 @@ class TestTiktokenCounter:
         assert restored.tokens_per_image == 200
 
 
+@tool
+def search(query: Annotated[str, "the search query"]) -> str:
+    """Search the web for a query and return the top results."""
+    return "result"
+
+
+class TestTiktokenCounterTools:
+    def test_tool_schemas_add_to_the_count(self, fake_encoder):
+        # A provider is sent the schemas alongside the messages, so they consume tokens too.
+        counter = TiktokenCounter()
+        messages = [ChatMessage.from_user("hi")]
+
+        assert counter.count(messages, tools=[search]) > counter.count(messages)
+
+    def test_tools_can_be_counted_without_messages(self, fake_encoder):
+        assert TiktokenCounter().count([], tools=[search]) > 0
+
+    def test_nothing_to_measure_is_zero(self):
+        assert TiktokenCounter().count([]) == 0
+        assert TiktokenCounter().count([], tools=None) == 0
+
+
 @pytest.mark.integration
 class TestTiktokenCounterIntegration:
     """Exercises the real encoder, which downloads its vocabulary on first use."""
@@ -137,25 +159,3 @@ class TestTiktokenCounterIntegration:
         counter = TiktokenCounter(tokens_per_image=85)
 
         assert counter.count([ChatMessage.from_user(content_parts=[IMAGE])]) > 85
-
-
-@tool
-def search(query: Annotated[str, "the search query"]) -> str:
-    """Search the web for a query and return the top results."""
-    return "result"
-
-
-class TestTiktokenCounterTools:
-    def test_tool_schemas_add_to_the_count(self):
-        # A provider is sent the schemas alongside the messages, so they consume tokens too.
-        counter = TiktokenCounter()
-        messages = [ChatMessage.from_user("hi")]
-
-        assert counter.count(messages, tools=[search]) > counter.count(messages)
-
-    def test_tools_can_be_counted_without_messages(self):
-        assert TiktokenCounter().count([], tools=[search]) > 0
-
-    def test_nothing_to_measure_is_zero(self):
-        assert TiktokenCounter().count([]) == 0
-        assert TiktokenCounter().count([], tools=None) == 0

--- a/test/token_counters/test_tiktoken_counter.py
+++ b/test/token_counters/test_tiktoken_counter.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack.dataclasses import ChatMessage, FileContent, ImageContent, ToolCall
+from haystack.token_counters import TiktokenCounter
+from haystack.token_counters import tiktoken_counter as tiktoken_counter_module
+
+IMAGE = ImageContent(base64_image="Zm9v", mime_type="image/png")
+FILE = FileContent(base64_data="Zm9v", mime_type="application/pdf", filename="report.pdf")
+
+
+def _tool_result(result: str, *, error: bool = False) -> ChatMessage:
+    return ChatMessage.from_tool(
+        tool_result=result, origin=ToolCall(tool_name="search", arguments={}, id="c1"), error=error
+    )
+
+
+class _FakeEncoder:
+    """Stands in for a `tiktoken.Encoding`, recording what it was asked to encode."""
+
+    def __init__(self) -> None:
+        self.encoded: list[str] = []
+
+    def encode(self, text: str) -> list[int]:
+        self.encoded.append(text)
+        return list(range(len(text.split())))
+
+
+@pytest.fixture
+def fake_encoder(monkeypatch) -> _FakeEncoder:
+    """Replace `tiktoken.get_encoding`, which downloads its vocabulary on first use."""
+    encoder = _FakeEncoder()
+    monkeypatch.setattr(tiktoken_counter_module.tiktoken, "get_encoding", lambda _name: encoder)
+    return encoder
+
+
+class TestTiktokenCounter:
+    def test_counts_an_empty_conversation_without_an_encoder(self):
+        # Short-circuits before the encoder is needed, so it never triggers a download.
+        counter = TiktokenCounter()
+
+        assert counter.count([]) == 0
+        assert counter._encoder is None
+
+    def test_a_missing_dependency_fails_at_construction(self, monkeypatch):
+        # Reported at setup rather than on the first count, which could be many steps into a run.
+        def raise_import_error() -> None:
+            raise ImportError("Run 'pip install tiktoken'")
+
+        monkeypatch.setattr(tiktoken_counter_module.tiktoken_imports, "check", raise_import_error)
+
+        with pytest.raises(ImportError, match="pip install tiktoken"):
+            TiktokenCounter()
+
+    def test_counting_loads_the_encoder_on_demand(self, fake_encoder):
+        counter = TiktokenCounter()
+
+        counter.count([ChatMessage.from_user("hi there")])
+
+        assert counter._encoder is fake_encoder
+
+    def test_warm_up_is_idempotent(self, monkeypatch):
+        calls: list[str] = []
+
+        def get_encoding(name: str) -> _FakeEncoder:
+            calls.append(name)
+            return _FakeEncoder()
+
+        monkeypatch.setattr(tiktoken_counter_module.tiktoken, "get_encoding", get_encoding)
+        counter = TiktokenCounter(encoding="cl100k_base")
+
+        counter.warm_up()
+        counter.warm_up()
+
+        assert calls == ["cl100k_base"]
+
+    def test_encodes_the_rendered_conversation(self, fake_encoder):
+        # The counter measures what the renderer produces, so tool calls and non-text parts are represented.
+        messages = [
+            ChatMessage.from_assistant("looking", tool_calls=[ToolCall(tool_name="search", arguments={"q": "x"})]),
+            _tool_result("found it"),
+            ChatMessage.from_user(content_parts=["look:", IMAGE, FILE]),
+        ]
+
+        TiktokenCounter().count(messages)
+
+        rendered = fake_encoder.encoded[0]
+        assert "[assistant] looking" in rendered
+        assert '[assistant -> tool_call] search({"q": "x"})' in rendered
+        assert "[tool:search] found it" in rendered
+        assert "<image>" in rendered
+        assert "<file: report.pdf>" in rendered
+
+    def test_serde_round_trip(self):
+        data = TiktokenCounter(encoding="cl100k_base", tokens_per_image=200, tokens_per_file=3000).to_dict()
+
+        assert data == {
+            "type": "haystack.token_counters.tiktoken_counter.TiktokenCounter",
+            "init_parameters": {"encoding": "cl100k_base", "tokens_per_image": 200, "tokens_per_file": 3000},
+        }
+        restored = TiktokenCounter.from_dict(data)
+        assert restored.encoding == "cl100k_base"
+        assert restored.tokens_per_image == 200
+
+
+@pytest.mark.integration
+class TestTiktokenCounterIntegration:
+    """Exercises the real encoder, which downloads its vocabulary on first use."""
+
+    def test_counts_grow_with_content(self):
+        counter = TiktokenCounter()
+
+        small = counter.count([ChatMessage.from_user("hi")])
+        large = counter.count([ChatMessage.from_user("hi " * 500)])
+
+        assert 0 < small < large
+
+    def test_every_message_contributes(self):
+        counter = TiktokenCounter()
+        messages = [
+            ChatMessage.from_system("rules"),
+            ChatMessage.from_assistant("looking", tool_calls=[ToolCall(tool_name="search", arguments={"q": "x"})]),
+            _tool_result("found it"),
+        ]
+
+        assert counter.count(messages) > max(counter.count([message]) for message in messages)
+
+    def test_an_image_is_charged_at_the_flat_rate(self):
+        # A tokenizer cannot price an image, so it gets a flat estimate rather than the handful of tokens its
+        # placeholder text would cost.
+        counter = TiktokenCounter(tokens_per_image=85)
+
+        assert counter.count([ChatMessage.from_user(content_parts=[IMAGE])]) > 85

--- a/test/token_counters/test_tiktoken_counter.py
+++ b/test/token_counters/test_tiktoken_counter.py
@@ -2,11 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Annotated
+
 import pytest
 
 from haystack.dataclasses import ChatMessage, FileContent, ImageContent, ToolCall
 from haystack.token_counters import TiktokenCounter
 from haystack.token_counters import tiktoken_counter as tiktoken_counter_module
+from haystack.tools import tool
 
 IMAGE = ImageContent(base64_image="Zm9v", mime_type="image/png")
 FILE = FileContent(base64_data="Zm9v", mime_type="application/pdf", filename="report.pdf")
@@ -134,3 +137,25 @@ class TestTiktokenCounterIntegration:
         counter = TiktokenCounter(tokens_per_image=85)
 
         assert counter.count([ChatMessage.from_user(content_parts=[IMAGE])]) > 85
+
+
+@tool
+def search(query: Annotated[str, "the search query"]) -> str:
+    """Search the web for a query and return the top results."""
+    return "result"
+
+
+class TestTiktokenCounterTools:
+    def test_tool_schemas_add_to_the_count(self):
+        # A provider is sent the schemas alongside the messages, so they consume tokens too.
+        counter = TiktokenCounter()
+        messages = [ChatMessage.from_user("hi")]
+
+        assert counter.count(messages, tools=[search]) > counter.count(messages)
+
+    def test_tools_can_be_counted_without_messages(self):
+        assert TiktokenCounter().count([], tools=[search]) > 0
+
+    def test_nothing_to_measure_is_zero(self):
+        assert TiktokenCounter().count([]) == 0
+        assert TiktokenCounter().count([], tools=None) == 0

--- a/test/token_counters/test_utils.py
+++ b/test/token_counters/test_utils.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack.dataclasses import ChatMessage, FileContent, ImageContent, TextContent, ToolCall
+from haystack.token_counters.utils import _render_message, _rendered_conversation, _tool_result_text
+
+IMAGE = ImageContent(base64_image="Zm9v", mime_type="image/png")
+FILE = FileContent(base64_data="Zm9v", mime_type="application/pdf", filename="report.pdf")
+
+
+def _tool_result(result: str, *, error: bool = False) -> ChatMessage:
+    return ChatMessage.from_tool(
+        tool_result=result, origin=ToolCall(tool_name="search", arguments={}, id="c1"), error=error
+    )
+
+
+class TestRenderMessage:
+    def test_renders_every_kind_of_message(self):
+        messages = [
+            ChatMessage.from_system("rules"),
+            ChatMessage.from_user("what is haystack?"),
+            ChatMessage.from_assistant(
+                "let me look", tool_calls=[ToolCall(tool_name="search", arguments={"b": 2, "a": 1})]
+            ),
+            _tool_result("found it"),
+            _tool_result("boom", error=True),
+            ChatMessage.from_user(content_parts=["look:", IMAGE, FILE]),
+            ChatMessage.from_assistant(),
+        ]
+        assert "\n".join(_render_message(message) for message in messages) == (
+            "[system] rules\n"
+            "[user] what is haystack?\n"
+            "[assistant] let me look\n"
+            '[assistant -> tool_call] search({"a": 1, "b": 2})\n'
+            "[tool:search] found it\n"
+            "[tool:search (error)] boom\n"
+            "[user] look:\n"
+            "[user] <image>\n"
+            "[user] <file: report.pdf>\n"
+            "[assistant] <no content>"
+        )
+
+
+class TestToolResultText:
+    @pytest.mark.parametrize(
+        ("result", "expected"),
+        [
+            pytest.param("hello", "hello", id="plain-string"),
+            pytest.param([TextContent(text="a"), TextContent(text="b")], "ab", id="text-blocks-concatenated"),
+            pytest.param([TextContent(text="see "), IMAGE], "see <image>", id="non-text-placeholder"),
+        ],
+    )
+    def test_tool_result_text(self, result, expected):
+        assert _tool_result_text(result) == expected
+
+
+class TestRenderedConversation:
+    def test_joins_messages_with_newlines(self):
+        messages = [ChatMessage.from_user("a"), ChatMessage.from_assistant("b")]
+
+        assert _rendered_conversation(messages) == "[user] a\n[assistant] b"
+
+    def test_empty_conversation(self):
+        assert _rendered_conversation([]) == ""

--- a/test/token_counters/test_utils.py
+++ b/test/token_counters/test_utils.py
@@ -2,10 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Annotated
+
 import pytest
 
-from haystack.dataclasses import ChatMessage, FileContent, ImageContent, TextContent, ToolCall
-from haystack.token_counters.utils import _render_message, _rendered_conversation, _tool_result_text
+from haystack.dataclasses import ChatMessage, FileContent, ImageContent, ReasoningContent, TextContent, ToolCall
+from haystack.token_counters.utils import (
+    _non_text_placeholder,
+    _render_message,
+    _rendered_conversation,
+    _rendered_tools,
+    _tool_result_text,
+)
+from haystack.tools import tool
 
 IMAGE = ImageContent(base64_image="Zm9v", mime_type="image/png")
 FILE = FileContent(base64_data="Zm9v", mime_type="application/pdf", filename="report.pdf")
@@ -65,3 +74,39 @@ class TestRenderedConversation:
 
     def test_empty_conversation(self):
         assert _rendered_conversation([]) == ""
+
+
+@tool
+def search(query: Annotated[str, "the search query"]) -> str:
+    """Search the web for a query."""
+    return "result"
+
+
+class TestNonTextPlaceholder:
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            pytest.param(IMAGE, "<image>", id="image"),
+            pytest.param(FILE, "<file: report.pdf>", id="file-with-name"),
+            pytest.param(
+                FileContent(base64_data="Zm9v", mime_type="application/pdf"), "<file: unnamed>", id="file-unnamed"
+            ),
+            # Anything else falls back to naming its type, so an unexpected block still shows up in the text.
+            pytest.param(ReasoningContent(reasoning_text="thinking"), "<ReasoningContent>", id="unknown-type"),
+        ],
+    )
+    def test_placeholder(self, content, expected):
+        assert _non_text_placeholder(content) == expected
+
+
+class TestRenderedTools:
+    def test_no_tools_renders_nothing(self):
+        assert _rendered_tools(None) == ""
+        assert _rendered_tools([]) == ""
+
+    def test_renders_the_schema_a_provider_would_be_sent(self):
+        rendered = _rendered_tools([search])
+
+        assert "search" in rendered
+        assert "Search the web for a query." in rendered
+        assert "the search query" in rendered


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack/issues/10866
- Determined in the thread https://github.com/deepset-ai/haystack/pull/12176#discussion_r3667415054 that for a better UX we should implement a way to count the tokens used up by a list of chat messages

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Added ``haystack.token_counters``: a ``TokenCounter`` protocol for estimating how many tokens a list of
``ChatMessage`` objects occupies, with two implementations.

Providers report token usage only after a call, and only for the call as a whole, so anything that needs a size beforehand - deciding whether a conversation still fits a model's context window, or how much of it to drop - has to
estimate one.

``ApproximateTokenCounter`` needs no deps and estimates from text length at a configurable ``chars_per_token``. ``TiktokenCounter`` counts with OpenAI's byte-pair encoder using ``tiktoken``.

Neither can measure an image or a file, since these are text only tokenizers. Both charge a flat ``tokens_per_image`` and ``tokens_per_file`` instead, counting images a tool returned inside its result as well as those a message carries directly. Raise those values if you send large images or long documents. Similar approach as LC.

```python
from haystack.dataclasses import ChatMessage
from haystack.token_counters import ApproximateTokenCounter, TiktokenCounter

messages = [ChatMessage.from_user("Hello, how are you?")]

# No dependencies: estimates from text length.
ApproximateTokenCounter(chars_per_token=4.0).count(messages)

# Closer for OpenAI models; needs: pip install tiktoken
TiktokenCounter(encoding="o200k_base").count(messages)
```

**Follow-up: provider-specific token counters**

Every major provider exposes an endpoint that counts *exactly*, including images and tool schemas, at the cost of a network round trip. The `TokenCounter` protocol exists so these can be added as separate implementations:

| Provider | API | Counts | Docs |
| --- | --- | --- | --- |
| OpenAI | `POST /v1/responses/input_tokens` (`client.responses.input_tokens.count`) | messages, images, files, tool schemas | [Counting tokens](https://developers.openai.com/api/docs/guides/token-counting) |
| Anthropic | `client.messages.count_tokens()` | messages, images, PDFs, tools. Free, rate-limited | [Token counting](https://platform.claude.com/docs/en/build-with-claude/token-counting) |
| Google Gemini | `models.countTokens` | text, images, audio, video, PDFs; returns a per-modality breakdown via `ModalityTokenCount` | [Understand and count tokens](https://ai.google.dev/gemini-api/docs/tokens) · [API reference](https://ai.google.dev/api/tokens) |
| Amazon Bedrock | `CountTokens` | messages for Bedrock-hosted models | [Count tokens](https://docs.aws.amazon.com/bedrock/latest/userguide/count-tokens.html) |

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

If we think this route makes sense I can open up issues for adding token counters for each of the different providers.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
