### PR TITLE
fix: MSGToDocument raises KeyError on ByteStream sources without file_path

### DIFF
--- a/haystack/components/converters/msg.py
+++ b/haystack/components/converters/msg.py
@@ -180,11 +180,9 @@ class MSGToDocument:
 
             documents.append(Document(content=text, meta=merged_metadata))
             for attachment in attachments:
-                attachment_meta = {
-                    **merged_metadata,
-                    "parent_file_path": merged_metadata["file_path"],
-                    "file_path": attachment.meta["file_path"],
-                }
+                attachment_meta = {**merged_metadata, "file_path": attachment.meta["file_path"]}
+                if "file_path" in merged_metadata:
+                    attachment_meta["parent_file_path"] = merged_metadata["file_path"]
                 all_attachments.append(
                     ByteStream(data=attachment.data, meta=attachment_meta, mime_type=attachment.mime_type)
                 )

--- a/releasenotes/notes/fix-msg-to-document-bytestream-keyerror-e4e44f7a4edd0e2d.yaml
+++ b/releasenotes/notes/fix-msg-to-document-bytestream-keyerror-e4e44f7a4edd0e2d.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed ``MSGToDocument`` raising a ``KeyError`` when converting a ``ByteStream``
+    source that has no ``file_path`` in its ``meta`` (for example a bare
+    ``ByteStream(data=...)``, rather than a file path or a stream produced via
+    ``ByteStream.from_file_path``). Attachments extracted from such a source no
+    longer include a ``parent_file_path`` key, since there is no source file path
+    to record.

--- a/test/components/converters/test_msg_to_document.py
+++ b/test/components/converters/test_msg_to_document.py
@@ -3,9 +3,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from haystack.components.converters.msg import MSGToDocument
+from haystack.dataclasses import ByteStream
 
 
 class TestMSGToDocument:
+    def test_run_bytestream_without_file_path(self, test_files_path):
+        """A bare ByteStream source (no 'file_path' in its meta) must not raise a KeyError."""
+        converter = MSGToDocument(store_full_path=True)
+        data = (test_files_path / "msg" / "sample.msg").read_bytes()
+        bytestream = ByteStream(data=data)
+
+        result = converter.run(sources=[bytestream], meta={"date_added": "2021-09-01T00:00:00"})
+
+        assert len(result["documents"]) == 1
+        assert result["documents"][0].meta == {"date_added": "2021-09-01T00:00:00"}
+        assert len(result["attachments"]) == 1
+        assert result["attachments"][0].meta == {"date_added": "2021-09-01T00:00:00", "file_path": "sample_pdf_1.pdf"}
+        assert "parent_file_path" not in result["attachments"][0].meta
+
     def test_run(self, test_files_path):
         converter = MSGToDocument(store_full_path=True)
         paths = [test_files_path / "msg" / "sample.msg"]


### PR DESCRIPTION
### Related Issues

- No existing issue filed; found via a direct code audit of `MSGToDocument`, not a bug report.

### Proposed Changes

`MSGToDocument.run()` builds attachment metadata via `merged_metadata["file_path"]`, but `merged_metadata` only contains `"file_path"` when the source was a `str`/`Path` (auto-populated by `get_bytestream_from_source`) or a `ByteStream` whose own `meta` happens to include it. A bare `ByteStream(data=...)` source — explicitly supported by the method's type signature (`sources: list[str | Path | ByteStream]`), and the exact pattern shown for other converters' `ByteStream.from_string`/manual-construction usage — has no such key. Converting a `.msg` file with attachments from such a source therefore raised an uncaught `KeyError: 'file_path'` instead of producing documents, crashing the whole `run()` call rather than just that one source.

Fixed by only setting `parent_file_path` on the attachment metadata when a source `file_path` is actually available, leaving it out otherwise instead of crashing.

### How did you test it?

Reproduced the crash directly against `main` with a minimal script (`MSGToDocument().run(sources=[ByteStream(data=open("test/test_files/msg/sample.msg","rb").read())])`), confirmed the exact `KeyError`.

Added `test_run_bytestream_without_file_path`, confirmed it fails on unpatched `msg.py` (`git stash`) with the same `KeyError`, and passes after the fix. Ran the full converters unit suite (`hatch run test:unit test/components/converters/`) — 263 passed, no regressions. `hatch run test:types` — no issues. `hatch run fmt` — clean.

### Notes for the reviewer

Small, behavior-preserving fix — no change for the existing (and already-tested) file-path-source path; only the previously-crashing `ByteStream`-without-`file_path` path changes, from an exception to a document/attachment without a `parent_file_path` key.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used a conventional commit type (`fix:`) for the PR title.
- [x] I have added a release note file.
- [x] I have run `hatch run fmt` / `hatch run test:types` / `hatch run test:unit` and fixed any issue.

This PR was developed with AI-assisted tooling (Claude Code); I reviewed the diagnosis, the fix, and the test, and ran the test suite and quality checks locally as noted above.