### PR TITLE
Simplify pipeline state serialization logic

### DIFF
--- a/haystack/core/pipeline/breakpoint.py
+++ b/haystack/core/pipeline/breakpoint.py
@@ -14,7 +14,6 @@ from networkx import MultiDiGraph
 from haystack import logging
 from haystack.core.errors import PipelineInvalidPipelineSnapshotError
 from haystack.dataclasses.breakpoints import INTERNAL_INPUTS_FORMAT, Breakpoint, PipelineSnapshot, PipelineState
-from haystack.utils import _deserialize_value_with_schema
 from haystack.utils.base_serialization import _serialize_with_field_fallback
 
 logger = logging.getLogger(__name__)
@@ -212,48 +211,6 @@ def _save_pipeline_snapshot(
     return str(full_path)
 
 
-def _serialize_internal_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
-    """
-    Serialize the pipeline's internal inputs state, keeping the `sender` of every input intact.
-
-    The `sender` tells a resumed run which inputs came from a predecessor and which from outside the pipeline, and
-    therefore whether the paused component can be triggered again.
-
-    The inputs a socket received are stored keyed by position rather than as a list, because a list gets a single
-    schema derived from its first item. A socket with several senders can hold values of different types, for
-    example a value from one sender and a `_NoOutputProduced` marker from another, and those need one schema
-    each to survive the round trip.
-
-    :param inputs: The pipeline's internal inputs state.
-    :returns: A dict of the form `{"serialization_schema": ..., "serialized_data": ...}`.
-    """
-    positional_inputs = {
-        component_name: {
-            socket_name: {str(position): entry for position, entry in enumerate(socket_inputs)}
-            for socket_name, socket_inputs in socket_dict.items()
-        }
-        for component_name, socket_dict in inputs.items()
-    }
-
-    return _serialize_with_field_fallback(positional_inputs, description="the inputs of the current pipeline state")
-
-
-def _deserialize_internal_inputs(serialized_inputs: dict[str, Any]) -> dict[str, Any]:
-    """
-    Restore the pipeline's internal inputs state from a snapshot written by `_serialize_internal_inputs`.
-
-    :param serialized_inputs: The `inputs` of a `PipelineState` whose `inputs_format` is `INTERNAL_INPUTS_FORMAT`.
-    :returns: The pipeline's internal inputs state.
-    """
-    return {
-        component_name: {
-            socket_name: [socket_inputs[position] for position in sorted(socket_inputs, key=int)]
-            for socket_name, socket_inputs in socket_dict.items()
-        }
-        for component_name, socket_dict in _deserialize_value_with_schema(serialized_inputs).items()
-    }
-
-
 def _create_pipeline_snapshot(
     *,
     inputs: dict[str, Any],
@@ -284,7 +241,9 @@ def _create_pipeline_snapshot(
 
     transformed_original_input_data = _transform_json_structure(original_input_data)
 
-    serialized_inputs = _serialize_internal_inputs({**inputs, component_name: component_inputs})
+    serialized_inputs = _serialize_with_field_fallback(
+        {**inputs, component_name: component_inputs}, description="the inputs of the current pipeline state"
+    )
     serialized_original_input_data = _serialize_with_field_fallback(
         transformed_original_input_data, description="original input data for `pipeline.run`"
     )

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -21,7 +21,6 @@ from haystack.core.pipeline.base import (
 from haystack.core.pipeline.breakpoint import (
     SnapshotCallback,
     _create_pipeline_snapshot,
-    _deserialize_internal_inputs,
     _save_pipeline_snapshot,
     _validate_break_point_against_pipeline,
     _validate_pipeline_snapshot_against_pipeline,
@@ -378,7 +377,7 @@ class Pipeline(PipelineBase):
             data = _deserialize_value_with_schema(pipeline_snapshot.original_input_data)
 
             if pipeline_snapshot.pipeline_state.inputs_format == INTERNAL_INPUTS_FORMAT:
-                inputs = _deserialize_internal_inputs(pipeline_snapshot.pipeline_state.inputs)
+                inputs = _deserialize_value_with_schema(pipeline_snapshot.pipeline_state.inputs)
             else:
                 # A legacy snapshot lost the sender of each input, so the only thing we can do is treat them as if
                 # they came from outside the pipeline. The paused component then has to be let through once.

--- a/haystack/dataclasses/breakpoints.py
+++ b/haystack/dataclasses/breakpoints.py
@@ -60,7 +60,7 @@ class PipelineState:
     :param inputs_format: Which format `inputs` are stored in. `"internal"` means each input records the component
         that sent it, in the order it arrived, as in `{component: {socket: [{"sender": ..., "value": ...}]}}`.
         `None` marks snapshots taken before Haystack recorded the sender, which hold one flattened value per socket,
-        {component: {socket: value}}`, and can only be resumed on a component's first visit.
+        `{component: {socket: value}}`, and can only be resumed on a component's first visit.
     """
 
     inputs: dict[str, Any]

--- a/haystack/dataclasses/breakpoints.py
+++ b/haystack/dataclasses/breakpoints.py
@@ -58,10 +58,9 @@ class PipelineState:
     :param inputs: The inputs processed by the pipeline at the time of the snapshot.
     :param pipeline_outputs: Dictionary containing the final outputs of the pipeline up to the breakpoint.
     :param inputs_format: Which format `inputs` are stored in. `"internal"` means each input records the component
-        that sent it, keyed by the position it arrived in, as in
-        `{component: {socket: {"0": {"sender": ..., "value": ...}}}}`. `None` marks snapshots taken before Haystack
-        recorded the sender, which hold one flattened value per socket, `{component: {socket: value}}`, and can only
-        be resumed on a component's first visit.
+        that sent it, in the order it arrived, as in `{component: {socket: [{"sender": ..., "value": ...}]}}`.
+        `None` marks snapshots taken before Haystack recorded the sender, which hold one flattened value per socket,
+        {component: {socket: value}}`, and can only be resumed on a component's first visit.
     """
 
     inputs: dict[str, Any]

--- a/releasenotes/notes/fix-pipeline-snapshot-resume-in-loops-0ab593c343026abb.yaml
+++ b/releasenotes/notes/fix-pipeline-snapshot-resume-in-loops-0ab593c343026abb.yaml
@@ -3,17 +3,16 @@ upgrade:
   - |
     ``PipelineSnapshot.pipeline_state.inputs`` changed shape. It used to store one flattened value per socket,
     ``{component: {socket: value}}``. It now stores the pipeline's internal inputs, keeping the component that sent
-    each one and keying the inputs a socket received by their position:
-    ``{component: {socket: {"0": {"sender": ..., "value": ...}}}}``. Positions are used instead of a list so that
-    each input carries its own type schema, which a list cannot do. ``PipelineState`` gained an ``inputs_format``
-    field recording which of the two shapes a snapshot uses. The same applies to ``BreakpointException.inputs``,
-    which returns that field.
+    each one in the order it arrived:
+    ``{component: {socket: [{"sender": ..., "value": ...}]}}``. ``PipelineState`` gained an ``inputs_format`` field
+    recording which of the two shapes a snapshot uses. The same applies to ``BreakpointException.inputs``, which
+    returns that field.
 
     You are affected if you read ``pipeline_state.inputs`` (or ``BreakpointException.inputs``) directly, for example
     to display or post-process a snapshot. Resuming a pipeline with ``Pipeline.run(pipeline_snapshot=...)`` is not
     affected, and neither is code that only passes snapshots around or persists them.
 
-    To adapt, read the input through its position and take its ``value``:
+    To adapt, read the input from the list and take its ``value``:
 
     .. code-block:: python
 
@@ -23,10 +22,10 @@ upgrade:
         value = inputs["my_component"]["my_socket"]
 
         # now
-        value = inputs["my_component"]["my_socket"]["0"]["value"]
+        value = inputs["my_component"]["my_socket"][0]["value"]
 
-    A socket that received inputs from several senders now has one entry per position, ``"0"``, ``"1"`` and so on,
-    each recording the ``sender`` that produced it.
+    A socket that received inputs from several senders has one list item per input, each recording the ``sender``
+    that produced it.
 
     Snapshots written by earlier versions of Haystack have ``inputs_format`` set to ``None`` and keep the flattened
     shape, so branch on that field if you need to handle both.

--- a/test/core/pipeline/test_breakpoint.py
+++ b/test/core/pipeline/test_breakpoint.py
@@ -18,7 +18,6 @@ from haystack.core.pipeline import Pipeline
 from haystack.core.pipeline.breakpoint import (
     HAYSTACK_PIPELINE_SNAPSHOT_SAVE_ENABLED,
     _create_pipeline_snapshot,
-    _deserialize_internal_inputs,
     _is_snapshot_save_enabled,
     _save_pipeline_snapshot,
     _transform_json_structure,
@@ -134,14 +133,14 @@ def test_breakpoint_saves_intermediate_outputs(tmp_path, monkeypatch):
         }
     )
 
-    # verify the saved inputs record which component sent each one, keyed by the position it arrived in.
+    # verify the saved inputs record which component sent each one, in the order it arrived.
     # The accompanying schema is asserted in TestCreatePipelineSnapshot.
     assert loaded_snapshot.pipeline_state.inputs_format == INTERNAL_INPUTS_FORMAT
     assert loaded_snapshot.pipeline_state.inputs["serialized_data"] == {
         # comp1 was given its input from outside the pipeline
-        "comp1": {"input_value": {"0": {"sender": None, "value": "test"}}},
+        "comp1": {"input_value": [{"sender": None, "value": "test"}]},
         # comp2 was given its input by comp1, and had not consumed it yet when the breakpoint hit
-        "comp2": {"input_value": {"0": {"sender": "comp1", "value": "processed_test"}}},
+        "comp2": {"input_value": [{"sender": "comp1", "value": "processed_test"}]},
     }
 
     # verify the whole pipeline state contains the expected data
@@ -277,9 +276,8 @@ class TestResumeFromPipelineSnapshot:
         snapshot = exc_info.value.pipeline_snapshot
         assert snapshot is not None
 
-        restored = _deserialize_internal_inputs(snapshot.pipeline_state.inputs)
+        restored = _deserialize_value_with_schema(snapshot.pipeline_state.inputs)
         assert restored["collect"]["b"] == [{"sender": "router", "value": _NoOutputProduced()}]
-
         assert pipeline.run(data={}, pipeline_snapshot=snapshot) == expected
 
 
@@ -294,7 +292,7 @@ class TestResumeFromLegacyPipelineSnapshot:
         assert snapshot is not None
 
         legacy_inputs = _serialize_value_with_schema(
-            _transform_json_structure(_deserialize_internal_inputs(snapshot.pipeline_state.inputs))
+            _transform_json_structure(_deserialize_value_with_schema(snapshot.pipeline_state.inputs))
         )
         assert legacy_inputs["serialized_data"]["comp2"] == {"input_value": "test_processed"}
         legacy_snapshot = replace(
@@ -360,15 +358,13 @@ class TestCreatePipelineSnapshot:
         assert snapshot.break_point == break_point
         assert snapshot.include_outputs_from == include_outputs_from
 
-        # Each input a socket received is stored under its position, so that it carries its own schema.
+        # Each input a socket received is stored in a list. Mixed-type lists carry one schema per position.
         def socket_schema(sender_type: str) -> dict[str, Any]:
             return {
-                "type": "object",
-                "properties": {
-                    "0": {
-                        "type": "object",
-                        "properties": {"sender": {"type": sender_type}, "value": {"type": "string"}},
-                    }
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"sender": {"type": sender_type}, "value": {"type": "string"}},
                 },
             }
 
@@ -382,8 +378,8 @@ class TestCreatePipelineSnapshot:
                     },
                 },
                 "serialized_data": {
-                    "comp1": {"input_value": {"0": {"sender": None, "value": "test"}}},
-                    "comp2": {"input_value": {"0": {"sender": "comp1", "value": "processed_test"}}},
+                    "comp1": {"input_value": [{"sender": None, "value": "test"}]},
+                    "comp2": {"input_value": [{"sender": "comp1", "value": "processed_test"}]},
                 },
             },
             component_visits={"comp1": 1, "comp2": 0},
@@ -396,6 +392,39 @@ class TestCreatePipelineSnapshot:
             },
             inputs_format=INTERNAL_INPUTS_FORMAT,
         )
+
+    def test_internal_inputs_with_mixed_socket_values_round_trip(self):
+        inputs = {
+            "joiner": {"value": [{"sender": "counter", "value": 1}, {"sender": "router", "value": _NoOutputProduced()}]}
+        }
+
+        snapshot = _create_pipeline_snapshot(
+            inputs={},
+            component_inputs=inputs["joiner"],
+            break_point=Breakpoint(component_name="joiner"),
+            component_visits={"joiner": 0},
+            original_input_data={},
+            ordered_component_names=["joiner"],
+            include_outputs_from=set(),
+            pipeline_outputs={},
+        )
+        serialized_inputs = snapshot.pipeline_state.inputs
+
+        socket_schema = serialized_inputs["serialization_schema"]["properties"]["joiner"]["properties"]["value"]
+        assert socket_schema == {
+            "type": "array",
+            "prefixItems": [
+                {"type": "object", "properties": {"sender": {"type": "string"}, "value": {"type": "integer"}}},
+                {
+                    "type": "object",
+                    "properties": {
+                        "sender": {"type": "string"},
+                        "value": {"type": "haystack.core.pipeline.component_checks._NoOutputProduced"},
+                    },
+                },
+            ],
+        }
+        assert _deserialize_value_with_schema(serialized_inputs) == inputs
 
     def test_create_pipeline_snapshot_with_dataclasses_in_pipeline_outputs(self):
         snapshot = _create_pipeline_snapshot(
@@ -489,7 +518,7 @@ class TestCreatePipelineSnapshot:
 
         # The non-serializable comp1 field is omitted while the serializable siblings are preserved.
         assert "comp1" not in deserialized_inputs
-        assert deserialized_inputs["comp2"] == {"input_value": {"0": {"sender": None, "value": "keep me"}}}
+        assert deserialized_inputs["comp2"] == {"input_value": [{"sender": None, "value": "keep me"}]}
         assert deserialized_inputs["comp3"] == {}
         # original_input_data and pipeline_outputs degrade to empty-but-valid payloads.
         assert deserialized_original_input_data == {}

--- a/test/core/pipeline/test_breakpoint.py
+++ b/test/core/pipeline/test_breakpoint.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 
 from haystack import component
-from haystack.components.joiners import BranchJoiner
+from haystack.components.joiners import BranchJoiner, ListJoiner
 from haystack.components.routers import ConditionalRouter
 from haystack.components.routers.conditional_router import Route
 from haystack.core.errors import BreakpointException, PipelineInvalidPipelineSnapshotError
@@ -171,13 +171,6 @@ class _CountUpTo:
         return {"done": f"finished at {value}"}
 
 
-@component
-class _CollectBranches:
-    @component.output_types(result=str)
-    def run(self, a: str | None = None, b: str | None = None) -> dict[str, str]:
-        return {"result": f"a={a} b={b}"}
-
-
 def _three_component_pipeline() -> Pipeline:
     pipeline = Pipeline()
     pipeline.add_component("comp1", _AppendingComponent())
@@ -258,16 +251,21 @@ class TestResumeFromPipelineSnapshot:
         assert _looping_pipeline().run(data={}, pipeline_snapshot=snapshot) == {"counter": {"done": "finished at 5"}}
 
     def test_snapshot_preserves_sockets_whose_sender_produced_no_output(self):
-        """A router that leaves a branch inactive puts the `_NoOutputProduced()` sentinel in the pipeline inputs."""
+        """A mixed socket queue containing a value and `_NoOutputProduced()` survives a snapshot and resume."""
         routes: list[Route] = [
-            {"condition": "{{ n > 5 }}", "output": "{{ 'big' }}", "output_name": "big", "output_type": str},
-            {"condition": "{{ n <= 5 }}", "output": "{{ 'small' }}", "output_name": "small", "output_type": str},
+            {"condition": "{{ n > 5 }}", "output": "{{ ['big'] }}", "output_name": "big", "output_type": list[str]},
+            {
+                "condition": "{{ n <= 5 }}",
+                "output": "{{ ['small'] }}",
+                "output_name": "small",
+                "output_type": list[str],
+            },
         ]
         pipeline = Pipeline()
         pipeline.add_component("router", ConditionalRouter(routes=routes))
-        pipeline.add_component("collect", _CollectBranches())
-        pipeline.connect("router.big", "collect.a")
-        pipeline.connect("router.small", "collect.b")
+        pipeline.add_component("collect", ListJoiner(list[str]))
+        pipeline.connect("router.big", "collect.values")
+        pipeline.connect("router.small", "collect.values")
 
         expected = pipeline.run({"router": {"n": 9}})
 
@@ -276,8 +274,15 @@ class TestResumeFromPipelineSnapshot:
         snapshot = exc_info.value.pipeline_snapshot
         assert snapshot is not None
 
+        socket_schema = snapshot.pipeline_state.inputs["serialization_schema"]["properties"]["collect"]["properties"][
+            "values"
+        ]
+        assert "prefixItems" in socket_schema
+
         restored = _deserialize_value_with_schema(snapshot.pipeline_state.inputs)
-        assert restored["collect"]["b"] == [{"sender": "router", "value": _NoOutputProduced()}]
+        restored_values = [entry["value"] for entry in restored["collect"]["values"]]
+        assert ["big"] in restored_values
+        assert any(isinstance(value, _NoOutputProduced) for value in restored_values)
         assert pipeline.run(data={}, pipeline_snapshot=snapshot) == expected
 
 
@@ -392,39 +397,6 @@ class TestCreatePipelineSnapshot:
             },
             inputs_format=INTERNAL_INPUTS_FORMAT,
         )
-
-    def test_internal_inputs_with_mixed_socket_values_round_trip(self):
-        inputs = {
-            "joiner": {"value": [{"sender": "counter", "value": 1}, {"sender": "router", "value": _NoOutputProduced()}]}
-        }
-
-        snapshot = _create_pipeline_snapshot(
-            inputs={},
-            component_inputs=inputs["joiner"],
-            break_point=Breakpoint(component_name="joiner"),
-            component_visits={"joiner": 0},
-            original_input_data={},
-            ordered_component_names=["joiner"],
-            include_outputs_from=set(),
-            pipeline_outputs={},
-        )
-        serialized_inputs = snapshot.pipeline_state.inputs
-
-        socket_schema = serialized_inputs["serialization_schema"]["properties"]["joiner"]["properties"]["value"]
-        assert socket_schema == {
-            "type": "array",
-            "prefixItems": [
-                {"type": "object", "properties": {"sender": {"type": "string"}, "value": {"type": "integer"}}},
-                {
-                    "type": "object",
-                    "properties": {
-                        "sender": {"type": "string"},
-                        "value": {"type": "haystack.core.pipeline.component_checks._NoOutputProduced"},
-                    },
-                },
-            ],
-        }
-        assert _deserialize_value_with_schema(serialized_inputs) == inputs
 
     def test_create_pipeline_snapshot_with_dataclasses_in_pipeline_outputs(self):
         snapshot = _create_pipeline_snapshot(


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/pull/12202 and https://github.com/deepset-ai/haystack/pull/12162

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

PR https://github.com/deepset-ai/haystack/pull/12202 introduced mixed type list serialization so we update the changes made in https://github.com/deepset-ai/haystack/pull/12162 to use this new support to simplify the existing code and not introduce more serialization formats. 

Updated the old reno as well to reflect the update. This change is okay to do since the neither of the already merged PRs have been released yet.  

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated existing tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
