### PR TITLE
docs: fix docstring parameter names in three components

### DIFF
--- a/haystack/components/fetchers/link_content.py
+++ b/haystack/components/fetchers/link_content.py
@@ -135,6 +135,8 @@ class LinkContentFetcher:
                      Requires the 'h2' package to be installed (via `pip install httpx[http2]`).
         :param client_kwargs: Additional keyword arguments to pass to the httpx client.
                      If `None`, default values are used.
+        :param request_headers: Additional headers to send with every request. These take precedence over the
+                     component's default headers but not over the rotating `User-Agent`.
         """
         self.raise_on_failure = raise_on_failure
         self.user_agents = user_agents or [DEFAULT_USER_AGENT]

--- a/haystack/testing/sample_components/sum.py
+++ b/haystack/testing/sample_components/sum.py
@@ -11,6 +11,6 @@ class Sum:
     @component.output_types(total=int)
     def run(self, values: Variadic[int]):
         """
-        :param value: the values to sum.
+        :param values: the values to sum.
         """
         return {"total": sum(values)}

--- a/haystack/testing/sample_components/threshold.py
+++ b/haystack/testing/sample_components/threshold.py
@@ -24,6 +24,7 @@ class Threshold:
         """
         Redirects the value, along a different connection whether the value is above or below the given threshold.
 
+        :param value: the value to compare against the threshold.
         :param threshold: the number to compare the input value against. This is also a parameter.
         """
         if threshold is None:


### PR DESCRIPTION
### Related Issues

None — no prior issue. This is a docstring-only correction found while reading the code; happy to open one if you'd prefer that order.

### Proposed Changes:

Three docstrings disagreed with their own signatures. I found these by walking every function in `haystack/` with `ast` and diffing the `:param` names against the actual parameters.

**1. `LinkContentFetcher.__init__` — `request_headers` was undocumented** (`haystack/components/fetchers/link_content.py`)

The signature takes `request_headers: dict[str, str] | None = None` and it is a real, functional parameter — `_get_headers()` merges `self.request_headers` into the outgoing headers. Every *other* init parameter is documented, so this one being absent reads as an omission rather than a deliberate choice. Added an entry describing it, including its precedence, which I took from the existing comment in `_get_headers`:

```python
# client defaults -> component defaults -> user-provided -> rotating UA
base = dict(self._client.headers) if self._client is not None else {}
return _merge_headers(
    base, REQUEST_HEADERS, self.request_headers, {"User-Agent": self.user_agents[...]}
)
```

**2. `Sum.run` — wrong parameter name** (`haystack/testing/sample_components/sum.py`)

Documents `:param value:`; the parameter is `values: Variadic[int]`. One-character fix.

**3. `Threshold.run` — missing parameter** (`haystack/testing/sample_components/threshold.py`)

Takes `value` and `threshold`, documented only `threshold`. Added `value`.

3 files, +4/-1. Docstrings only — no executable line changed.

### How did you test it?

No new tests: nothing executable changed, so there is no behavior to assert on. I ran the existing suites instead.

```
$ hatch run test:unit
5794 passed, 8 skipped, 322 deselected, 6 warnings in 33.98s

$ hatch run test:types
Success: no issues found in 382 source files

$ hatch run fmt
All checks passed!
273 files left unchanged
```

I also re-ran the `ast` walk after the change: the three functions now have no documented-but-nonexistent params and no undocumented ones.

### Notes for the reviewer

**On the release note:** I did not add one. Per CONTRIBUTING, *"Pull requests with changes limited to tests, code comments or docstrings ... can be labeled with `ignore-for-release-notes` by a maintainer in order to bypass the CI check."* This PR is entirely docstrings, so I believe it qualifies — but only a maintainer can apply that label, so the release-note CI check will fail until someone does. Say the word if you'd rather I add a `reno` note instead and I'll push one.

**Four near-misses I deliberately left alone.** My scan also flagged these, and I checked each against the source and concluded they are *correct as written* — noting them so you know they were considered, not missed:

- `ContextRelevanceEvaluator.run` / `run_async` and `FaithfulnessEvaluator.run` / `run_async` document `questions`/`contexts`/`predicted_answers` while the signature is `**inputs`. Those names come from `self.inputs` in `__init__`, so documenting the real keyword names is more useful to a caller than documenting `**inputs`.
- `LLM.run` / `run_async` document `messages`, which lives in `**kwargs`. The code says why (`# messages is intentionally omitted from the signature so the framework can treat it as required or optional depending on init configuration`), and the docstring already says *"Passed via `**kwargs`."*

**Three typos I did not touch.** `codespell` finds `trough`→`through`, `Docmentation`→`Documentation`, and `alogrithm`→`algorithm` in `releasenotes/notes/*.yaml`. Those are notes for already-shipped releases, so I left them as historical record rather than rewriting them here. Let me know if you'd like a separate PR.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes. — N/A, no related issue.
- [x] I have added unit tests and updated the docstrings. — docstrings updated; no tests, see above.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title (`docs:`).
- [x] I have documented my code.
- [ ] I have added a release note file — requesting `ignore-for-release-notes` instead, see Notes for the reviewer.
- [x] I have run pre-commit hooks and fixed any issue. — `hatch run fmt` clean, no files changed.

---

I used an AI assistant (Claude Code) to help write and verify this change. I have reviewed every line and run the tests above myself.
