### PR TITLE
chore: Update name from `ContextCompactionHook` to `CompactionHook`

### DIFF
--- a/docs-website/docs/pipeline-components/agents-1/compaction.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/compaction.mdx
@@ -17,7 +17,7 @@ Context compaction separates three responsibilities:
 
 | Responsibility | Abstraction | Purpose |
 | --- | --- | --- |
-| Decide when to compact | [`ContextCompactionHook`](compaction/context-compaction-hook.mdx) | Monitors the Agent's context before LLM calls and invokes a compactor after a configured threshold is reached. |
+| Decide when to compact | [`CompactionHook`](compaction/compaction-hook.mdx) | Monitors the Agent's context before LLM calls and invokes a compactor after a configured threshold is reached. |
 | Decide how to compact | `Compactor` protocol | Defines how a conversation is rewritten. Haystack includes [`SlidingWindowCompactor`](compaction/sliding-window-compactor.mdx) and [`ToolResultPruningCompactor`](compaction/tool-result-pruning-compactor.mdx). |
 | Measure the conversation | [`TokenCounter`](../../token-counters.mdx) protocol | Estimates the size of messages and tool schemas before they are sent to a model. |
 
@@ -25,7 +25,7 @@ This separation lets you combine a standard trigger with different compaction st
 
 ## Basic setup
 
-The following example registers a `ContextCompactionHook` under the Agent's `before_llm` [hook point](./hooks.mdx). It starts compacting at 70% of the model's context window and asks the compactor to reduce the context to approximately 40%.
+The following example registers a `CompactionHook` under the Agent's `before_llm` [hook point](./hooks.mdx). It starts compacting at 70% of the model's context window and asks the compactor to reduce the context to approximately 40%.
 
 <!-- test-concept -->
 ```python
@@ -34,7 +34,7 @@ from typing import Annotated
 from haystack.components.agents import Agent
 from haystack.components.generators.chat import OpenAIResponsesChatGenerator
 from haystack.dataclasses import ChatMessage
-from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
 from haystack.tools import tool
 
 
@@ -44,7 +44,7 @@ def fetch_page(url: Annotated[str, "The URL to fetch"]) -> str:
     return "Fusion startups reported net-energy-gain milestones this year. " * 500
 
 
-compaction_hook = ContextCompactionHook(
+compaction_hook = CompactionHook(
     compactor=SlidingWindowCompactor(),
     context_window=400_000,  # gpt-5.4-nano's context window
     compact_at=0.7,
@@ -64,7 +64,7 @@ result = agent.run(
 print(result["last_message"].text)
 ```
 
-See [`ContextCompactionHook`](compaction/context-compaction-hook.mdx) for threshold configuration, context measurement, lifecycle, and serialization.
+See [`CompactionHook`](compaction/compaction-hook.mdx) for threshold configuration, context measurement, lifecycle, and serialization.
 
 ## Compaction strategies
 
@@ -77,24 +77,24 @@ Compactors receive the current messages, a target token count, and the same toke
 
 ## Combining compaction strategies
 
-Register multiple `ContextCompactionHook` instances at `before_llm` to apply progressively more aggressive strategies. Hooks run in list order against the same Agent state, so each hook measures the messages left by the previous one.
+Register multiple `CompactionHook` instances at `before_llm` to apply progressively more aggressive strategies. Hooks run in list order against the same Agent state, so each hook measures the messages left by the previous one.
 
 For example, prune large tool results first and use a sliding window as a fallback:
 
 ```python
 from haystack.hooks.compaction import (
-    ContextCompactionHook,
+    CompactionHook,
     SlidingWindowCompactor,
     ToolResultPruningCompactor,
 )
 
-prune_tool_results = ContextCompactionHook(
+prune_tool_results = CompactionHook(
     compactor=ToolResultPruningCompactor(),
     context_window=400_000,
     compact_at=0.7,
     compact_to=0.4,
 )
-drop_old_steps = ContextCompactionHook(
+drop_old_steps = CompactionHook(
     compactor=SlidingWindowCompactor(),
     context_window=400_000,
     compact_at=0.7,

--- a/docs-website/docs/pipeline-components/agents-1/compaction/compaction-hook.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/compaction/compaction-hook.mdx
@@ -1,17 +1,17 @@
 ---
-title: "ContextCompactionHook"
-id: context-compaction-hook
-slug: "/context-compaction-hook"
-description: "Use ContextCompactionHook to shorten an Agent's conversation before it exceeds the model's context window."
+title: "CompactionHook"
+id: compaction-hook
+slug: "/compaction-hook"
+description: "Use CompactionHook to shorten an Agent's conversation before it exceeds the model's context window."
 ---
 
-# ContextCompactionHook
+# CompactionHook
 
-`ContextCompactionHook` monitors an Agent's conversation before each LLM call. When the estimated context reaches a configured threshold, the hook passes the messages to a `Compactor` and writes the shorter conversation back to the Agent's state.
+`CompactionHook` monitors an Agent's conversation before each LLM call. When the estimated context reaches a configured threshold, the hook passes the messages to a `Compactor` and writes the shorter conversation back to the Agent's state.
 
 :::warning[Experimental]
 
-`ContextCompactionHook` is experimental and may change without a deprecation cycle.
+`CompactionHook` is experimental and may change without a deprecation cycle.
 :::
 
 <div className="key-value-table">
@@ -20,7 +20,7 @@ description: "Use ContextCompactionHook to shorten an Agent's conversation befor
 | --- | --- |
 | **Configured on** | The [`Agent`](../agent.mdx) component under the `before_llm` [hook point](../hooks.mdx) |
 | **Mandatory init variables** | `compactor`: The strategy used to shorten the messages <br /> <br /> `context_window`: The model's context-window size in tokens |
-| **Import path** | `haystack.hooks.compaction.ContextCompactionHook` |
+| **Import path** | `haystack.hooks.compaction.CompactionHook` |
 | **API reference** | [Hooks](/reference/hooks-api) |
 | **GitHub link** | https://github.com/deepset-ai/haystack/blob/main/haystack/hooks/compaction/hooks.py |
 | **Package name** | `haystack-ai` |
@@ -34,9 +34,9 @@ Register the hook under `before_llm` and configure the context window of the Age
 ```python
 from haystack.components.agents import Agent
 from haystack.components.generators.chat import OpenAIResponsesChatGenerator
-from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
 
-compaction_hook = ContextCompactionHook(
+compaction_hook = CompactionHook(
     compactor=SlidingWindowCompactor(),
     context_window=400_000,  # gpt-5.4-nano's context window
     compact_at=0.7,
@@ -51,7 +51,7 @@ agent = Agent(
 )
 ```
 
-`ContextCompactionHook` can only be registered under `before_llm`. The Agent raises a `ValueError` if you register it at another hook point.
+`CompactionHook` can only be registered under `before_llm`. The Agent raises a `ValueError` if you register it at another hook point.
 
 ## Configuration
 
@@ -72,10 +72,10 @@ After an LLM call, the Agent stores the generator's reported prompt-plus-complet
 If the generator does not report usage and `context_tokens` remains `0`, the hook estimates the complete conversation and tool schemas locally. The default `ApproximateTokenCounter` needs no extra dependency. You can provide another built-in or custom counter:
 
 ```python
-from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
 from haystack.token_counters import TiktokenCounter
 
-compaction_hook = ContextCompactionHook(
+compaction_hook = CompactionHook(
     compactor=SlidingWindowCompactor(),
     context_window=128_000,
     token_counter=TiktokenCounter(encoding="o200k_base"),

--- a/docs-website/docs/pipeline-components/agents-1/compaction/sliding-window-compactor.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/compaction/sliding-window-compactor.mdx
@@ -18,7 +18,7 @@ description: "Use SlidingWindowCompactor to remove older Agent history while pre
 
 |  |  |
 | --- | --- |
-| **Used by** | [`ContextCompactionHook`](context-compaction-hook.mdx) |
+| **Used by** | [`CompactionHook`](compaction-hook.mdx) |
 | **Mandatory init variables** | None |
 | **Import path** | `haystack.hooks.compaction.SlidingWindowCompactor` |
 | **API reference** | [Hooks](/reference/hooks-api) |
@@ -29,12 +29,12 @@ description: "Use SlidingWindowCompactor to remove older Agent history while pre
 
 ## Usage
 
-Pass the compactor to a `ContextCompactionHook`:
+Pass the compactor to a `CompactionHook`:
 
 ```python
-from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
 
-compaction_hook = ContextCompactionHook(
+compaction_hook = CompactionHook(
     compactor=SlidingWindowCompactor(
         min_keep_steps=1,
         omission_note=(
@@ -47,7 +47,7 @@ compaction_hook = ContextCompactionHook(
 )
 ```
 
-`ContextCompactionHook` determines when compaction runs and provides the target token count. `SlidingWindowCompactor` determines which messages to retain.
+`CompactionHook` determines when compaction runs and provides the target token count. `SlidingWindowCompactor` determines which messages to retain.
 
 ## How the sliding window is selected
 

--- a/docs-website/docs/pipeline-components/agents-1/compaction/tool-result-pruning-compactor.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/compaction/tool-result-pruning-compactor.mdx
@@ -18,7 +18,7 @@ description: "Use ToolResultPruningCompactor to replace older tool results with 
 
 |  |  |
 | --- | --- |
-| **Used by** | [`ContextCompactionHook`](context-compaction-hook.mdx) |
+| **Used by** | [`CompactionHook`](compaction-hook.mdx) |
 | **Mandatory init variables** | None |
 | **Import path** | `haystack.hooks.compaction.ToolResultPruningCompactor` |
 | **API reference** | [Hooks](/reference/hooks-api) |
@@ -29,12 +29,12 @@ description: "Use ToolResultPruningCompactor to replace older tool results with 
 
 ## Usage
 
-Pass the compactor to a `ContextCompactionHook`:
+Pass the compactor to a `CompactionHook`:
 
 ```python
-from haystack.hooks.compaction import ContextCompactionHook, ToolResultPruningCompactor
+from haystack.hooks.compaction import CompactionHook, ToolResultPruningCompactor
 
-compaction_hook = ContextCompactionHook(
+compaction_hook = CompactionHook(
     compactor=ToolResultPruningCompactor(
         min_keep_steps=1,
         min_tokens=200,
@@ -45,7 +45,7 @@ compaction_hook = ContextCompactionHook(
 )
 ```
 
-`ContextCompactionHook` determines when compaction runs and provides the target token count. `ToolResultPruningCompactor` replaces only as many eligible results as needed to reach that target.
+`CompactionHook` determines when compaction runs and provides the target token count. `ToolResultPruningCompactor` replaces only as many eligible results as needed to reach that target.
 
 ## How pruning works
 
@@ -85,7 +85,7 @@ The compactor records `context_compaction` metadata on each rewritten result wit
 
 ## Token counting
 
-The compactor uses the [`TokenCounter`](../../../token-counters.mdx) supplied by `ContextCompactionHook` to determine whether a result exceeds `min_tokens` and whether replacing it saves context.
+The compactor uses the [`TokenCounter`](../../../token-counters.mdx) supplied by `CompactionHook` to determine whether a result exceeds `min_tokens` and whether replacing it saves context.
 
 The complete conversation is counted once. For each eligible result, the counter then measures only the original result message and its short replacement. The compactor updates its running total using the difference between those two counts.
 

--- a/docs-website/docs/pipeline-components/agents-1/hooks.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/hooks.mdx
@@ -201,6 +201,6 @@ print(result["last_message"].text)
 
 Haystack ships several ready-made hooks, each in its own submodule of `haystack.hooks`:
 
-- `ContextCompactionHook` (from `haystack.hooks.compaction`): A `before_llm` hook that shortens an Agent's conversation when it reaches a configured fraction of the model's context window. A `Compactor` determines how the conversation is shortened. See [Context Compaction](./compaction.mdx).
+- `CompactionHook` (from `haystack.hooks.compaction`): A `before_llm` hook that shortens an Agent's conversation when it reaches a configured fraction of the model's context window. A `Compactor` determines how the conversation is shortened. See [Context Compaction](./compaction.mdx).
 - `ConfirmationHook` (from `haystack.hooks.human_in_the_loop`): A `before_tool` hook that applies Human-in-the-Loop confirmation strategies to pending tool calls — a human can confirm, modify, or reject the tool calls the model requested before they run. See [Human in the Loop](./human-in-the-loop.mdx).
 - `ToolResultOffloadHook` (from `haystack.hooks.tool_result_offloading`): An `after_tool` hook that offloads tool results to a `ToolResultStore` (such as `FileSystemToolResultStore`) and replaces them in the conversation with a compact pointer, so the next LLM call sees a reference instead of the full result. Per-tool policies (`AlwaysOffload`, `NeverOffload`, `OffloadOverChars`) control which results are offloaded. See [Tool Result Offloading](./tool-result-offloading.mdx).

--- a/docs-website/reference/haystack-api/hooks_api.md
+++ b/docs-website/reference/haystack-api/hooks_api.md
@@ -8,7 +8,7 @@ slug: "/hooks-api"
 
 ## compaction/hooks
 
-### ContextCompactionHook
+### CompactionHook
 
 Compacts an Agent's conversation once it fills too much of the model's context window.
 
@@ -19,9 +19,9 @@ reaches `compact_at` of the window, hands it to a `Compactor` to bring back down
 ```python
 from haystack.components.agents import Agent
 from haystack.components.generators.chat import OpenAIResponsesChatGenerator
-from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
 
-hook = ContextCompactionHook(
+hook = CompactionHook(
     compactor=SlidingWindowCompactor(),
     context_window=400_000,
     compact_at=0.7,
@@ -156,7 +156,7 @@ Serialize the hook, including its compactor and token counter.
 #### from_dict
 
 ```python
-from_dict(data: dict[str, Any]) -> ContextCompactionHook
+from_dict(data: dict[str, Any]) -> CompactionHook
 ```
 
 Deserialize the hook, reconstructing its compactor and token counter.
@@ -167,7 +167,7 @@ Deserialize the hook, reconstructing its compactor and token counter.
 
 **Returns:**
 
-- <code>ContextCompactionHook</code> – The deserialized `ContextCompactionHook`.
+- <code>CompactionHook</code> – The deserialized `CompactionHook`.
 
 ## compaction/sliding_window
 
@@ -184,9 +184,9 @@ steps, where a step is an assistant message together with all immediately follow
 ```python
 from haystack.components.agents import Agent
 from haystack.components.generators.chat import OpenAIResponsesChatGenerator
-from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
 
-hook = ContextCompactionHook(
+hook = CompactionHook(
     compactor=SlidingWindowCompactor(), context_window=400_000, compact_at=0.7, compact_to=0.4
 )
 agent = Agent(
@@ -268,9 +268,9 @@ result and the model can see what it ran and re-run it if needed.
 ```python
 from haystack.components.agents import Agent
 from haystack.components.generators.chat import OpenAIResponsesChatGenerator
-from haystack.hooks.compaction import ContextCompactionHook, ToolResultPruningCompactor
+from haystack.hooks.compaction import CompactionHook, ToolResultPruningCompactor
 
-hook = ContextCompactionHook(
+hook = CompactionHook(
     compactor=ToolResultPruningCompactor(min_keep_steps=1),
     context_window=400_000,
     compact_at=0.7,
@@ -361,7 +361,7 @@ Bases: <code>Protocol</code>
 Rewrites an Agent's conversation into a shorter one that carries the same working context.
 
 A compactor is the *how* of context compaction; deciding *when* to compact is the caller's job, which
-`ContextCompactionHook` does by comparing the context size against a fraction of the model's window. Strategies
+`CompactionHook` does by comparing the context size against a fraction of the model's window. Strategies
 differ widely in cost and fidelity, from dropping the oldest messages outright to condensing them with an LLM.
 
 Implementations must honor three rules:

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -171,7 +171,7 @@ export default {
                     id: 'pipeline-components/agents-1/compaction',
                   },
                   items: [
-                    'pipeline-components/agents-1/compaction/context-compaction-hook',
+                    'pipeline-components/agents-1/compaction/compaction-hook',
                     'pipeline-components/agents-1/compaction/sliding-window-compactor',
                     'pipeline-components/agents-1/compaction/tool-result-pruning-compactor',
                   ],

--- a/haystack/hooks/compaction/__init__.py
+++ b/haystack/hooks/compaction/__init__.py
@@ -8,14 +8,14 @@ from typing import TYPE_CHECKING
 from lazy_imports import LazyImporter
 
 _import_structure = {
-    "hooks": ["ContextCompactionHook"],
+    "hooks": ["CompactionHook"],
     "sliding_window": ["SlidingWindowCompactor"],
     "tool_result_pruning": ["ToolResultPruningCompactor"],
     "types": ["Compactor"],
 }
 
 if TYPE_CHECKING:
-    from .hooks import ContextCompactionHook as ContextCompactionHook
+    from .hooks import CompactionHook as CompactionHook
     from .sliding_window import SlidingWindowCompactor as SlidingWindowCompactor
     from .tool_result_pruning import ToolResultPruningCompactor as ToolResultPruningCompactor
     from .types import Compactor as Compactor

--- a/haystack/hooks/compaction/hooks.py
+++ b/haystack/hooks/compaction/hooks.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @_experimental
-class ContextCompactionHook:
+class CompactionHook:
     """
     Compacts an Agent's conversation once it fills too much of the model's context window.
 
@@ -31,9 +31,9 @@ class ContextCompactionHook:
     ```python
     from haystack.components.agents import Agent
     from haystack.components.generators.chat import OpenAIResponsesChatGenerator
-    from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+    from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
 
-    hook = ContextCompactionHook(
+    hook = CompactionHook(
         compactor=SlidingWindowCompactor(),
         context_window=400_000,
         compact_at=0.7,
@@ -268,12 +268,12 @@ class ContextCompactionHook:
         )
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "ContextCompactionHook":
+    def from_dict(cls, data: dict[str, Any]) -> "CompactionHook":
         """
         Deserialize the hook, reconstructing its compactor and token counter.
 
         :param data: A dictionary representation produced by `to_dict`.
-        :returns: The deserialized `ContextCompactionHook`.
+        :returns: The deserialized `CompactionHook`.
         """
         init_params = data.get("init_parameters", {})
         for key in ("compactor", "token_counter"):

--- a/haystack/hooks/compaction/sliding_window.py
+++ b/haystack/hooks/compaction/sliding_window.py
@@ -101,9 +101,9 @@ class SlidingWindowCompactor(Compactor):
     ```python
     from haystack.components.agents import Agent
     from haystack.components.generators.chat import OpenAIResponsesChatGenerator
-    from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+    from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
 
-    hook = ContextCompactionHook(
+    hook = CompactionHook(
         compactor=SlidingWindowCompactor(), context_window=400_000, compact_at=0.7, compact_to=0.4
     )
     agent = Agent(

--- a/haystack/hooks/compaction/tool_result_pruning.py
+++ b/haystack/hooks/compaction/tool_result_pruning.py
@@ -26,9 +26,9 @@ class ToolResultPruningCompactor(Compactor):
     ```python
     from haystack.components.agents import Agent
     from haystack.components.generators.chat import OpenAIResponsesChatGenerator
-    from haystack.hooks.compaction import ContextCompactionHook, ToolResultPruningCompactor
+    from haystack.hooks.compaction import CompactionHook, ToolResultPruningCompactor
 
-    hook = ContextCompactionHook(
+    hook = CompactionHook(
         compactor=ToolResultPruningCompactor(min_keep_steps=1),
         context_window=400_000,
         compact_at=0.7,

--- a/haystack/hooks/compaction/types/protocol.py
+++ b/haystack/hooks/compaction/types/protocol.py
@@ -14,7 +14,7 @@ class Compactor(Protocol):
     Rewrites an Agent's conversation into a shorter one that carries the same working context.
 
     A compactor is the *how* of context compaction; deciding *when* to compact is the caller's job, which
-    `ContextCompactionHook` does by comparing the context size against a fraction of the model's window. Strategies
+    `CompactionHook` does by comparing the context size against a fraction of the model's window. Strategies
     differ widely in cost and fidelity, from dropping the oldest messages outright to condensing them with an LLM.
 
     Implementations must honor three rules:

--- a/releasenotes/notes/add-agent-context-compaction-3258c08dec9d2b34.yaml
+++ b/releasenotes/notes/add-agent-context-compaction-3258c08dec9d2b34.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Added experimental context compaction for the ``Agent``. ``ContextCompactionHook`` runs before LLM calls and
+    Added experimental context compaction for the ``Agent``. ``CompactionHook`` runs before LLM calls and
     shortens the conversation when it reaches a configured fraction of the model's context window.
 
     The first built-in strategy, ``SlidingWindowCompactor``, preserves leading system messages, the latest user task,
@@ -12,9 +12,9 @@ features:
 
         from haystack.components.agents import Agent
         from haystack.components.generators.chat import OpenAIResponsesChatGenerator
-        from haystack.hooks.compaction import ContextCompactionHook, SlidingWindowCompactor
+        from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
 
-        hook = ContextCompactionHook(
+        hook = CompactionHook(
             compactor=SlidingWindowCompactor(),
             context_window=400_000,
             compact_at=0.7,
@@ -34,5 +34,5 @@ features:
     current task or the configured minimum number of steps. Compaction is lossy: removed messages cannot be recovered
     or summarized by this strategy. Implement the ``Compactor`` protocol to provide a custom strategy.
 
-    ``ContextCompactionHook`` and ``SlidingWindowCompactor`` emit an ``ExperimentalWarning`` and may change without a
+    ``CompactionHook`` and ``SlidingWindowCompactor`` emit an ``ExperimentalWarning`` and may change without a
     deprecation cycle.

--- a/releasenotes/notes/add-tool-result-pruning-compactor-f827857c67a6bbc6.yaml
+++ b/releasenotes/notes/add-tool-result-pruning-compactor-f827857c67a6bbc6.yaml
@@ -8,9 +8,9 @@ features:
 
     .. code-block:: python
 
-        from haystack.hooks.compaction import ContextCompactionHook, ToolResultPruningCompactor
+        from haystack.hooks.compaction import CompactionHook, ToolResultPruningCompactor
 
-        compaction_hook = ContextCompactionHook(
+        compaction_hook = CompactionHook(
             compactor=ToolResultPruningCompactor(
                 min_keep_steps=2,
                 min_tokens=200,

--- a/test/hooks/compaction/test_hooks.py
+++ b/test/hooks/compaction/test_hooks.py
@@ -10,12 +10,7 @@ import pytest
 from haystack.components.agents import Agent
 from haystack.components.generators.chat import MockChatGenerator
 from haystack.dataclasses import ChatMessage
-from haystack.hooks.compaction import (
-    Compactor,
-    ContextCompactionHook,
-    SlidingWindowCompactor,
-    ToolResultPruningCompactor,
-)
+from haystack.hooks.compaction import CompactionHook, Compactor, SlidingWindowCompactor, ToolResultPruningCompactor
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _estimated_context_tokens, _last_assistant_index
 from haystack.token_counters import TokenCounter
 from haystack.tools import tool
@@ -79,9 +74,9 @@ class _RecordingCompactor(Compactor):
         self.calls.append("close_async")
 
 
-def _hook(compactor=None, **overrides) -> ContextCompactionHook:
+def _hook(compactor=None, **overrides) -> CompactionHook:
     settings = {"context_window": WINDOW, "compact_at": 0.7, "compact_to": 0.4, "token_counter": FakeCounter()}
-    return ContextCompactionHook(compactor or SlidingWindowCompactor(), **{**settings, **overrides})
+    return CompactionHook(compactor or SlidingWindowCompactor(), **{**settings, **overrides})
 
 
 def _fetch_call(call_id: str) -> ChatMessage:
@@ -110,7 +105,7 @@ def _assert_every_tool_result_is_answered(messages: list[ChatMessage]) -> None:
             assert result.origin.id in offered_call_ids, f"orphaned tool result: {result.origin}"
 
 
-class TestContextCompactionHookConfiguration:
+class TestCompactionHookConfiguration:
     @pytest.mark.parametrize(
         ("compact_at", "compact_to"),
         [
@@ -126,7 +121,7 @@ class TestContextCompactionHookConfiguration:
 
     @pytest.mark.filterwarnings("always::haystack.utils.experimental.ExperimentalWarning")
     def test_warns_that_the_feature_is_experimental(self):
-        with pytest.warns(ExperimentalWarning, match="ContextCompactionHook.*experimental"):
+        with pytest.warns(ExperimentalWarning, match="CompactionHook.*experimental"):
             _hook()
 
     def test_rejects_a_non_positive_window(self):
@@ -134,7 +129,7 @@ class TestContextCompactionHookConfiguration:
             _hook(context_window=0)
 
     def test_serde_round_trip(self):
-        hook = ContextCompactionHook(
+        hook = CompactionHook(
             compactor=SlidingWindowCompactor(min_keep_steps=4), context_window=200_000, compact_at=0.6
         )
         data = hook.to_dict()
@@ -142,7 +137,7 @@ class TestContextCompactionHookConfiguration:
         assert data["init_parameters"]["compact_at"] == 0.6
         assert data["init_parameters"]["compactor"]["init_parameters"]["min_keep_steps"] == 4
         assert data["init_parameters"]["token_counter"]["type"].endswith("ApproximateTokenCounter")
-        restored = ContextCompactionHook.from_dict(data)
+        restored = CompactionHook.from_dict(data)
         assert isinstance(restored.compactor, SlidingWindowCompactor)
         assert restored.context_window == 200_000
         assert restored.compact_at == 0.6
@@ -150,7 +145,7 @@ class TestContextCompactionHookConfiguration:
     def test_survives_an_agent_serde_round_trip(self):
         agent = _agent({"before_llm": [_hook()]})
         hook = Agent.from_dict(agent.to_dict()).hooks["before_llm"][0]
-        assert isinstance(hook, ContextCompactionHook)
+        assert isinstance(hook, CompactionHook)
         assert isinstance(hook.compactor, SlidingWindowCompactor)
         assert hook.context_window == WINDOW
 
@@ -159,7 +154,7 @@ class TestContextCompactionHookConfiguration:
             Agent(chat_generator=MockChatGenerator(), tools=[fetch], hooks={"after_tool": [_hook()]})
 
 
-class TestContextCompactionHook:
+class TestCompactionHook:
     @pytest.mark.parametrize(
         ("context_tokens", "should_compact"),
         [
@@ -265,10 +260,8 @@ class TestContextCompactionHook:
             tool_result("recent result " * 400, call_id="recent"),
         ]
         settings = {"context_window": 2000, "compact_at": 0.5, "compact_to": 0.1, "token_counter": counter}
-        pruning_hook = ContextCompactionHook(
-            compactor=ToolResultPruningCompactor(min_keep_steps=1, min_tokens=0), **settings
-        )
-        sliding_window_hook = ContextCompactionHook(compactor=SlidingWindowCompactor(), **settings)
+        pruning_hook = CompactionHook(compactor=ToolResultPruningCompactor(min_keep_steps=1, min_tokens=0), **settings)
+        sliding_window_hook = CompactionHook(compactor=SlidingWindowCompactor(), **settings)
         # Provider usage covers through the last assistant call plus request overhead; the trailing result is local.
         reported_context_tokens = counter.count(messages=messages[:-1]) + 100
         state = make_state(messages, context_tokens=reported_context_tokens)
@@ -296,7 +289,7 @@ class TestContextCompactionHook:
         assert compactor.calls == ["warm_up", "close"]
 
 
-class TestContextCompactionHookInAgent:
+class TestCompactionHookInAgent:
     def test_compacts_a_multi_step_run(self):
         compacted = _agent({"before_llm": [_hook()]}).run(messages=[ChatMessage.from_user("start")])
         uncompacted = _agent(None).run(messages=[ChatMessage.from_user("start")])
@@ -315,7 +308,7 @@ class TestContextCompactionHookInAgent:
         assert count_markers(messages=result["messages"]) == 0
 
 
-class TestContextCompactionHookAsync:
+class TestCompactionHookAsync:
     @pytest.mark.asyncio
     async def test_run_async_uses_the_async_compaction_path(self):
         compactor = _RecordingCompactor()

--- a/test/hooks/compaction/test_tool_result_pruning.py
+++ b/test/hooks/compaction/test_tool_result_pruning.py
@@ -5,7 +5,7 @@
 import pytest
 
 from haystack.dataclasses import ChatMessage, ImageContent
-from haystack.hooks.compaction import ContextCompactionHook, ToolResultPruningCompactor
+from haystack.hooks.compaction import CompactionHook, ToolResultPruningCompactor
 from haystack.hooks.compaction.tool_result_pruning import _DEFAULT_PLACEHOLDER
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY
 from haystack.hooks.tool_result_offloading import AlwaysOffload, FileSystemToolResultStore, ToolResultOffloadHook
@@ -236,7 +236,7 @@ class TestToolResultPruningCompactor:
         assert restored.skip_meta_keys == ("stored", "cached")
 
     def test_hook_serialization_round_trip(self):
-        hook = ContextCompactionHook(compactor=ToolResultPruningCompactor(min_keep_steps=2), context_window=10_000)
-        restored = ContextCompactionHook.from_dict(data=hook.to_dict())
+        hook = CompactionHook(compactor=ToolResultPruningCompactor(min_keep_steps=2), context_window=10_000)
+        restored = CompactionHook.from_dict(data=hook.to_dict())
         assert isinstance(restored.compactor, ToolResultPruningCompactor)
         assert restored.compactor.min_keep_steps == 2


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

I realized to be consistent with the naming of the new `compaction` module and how the wider community usually refers to just "compaction" and not "context compaction" (e.g. the options are both called `/compact` in Claude Code and Codex), I opted to change the name to just `CompactionHook`. 

Updated code, release notes, and docs pages to use the new name. This is done before Compaction Hook was released so this is not a breaking change. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
