### PR TITLE
fix: round-trip serialization of mixed-type lists in schema-based serialization

### DIFF
--- a/haystack/utils/base_serialization.py
+++ b/haystack/utils/base_serialization.py
@@ -28,7 +28,9 @@ def _serialize_value_with_schema(payload: Any) -> dict[str, Any]:  # noqa: PLR09
     - Objects with to_dict() methods (e.g. dataclasses)
     - Objects with __dict__ attributes
     - Dictionaries
-    - Lists, tuples, and sets. Lists with mixed types are not supported.
+    - Lists, tuples, and sets, including ones holding mixed types. A mixed-type array records one
+      schema per position under the JSON Schema `prefixItems` keyword, while a homogeneous array
+      keeps the single shared `items` schema.
     - Primitive types (str, int, float, bool, None)
 
     This is for runtime values (Agent/State data, pipeline inputs/outputs at a breakpoint), not
@@ -61,20 +63,23 @@ def _serialize_value_with_schema(payload: Any) -> dict[str, Any]:  # noqa: PLR09
 
     # Handle array case - iterate through elements
     if isinstance(payload, (list, tuple, set, frozenset)):
-        # Serialize each item in the array
+        # Serialize each item in the array, keeping its own schema
         serialized_list = []
+        item_schemas: list[Any] = []
+        base_schema: dict[str, Any]
         for item in payload:
             serialized_value = _serialize_value_with_schema(item)
             serialized_list.append(serialized_value["serialized_data"])
+            item_schemas.append(serialized_value["serialization_schema"])
 
-        # Determine item type from first element (if any)
-        # NOTE: We do not support mixed-type lists
-        if payload:
-            first = next(iter(payload))
-            item_schema = _serialize_value_with_schema(first)
-            base_schema = {"type": "array", "items": item_schema["serialization_schema"]}
-        else:
+        if not item_schemas:
             base_schema = {"type": "array", "items": {}}
+        elif all(item_schema == item_schemas[0] for item_schema in item_schemas):
+            # Homogeneous array: keep the historical `items` envelope so older readers keep working
+            base_schema = {"type": "array", "items": item_schemas[0]}
+        else:
+            # Mixed-type array: describe every position with the JSON Schema `prefixItems` keyword
+            base_schema = {"type": "array", "prefixItems": item_schemas}
 
         # Add JSON Schema properties to infer sets, frozensets and tuples
         if isinstance(payload, (set, frozenset)):
@@ -194,7 +199,8 @@ def _deserialize_value_with_schema(serialized: dict[str, Any]) -> Any:
          "serialized_data": <the actual data>
       }
 
-    NOTE: For array types we only support homogeneous lists (all elements of the same type).
+    For array types, `prefixItems` (one schema per position, emitted for mixed-type arrays) takes
+    precedence over `items` (a single shared schema, emitted for homogeneous arrays).
 
     :param serialized: The serialized dict with schema and data.
     :returns: The deserialized value in its original form.
@@ -233,10 +239,23 @@ def _deserialize_value_with_schema(serialized: dict[str, Any]) -> Any:
 
     # Handle array case
     if schema_type == "array":
-        # Deserialize each item
+        # Mixed-type arrays carry one schema per position under `prefixItems`,
+        # homogeneous ones carry a single shared schema under `items`.
+        prefix_items = schema.get("prefixItems")
+        if prefix_items is not None:
+            if len(prefix_items) != len(data):
+                raise DeserializationError(
+                    f"Invalid array payload: 'prefixItems' declares {len(prefix_items)} element schemas "
+                    f"but 'serialized_data' holds {len(data)} elements."
+                )
+            item_schemas: list[Any] = list(prefix_items)
+        else:
+            item_schemas = [schema["items"]] * len(data)
+
+        # Deserialize each item with the schema of its own position
         deserialized_items = [
-            _deserialize_value_with_schema({"serialization_schema": schema["items"], "serialized_data": item})
-            for item in data
+            _deserialize_value_with_schema({"serialization_schema": item_schema, "serialized_data": item})
+            for item_schema, item in zip(item_schemas, data, strict=True)
         ]
         final_array: list | set | frozenset | tuple
         # Is a set or frozenset if uniqueItems is True

--- a/releasenotes/notes/fix-mixed-type-lists-schema-serialization-3f1c5a2b7d904e18.yaml
+++ b/releasenotes/notes/fix-mixed-type-lists-schema-serialization-3f1c5a2b7d904e18.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed schema-based serialization of lists, tuples and sets holding mixed types. Previously the
+    schema was derived from the first element only, so deserializing such a value raised an
+    `AttributeError` or silently returned mis-typed data (for example an Agent `State` field or a
+    pipeline breakpoint input holding `[Document(...), "text", 3]`). Mixed-type arrays now record one
+    schema per position using the JSON Schema `prefixItems` keyword and round-trip correctly.
+    Homogeneous arrays keep the exact same output as before, so existing snapshots still load.

--- a/releasenotes/notes/fix-mixed-type-lists-schema-serialization-3f1c5a2b7d904e18.yaml
+++ b/releasenotes/notes/fix-mixed-type-lists-schema-serialization-3f1c5a2b7d904e18.yaml
@@ -3,7 +3,7 @@ fixes:
   - |
     Fixed schema-based serialization of lists, tuples and sets holding mixed types. Previously the
     schema was derived from the first element only, so deserializing such a value raised an
-    `AttributeError` or silently returned mis-typed data (for example an Agent `State` field or a
-    pipeline breakpoint input holding `[Document(...), "text", 3]`). Mixed-type arrays now record one
-    schema per position using the JSON Schema `prefixItems` keyword and round-trip correctly.
+    ``AttributeError`` or silently returned mis-typed data (for example an Agent ``State`` field or a
+    pipeline breakpoint input holding ``[Document(...), "text", 3]``). Mixed-type arrays now record one
+    schema per position using the JSON Schema ``prefixItems`` keyword and round-trip correctly.
     Homogeneous arrays keep the exact same output as before, so existing snapshots still load.

--- a/test/utils/test_base_serialization.py
+++ b/test/utils/test_base_serialization.py
@@ -373,6 +373,86 @@ def test_serialize_and_deserialize_value_with_schema_with_various_types():
     assert _deserialize_value_with_schema(expected) == data
 
 
+class TestMixedTypeArrays:
+    """Mixed-type arrays keep one schema per position under `prefixItems`."""
+
+    def test_serialize_mixed_primitives(self):
+        assert _serialize_value_with_schema({"y": [1, "a", {"k": 2}]}) == {
+            "serialization_schema": {
+                "type": "object",
+                "properties": {
+                    "y": {
+                        "type": "array",
+                        "prefixItems": [
+                            {"type": "integer"},
+                            {"type": "string"},
+                            {"type": "object", "properties": {"k": {"type": "integer"}}},
+                        ],
+                    }
+                },
+            },
+            "serialized_data": {"y": [1, "a", {"k": 2}]},
+        }
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param({"y": [1, "a", {"k": 2}]}, id="mixed-primitives"),
+            pytest.param({"x": [Document(content="a", id="1"), "plain string", 3]}, id="object-and-primitives"),
+            pytest.param({"t": (1, "a", Document(content="a", id="1"))}, id="mixed-tuple"),
+            pytest.param({"n": [[1, "a"], [Document(content="a", id="1"), None]]}, id="nested-mixed-lists"),
+            pytest.param({"e": []}, id="empty-list"),
+            pytest.param({"m": [1, None, True, 2.5, "s"]}, id="all-primitive-kinds"),
+        ],
+    )
+    def test_round_trip_mixed_arrays(self, value):
+        deserialized = _deserialize_value_with_schema(_serialize_value_with_schema(value))
+        assert deserialized == value
+        for key, original in value.items():
+            assert type(deserialized[key]) is type(original)
+
+    def test_round_trip_mixed_set(self):
+        value = {1, "a", None}
+        deserialized = _deserialize_value_with_schema(_serialize_value_with_schema(value))
+        assert deserialized == value
+        assert type(deserialized) is set
+
+    def test_round_trip_mixed_frozenset(self):
+        value = frozenset({1, "a", None})
+        deserialized = _deserialize_value_with_schema(_serialize_value_with_schema(value))
+        assert deserialized == value
+        assert type(deserialized) is frozenset
+
+    def test_homogeneous_output_is_unchanged(self):
+        # Backward compatibility: homogeneous arrays keep the historical `items` envelope.
+        document = Document(content="a", id="1")
+        assert _serialize_value_with_schema({"docs": [document], "nums": (1, 2)}) == {
+            "serialization_schema": {
+                "type": "object",
+                "properties": {
+                    "docs": {"type": "array", "items": {"type": "haystack.dataclasses.document.Document"}},
+                    "nums": {"type": "array", "items": {"type": "integer"}, "minItems": 2, "maxItems": 2},
+                },
+            },
+            "serialized_data": {"docs": [document.to_dict()], "nums": [1, 2]},
+        }
+
+    def test_deserialize_old_format_with_only_items(self):
+        # Payloads written before `prefixItems` existed still deserialize through `items`.
+        assert _deserialize_value_with_schema(
+            {"serialization_schema": {"type": "array", "items": {"type": "integer"}}, "serialized_data": [1, 2, 3]}
+        ) == [1, 2, 3]
+
+    def test_deserialize_prefix_items_length_mismatch_raises(self):
+        with pytest.raises(DeserializationError, match="'prefixItems' declares 2 element schemas"):
+            _deserialize_value_with_schema(
+                {
+                    "serialization_schema": {"type": "array", "prefixItems": [{"type": "integer"}, {"type": "string"}]},
+                    "serialized_data": [1],
+                }
+            )
+
+
 class TestErrorHandling:
     @pytest.mark.parametrize(
         "value",


### PR DESCRIPTION
### Related Issues

- partially addresses #9539 (the second follow-up there — promoting the schema serialization helpers to public utilities — is intentionally not part of this PR and the issue should stay open)

### Proposed Changes:

`_serialize_value_with_schema` derived the array schema from the first element only, so any list/tuple/set holding mixed types was described by a schema that lied about every element after the first. Two concrete failures on `main` (commit 5add74e):

```python
_deserialize_value_with_schema(_serialize_value_with_schema({"x": [Document(content="a"), "plain string", 3]}))
# AttributeError: 'str' object has no attribute 'copy'

_serialize_value_with_schema({"y": [1, "a", {"k": 2}]})["serialization_schema"]
# {'type': 'object', 'properties': {'y': {'type': 'array', 'items': {'type': 'integer'}}}}
# -> every element typed as integer, payload silently mis-typed
```

This hits real runtime values: Agent `State` fields and pipeline-breakpoint inputs holding heterogeneous lists crash or corrupt on resume.

Changes in `haystack/utils/base_serialization.py`:

- **Serializer**: compute each element's schema during the single existing pass instead of re-serializing the first element. When all element schemas are equal, emit the current `{"type": "array", "items": {...}}` envelope unchanged. Only when they differ, emit the JSON-Schema-standard `{"type": "array", "prefixItems": [schema_per_item, ...]}`. The `uniqueItems` / `frozen` / `minItems` / `maxItems` markers are attached exactly as before, so set/frozenset/tuple reconstruction is untouched.
- **Deserializer**: in the array branch, prefer `prefixItems` when present (each item is zipped with its own schema) and otherwise fall back to `schema["items"]` exactly as today. A `prefixItems` length that disagrees with the data length raises a `DeserializationError` instead of a raw `zip` error.
- Updated the two docstring notes that stated mixed-type lists are unsupported.
- Added a release note under `releasenotes/notes/`.

**Backward compatibility**: homogeneous arrays serialize to the byte-for-byte same dict as before, and payloads written by older versions (which only ever carry `items`) still deserialize through the unchanged `items` path. Both are asserted by dedicated tests.

### How did you test it?

Unit tests added in `test/utils/test_base_serialization.py` (new `TestMixedTypeArrays` class): the exact serialized schema for mixed primitives, round-trips for mixed primitives, primitives mixed with a `to_dict` object (`Document`), a mixed tuple, mixed sets and frozensets (with container-type assertions), nested mixed lists, the empty list, plus a backward-compat assertion that a homogeneous list/tuple still serializes to the pre-change dict, that an old-format `items`-only payload still deserializes, and that a `prefixItems`/data length mismatch raises `DeserializationError`.

Verified red-before / green-after: with the new tests against the unmodified `base_serialization.py`, 5 of them fail (including the `AttributeError` crash); with the fix all pass.

Ran locally (Python 3.12, editable install):

- `pytest test/utils/test_base_serialization.py test/core/pipeline/test_breakpoint.py test/core/pipeline/test_component_checks.py` — the three call sites of these helpers: **160 passed**.
- `pytest test/utils test/core test/dataclasses -m "not integration"` — **2534 passed**, 4 failures all pre-existing and unrelated to this change (missing optional `torch`/`ipython` in this environment).
- `ruff check` and `ruff format --check` on both touched files — clean.
- `mypy` on `haystack/utils/base_serialization.py` — clean.

### Notes for the reviewer

The issue offers "implement or document" as alternatives. This PR takes the implement route because the current behaviour is a hard crash (`AttributeError` leaking out of deserialization), not just a documented gap. The mechanism is deliberately conservative: nothing about homogeneous output changes, so existing snapshots and stored `State` payloads keep loading unchanged, and `prefixItems` is the standard JSON Schema keyword for positional element schemas rather than a Haystack-specific marker.

One behavioural detail worth a look: a set or frozenset with mixed types now round-trips too. The per-position schemas are produced from the same single iteration that produces the data, so the pairing is always consistent even though set iteration order is arbitrary.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
