### PR TITLE
fix: pick deterministic conversion strategy for union receivers

### DIFF
--- a/haystack/core/type_utils.py
+++ b/haystack/core/type_utils.py
@@ -219,7 +219,15 @@ def _get_conversion_strategy(sender: Any, receiver: Any) -> ConversionStrategyTy
         for preferred in (ConversionStrategy.WRAP, ConversionStrategy.UNWRAP):
             if preferred in strategies:
                 return preferred
-        return strategies.pop() if strategies else None
+        # A set of enum members has no inherent order (enum members hash by identity),
+        # so `set.pop()` would select a strategy non-deterministically across processes.
+        # Pick the strategy of the first receiver member that yields one instead, honoring
+        # the order in which the user declared the union members.
+        for arg in get_args(receiver):
+            strategy = _get_conversion_strategy(sender, arg)
+            if strategy in strategies:
+                return strategy
+        return None
 
     # ChatMessage -> str
     if sender is ChatMessage and receiver is str:

--- a/releasenotes/notes/fix-deterministic-conversion-strategy-235a6b9b11efc0b8.yaml
+++ b/releasenotes/notes/fix-deterministic-conversion-strategy-235a6b9b11efc0b8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a non-deterministic conversion strategy selection when a `Union` receiver admits several
+    applicable conversion strategies: the strategy is now chosen deterministically, honoring the order
+    in which the union members were declared.

--- a/releasenotes/notes/fix-deterministic-conversion-strategy-235a6b9b11efc0b8.yaml
+++ b/releasenotes/notes/fix-deterministic-conversion-strategy-235a6b9b11efc0b8.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Fixed a non-deterministic conversion strategy selection when a `Union` receiver admits several
+    Fixed a non-deterministic conversion strategy selection when a ``Union`` receiver admits several
     applicable conversion strategies: the strategy is now chosen deterministically, honoring the order
     in which the union members were declared.

--- a/test/core/test_type_utils.py
+++ b/test/core/test_type_utils.py
@@ -1030,6 +1030,18 @@ class TestConversion:
             ConversionStrategy.STR_TO_CHAT_MESSAGE,
         )
 
+        # Regression test: when a Union receiver admits several non-WRAP/non-UNWRAP conversion strategies,
+        # the selection must be deterministic and honor the declared union member order
+        # (see https://github.com/deepset-ai/haystack/issues/12282).
+        assert _types_are_compatible(sender=ChatMessage, receiver=str | list[str]) == (
+            True,
+            ConversionStrategy.CHAT_MESSAGE_TO_STR,
+        )
+        assert _types_are_compatible(sender=ChatMessage, receiver=list[str] | str) == (
+            True,
+            ConversionStrategy.WRAP_CHAT_MESSAGE_TO_STR,
+        )
+
         assert _types_are_compatible(sender=int, receiver=str | ChatMessage) == (False, None)
 
         assert _types_are_compatible(sender=ChatMessage, receiver=list[ChatMessage] | None) == (


### PR DESCRIPTION
### Related Issues

- fixes #12282

### Proposed Changes:

`_get_conversion_strategy` resolves the strategy for a `Union` receiver by collecting the strategies of every member into a set and, when neither `WRAP` nor `UNWRAP` is among them, falling back to `strategies.pop()`. Because enum members hash by identity, `set.pop()` is non-deterministic across processes (ASLR): the same sender/receiver pair could resolve to different conversion strategies on different runs.

Example: converting a `ChatMessage` to `str | list[str]` could resolve to either `CHAT_MESSAGE_TO_STR` or `WRAP_CHAT_MESSAGE_TO_STR` depending on the process.

This PR replaces the `set.pop()` with a deterministic scan of the receiver's union members in declaration order, returning the strategy of the first member that yields one. The chosen strategy now honors the order in which the user declared the union members.

### How did you test it?

Added regression assertions to `test_types_are_compatible_with_conversion`:
- `ChatMessage` -> `str | list[str]` resolves to `CHAT_MESSAGE_TO_STR`
- `ChatMessage` -> `list[str] | str` resolves to `WRAP_CHAT_MESSAGE_TO_STR`

Under the previous code, the first assertion would flip between the two strategies at random across processes; both now always pass.

Ran the full `test_type_utils.py` and `test_recursive_splitter.py` suites: 1122 tests pass.

### Notes for the reviewer

The existing WRAP/UNWRAP preference loop is unchanged; only the fallback selection is now deterministic.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
