### PR TITLE
fix: preserve nested metadata key named "meta" during Document.from_dict() round-trip

### DIFF
--- a/haystack/dataclasses/document.py
+++ b/haystack/dataclasses/document.py
@@ -150,18 +150,25 @@ class Document(metaclass=_RemoveLegacyFields):  # noqa: PLW1641
         # Store metadata for a moment while we try un-flattening allegedly flatten metadata.
         # We don't expect both a `meta=` keyword and flatten metadata keys so we'll raise a
         # ValueError later if this is the case.
+        has_meta = "meta" in data
         meta = data.pop("meta", {})
         # Unflatten metadata if it was flattened. We assume any keyword argument that's not
         # a document field is a metadata key. We treat legacy fields as document fields, so that
         # `_RemoveLegacyFields` drops them instead of them ending up in `meta`.
         flatten_meta = {}
+        document_fields = _LEGACY_FIELDS + [f.name for f in fields(cls)]
+        is_flattened = any(key not in document_fields for key in data)
+
         # A non-mapping value under the "meta" key can't be the `meta` parameter (which must be a
         # dictionary). It can only be a flattened metadata key literally named "meta", produced by
         # to_dict(flatten=True) for a document whose metadata contains a "meta" key.
-        if not isinstance(meta, dict):
+        if is_flattened and has_meta and "id" in data:
             flatten_meta["meta"] = meta
             meta = {}
-        document_fields = _LEGACY_FIELDS + [f.name for f in fields(cls)]
+        elif not isinstance(meta, dict):
+            flatten_meta["meta"] = meta
+            meta = {}
+
         for key in list(data.keys()):
             if key not in document_fields:
                 flatten_meta[key] = data.pop(key)

--- a/haystack/dataclasses/document.py
+++ b/haystack/dataclasses/document.py
@@ -150,18 +150,22 @@ class Document(metaclass=_RemoveLegacyFields):  # noqa: PLW1641
         # Store metadata for a moment while we try un-flattening allegedly flatten metadata.
         # We don't expect both a `meta=` keyword and flatten metadata keys so we'll raise a
         # ValueError later if this is the case.
+        has_meta = "meta" in data
         meta = data.pop("meta", {})
         # Unflatten metadata if it was flattened. We assume any keyword argument that's not
         # a document field is a metadata key. We treat legacy fields as document fields, so that
         # `_RemoveLegacyFields` drops them instead of them ending up in `meta`.
         flatten_meta = {}
+        document_fields = _LEGACY_FIELDS + [f.name for f in fields(cls)]
+        is_flattened = any(key not in document_fields for key in data)
+
         # A non-mapping value under the "meta" key can't be the `meta` parameter (which must be a
         # dictionary). It can only be a flattened metadata key literally named "meta", produced by
         # to_dict(flatten=True) for a document whose metadata contains a "meta" key.
-        if not isinstance(meta, dict):
+        if is_flattened and has_meta and "id" in data or not isinstance(meta, dict):
             flatten_meta["meta"] = meta
             meta = {}
-        document_fields = _LEGACY_FIELDS + [f.name for f in fields(cls)]
+
         for key in list(data.keys()):
             if key not in document_fields:
                 flatten_meta[key] = data.pop(key)

--- a/releasenotes/notes/Fix-Document-from_dict-for-nested-meta-key-named-meta-6243e9fdbde464ab.yaml
+++ b/releasenotes/notes/Fix-Document-from_dict-for-nested-meta-key-named-meta-6243e9fdbde464ab.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix a bug in ``Document.from_dict`` that caused deserialization failures (ValueError or loss of key)
+    when a flattened serialized document's metadata legitimately contained a key literally named ``"meta"``
+    along with other metadata keys.

--- a/test/dataclasses/test_document.py
+++ b/test/dataclasses/test_document.py
@@ -357,6 +357,33 @@ def test_to_dict_from_dict_roundtrip_with_meta_key_named_meta():
     assert Document.from_dict(doc.to_dict()).meta == {"meta": "value"}
 
 
+def test_to_dict_from_dict_roundtrip_with_meta_key_named_meta_and_other_keys():
+    """
+    A metadata key literally named "meta" must survive the default
+    to_dict(flatten=True)/from_dict() round-trip when other metadata keys are present.
+    """
+    doc = Document(content="hi", meta={"meta": {"nested": "value"}, "author": "Alice"})
+
+    assert Document.from_dict(doc.to_dict()) == doc
+    assert Document.from_dict(doc.to_dict()).meta == {"meta": {"nested": "value"}, "author": "Alice"}
+
+
+def test_to_dict_from_dict_roundtrip_flatten_false():
+    doc = Document(content="hi", meta={"author": "Alice", "meta": {"nested": "value"}})
+    serialized = doc.to_dict(flatten=False)
+    deserialized = Document.from_dict(serialized)
+    assert deserialized == doc
+    assert deserialized.meta == {"author": "Alice", "meta": {"nested": "value"}}
+
+
+def test_to_dict_from_dict_roundtrip_flatten_true():
+    doc = Document(content="hi", meta={"author": "Alice", "meta": {"nested": "value"}})
+    serialized = doc.to_dict(flatten=True)
+    deserialized = Document.from_dict(serialized)
+    assert deserialized == doc
+    assert deserialized.meta == {"author": "Alice", "meta": {"nested": "value"}}
+
+
 def test_from_dict_with_flat_and_non_flat_meta():
     with pytest.raises(ValueError, match="Pass either the 'meta' parameter or flattened metadata keys"):
         Document.from_dict(


### PR DESCRIPTION
### Related Issues

- Fixes #12211

---

### Proposed Changes:

This PR fixes a round-trip serialization issue in `Document.from_dict()` when deserializing dictionaries produced by `Document.to_dict()` with the default `flatten=True` behavior.

Previously, if a document's metadata contained a key literally named `"meta"` alongside additional metadata keys, deserialization incorrectly interpreted the top-level `"meta"` entry as the metadata container. This caused `Document.from_dict()` to detect both nested and flattened metadata simultaneously and raise a `ValueError`, breaking the expected round-trip invariant.

This change preserves flattened metadata entries named `"meta"` during deserialization while maintaining the existing behavior for:

- Standard flattened serialization.
- Unflattened (`flatten=False`) serialization.
- Validation of manually mixed flattened and nested metadata representations.

As a result, documents serialized with `Document.to_dict()` now correctly round-trip for this metadata shape.

---

### How did you test it?

Added regression tests covering both serialization modes:

- ✅ `flatten=True` round-trip serialization.
- ✅ `flatten=False` round-trip serialization.

Each test verifies that:

```python
restored = Document.from_dict(serialized)

assert restored == doc
assert restored.meta == doc.meta
```

The full test suite and pre-commit hooks pass locally.

---

### Notes for the reviewer

This issue is related to, but distinct from, PR #11952.

PR #11952 fixed the case where a metadata key named `"meta"` contained a non-mapping value.

This PR addresses the remaining edge case where `"meta"` itself contains a mapping alongside additional flattened metadata keys, which still prevented successful round-trip deserialization.

The implementation intentionally preserves the existing behavior for ambiguous manually constructed dictionaries where the serialized representation does not provide enough information to distinguish between flattened and nested metadata.

---

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run the pre-commit hooks and fixed any issues.