### PR TITLE
fix: from_dict should not mutate the input dictionary

### DIFF
--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -4,6 +4,7 @@
 
 import ast
 import contextlib
+import copy
 from collections.abc import Callable
 from typing import Any, TypeAlias
 
@@ -167,6 +168,7 @@ class OutputAdapter:
         :returns:
             The deserialized component.
         """
+        data = copy.deepcopy(data)
         init_params = data.get("init_parameters", {})
         init_params["output_type"] = deserialize_type(init_params["output_type"])
 

--- a/haystack/components/joiners/branch.py
+++ b/haystack/components/joiners/branch.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict
@@ -113,6 +114,7 @@ class BranchJoiner:
         :returns:
             A deserialized `BranchJoiner` instance.
         """
+        data = copy.deepcopy(data)
         data["init_parameters"]["type_"] = deserialize_type(data["init_parameters"]["type_"])
         return default_from_dict(cls, data)
 

--- a/haystack/components/joiners/list_joiner.py
+++ b/haystack/components/joiners/list_joiner.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 from itertools import chain
 from typing import Any
 
@@ -96,6 +97,7 @@ class ListJoiner:
         :param data: Dictionary to deserialize from.
         :returns: Deserialized component.
         """
+        data = copy.deepcopy(data)
         init_parameters = data.get("init_parameters")
         if init_parameters is not None and init_parameters.get("list_type_") is not None:
             data["init_parameters"]["list_type_"] = deserialize_type(data["init_parameters"]["list_type_"])

--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -4,6 +4,7 @@
 
 import ast
 import contextlib
+import copy
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, TypedDict, get_args, get_origin
 
@@ -362,6 +363,7 @@ class ConditionalRouter:
         :returns:
             The deserialized component.
         """
+        data = copy.deepcopy(data)
         init_params = data.get("init_parameters", {})
         routes = init_params.get("routes")
         for route in routes:

--- a/haystack/components/routers/metadata_router.py
+++ b/haystack/components/routers/metadata_router.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
@@ -169,6 +170,7 @@ class MetadataRouter:
         :returns:
             The deserialized component instance.
         """
+        data = copy.deepcopy(data)
         init_params = data.get("init_parameters", {})
         if "output_type" in init_params:
             # Deserialize the output_type to its original type

--- a/releasenotes/notes/fix-from-dict-mutates-input-3f9c1a7b2e4d5068.yaml
+++ b/releasenotes/notes/fix-from-dict-mutates-input-3f9c1a7b2e4d5068.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed `from_dict` in `OutputAdapter`, `ConditionalRouter`, `BranchJoiner`, `ListJoiner` and
+    `MetadataRouter` so it no longer mutates the input dictionary. These components deserialized their
+    type parameters in place, which left the input dict holding live `type` objects. The dict was then
+    no longer JSON-serializable and calling `from_dict` a second time on the same dict raised an error.

--- a/test/components/converters/test_output_adapter.py
+++ b/test/components/converters/test_output_adapter.py
@@ -185,6 +185,14 @@ class TestOutputAdapter:
         assert component.custom_filters == {}
         assert not component._unsafe
 
+    def test_from_dict_does_not_mutate_input(self):
+        adapter = OutputAdapter(template="{{ documents[0].content }}", output_type=str)
+        data = adapter.to_dict()
+        OutputAdapter.from_dict(data)
+        # from_dict must not mutate its input, so the same dict stays serializable and reusable
+        assert data == adapter.to_dict()
+        OutputAdapter.from_dict(data)
+
     def test_output_adapter_in_pipeline(self):
         @component
         class DocumentProducer:

--- a/test/components/joiners/test_branch_joiner.py
+++ b/test/components/joiners/test_branch_joiner.py
@@ -34,3 +34,11 @@ class TestBranchJoiner:
         joiner = BranchJoiner(int)
         with pytest.raises(ValueError, match="BranchJoiner expects only one input, but 0 were received."):
             joiner.run(value=[])
+
+    def test_from_dict_does_not_mutate_input(self):
+        joiner = BranchJoiner(int)
+        data = joiner.to_dict()
+        BranchJoiner.from_dict(data)
+        # from_dict must not mutate its input, so the same dict stays serializable and reusable
+        assert data == joiner.to_dict()
+        BranchJoiner.from_dict(data)

--- a/test/components/joiners/test_list_joiner.py
+++ b/test/components/joiners/test_list_joiner.py
@@ -36,6 +36,14 @@ class TestListJoiner:
             "init_parameters": {"list_type_": None},
         }
 
+    def test_from_dict_does_not_mutate_input(self):
+        joiner = ListJoiner(list_type_=list)
+        data = joiner.to_dict()
+        ListJoiner.from_dict(data)
+        # from_dict must not mutate its input, so the same dict stays serializable and reusable
+        assert data == joiner.to_dict()
+        ListJoiner.from_dict(data)
+
     def test_to_dict_non_default(self):
         joiner = ListJoiner(list[ChatMessage])
         data = joiner.to_dict()

--- a/test/components/routers/test_conditional_router.py
+++ b/test/components/routers/test_conditional_router.py
@@ -678,6 +678,17 @@ class TestRouter:
         assert new_router.routes[0]["output_type"] is str
         assert new_router.routes[0]["output_type"] is original_output_type
 
+    def test_from_dict_does_not_mutate_input(self):
+        routes = [
+            {"condition": "{{streams|length < 2}}", "output": "{{query}}", "output_type": str, "output_name": "query"}
+        ]
+        router = ConditionalRouter(routes)
+        data = router.to_dict()
+        ConditionalRouter.from_dict(data)
+        # from_dict must not mutate its input, so the same dict stays serializable and reusable
+        assert data == router.to_dict()
+        ConditionalRouter.from_dict(data)
+
     def test_multiple_outputs_per_route(self):
         """Test that router handles multiple outputs per route correctly"""
         routes = [

--- a/test/components/routers/test_metadata_router.py
+++ b/test/components/routers/test_metadata_router.py
@@ -157,6 +157,14 @@ class TestMetadataRouter:
         }
         assert router.to_dict() == expected_dict
 
+    def test_from_dict_does_not_mutate_input(self):
+        router = MetadataRouter(rules={"g": {"field": "meta.k", "operator": "==", "value": 1}})
+        data = router.to_dict()
+        MetadataRouter.from_dict(data)
+        # from_dict must not mutate its input, so the same dict stays serializable and reusable
+        assert data == router.to_dict()
+        MetadataRouter.from_dict(data)
+
     def test_from_dict(self):
         router_dict = {
             "type": "haystack.components.routers.metadata_router.MetadataRouter",


### PR DESCRIPTION
### Related Issues

No open issue tracks these five components. The same bug class was fixed for `PipelineTool.from_dict` in #10280.

### Proposed Changes:

`from_dict` in `OutputAdapter`, `ConditionalRouter`, `BranchJoiner`, `ListJoiner` and `MetadataRouter` deserializes its type parameters in place on the input dict (for example `init_params["output_type"] = deserialize_type(...)`). This leaves the caller's dict holding live `type` objects, so it is no longer JSON-serializable and a second `from_dict` on the same dict raises an error.

Each `from_dict` now copies the input with `copy.deepcopy(data)` before deserializing, matching the fix already applied to `PipelineTool.from_dict` in #10280.

Reproduction on `main`:

```python
import json
from haystack.components.converters.output_adapter import OutputAdapter

comp = OutputAdapter(template="{{ x }}", output_type=str)
data = comp.to_dict()
OutputAdapter.from_dict(data)
json.dumps(data)               # TypeError: Object of type type is not JSON serializable
OutputAdapter.from_dict(data)  # TypeError: 'type' object is not iterable
```

### How did you test it?

Added a `test_from_dict_does_not_mutate_input` regression test to each of the five components. Each test fails on the current code and passes with the fix. Ran the existing suites for all five components plus the new tests (100 passed), the full unit suite, `ruff`, and `mypy`.

### Notes for the reviewer

All five components take the same one-line `copy.deepcopy(data)` guard. I grouped them in one PR because it is the same fix; I can split it per-component if you prefer.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
