### PR TITLE
fix: validate runtime top_k in MetaFieldRanker

### DIFF
--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -234,7 +234,7 @@ class MetaFieldRanker:
         if not documents:
             return {"documents": []}
 
-        top_k = top_k or self.top_k
+        top_k = self.top_k if top_k is None else top_k
         weight = weight if weight is not None else self.weight
         ranking_mode = ranking_mode or self.ranking_mode
         sort_order = sort_order or self.sort_order

--- a/releasenotes/notes/metafield-ranker-runtime-top-k-zero-905467e2c1a7e891.yaml
+++ b/releasenotes/notes/metafield-ranker-runtime-top-k-zero-905467e2c1a7e891.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes ``MetaFieldRanker`` silently treating a runtime ``top_k=0`` as unset and falling back to the value
+    configured at initialization. Runtime values that are not greater than zero now raise a ``ValueError`` as
+    documented.

--- a/test/components/rankers/test_llm_ranker.py
+++ b/test/components/rankers/test_llm_ranker.py
@@ -20,9 +20,10 @@ def mock_chat_generator():
     return Mock(spec=OpenAIChatGenerator)
 
 
-def test_init_invalid_top_k():
-    with pytest.raises(ValueError, match="top_k must be > 0"):
-        LLMRanker(top_k=0)
+@pytest.mark.parametrize("top_k", [0, -1])
+def test_init_invalid_top_k(top_k):
+    with pytest.raises(ValueError, match=rf"top_k must be > 0, but got {top_k}"):
+        LLMRanker(top_k=top_k)
 
 
 def test_init_default_generator(monkeypatch):
@@ -87,11 +88,21 @@ def test_from_dict(monkeypatch):
     assert ranker._chat_generator.to_dict() == chat_generator.to_dict()
 
 
-def test_run_invalid_runtime_top_k(mock_chat_generator):
-    ranker = LLMRanker(chat_generator=mock_chat_generator)
+@pytest.mark.parametrize(("init_top_k", "run_top_k"), [(10, 0), (10, -1), (1, 0)])
+def test_run_invalid_runtime_top_k(mock_chat_generator, init_top_k, run_top_k):
+    ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=init_top_k)
 
-    with pytest.raises(ValueError, match="top_k must be > 0"):
-        ranker.run(query="test", documents=[Document(content="doc")], top_k=0)
+    with pytest.raises(ValueError, match=rf"top_k must be > 0, but got {run_top_k}"):
+        ranker.run(query="test", documents=[Document(content="doc")], top_k=run_top_k)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("init_top_k", "run_top_k"), [(10, 0), (10, -1), (1, 0)])
+async def test_run_async_invalid_runtime_top_k(mock_chat_generator, init_top_k, run_top_k):
+    ranker = LLMRanker(chat_generator=mock_chat_generator, top_k=init_top_k)
+
+    with pytest.raises(ValueError, match=rf"top_k must be > 0, but got {run_top_k}"):
+        await ranker.run_async(query="test", documents=[Document(content="doc")], top_k=run_top_k)
 
 
 def test_run_empty_documents(mock_chat_generator):

--- a/test/components/rankers/test_lost_in_the_middle.py
+++ b/test/components/rankers/test_lost_in_the_middle.py
@@ -58,6 +58,22 @@ class TestLostInTheMiddleRanker:
         with pytest.raises(ValueError, match="Invalid value for word_count_threshold"):
             LostInTheMiddleRanker(word_count_threshold=-5)
 
+    @pytest.mark.parametrize("top_k", [0, -1])
+    def test_lost_in_the_middle_init_invalid_top_k(self, top_k):
+        # tests that LostInTheMiddleRanker raises an error when top_k is <= 0
+        with pytest.raises(ValueError, match=rf"top_k must be > 0, but got {top_k}"):
+            LostInTheMiddleRanker(top_k=top_k)
+
+    @pytest.mark.parametrize(("init_top_k", "run_top_k"), [(None, 0), (None, -1), (3, 0)])
+    def test_lost_in_the_middle_run_invalid_runtime_top_k(self, init_top_k, run_top_k):
+        # tests that LostInTheMiddleRanker.run raises an error for an invalid runtime top_k,
+        # even when the instance top_k is valid
+        ranker = LostInTheMiddleRanker(top_k=init_top_k)
+        docs = [Document(content=str(i)) for i in range(1, 5)]
+
+        with pytest.raises(ValueError, match=rf"top_k must be > 0, but got {run_top_k}"):
+            ranker.run(documents=docs, top_k=run_top_k)
+
     def test_lost_in_the_middle_with_word_count_threshold(self):
         # tests that lost_in_the_middle with word_count_threshold works as expected
         ranker = LostInTheMiddleRanker(word_count_threshold=6)

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -187,9 +187,18 @@ class TestMetaFieldRanker:
         with pytest.raises(ValueError):
             MetaFieldRanker(meta_field="rating", ranking_mode="wrong_mode")
 
-    def test_raises_value_error_if_wrong_top_k(self):
-        with pytest.raises(ValueError):
-            MetaFieldRanker(meta_field="rating", top_k=-1)
+    @pytest.mark.parametrize("top_k", [0, -1])
+    def test_raises_value_error_if_wrong_top_k(self, top_k):
+        with pytest.raises(ValueError, match=rf"top_k must be > 0, but got {top_k}"):
+            MetaFieldRanker(meta_field="rating", top_k=top_k)
+
+    @pytest.mark.parametrize(("init_top_k", "run_top_k"), [(None, 0), (1, 0), (1, -1)])
+    def test_run_raises_value_error_if_wrong_top_k(self, init_top_k, run_top_k):
+        ranker = MetaFieldRanker(meta_field="rating", top_k=init_top_k)
+        documents = [Document(content="abc", meta={"rating": 1.3})]
+
+        with pytest.raises(ValueError, match=rf"top_k must be > 0, but got {run_top_k}"):
+            ranker.run(documents=documents, top_k=run_top_k)
 
     @pytest.mark.parametrize("score", [-1, 2, 1.3, 2.1])
     def test_raises_component_error_if_wrong_weight(self, score):


### PR DESCRIPTION
### Related Issues

- No direct issue. This follows the related `top_k` resolution discussion in #12217.

### Proposed Changes:

`MetaFieldRanker.run()` used `top_k or self.top_k`, so an explicit runtime `top_k=0` was treated as unset and silently replaced with the initialization value. This was inconsistent with the component's documented `top_k > 0` validation.

The fallback now checks explicitly for `None`, so runtime `top_k=0` and negative values reach the existing validation and raise `ValueError`. Initialization validation coverage was extended to include `0`, and runtime regression tests cover both an unset initialization value and an initialization value of `1`.

This intentionally does not change empty-document handling or the separate semantics of `DocumentJoiner` and `AnswerJoiner`, where runtime `top_k=0` returns an empty list.

### How did you test it?

- `pytest -m "not integration" test/components/rankers/test_metafield.py -q` (41 passed)
- `ruff check haystack/components/rankers/meta_field.py test/components/rankers/test_metafield.py`
- `ruff format --check haystack/components/rankers/meta_field.py test/components/rankers/test_metafield.py`
- `git diff --check`
- Release note YAML parsed successfully.

The full Hatch test environment could not finish dependency resolution in the local environment; the focused test suite passed in Python 3.12 with Haystack's core dependencies installed.
