### PR TITLE
docs: add Pixeltable to choosing a Document Store

### DIFF
--- a/docs-website/docs/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/docs/concepts/document-store/choosing-a-document-store.mdx
@@ -65,6 +65,7 @@ The tables below list every available integration alongside the key properties y
 | Milvus | Vector Database | Open-source vector database built for scalable similarity search | Yes | No | Embedding |
 | Needle | Search Engine | Managed RAG-as-a-service platform with built-in document storage and vector search | No | Yes | Embedding, Sparse Embedding, Hybrid |
 | Neo4j | Multi-model Database | Graph database with native vector index support for combined graph traversal and similarity search | Partial | No | Embedding |
+| Pixeltable | Multimodal Data Infrastructure | Open-source multimodal data infrastructure with persistent tables, embedding indexes, and incremental computation | Yes | No | Embedding |
 | SingleStore | Relational Database | Distributed SQL database with native vector search and full-text search support | No | Yes | Embedding, Full-text, Keyword |
 
 ## Vector Databases
@@ -84,6 +85,7 @@ The tables below list every available integration alongside the key properties y
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
 - [LanceDB](https://haystack.deepset.ai/integrations/lancedb) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
+- [Pixeltable](https://haystack.deepset.ai/integrations/pixeltable) (external integration)
 
 ## Search Engines
 

--- a/docs-website/versioned_docs/version-2.31/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/versioned_docs/version-2.31/concepts/document-store/choosing-a-document-store.mdx
@@ -65,6 +65,7 @@ The tables below list every available integration alongside the key properties y
 | Milvus | Vector Database | Open-source vector database built for scalable similarity search | Yes | No | Embedding |
 | Needle | Search Engine | Managed RAG-as-a-service platform with built-in document storage and vector search | No | Yes | Embedding, Sparse Embedding, Hybrid |
 | Neo4j | Multi-model Database | Graph database with native vector index support for combined graph traversal and similarity search | Partial | No | Embedding |
+| Pixeltable | Multimodal Data Infrastructure | Open-source multimodal data infrastructure with persistent tables, embedding indexes, and incremental computation | Yes | No | Embedding |
 | SingleStore | Relational Database | Distributed SQL database with native vector search and full-text search support | No | Yes | Embedding, Full-text, Keyword |
 
 ## Vector Databases
@@ -84,6 +85,7 @@ The tables below list every available integration alongside the key properties y
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
 - [LanceDB](https://haystack.deepset.ai/integrations/lancedb) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
+- [Pixeltable](https://haystack.deepset.ai/integrations/pixeltable) (external integration)
 
 ## Search Engines
 

--- a/docs-website/versioned_docs/version-3.0/concepts/document-store/choosing-a-document-store.mdx
+++ b/docs-website/versioned_docs/version-3.0/concepts/document-store/choosing-a-document-store.mdx
@@ -65,6 +65,7 @@ The tables below list every available integration alongside the key properties y
 | Milvus | Vector Database | Open-source vector database built for scalable similarity search | Yes | No | Embedding |
 | Needle | Search Engine | Managed RAG-as-a-service platform with built-in document storage and vector search | No | Yes | Embedding, Sparse Embedding, Hybrid |
 | Neo4j | Multi-model Database | Graph database with native vector index support for combined graph traversal and similarity search | Partial | No | Embedding |
+| Pixeltable | Multimodal Data Infrastructure | Open-source multimodal data infrastructure with persistent tables, embedding indexes, and incremental computation | Yes | No | Embedding |
 | SingleStore | Relational Database | Distributed SQL database with native vector search and full-text search support | No | Yes | Embedding, Full-text, Keyword |
 
 ## Vector Databases
@@ -84,6 +85,7 @@ The tables below list every available integration alongside the key properties y
 - [Weaviate](../../document-stores/weaviatedocumentstore.mdx)
 - [LanceDB](https://haystack.deepset.ai/integrations/lancedb) (external integration)
 - [Milvus](https://haystack.deepset.ai/integrations/milvus-document-store) (external integration)
+- [Pixeltable](https://haystack.deepset.ai/integrations/pixeltable) (external integration)
 
 ## Search Engines
 


### PR DESCRIPTION
## Summary
- Add Pixeltable to the external Document Store comparison table
- Link it under Vector Databases (external integration)
- Mirrors the live listing: https://haystack.deepset.ai/integrations/pixeltable

## Notes
Pixeltable is a community Document Store (`haystack-pixeltable` on PyPI). This docs update follows the merged integrations PR [#486](https://github.com/deepset-ai/haystack-integrations/pull/486).

## Test plan
- [ ] Confirm Pixeltable appears in the External integrations table
- [ ] Confirm the Vector Databases bullet links to the integrations page

Made with [Cursor](https://cursor.com)