### PR TITLE
docs: mention pgvector array_contains and array_overlaps filter operators

### DIFF
--- a/docs-website/docs/concepts/metadata-filtering.mdx
+++ b/docs-website/docs/concepts/metadata-filtering.mdx
@@ -41,7 +41,7 @@ Comparison dictionaries must contain the following keys:
 ```
 
 :::info
-The available comparison operators may vary depending on the specific Document Store integration. For example, the `ChromaDocumentStore` supports two additional operators: `contains` and `not contains`. Find the details about the supported filters in the specific integration’s API reference.
+The available comparison operators may vary depending on the specific Document Store integration. For example, the `ChromaDocumentStore` supports two additional operators: `contains` and `not contains`, and the `PgvectorDocumentStore` supports `array_contains` and `array_overlaps` for matching against list-valued meta fields. Find the details about the supported filters in the specific integration’s API reference.
 :::
 
 \-`value`: takes a single value or (in the case of "in" and “not in”) a list of values.

--- a/docs-website/versioned_docs/version-3.0/concepts/metadata-filtering.mdx
+++ b/docs-website/versioned_docs/version-3.0/concepts/metadata-filtering.mdx
@@ -41,7 +41,7 @@ Comparison dictionaries must contain the following keys:
 ```
 
 :::info
-The available comparison operators may vary depending on the specific Document Store integration. For example, the `ChromaDocumentStore` supports two additional operators: `contains` and `not contains`. Find the details about the supported filters in the specific integration’s API reference.
+The available comparison operators may vary depending on the specific Document Store integration. For example, the `ChromaDocumentStore` supports two additional operators: `contains` and `not contains`, and the `PgvectorDocumentStore` supports `array_contains` and `array_overlaps` for matching against list-valued meta fields. Find the details about the supported filters in the specific integration’s API reference.
 :::
 
 \-`value`: takes a single value or (in the case of "in" and “not in”) a list of values.


### PR DESCRIPTION
### Related Issues

- Documents the operators added in deepset-ai/haystack-core-integrations#3459

### Proposed Changes:

- Extend the existing `:::info` admonition on the Metadata Filtering page, which already states that comparison operators vary by Document Store integration and cites `ChromaDocumentStore`'s `contains` / `not contains`, to also name `PgvectorDocumentStore`'s `array_contains` and `array_overlaps` for matching against list-valued meta fields.
- Applied the same edit to both `docs-website/docs/concepts/metadata-filtering.mdx` (next) and `docs-website/versioned_docs/version-3.0/concepts/metadata-filtering.mdx`

### How did you test it?

### Notes for the reviewer

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings. — n/a, documentation-only change with no code touched.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `docs:`.
- [x] I have documented my code. — this PR is the documentation.
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes). — not required: `release_notes.yml` only triggers on `**.py` / `pyproject.toml`, so a docs-website-only PR hits the skipper workflow.
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)