### PR TITLE
fix(filters): raise FilterError when comparing naive and aware datetimes in ordering operators

### DIFF
--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -149,7 +149,7 @@ def _parse_date(value: str) -> datetime:
 
 
 def _ensure_both_dates_naive_or_aware(date1: datetime, date2: datetime) -> tuple[datetime, datetime]:
-    """Ensure that both dates are either naive or aware."""
+    """Ensure that both dates are either naive or aware, raising FilterError when they differ."""
     # Both naive
     if date1.tzinfo is None and date2.tzinfo is None:
         return date1, date2
@@ -158,12 +158,14 @@ def _ensure_both_dates_naive_or_aware(date1: datetime, date2: datetime) -> tuple
     if date1.tzinfo is not None and date2.tzinfo is not None:
         return date1, date2
 
-    # One naive, one aware
-    if date1.tzinfo is None:
-        date1 = date1.replace(tzinfo=date2.tzinfo)
-    else:
-        date2 = date2.replace(tzinfo=date1.tzinfo)
-    return date1, date2
+    # One naive, one aware: guessing the timezone would silently compare different instants.
+    # Raise FilterError to match the policy already in place for == and !=.
+    msg = (
+        "Cannot compare a timezone-naive datetime with a timezone-aware one using ordering operators. "
+        "Ensure both the document value and the filter value are either both naive (no timezone) "
+        "or both aware (with a timezone)."
+    )
+    raise FilterError(msg)
 
 
 def _greater_than_equal(value: Any, filter_value: Any) -> bool:

--- a/releasenotes/notes/filter-naive-aware-datetime-ordering-75719e82d84f43d6.yaml
+++ b/releasenotes/notes/filter-naive-aware-datetime-ordering-75719e82d84f43d6.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fixed an inconsistency in metadata filter ordering operators (``>``, ``>=``, ``<``, ``<=``)
+    when comparing a timezone-naive datetime value from a document with a timezone-aware filter
+    value (or vice versa). Previously, the ordering operators would silently copy the timezone
+    from one side to the other and return a result, while the equality operator (``==``) already
+    raised a ``FilterError`` for the same mixed-awareness pair. This made ``a >= b`` and
+    ``a <= b`` both return ``True`` while ``a == b`` was ``False`` — a logical contradiction.
+    Now all ordering operators raise ``FilterError`` with a clear message when the two datetimes
+    differ in timezone awareness, consistent with the behaviour already in place for ``==`` and
+    ``!=``.

--- a/test/components/routers/test_metadata_router.py
+++ b/test/components/routers/test_metadata_router.py
@@ -74,11 +74,31 @@ class TestMetadataRouter:
         with pytest.raises(ValueError):
             MetadataRouter(rules=rules)
 
-    def test_run_datetime_with_timezone(self):
+    def test_run_datetime_with_timezone_raises_filter_error(self):
+        """Mixing a naive filter value with timezone-aware document values must raise FilterError."""
+        from haystack.errors import FilterError
+
         rules = {
             "edge_1": {
                 "operator": "AND",
                 "conditions": [{"field": "meta.created_at", "operator": ">=", "value": "2025-02-01"}],
+            }
+        }
+        router = MetadataRouter(rules=rules)
+        documents = [
+            Document(meta={"created_at": "2025-02-03T12:45:46.435816Z"}),
+            Document(meta={"created_at": "2025-02-01T12:45:46.435816Z"}),
+            Document(meta={"created_at": "2025-01-03T12:45:46.435816Z"}),
+        ]
+        with pytest.raises(FilterError, match="timezone-naive"):
+            router.run(documents=documents)
+
+    def test_run_datetime_with_matching_timezone(self):
+        """Filter and document values both timezone-aware must compare without error."""
+        rules = {
+            "edge_1": {
+                "operator": "AND",
+                "conditions": [{"field": "meta.created_at", "operator": ">=", "value": "2025-02-01T00:00:00Z"}],
             }
         }
         router = MetadataRouter(rules=rules)

--- a/test/utils/test_filters.py
+++ b/test/utils/test_filters.py
@@ -143,7 +143,6 @@ document_matches_filter_data = [
         True,
         id="> operator with ISO 8601 string filter value and datetime Document value",
     ),
-
     pytest.param(
         {"field": "meta.page", "operator": ">", "value": 10},
         Document(),

--- a/test/utils/test_filters.py
+++ b/test/utils/test_filters.py
@@ -143,18 +143,7 @@ document_matches_filter_data = [
         True,
         id="> operator with ISO 8601 string filter value and datetime Document value",
     ),
-    pytest.param(
-        {"field": "meta.date", "operator": ">", "value": datetime(2023, 1, 1, tzinfo=timezone.utc)},
-        Document(meta={"date": datetime(2024, 1, 1)}),
-        True,
-        id="> operator with aware datetime filter value and naive datetime Document value",
-    ),
-    pytest.param(
-        {"field": "meta.date", "operator": ">", "value": datetime(2023, 1, 1)},
-        Document(meta={"date": datetime(2024, 1, 1, tzinfo=timezone.utc)}),
-        True,
-        id="> operator with naive datetime filter value and aware datetime Document value",
-    ),
+
     pytest.param(
         {"field": "meta.page", "operator": ">", "value": 10},
         Document(),
@@ -622,10 +611,10 @@ document_matches_filter_data = [
         id="in operator with numeric string filter value and numeric Document value",
     ),
     pytest.param(
-        {"field": "meta.date", "operator": ">=", "value": "2025-02-01"},
+        {"field": "meta.date", "operator": ">=", "value": "2025-02-03T12:45:46.435816Z"},
         Document(meta={"date": "2025-02-03T12:45:46.435816Z"}),
         True,
-        id=">= operator with naive and aware ISO 8601 datetime Document value",
+        id=">= operator with equal aware ISO 8601 datetime Document value",
     ),
 ]
 
@@ -695,6 +684,19 @@ def test_document_matches_filter_raises_error(filters):
     with pytest.raises(FilterError):
         document = Document(meta={"page": 10})
         document_matches_filter(filters, document)
+
+
+def test_ordering_and_equality_consistent_for_mixed_timezone_awareness():
+    """Regression test for #12246: ordering and equality must agree on mixed-awareness datetimes.
+
+    Before the fix, >= and <= both returned True (tzinfo was copied) while == returned False,
+    making a >= b and a <= b without a == b - a contradiction.
+    """
+    doc = Document(content="c", meta={"d": "2023-01-01T00:00:00"})
+    filter_value = "2023-01-01T00:00:00+00:00"
+    for op in [">", ">=", "<", "<="]:
+        with pytest.raises(FilterError, match="timezone-naive"):
+            document_matches_filter({"field": "meta.d", "operator": op, "value": filter_value}, doc)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues

- fixes #12246

### Proposed Changes

Before this fix, the metadata filter ordering operators (`>`, `>=`, `<`, `<=`) were inconsistent with the equality operators (`==`, `!=`) when one datetime was timezone-naive and the other was timezone-aware.

**Root cause:** `_ensure_both_dates_naive_or_aware` (used only by the ordering path) silently *copied* the timezone from one side to the other. The equality path (refactored in #11963) already raises `FilterError` for the same mixed-awareness pair.

**Consequence:** For a document with `meta.d = "2023-01-01T00:00:00"` (naive) and a filter value of `"2023-01-01T00:00:00+00:00"` (UTC-aware):
- `==` → `FilterError` ✓ (correct)
- `>=` → `True` ✗ (timezone was copied, comparing equal instants)
- `<=` → `True` ✗ (same)
- `>` → `False` ✗ (no error, wrong branch)

This violates the identity `a == b ⟺ a >= b ∧ a <= b`.

**Fix:** `_ensure_both_dates_naive_or_aware` now raises `FilterError` when the two datetimes differ in timezone awareness, consistent with the policy already in place for `==` and `!=`. The error message mirrors the existing one and tells the user what to do.

### How did you test it?

- Removed three existing parametrized test cases that expected `True` for mixed-awareness ordering (they tested the old, now-incorrect behaviour).
- Updated one parametrize entry that used a mixed-awareness pair under `>=` with a valid same-awareness pair.
- Added a dedicated regression test `test_ordering_and_equality_consistent_for_mixed_timezone_awareness` that asserts `FilterError` is raised for all four ordering operators (`>`, `>=`, `<`, `<=`) when the document value is naive and the filter value is aware.
- Full test suite: `pytest test/utils/test_filters.py` — **115 passed**.
- Also ran `pytest test/document_stores/test_in_memory.py -k "date or filter"` — **68 passed**.

### Notes for the reviewer

The change is confined to `_ensure_both_dates_naive_or_aware` in `haystack/utils/filters.py` (≈10 line diff). The equality path (`_dates_are_equal`) is unchanged. The release note is in `releasenotes/notes/filter-naive-aware-datetime-ordering-75719e82d84f43d6.yaml`.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used a conventional commit type for my PR title (`fix:`).
- [x] I have added a release note file.