### PR TITLE
fix: divide DocumentMAPEvaluator average precision by all relevant documents

### DIFF
--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -117,19 +117,25 @@ class DocumentMAPEvaluator:
         for ground_truth, retrieved in zip(ground_truth_documents, retrieved_documents, strict=True):
             average_precision = 0.0
             average_precision_numerator = 0.0
-            relevant_documents = 0
+            retrieved_relevant_documents = 0
 
-            ground_truth_values = [val for doc in ground_truth if (val := self._get_comparison_value(doc)) is not None]
+            ground_truth_values = []
+            for doc in ground_truth:
+                value = self._get_comparison_value(doc)
+                if value is not None and value not in ground_truth_values:
+                    ground_truth_values.append(value)
+            total_relevant_documents = len(ground_truth_values)
             for rank, retrieved_document in enumerate(retrieved):
                 retrieved_value = self._get_comparison_value(retrieved_document)
                 if retrieved_value is None:
                     continue
 
                 if retrieved_value in ground_truth_values:
-                    relevant_documents += 1
-                    average_precision_numerator += relevant_documents / (rank + 1)
-            if relevant_documents > 0:
-                average_precision = average_precision_numerator / relevant_documents
+                    ground_truth_values.remove(retrieved_value)
+                    retrieved_relevant_documents += 1
+                    average_precision_numerator += retrieved_relevant_documents / (rank + 1)
+            if total_relevant_documents:
+                average_precision = average_precision_numerator / total_relevant_documents
             individual_scores.append(average_precision)
 
         score = sum(individual_scores) / len(ground_truth_documents)

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -119,11 +119,9 @@ class DocumentMAPEvaluator:
             average_precision_numerator = 0.0
             retrieved_relevant_documents = 0
 
-            ground_truth_values = []
-            for doc in ground_truth:
-                value = self._get_comparison_value(doc)
-                if value is not None and value not in ground_truth_values:
-                    ground_truth_values.append(value)
+            ground_truth_values = {
+                value for doc in ground_truth if (value := self._get_comparison_value(doc)) is not None
+            }
             total_relevant_documents = len(ground_truth_values)
             for rank, retrieved_document in enumerate(retrieved):
                 retrieved_value = self._get_comparison_value(retrieved_document)
@@ -131,7 +129,7 @@ class DocumentMAPEvaluator:
                     continue
 
                 if retrieved_value in ground_truth_values:
-                    ground_truth_values.remove(retrieved_value)
+                    ground_truth_values.discard(retrieved_value)
                     retrieved_relevant_documents += 1
                     average_precision_numerator += retrieved_relevant_documents / (rank + 1)
             if total_relevant_documents:

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -119,17 +119,22 @@ class DocumentMAPEvaluator:
             average_precision_numerator = 0.0
             retrieved_relevant_documents = 0
 
-            ground_truth_values = {
-                value for doc in ground_truth if (value := self._get_comparison_value(doc)) is not None
-            }
-            total_relevant_documents = len(ground_truth_values)
+            # A list keeps the deduplication working for unhashable comparison values, for example when
+            # document_comparison_field points to a meta key holding a list.
+            uncredited_ground_truth_values: list[Any] = []
+            for doc in ground_truth:
+                value = self._get_comparison_value(doc)
+                if value is not None and value not in uncredited_ground_truth_values:
+                    uncredited_ground_truth_values.append(value)
+
+            total_relevant_documents = len(uncredited_ground_truth_values)
             for rank, retrieved_document in enumerate(retrieved):
                 retrieved_value = self._get_comparison_value(retrieved_document)
                 if retrieved_value is None:
                     continue
 
-                if retrieved_value in ground_truth_values:
-                    ground_truth_values.discard(retrieved_value)
+                if retrieved_value in uncredited_ground_truth_values:
+                    uncredited_ground_truth_values.remove(retrieved_value)
                     retrieved_relevant_documents += 1
                     average_precision_numerator += retrieved_relevant_documents / (rank + 1)
             if total_relevant_documents:

--- a/releasenotes/notes/fix-document-map-average-precision.yaml
+++ b/releasenotes/notes/fix-document-map-average-precision.yaml
@@ -3,3 +3,8 @@ fixes:
   - |
     Fix ``DocumentMAPEvaluator`` to include missed relevant documents in the average precision denominator and avoid
     crediting duplicate retrievals of the same document.
+upgrade:
+  - |
+    ``DocumentMAPEvaluator`` scores can change because average precision now uses all unique, valid ground-truth
+    comparison values as its denominator and credits each value at most once. Re-baseline evaluations that relied on
+    the previous scores.

--- a/releasenotes/notes/fix-document-map-average-precision.yaml
+++ b/releasenotes/notes/fix-document-map-average-precision.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix ``DocumentMAPEvaluator`` to include missed relevant documents in the average precision denominator and avoid
+    crediting duplicate retrievals of the same document.

--- a/test/components/evaluators/test_document_map.py
+++ b/test/components/evaluators/test_document_map.py
@@ -96,8 +96,7 @@ def test_run_with_partial_matching():
 
 
 @pytest.mark.parametrize(
-    "retrieved_documents",
-    [[Document(content="A")], [Document(content="A"), Document(content="A")]],
+    "retrieved_documents", [[Document(content="A")], [Document(content="A"), Document(content="A")]]
 )
 def test_run_with_missed_and_duplicate_relevant_documents(retrieved_documents):
     evaluator = DocumentMAPEvaluator()

--- a/test/components/evaluators/test_document_map.py
+++ b/test/components/evaluators/test_document_map.py
@@ -138,10 +138,10 @@ def test_run_with_complex_data():
         "individual_scores": [
             1.0,
             pytest.approx(0.8333333333333333),
-            0.5,
+            0.5,  # Only one of two relevant documents was retrieved.
             pytest.approx(0.5833333333333333),
             0.0,
-            pytest.approx(0.8333333333333333),
+            pytest.approx(0.8333333333333333),  # The duplicate retrieval is not credited again.
         ],
         "score": pytest.approx(0.625),
     }

--- a/test/components/evaluators/test_document_map.py
+++ b/test/components/evaluators/test_document_map.py
@@ -95,6 +95,20 @@ def test_run_with_partial_matching():
     assert result == {"individual_scores": [1.0, 0.0], "score": 0.5}
 
 
+@pytest.mark.parametrize(
+    "retrieved_documents",
+    [[Document(content="A")], [Document(content="A"), Document(content="A")]],
+)
+def test_run_with_missed_and_duplicate_relevant_documents(retrieved_documents):
+    evaluator = DocumentMAPEvaluator()
+    result = evaluator.run(
+        ground_truth_documents=[[Document(content="A"), Document(content="B")]],
+        retrieved_documents=[retrieved_documents],
+    )
+
+    assert result == {"individual_scores": [0.5], "score": 0.5}
+
+
 def test_run_with_complex_data():
     evaluator = DocumentMAPEvaluator()
     result = evaluator.run(
@@ -124,12 +138,12 @@ def test_run_with_complex_data():
         "individual_scores": [
             1.0,
             pytest.approx(0.8333333333333333),
-            1.0,
+            0.5,
             pytest.approx(0.5833333333333333),
             0.0,
-            pytest.approx(0.8055555555555555),
+            pytest.approx(0.8333333333333333),
         ],
-        "score": pytest.approx(0.7037037037037037),
+        "score": pytest.approx(0.625),
     }
 
 

--- a/test/components/evaluators/test_document_map.py
+++ b/test/components/evaluators/test_document_map.py
@@ -65,6 +65,18 @@ def test_run_with_nested_meta_comparison():
     assert result == {"individual_scores": [1.0, 0.0], "score": 0.5}
 
 
+def test_run_with_unhashable_meta_comparison():
+    evaluator = DocumentMAPEvaluator(document_comparison_field="meta.tags")
+    result = evaluator.run(
+        ground_truth_documents=[
+            [Document(content="x", meta={"tags": ["a"]}), Document(content="y", meta={"tags": ["b"]})]
+        ],
+        retrieved_documents=[[Document(content="z", meta={"tags": ["a"]})]],
+    )
+
+    assert result == {"individual_scores": [0.5], "score": 0.5}
+
+
 def test_run_with_all_matching():
     evaluator = DocumentMAPEvaluator()
     result = evaluator.run(


### PR DESCRIPTION
**Related Issues**

- No existing issue; found while comparing `DocumentMAPEvaluator` output against the standard mean average precision definition.

**Proposed Changes:**

`DocumentMAPEvaluator` computed average precision as `sum(precision@k) / number_of_retrieved_relevant_documents`. Average precision is defined as `sum(precision@k) / number_of_relevant_documents`, where relevant documents that were never retrieved contribute a precision of zero (see the TREC measure definitions at https://trec.nist.gov/pubs/trec16/appendices/measures.pdf and the `trec_eval` reference implementation, which accumulates precision and then divides by the total number of relevant documents).

Because of the wrong denominator, a query with two relevant documents where only one was retrieved scored `1.0` instead of `0.5`. In addition, the ground-truth values were never consumed once matched, so retrieving the same relevant document twice was credited twice and could push the score back up while a relevant document was still missing.

This PR:

- collects the ground-truth comparison values into a set, so the denominator is the number of unique valid ground-truth documents;
- divides the accumulated precision by that total instead of by the hit count;
- removes a value from the pending set once it has been credited, so duplicate retrievals of the same document are not counted again.

Documented behaviour of the class (the usage example in the docstring) is unaffected: its expected scores are unchanged. Scores for evaluations with missed or duplicated relevant documents will change, which is called out in the release note under `upgrade`.

**How did you test it?**

- Added a regression test covering a missed relevant document and a duplicated retrieval; both now yield `0.5` for a query with two relevant documents and one distinct hit.
- Updated `test_run_with_complex_data` expectations, which previously encoded the inflated values (`1.0` for a query where only one of two relevant documents was retrieved, and `0.805…` for a query where a duplicate retrieval was credited).
- Ran the evaluator's unit test module locally; all tests pass.

**Notes for the reviewer**

This is a behaviour change for users who track absolute MAP values, so a release note with an `upgrade` section is included. Happy to split the duplicate-retrieval part out if you would rather land the denominator fix on its own.

Disclosure: this change was drafted with AI assistance and reviewed by a human before submission.

**Checklist**

- [x] I have read the contributors guidelines and the code of conduct
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the conventional commit types for my PR title: `fix:`
- [x] I documented my code
- [x] I ran pre-commit hooks and fixed any issue
