### PR TITLE
fix: JSONConverter raises KeyError on ByteStream sources without file_path

### DIFF
--- a/haystack/components/converters/json.py
+++ b/haystack/components/converters/json.py
@@ -191,7 +191,7 @@ class JSONConverter:
         except UnicodeError as exc:
             logger.warning(
                 "Failed to extract text from {source}. Skipping it. Error: {error}",
-                source=source.meta["file_path"],
+                source=source.meta.get("file_path", "unknown"),
                 error=exc,
             )
             return []
@@ -204,7 +204,7 @@ class JSONConverter:
             except Exception as exc:
                 logger.warning(
                     "Failed to extract text from {source}. Skipping it. Error: {error}",
-                    source=source.meta["file_path"],
+                    source=source.meta.get("file_path", "unknown"),
                     error=exc,
                 )
                 return []
@@ -216,7 +216,7 @@ class JSONConverter:
             except json.JSONDecodeError as exc:
                 logger.warning(
                     "Failed to extract text from {source}. Skipping it. Error: {error}",
-                    source=source.meta["file_path"],
+                    source=source.meta.get("file_path", "unknown"),
                     error=exc,
                 )
                 return []

--- a/releasenotes/notes/fix-json-converter-bytestream-keyerror-9c55c4ccd0ccca4c.yaml
+++ b/releasenotes/notes/fix-json-converter-bytestream-keyerror-9c55c4ccd0ccca4c.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed ``JSONConverter`` raising a ``KeyError`` instead of logging its
+    intended "Failed to extract text, skipping it" warning when a source is a
+    ``ByteStream`` without a ``file_path`` in its ``meta`` (for example
+    ``ByteStream.from_string(...)``, the exact usage shown in the component's
+    own docstring examples). Affected error paths: invalid UTF-8 content, a
+    ``jq_schema`` filter that fails to apply, and malformed JSON content.

--- a/test/components/converters/test_json.py
+++ b/test/components/converters/test_json.py
@@ -275,6 +275,51 @@ def test_run_with_malformed_json_and_content_key(tmpdir, caplog):
     assert result == {"documents": []}
 
 
+def test_run_with_bad_filter_and_bytestream_without_file_path(caplog):
+    """A bare ByteStream source (no 'file_path' in its meta) must not raise a KeyError."""
+    source = ByteStream(data=json.dumps(test_data[0]).encode("utf-8"))
+    converter = JSONConverter(".laureates | .motivation")
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        result = converter.run(sources=[source])
+
+    records = caplog.records
+    assert len(records) == 1
+    assert records[0].msg.startswith("Failed to extract text from unknown. Skipping it. Error:")
+    assert result == {"documents": []}
+
+
+def test_run_with_bad_encoding_and_bytestream_without_file_path(caplog):
+    """A bare ByteStream source (no 'file_path' in its meta) must not raise a KeyError."""
+    source = ByteStream(data=json.dumps(test_data[0]).encode("utf-16"))
+    converter = JSONConverter(".laureates")
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        result = converter.run(sources=[source])
+
+    records = caplog.records
+    assert len(records) == 1
+    assert records[0].msg.startswith("Failed to extract text from unknown. Skipping it. Error:")
+    assert result == {"documents": []}
+
+
+def test_run_with_malformed_json_and_bytestream_without_file_path(caplog):
+    """A bare ByteStream source (no 'file_path' in its meta) must not raise a KeyError."""
+    source = ByteStream(data=b"This is not valid JSON.")
+    converter = JSONConverter(content_key="motivation")
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        result = converter.run(sources=[source])
+
+    records = caplog.records
+    assert len(records) == 1
+    assert records[0].msg.startswith("Failed to extract text from unknown. Skipping it. Error:")
+    assert result == {"documents": []}
+
+
 def test_run_with_single_meta(tmpdir):
     first_test_file = Path(tmpdir / "first_test_file.json")
     second_test_file = Path(tmpdir / "second_test_file.json")


### PR DESCRIPTION
### Related Issues

- No existing issue filed; found via a direct code audit of `JSONConverter`, in the same pass as #12207.

### Proposed Changes

All three exception handlers in `_get_content_and_meta()` — invalid UTF-8 decoding, a `jq_schema` filter that fails to apply, and malformed JSON — log a warning using `source.meta["file_path"]`, an unconditional dict-key access. A bare `ByteStream` (e.g. `ByteStream.from_string(...)`, the exact pattern shown in this component's own docstring usage examples) has empty `meta` by default, so on any of these three error paths the *error-handling code itself* raises `KeyError: 'file_path'`, masking the real error (`UnicodeDecodeError`, filter failure, or `JSONDecodeError`) and crashing `run()` entirely instead of logging a warning and skipping that one source, which is the documented/intended behavior.

Two prior merged PRs (#8775, #11980) touched this exact function, but both only tested via file-path sources, which auto-populate `file_path` in `meta` — so this bug survived both.

Fixed by using `source.meta.get("file_path", "unknown")` at all three call sites, consistent with how `run()` itself already safely does `bytestream.meta.get("file_path")` a few lines below.

### How did you test it?

Reproduced the crash directly against `main` (`JSONConverter(content_key="text").run(sources=[ByteStream(data=b"\xff\xfe not valid utf-8")])`), confirmed the `KeyError`.

Added three new tests, one per exception path, each using a bare `ByteStream` mirroring the repo's existing file-path-based tests for the same three paths (`test_run_with_bad_filter`, `test_run_with_bad_encoding`, `test_run_with_malformed_json_and_content_key`). Confirmed all three fail on unpatched `json.py` (`git stash`) with the same `KeyError`, and pass after the fix. Ran the full converters unit suite (`hatch run test:unit test/components/converters/`) — 265 passed, no regressions. `hatch run test:types` — no issues. `hatch run fmt` — clean.

### Notes for the reviewer

Same shape of bug and same root cause as #12207 (`MSGToDocument`), found in the same audit pass — flagging in case a reviewer wants to look at both together, though they're independent files/components and can be merged separately.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used a conventional commit type (`fix:`) for the PR title.
- [x] I have added a release note file.
- [x] I have run `hatch run fmt` / `hatch run test:types` / `hatch run test:unit` and fixed any issue.

This PR was developed with AI-assisted tooling (Claude Code); I reviewed the diagnosis, the fix, and the tests, and ran the test suite and quality checks locally as noted above.