### PR TITLE
fix: match Human-in-the-Loop decisions to the tool call they were made about

### DIFF
--- a/haystack/hooks/human_in_the_loop/strategies.py
+++ b/haystack/hooks/human_in_the_loop/strategies.py
@@ -238,6 +238,23 @@ def _passthrough_tool_call(tool_call: ToolCall) -> ToolExecutionDecision:
     )
 
 
+def _with_tool_call_id(decision: ToolExecutionDecision, tool_call: ToolCall) -> ToolExecutionDecision:
+    """
+    Stamp the ID of the tool call a decision was made about onto that decision, if the strategy did not pass it back.
+
+    A custom `ConfirmationStrategy` receives `tool_call_id` but is free to return a decision without it, and a decision
+    that carries no ID can only be matched back to its tool call by tool name. Restoring the ID here keeps that
+    name-based fallback for tool calls that genuinely have no ID.
+
+    :param decision: The decision a confirmation strategy returned.
+    :param tool_call: The tool call the strategy was asked about.
+    :returns: The decision, with the tool call's ID set if it had none.
+    """
+    if tool_call.id is None or decision.tool_call_id is not None:
+        return decision
+    return replace(decision, tool_call_id=tool_call.id)
+
+
 def _process_confirmation_strategies(
     *,
     confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy],
@@ -387,7 +404,7 @@ def _run_confirmation_strategies(
                 tool_call_id=tool_call.id,
                 confirmation_strategy_context=confirmation_strategy_context,
             )
-            teds.append(ted)
+            teds.append(_with_tool_call_id(ted, tool_call))
 
     return teds
 
@@ -457,7 +474,7 @@ async def _run_confirmation_strategies_async(
                     tool_call_id=tool_call.id,
                     confirmation_strategy_context=confirmation_strategy_context,
                 )
-            teds.append(ted)
+            teds.append(_with_tool_call_id(ted, tool_call))
 
     return teds
 
@@ -478,15 +495,17 @@ def _apply_tool_execution_decisions(
           a user message explaining the modification is included before the tool call message.
     """
     decision_by_id = {d.tool_call_id: d for d in tool_execution_decisions if d.tool_call_id}
-    decision_by_name = {d.tool_name: d for d in tool_execution_decisions if d.tool_name}
-
     # Known limitation: If tool calls are missing IDs, we rely on tool names to match decisions to tool calls.
     # This can lead to incorrect matches if there are multiple tool calls in the provided messages with duplicate names.
-    if not decision_by_id and len(decision_by_name) < len(tool_execution_decisions):
+    # Decisions that carry an ID stay out of the name lookup, so they cannot be handed to a different tool call.
+    decisions_without_id = [d for d in tool_execution_decisions if not d.tool_call_id]
+    decision_by_name = {d.tool_name: d for d in decisions_without_id if d.tool_name}
+
+    if len(decision_by_name) < len(decisions_without_id):
         raise ValueError(
-            "ToolExecutionDecisions are missing tool_call_id fields and there are multiple tool calls with the same "
-            "name. When multiple tool calls with the same name are present, tool_call_id is required to correctly "
-            "match decisions to tool calls."
+            "ToolExecutionDecisions are missing tool_call_id fields and cannot be matched by tool name. A decision "
+            "without a tool_call_id is matched to its tool call by name, so those names have to be non-empty and "
+            "unique. Set tool_call_id to match decisions to tool calls reliably."
         )
 
     def make_assistant_message(chat_message: ChatMessage, tool_calls: list[ToolCall]) -> ChatMessage:

--- a/releasenotes/notes/hitl-mixed-tool-call-id-decisions-a70172176717c38f.yaml
+++ b/releasenotes/notes/hitl-mixed-tool-call-id-decisions-a70172176717c38f.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed ``ConfirmationHook`` applying a Human-in-the-Loop decision to the wrong tool call when a custom
+    ``ConfirmationStrategy`` returns decisions without a ``tool_call_id``. The ID of the tool call a strategy was asked
+    about is now restored on the decision it returns, decisions that carry an ID are no longer matched to a different
+    tool call by name, and two ID-less decisions for the same tool name raise a ``ValueError`` as documented instead of
+    both tool calls taking the last decision. The text of that ``ValueError`` changed, since it now also covers an
+    ID-less decision with an empty tool name.

--- a/test/hooks/human_in_the_loop/test_strategies.py
+++ b/test/hooks/human_in_the_loop/test_strategies.py
@@ -341,8 +341,7 @@ class TestApplyToolExecutionDecisions:
         # so we cannot disambiguate which TED applies to which tool call.
         with pytest.raises(
             ValueError,
-            match="ToolExecutionDecisions are missing tool_call_id fields and there are multiple tool calls with the "
-            "same name",
+            match="ToolExecutionDecisions are missing tool_call_id fields and cannot be matched by tool name",
         ):
             _apply_tool_execution_decisions(
                 tool_call_messages=[message_with_tool_calls],
@@ -353,6 +352,85 @@ class TestApplyToolExecutionDecisions:
                     ToolExecutionDecision(
                         tool_name="add_database_tool", execute=True, final_tool_params={"name": "Milos"}
                     ),
+                ],
+            )
+
+    def test_two_teds_same_name_no_ids_and_one_with_an_id(self):
+        message_with_tool_calls = ChatMessage.from_assistant(
+            tool_calls=[
+                ToolCall(tool_name="get_weather", arguments={"city": "Berlin"}, id="1"),
+                ToolCall(tool_name="add_database_tool", arguments={"name": "Malte"}),
+                ToolCall(tool_name="add_database_tool", arguments={"name": "Milos"}),
+            ]
+        )
+        # The two decisions without an ID are still ambiguous, even though an unrelated decision in the same batch
+        # carries one.
+        with pytest.raises(
+            ValueError,
+            match="ToolExecutionDecisions are missing tool_call_id fields and cannot be matched by tool name",
+        ):
+            _apply_tool_execution_decisions(
+                tool_call_messages=[message_with_tool_calls],
+                tool_execution_decisions=[
+                    ToolExecutionDecision(
+                        tool_name="get_weather", execute=True, tool_call_id="1", final_tool_params={"city": "Berlin"}
+                    ),
+                    ToolExecutionDecision(tool_name="add_database_tool", execute=False, feedback="Not this one"),
+                    ToolExecutionDecision(
+                        tool_name="add_database_tool", execute=True, final_tool_params={"name": "Milos"}
+                    ),
+                ],
+            )
+
+    def test_ted_with_an_id_is_not_matched_by_name(self):
+        rejected_tool_call = ToolCall(tool_name="add_database_tool", arguments={"name": "Malte"})
+        message_with_tool_calls = ChatMessage.from_assistant(
+            tool_calls=[
+                rejected_tool_call,
+                ToolCall(tool_name="add_database_tool", arguments={"name": "Milos"}, id="2"),
+            ]
+        )
+
+        rejection_messages, new_tool_call_messages = _apply_tool_execution_decisions(
+            tool_call_messages=[message_with_tool_calls],
+            tool_execution_decisions=[
+                ToolExecutionDecision(tool_name="add_database_tool", execute=False, feedback="Malte is already in"),
+                ToolExecutionDecision(
+                    tool_name="add_database_tool", execute=True, tool_call_id="2", final_tool_params={"name": "Milos"}
+                ),
+            ],
+        )
+
+        assert rejection_messages == [
+            ChatMessage.from_assistant(tool_calls=[rejected_tool_call]),
+            ChatMessage.from_tool(tool_result="Malte is already in", origin=rejected_tool_call, error=True),
+        ]
+        assert new_tool_call_messages == [
+            ChatMessage.from_assistant(
+                tool_calls=[ToolCall(tool_name="add_database_tool", arguments={"name": "Milos"}, id="2")]
+            )
+        ]
+
+    def test_ted_with_an_empty_name_and_no_id(self):
+        message_with_tool_calls = ChatMessage.from_assistant(
+            tool_calls=[
+                ToolCall(tool_name="get_weather", arguments={"city": "Berlin"}, id="1"),
+                ToolCall(tool_name="add_database_tool", arguments={"name": "Malte"}),
+            ]
+        )
+        # Without an ID or a name there is nothing left to match on, so the batch is rejected instead of the decision
+        # being dropped.
+        with pytest.raises(
+            ValueError,
+            match="ToolExecutionDecisions are missing tool_call_id fields and cannot be matched by tool name",
+        ):
+            _apply_tool_execution_decisions(
+                tool_call_messages=[message_with_tool_calls],
+                tool_execution_decisions=[
+                    ToolExecutionDecision(
+                        tool_name="get_weather", execute=True, tool_call_id="1", final_tool_params={"city": "Berlin"}
+                    ),
+                    ToolExecutionDecision(tool_name="", execute=False),
                 ],
             )
 
@@ -743,3 +821,77 @@ class TestAsyncConfirmationStrategies:
                 tool_call_id="tc-1", tool_name="hallucinated_tool", execute=True, final_tool_params={"a": 1}
             )
         ]
+
+
+class IdDroppingConfirmationStrategy:
+    """A strategy that ignores the tool_call_id it is given, as a custom strategy is free to do."""
+
+    def run(
+        self,
+        tool_name: str,
+        tool_description: str,
+        tool_params: dict[str, Any],
+        tool_call_id: str | None = None,
+        confirmation_strategy_context: dict[str, Any] | None = None,
+    ) -> ToolExecutionDecision:
+        return ToolExecutionDecision(tool_name=tool_name, execute=True, final_tool_params=tool_params)
+
+    async def run_async(
+        self,
+        tool_name: str,
+        tool_description: str,
+        tool_params: dict[str, Any],
+        tool_call_id: str | None = None,
+        confirmation_strategy_context: dict[str, Any] | None = None,
+    ) -> ToolExecutionDecision:
+        return ToolExecutionDecision(tool_name=tool_name, execute=True, final_tool_params=tool_params)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"type": "test.IdDroppingConfirmationStrategy", "init_parameters": {}}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "IdDroppingConfirmationStrategy":
+        return cls()
+
+
+class TestDecisionsCarryTheirToolCallId:
+    def test_id_is_restored_when_the_strategy_drops_it(self, tools):
+        teds = _run_confirmation_strategies(
+            confirmation_strategies={tools[0].name: IdDroppingConfirmationStrategy()},
+            messages_with_tool_calls=[
+                ChatMessage.from_assistant(
+                    tool_calls=[
+                        ToolCall(tools[0].name, {"a": 1, "b": 2}, id="1"),
+                        ToolCall(tools[0].name, {"a": 3, "b": 4}, id="2"),
+                    ]
+                )
+            ],
+            tools=tools,
+        )
+        assert [ted.tool_call_id for ted in teds] == ["1", "2"]
+
+    def test_id_is_left_alone_when_the_tool_call_has_none(self, tools):
+        teds = _run_confirmation_strategies(
+            confirmation_strategies={tools[0].name: IdDroppingConfirmationStrategy()},
+            messages_with_tool_calls=[
+                ChatMessage.from_assistant(tool_calls=[ToolCall(tools[0].name, {"a": 1, "b": 2})])
+            ],
+            tools=tools,
+        )
+        assert teds[0].tool_call_id is None
+
+    @pytest.mark.asyncio
+    async def test_id_is_restored_when_the_strategy_drops_it_async(self, tools):
+        teds = await _run_confirmation_strategies_async(
+            confirmation_strategies={tools[0].name: IdDroppingConfirmationStrategy()},
+            messages_with_tool_calls=[
+                ChatMessage.from_assistant(
+                    tool_calls=[
+                        ToolCall(tools[0].name, {"a": 1, "b": 2}, id="1"),
+                        ToolCall(tools[0].name, {"a": 3, "b": 4}, id="2"),
+                    ]
+                )
+            ],
+            tools=tools,
+        )
+        assert [ted.tool_call_id for ted in teds] == ["1", "2"]


### PR DESCRIPTION
### Related Issues

- fixes #12276

### Proposed Changes:

`_apply_tool_execution_decisions` matches each `ToolExecutionDecision` to its tool call by `tool_call_id` and falls back to the tool name when a decision has none. The guard on that fallback only fired when *no* decision in the batch carried an ID, so a single ID-bearing decision switched it off and the remaining ID-less decisions collapsed onto the last one per tool name. On `e97e713`, a batch of `get_weather` (with an ID) plus a rejected `delete_file(path="/etc/passwd")` and a confirmed `delete_file(path="/tmp/scratch")` (both without) produced zero rejection messages and queued `delete_file` twice against `/tmp/scratch`. The user's rejection came back out as an approval.

Three changes, all in `haystack/hooks/human_in_the_loop/strategies.py`:

- `_run_confirmation_strategies` and its async twin now put the tool call's ID back on a decision that a custom strategy returned without one. That removes the ambiguity at the source for every call the model gave an ID. An ID the strategy did set is left alone.
- `decision_by_name` is built only from decisions that have no ID. A decision with an ID is already reachable through `decision_by_id`, so matching it by name only ever let it reach a *different* tool call that shared its name, with dict insertion order deciding which one won.
- The ambiguity check compares against the number of ID-less decisions instead of the whole batch, so it fires on a mixed batch too.

The `ValueError` text changed, because the same check now also covers an ID-less decision with an empty tool name, which previously slipped through a mixed batch and had its tool call dropped without a word.

### How did you test it?

Unit tests in `test/hooks/human_in_the_loop/test_strategies.py`, five of which fail on `e97e713` and pass here:

- `test_two_teds_same_name_no_ids_and_one_with_an_id`: the guard now fires on the mixed batch.
- `test_ted_with_an_id_is_not_matched_by_name`: the ID-less call gets its own rejection, the ID-bearing call gets its own approval.
- `test_ted_with_an_empty_name_and_no_id`: an unmatchable decision is rejected rather than dropped.
- `test_id_is_restored_when_the_strategy_drops_it` and its async twin: a strategy that ignores `tool_call_id` still yields decisions carrying `["1", "2"]`.
- `test_id_is_left_alone_when_the_tool_call_has_none` pins the boundary the name fallback depends on. It is the one new test that does not fail on `main`.

Gates run locally on macOS 15.7, Python 3.13:

```
hatch run test:unit -- test/hooks test/components/agents   536 passed, 6 deselected
hatch run test:types                                       Success: no issues found in 406 source files
hatch run fmt                                              All checks passed!
```

I also re-ran the issue's repro script against the branch: it raises the documented `ValueError` instead of silently approving the rejected call.

### Notes for the reviewer

I opened #12276 first with the repro and this plan, and started on it without waiting for a reply because the fix is contained and the guard's own error message already says what the intended behaviour is. If you would rather the matching be positional and the name fallback go away entirely, say so and I will redo it that way.

Two related problems I deliberately left out of this PR, happy to file them separately:

- A tool call that matches no decision is still dropped silently at `strategies.py:511`, under a comment saying it should not happen.
- A strategy that returns an ID belonging to a *different* tool call is still trusted.

One behaviour I did give up on purpose: an ID-bearing decision whose ID matches no tool call used to be rescued by name. It now goes unmatched. That input is malformed strategy output, and pairing it with an unrelated call is what this PR is fixing.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the tests and checks listed above.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
