### PR TITLE
feat: add FilterBuilder for constructing metadata filters

### DIFF
--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -14,6 +14,7 @@ _import_structure = {
     "callable_serialization": ["deserialize_callable", "serialize_callable"],
     "device": ["ComponentDevice", "Device", "DeviceMap", "DeviceType"],
     "deserialization": ["deserialize_chatgenerator_inplace", "deserialize_component_inplace"],
+    "filter_builder": ["FilterBuilder"],
     "filters": ["document_matches_filter"],
     "jinja2_extensions": ["Jinja2TimeExtension"],
     "jupyter": ["is_in_jupyter"],
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
     from .device import Device as Device
     from .device import DeviceMap as DeviceMap
     from .device import DeviceType as DeviceType
+    from .filter_builder import FilterBuilder as FilterBuilder
     from .filters import document_matches_filter as document_matches_filter
     from .jinja2_extensions import Jinja2TimeExtension as Jinja2TimeExtension
     from .jupyter import is_in_jupyter as is_in_jupyter

--- a/haystack/utils/filter_builder.py
+++ b/haystack/utils/filter_builder.py
@@ -8,12 +8,12 @@ from collections.abc import Callable
 from typing import Any
 
 from haystack.errors import FilterError
-from haystack.utils.filters import COMPARISON_OPERATORS
 
-# The operator strings come from the keys of COMPARISON_OPERATORS, the single source of truth
-# used by `document_matches_filter`, so the emitted conditions are always valid filter dicts.
-# This also fails loudly if the set of operators in `haystack.utils.filters` ever changes.
-_EQ, _NE, _GT, _GTE, _LT, _LTE, _IN, _NOT_IN = COMPARISON_OPERATORS
+# Operator strings are spelled out rather than unpacked from COMPARISON_OPERATORS, whose
+# iteration order is an implementation detail: reordering that dict must not silently
+# remap `gt` onto "<". test_filter_builder.py asserts this list stays in sync with
+# COMPARISON_OPERATORS, the single source of truth used by `document_matches_filter`.
+_EQ, _NE, _GT, _GTE, _LT, _LTE, _IN, _NOT_IN = ("==", "!=", ">", ">=", "<", "<=", "in", "not in")
 
 
 class FilterBuilder:

--- a/haystack/utils/filter_builder.py
+++ b/haystack/utils/filter_builder.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from haystack.errors import FilterError
+from haystack.utils.filters import COMPARISON_OPERATORS
+
+# The operator strings come from the keys of COMPARISON_OPERATORS, the single source of truth
+# used by `document_matches_filter`, so the emitted conditions are always valid filter dicts.
+# This also fails loudly if the set of operators in `haystack.utils.filters` ever changes.
+_EQ, _NE, _GT, _GTE, _LT, _LTE, _IN, _NOT_IN = COMPARISON_OPERATORS
+
+
+class FilterBuilder:
+    """
+    Helper class to build Haystack metadata filter dictionaries with a fluent interface.
+
+    The builder emits the same dictionary format that `document_matches_filter` and the
+    DocumentStore protocol already understand: a comparison condition is
+    `{"field": ..., "operator": ..., "value": ...}` and a logical condition is
+    `{"operator": "AND"|"OR"|"NOT", "conditions": [...]}`.
+
+    Example:
+    ```python
+    from haystack.utils import FilterBuilder
+
+    filters = (
+        FilterBuilder()
+        .eq("meta.type", "article")
+        .or_group(lambda f: f.in_("meta.genre", ["economy"]).eq("meta.publisher", "nytimes"))
+        .build()
+    )
+    ```
+    """
+
+    def __init__(self) -> None:
+        self._conditions: list[dict[str, Any]] = []
+
+    def _add_condition(self, field: str, operator: str, value: Any) -> FilterBuilder:
+        self._conditions.append({"field": field, "operator": operator, "value": value})
+        return self
+
+    def eq(self, field: str, value: Any) -> FilterBuilder:
+        """
+        Add a condition that `field` must be equal to `value`.
+        """
+        return self._add_condition(field, _EQ, value)
+
+    def ne(self, field: str, value: Any) -> FilterBuilder:
+        """
+        Add a condition that `field` must not be equal to `value`.
+        """
+        return self._add_condition(field, _NE, value)
+
+    def gt(self, field: str, value: Any) -> FilterBuilder:
+        """
+        Add a condition that `field` must be greater than `value`.
+        """
+        return self._add_condition(field, _GT, value)
+
+    def gte(self, field: str, value: Any) -> FilterBuilder:
+        """
+        Add a condition that `field` must be greater than or equal to `value`.
+        """
+        return self._add_condition(field, _GTE, value)
+
+    def lt(self, field: str, value: Any) -> FilterBuilder:
+        """
+        Add a condition that `field` must be less than `value`.
+        """
+        return self._add_condition(field, _LT, value)
+
+    def lte(self, field: str, value: Any) -> FilterBuilder:
+        """
+        Add a condition that `field` must be less than or equal to `value`.
+        """
+        return self._add_condition(field, _LTE, value)
+
+    def in_(self, field: str, value: Any) -> FilterBuilder:
+        """
+        Add a condition that `field` must be one of the values contained in `value`.
+        """
+        return self._add_condition(field, _IN, value)
+
+    def not_in(self, field: str, value: Any) -> FilterBuilder:
+        """
+        Add a condition that `field` must not be any of the values contained in `value`.
+        """
+        return self._add_condition(field, _NOT_IN, value)
+
+    def _add_group(self, operator: str, builder: Callable[[FilterBuilder], Any]) -> FilterBuilder:
+        """
+        Add a logical group condition built by `builder`.
+        """
+        sub_builder = FilterBuilder()
+        builder(sub_builder)
+        self._conditions.append({"operator": operator, "conditions": sub_builder._conditions})
+        return self
+
+    def and_group(self, builder: Callable[[FilterBuilder], Any]) -> FilterBuilder:
+        """
+        Add a logical AND group. `builder` receives a fresh FilterBuilder to fill with conditions.
+        """
+        return self._add_group("AND", builder)
+
+    def or_group(self, builder: Callable[[FilterBuilder], Any]) -> FilterBuilder:
+        """
+        Add a logical OR group. `builder` receives a fresh FilterBuilder to fill with conditions.
+        """
+        return self._add_group("OR", builder)
+
+    def not_group(self, builder: Callable[[FilterBuilder], Any]) -> FilterBuilder:
+        """
+        Add a logical NOT group. `builder` receives a fresh FilterBuilder to fill with conditions.
+        """
+        return self._add_group("NOT", builder)
+
+    def build(self) -> dict[str, Any]:
+        """
+        Build the filter dictionary.
+
+        A single condition is returned unwrapped. Multiple conditions are combined with a
+        top-level logical "AND". Raises `FilterError` if no condition has been added.
+        """
+        if not self._conditions:
+            msg = "The FilterBuilder contains no conditions. Add one before calling build()."
+            raise FilterError(msg)
+        if len(self._conditions) == 1:
+            return self._conditions[0]
+        return {"operator": "AND", "conditions": self._conditions}

--- a/releasenotes/notes/add-filter-builder-54310f4a66d3069c.yaml
+++ b/releasenotes/notes/add-filter-builder-54310f4a66d3069c.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added a ``FilterBuilder`` utility class that constructs metadata filters with
+    a fluent interface, producing the same filter dictionaries that Haystack Document
+    Stores and ``document_matches_filter`` already understand.

--- a/test/utils/test_filter_builder.py
+++ b/test/utils/test_filter_builder.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack.dataclasses import Document
+from haystack.utils import FilterBuilder
+from haystack.utils.filters import document_matches_filter
+
+
+def test_single_condition_builds_a_comparison_dict():
+    filters = FilterBuilder().eq("meta.type", "article").build()
+
+    assert filters == {"field": "meta.type", "operator": "==", "value": "article"}
+
+
+def test_multiple_conditions_are_anded():
+    filters = FilterBuilder().eq("meta.type", "article").gte("meta.year", 2024).build()
+
+    assert filters == {
+        "operator": "AND",
+        "conditions": [
+            {"field": "meta.type", "operator": "==", "value": "article"},
+            {"field": "meta.year", "operator": ">=", "value": 2024},
+        ],
+    }
+
+
+def test_or_group_nests_correctly():
+    filters = (
+        FilterBuilder()
+        .eq("meta.type", "article")
+        .or_group(lambda f: f.in_("meta.genre", ["economy"]).eq("meta.publisher", "nytimes"))
+        .build()
+    )
+
+    assert filters == {
+        "operator": "AND",
+        "conditions": [
+            {"field": "meta.type", "operator": "==", "value": "article"},
+            {
+                "operator": "OR",
+                "conditions": [
+                    {"field": "meta.genre", "operator": "in", "value": ["economy"]},
+                    {"field": "meta.publisher", "operator": "==", "value": "nytimes"},
+                ],
+            },
+        ],
+    }
+
+
+def test_built_filters_are_accepted_by_document_matches_filter():
+    """The builder must produce dicts the existing filter engine already understands."""
+    document = Document(content="x", meta={"type": "article", "year": 2025})
+
+    filters = FilterBuilder().eq("meta.type", "article").gte("meta.year", 2024).build()
+
+    assert document_matches_filter(filters, document)
+
+
+def test_empty_builder_raises():
+    import pytest
+
+    from haystack.errors import FilterError
+
+    with pytest.raises(FilterError):
+        FilterBuilder().build()

--- a/test/utils/test_filter_builder.py
+++ b/test/utils/test_filter_builder.py
@@ -64,3 +64,32 @@ def test_empty_builder_raises():
 
     with pytest.raises(FilterError):
         FilterBuilder().build()
+
+
+def test_builder_operators_stay_in_sync_with_the_filter_engine():
+    """The builder must only emit operators `document_matches_filter` understands.
+
+    FilterBuilder spells its operator strings out instead of unpacking
+    COMPARISON_OPERATORS, so this is the check that catches a drift between the two.
+    """
+    from haystack.utils.filter_builder import _EQ, _GT, _GTE, _IN, _LT, _LTE, _NE, _NOT_IN
+    from haystack.utils.filters import COMPARISON_OPERATORS
+
+    assert set(COMPARISON_OPERATORS) == {_EQ, _NE, _GT, _GTE, _LT, _LTE, _IN, _NOT_IN}
+
+
+def test_each_builder_method_emits_the_operator_it_names():
+    """Guards against an operator constant being wired to the wrong method."""
+    cases = [
+        ("eq", "=="),
+        ("ne", "!="),
+        ("gt", ">"),
+        ("gte", ">="),
+        ("lt", "<"),
+        ("lte", "<="),
+        ("in_", "in"),
+        ("not_in", "not in"),
+    ]
+    for method, operator in cases:
+        built = getattr(FilterBuilder(), method)("meta.x", 1).build()
+        assert built == {"field": "meta.x", "operator": operator, "value": 1}


### PR DESCRIPTION
Closes #12157

Credit to @Aarkin7 for the issue and the proposed shape — this follows their sketch closely.

Adds a `FilterBuilder` that constructs Haystack metadata filters with a fluent interface:

```python
filters = (
    FilterBuilder()
    .eq("meta.type", "article")
    .gte("meta.year", 2024)
    .or_group(lambda f: f.in_("meta.genre", ["economy"]).eq("meta.publisher", "nytimes"))
    .build()
)
```

The important property is that this adds no filtering semantics. It is a pure constructor of the dictionaries `document_matches_filter` and the `DocumentStore` protocol already accept: `{"field": ..., "operator": ..., "value": ...}` for comparisons, `{"operator": "AND"|"OR"|"NOT", "conditions": [...]}` for logic. Existing filter behaviour is untouched, and one of the tests asserts the built dict round-trips through `document_matches_filter` rather than only checking its shape.

`build()` returns a single condition unwrapped, combines multiple with a top-level `AND`, and raises `FilterError` when nothing has been added.

On the operator constants: I spelled the strings out rather than unpacking them from `COMPARISON_OPERATORS`. Unpacking would tie them to that dict's iteration order, so inserting or reordering an operator there would silently remap `gt()` onto `<` with no test failure. Two tests guard the explicit list instead — one asserts the set stays equal to `COMPARISON_OPERATORS`, the other pins each builder method to the operator it names.

Includes a reno release note.

Checks run locally: `hatch run test:unit -k filter_builder` → 7 passed; `hatch run test:types` → "Success: no issues found in 408 source files"; `hatch run fmt-check` clean on the touched files.
