### PR TITLE
fix: `InMemoryDocumentStore` adding optional parameter `filters` to `get_metadata_field_unique_values()`

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -653,7 +653,12 @@ class InMemoryDocumentStore:
             return {"min": None, "max": None}
 
     def get_metadata_field_unique_values(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Returns unique values for a metadata field, optionally filtered by a search term, with pagination.
@@ -663,11 +668,12 @@ class InMemoryDocumentStore:
             against the metadata field's value.
         :param from_: The offset to start returning values from (for pagination).
         :param size: The maximum number of unique values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple of (paginated list of unique values, total count of unique values).
         """
         key = metadata_field.removeprefix("meta.") if metadata_field.startswith("meta.") else metadata_field
         unique_values: dict[tuple[str, str], Any] = {}
-        for doc in self.storage.values():
+        for doc in self.filter_documents(filters=filters):
             value = doc.meta.get(key)
             if value is not None:
                 unique_values.setdefault((type(value).__name__, str(value)), value)
@@ -972,7 +978,12 @@ class InMemoryDocumentStore:
         )
 
     async def get_metadata_field_unique_values_async(
-        self, metadata_field: str, search_term: str | None = None, from_: int = 0, size: int = 10
+        self,
+        metadata_field: str,
+        search_term: str | None = None,
+        from_: int = 0,
+        size: int = 10,
+        filters: dict[str, Any] | None = None,
     ) -> tuple[list[Any], int]:
         """
         Returns unique values for a metadata field, optionally filtered by a search term, with pagination.
@@ -982,12 +993,13 @@ class InMemoryDocumentStore:
             against the metadata field's value.
         :param from_: The offset to start returning values from (for pagination).
         :param size: The maximum number of unique values to return.
+        :param filters: Optional filters to restrict the documents considered.
         :returns: A tuple of (paginated list of unique values, total count of unique values).
         """
         return await asyncio.get_running_loop().run_in_executor(
             self.executor,
             lambda: self.get_metadata_field_unique_values(
-                metadata_field=metadata_field, search_term=search_term, from_=from_, size=size
+                metadata_field=metadata_field, search_term=search_term, from_=from_, size=size, filters=filters
             ),
         )
 

--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -1205,8 +1205,8 @@ class GetMetadataFieldUniqueValuesTest:
     Tests for Document Store get_metadata_field_unique_values().
 
     Only mix in for stores that implement get_metadata_field_unique_values() with the standardized
-    signature: get_metadata_field_unique_values(metadata_field, search_term=None, from_=0, size=10)
-        returns (values, total_count).
+    signature: get_metadata_field_unique_values(metadata_field, search_term=None, from_=0, size=10,
+        filters=None) returns (values, total_count).
     """
 
     @staticmethod
@@ -1358,6 +1358,24 @@ class GetMetadataFieldUniqueValuesTest:
         assert values_by_type[str] == "1"
         assert values_by_type[float] == 1.0
         assert values_by_type[bool] is True
+
+    @staticmethod
+    def test_get_metadata_field_unique_values_with_filters(document_store: DocumentStore):
+        """Test get_metadata_field_unique_values() restricts documents using the filters param."""
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        document_store.write_documents(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total_count = document_store.get_metadata_field_unique_values(  # type:ignore[attr-defined]
+            metadata_field="category", filters=filters
+        )
+
+        assert set(values) == {"A", "B"}
+        assert total_count == 2
 
 
 class DocumentStoreBaseTests(CountDocumentsTest, DeleteDocumentsTest, FilterDocumentsTest, WriteDocumentsTest):

--- a/haystack/testing/document_store_async.py
+++ b/haystack/testing/document_store_async.py
@@ -710,8 +710,8 @@ class GetMetadataFieldUniqueValuesAsyncTest:
     Tests for Document Store get_metadata_field_unique_values_async().
 
     Only mix in for stores that implement get_metadata_field_unique_values_async() with the standardized
-    signature: get_metadata_field_unique_values_async(metadata_field, search_term=None, from_=0, size=10)
-    -> (values, total_count).
+    signature: get_metadata_field_unique_values_async(metadata_field, search_term=None, from_=0, size=10,
+    filters=None) -> (values, total_count).
     """
 
     @staticmethod
@@ -840,6 +840,25 @@ class GetMetadataFieldUniqueValuesAsyncTest:
 
         assert set(values) == {1, 2}
         assert all(isinstance(value, int) for value in values)
+        assert total_count == 2
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_get_metadata_field_unique_values_with_filters_async(document_store: AsyncDocumentStore):
+        """Test get_metadata_field_unique_values_async() restricts documents using the filters param."""
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total_count = await document_store.get_metadata_field_unique_values_async(  # type:ignore[attr-defined]
+            metadata_field="category", filters=filters
+        )
+
+        assert set(values) == {"A", "B"}
         assert total_count == 2
 
 

--- a/releasenotes/notes/in-memory-add-filters-to-unique-values-9caf93d474ac922d.yaml
+++ b/releasenotes/notes/in-memory-add-filters-to-unique-values-9caf93d474ac922d.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Added a ``filters`` parameter to ``InMemoryDocumentStore.get_metadata_field_unique_values`` (sync and async), allowing
+    the set of documents considered when computing unique metadata field values to be restricted.

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -102,32 +102,6 @@ class TestMemoryDocumentStore(
         self.assert_documents_are_equal(equal_result, docs)
         self.assert_documents_are_equal(in_result, docs)
 
-    def test_get_metadata_field_unique_values_with_filters(self, document_store: InMemoryDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
-            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
-            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
-        ]
-        document_store.write_documents(docs)
-
-        filters = {"field": "meta.status", "operator": "==", "value": "active"}
-        values, total = document_store.get_metadata_field_unique_values("category", filters=filters)
-        assert set(values) == {"A", "B"}
-        assert total == 2
-
-    async def test_get_metadata_field_unique_values_with_filters_async(self, document_store: InMemoryDocumentStore):
-        docs = [
-            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
-            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
-            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
-        ]
-        await document_store.write_documents_async(docs)
-
-        filters = {"field": "meta.status", "operator": "==", "value": "active"}
-        values, total = await document_store.get_metadata_field_unique_values_async("category", filters=filters)
-        assert set(values) == {"A", "B"}
-        assert total == 2
-
     def test_to_dict(self, in_memory_doc_store):
         data = in_memory_doc_store.to_dict()
         assert data == {

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -102,6 +102,32 @@ class TestMemoryDocumentStore(
         self.assert_documents_are_equal(equal_result, docs)
         self.assert_documents_are_equal(in_result, docs)
 
+    def test_get_metadata_field_unique_values_with_filters(self, document_store: InMemoryDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        document_store.write_documents(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = document_store.get_metadata_field_unique_values("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2
+
+    async def test_get_metadata_field_unique_values_with_filters_async(self, document_store: InMemoryDocumentStore):
+        docs = [
+            Document(content="Doc 1", meta={"category": "A", "status": "active"}),
+            Document(content="Doc 2", meta={"category": "B", "status": "active"}),
+            Document(content="Doc 3", meta={"category": "C", "status": "inactive"}),
+        ]
+        await document_store.write_documents_async(docs)
+
+        filters = {"field": "meta.status", "operator": "==", "value": "active"}
+        values, total = await document_store.get_metadata_field_unique_values_async("category", filters=filters)
+        assert set(values) == {"A", "B"}
+        assert total == 2
+
     def test_to_dict(self, in_memory_doc_store):
         data = in_memory_doc_store.to_dict()
         assert data == {


### PR DESCRIPTION
### Proposed Changes:

- adding optional parameter `filters` to `get_metadata_field_unique_values() `

### How did you test it?

- added one more test to check filters usage
