### PR TITLE
fix: CSVDocumentSplitter recursion on multi-block CSVs

### DIFF
--- a/haystack/components/preprocessors/csv_document_splitter.py
+++ b/haystack/components/preprocessors/csv_document_splitter.py
@@ -176,10 +176,11 @@ class CSVDocumentSplitter:
         :param axis: Axis along which to find empty elements. Either "row" or "column".
         :return: List of indices where consecutive empty rows or columns start.
         """
-        if axis == "row":
-            empty_elements = df[df.isnull().all(axis=1)].index.tolist()
-        else:
-            empty_elements = df.columns[df.isnull().all(axis=0)].tolist()
+        # Return positional indices, not index/column labels: ``_split_dataframe`` slices with
+        # ``iloc``, so a sub-table that no longer has a zero-based index would otherwise recurse
+        # forever on itself (see https://github.com/deepset-ai/haystack/issues/12190).
+        empty_mask = df.isnull().all(axis=1 if axis == "row" else 0)
+        empty_elements = [position for position, is_empty in enumerate(empty_mask) if is_empty]
 
         # If no empty elements found, return empty list
         if len(empty_elements) == 0:

--- a/releasenotes/notes/fix-csv-splitter-recursion-8b1d4c6a5f902e37.yaml
+++ b/releasenotes/notes/fix-csv-splitter-recursion-8b1d4c6a5f902e37.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a `RecursionError` in `CSVDocumentSplitter` that occurred when both `row_split_threshold`
+    and `column_split_threshold` were set and a later row block also required a column split.
+    `_find_split_indices` returned index labels while `_split_dataframe` sliced by position, so a
+    sub-table that no longer had a zero-based index recursed forever on itself. `_find_split_indices`
+    now returns positional indices.

--- a/test/components/preprocessors/test_csv_document_splitter.py
+++ b/test/components/preprocessors/test_csv_document_splitter.py
@@ -211,6 +211,25 @@ P,Q,,,,
             assert table.content == expected_tables[i]
             assert table.meta == expected_meta[i]
 
+    def test_recursive_split_later_row_block_needing_a_column_split(self, splitter: CSVDocumentSplitter) -> None:
+        # Regression test for https://github.com/deepset-ai/haystack/issues/12190: a later row block
+        # that also needs a column split used to recurse forever and raise RecursionError.
+        csv_content = "A,B,C,D,E,F\n1,2,3,4,5,6\n,,,,,\nP,Q,,,X,Y\n1,2,,,7,8\n,,,,M,N\n,,,,9,10\nR,S,,,,\n3,4,,,,\n"
+        splitter = CSVDocumentSplitter(row_split_threshold=1, column_split_threshold=1)
+        doc = Document(content=csv_content, id="test_id")
+        result = splitter.run([doc])["documents"]
+        assert len(result) == 4
+        expected_tables = ["A,B,C,D,E,F\n1,2,3,4,5,6\n", "P,Q\n1,2\n", "X,Y\n7,8\nM,N\n9,10\n", "R,S\n3,4\n"]
+        expected_meta = [
+            {"source_id": "test_id", "row_idx_start": 0, "col_idx_start": 0, "split_id": 0},
+            {"source_id": "test_id", "row_idx_start": 3, "col_idx_start": 0, "split_id": 1},
+            {"source_id": "test_id", "row_idx_start": 3, "col_idx_start": 4, "split_id": 2},
+            {"source_id": "test_id", "row_idx_start": 7, "col_idx_start": 0, "split_id": 3},
+        ]
+        for i, table in enumerate(result):
+            assert table.content == expected_tables[i]
+            assert table.meta == expected_meta[i]
+
     def test_csv_with_blank_lines(self, splitter: CSVDocumentSplitter) -> None:
         csv_data = """ID,LeftVal,,,RightVal,Extra
 1,Hello,,,World,Joined


### PR DESCRIPTION
### Related Issues

- fixes #12190

### Proposed Changes:

`CSVDocumentSplitter` raised `RecursionError` when both `row_split_threshold` and `column_split_threshold` were set and a later row block also needed a column split.

`_find_split_indices` returned index labels (`df.index.tolist()`), but `_split_dataframe` slices with `iloc`, which is positional. On the first split pandas keeps the original labels, so a later sub-table ends up with a non-zero-based index (for example `[3, 4, 5, 6, 7]`). From then on the label returned by `_find_split_indices` no longer matched the position `iloc` expected: the split returned the same table again, `_recursive_split` saw it still had empty rows, and recursed on it forever.

`_find_split_indices` now returns positional indices, so `iloc` slices the intended rows/columns and the recursion terminates. Sub-tables still keep their original index, so `row_idx_start` / `col_idx_start` are unchanged.

### How did you test it?

Added a regression test using the CSV from #12190. It raises `RecursionError` on the current code and returns the four expected sub-tables (with correct `row_idx_start` / `col_idx_start`) once the fix is applied. The existing `CSVDocumentSplitter` and `_find_split_indices` tests all pass.

### Notes for the reviewer

The change is limited to `_find_split_indices`. Its only callers are `_split_dataframe` and the termination check in `_recursive_split`, both inside `CSVDocumentSplitter`.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
