### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
@@ -39,6 +39,8 @@ You can pass any chat completion parameters valid for the `openai.ChatCompletion
 
 `OpenAIChatGenerator` can support custom deployments of your OpenAI models through the `api_base_url` init parameter.
 
+> **Tip:** The same `api_base_url` pattern works with OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=haystack&utm_content=openaichatgenerator) at `https://api.daoxe.com/v1`.
+
 ### Structured Output
 
 `OpenAIChatGenerator` supports structured output generation, allowing you to receive responses in a predictable format. You can use Pydantic models or JSON schemas to define the structure of the output through the `response_format` parameter in `generation_kwargs`.

--- a/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
+++ b/docs-website/docs/pipeline-components/generators/openaichatgenerator.mdx
@@ -39,7 +39,7 @@ You can pass any chat completion parameters valid for the `openai.ChatCompletion
 
 `OpenAIChatGenerator` can support custom deployments of your OpenAI models through the `api_base_url` init parameter.
 
-> **Tip:** The same `api_base_url` pattern works with OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=haystack&utm_content=openaichatgenerator) at `https://api.daoxe.com/v1`.
+> **Tip:** The same `api_base_url` pattern works with OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 
 ### Structured Output
 


### PR DESCRIPTION
## Summary

`OpenAIChatGenerator` already documents custom deployments via `api_base_url`.

This PR adds a short tip that the same parameter works with OpenAI-compatible multi-model gateways, using [DaoXE](https://daoxe.com/) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Docs page renders
- [ ] Existing api_base_url sentence unchanged in meaning
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>