### PR TITLE
fix: serialize and deserialize typing.Literal

### DIFF
--- a/haystack/utils/type_serialization.py
+++ b/haystack/utils/type_serialization.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import ast
 import builtins
 import importlib
 import inspect
@@ -86,6 +87,12 @@ def serialize_type(target: Any) -> str:
     # str(Ellipsis) == "Ellipsis", which deserialize_type then rejects as a non-type builtin.
     if target is Ellipsis:
         return "..."
+
+    # Literal holds values (e.g. Literal["yes", "no"]), not types. Serialize each value with repr() so
+    # strings keep their quotes and round-trip through ast.literal_eval on deserialization, rather than
+    # being rendered as bare tokens that deserialize_type would then try (and fail) to resolve as types.
+    if typing.get_origin(target) is typing.Literal:
+        return f"typing.Literal[{', '.join(repr(a) for a in get_args(target))}]"
 
     args = get_args(target)
 
@@ -235,6 +242,13 @@ def deserialize_type(type_str: str) -> Any:
         generics_str = generics_str[:-1]
 
         main_type = deserialize_type(main_type_str)
+
+        # Literal arguments are values, not types. Parse them with ast.literal_eval, which safely handles
+        # str/int/bool/None/bytes and is quote-aware, so a comma inside a string value does not split the
+        # arguments the way _parse_generic_args would.
+        if main_type is typing.Literal:
+            return typing.Literal[ast.literal_eval(f"({generics_str},)")]
+
         generic_args = [_deserialize_type_arg(arg) for arg in _parse_generic_args(generics_str)]
 
         # Reconstruct

--- a/haystack/utils/type_serialization.py
+++ b/haystack/utils/type_serialization.py
@@ -89,8 +89,7 @@ def serialize_type(target: Any) -> str:
         return "..."
 
     # Literal holds values (e.g. Literal["yes", "no"]), not types. Serialize each value with repr() so
-    # strings keep their quotes and round-trip through ast.literal_eval on deserialization, rather than
-    # being rendered as bare tokens that deserialize_type would then try (and fail) to resolve as types.
+    # strings keep their quotes.
     if typing.get_origin(target) is typing.Literal:
         return f"typing.Literal[{', '.join(repr(a) for a in get_args(target))}]"
 
@@ -243,9 +242,9 @@ def deserialize_type(type_str: str) -> Any:
 
         main_type = deserialize_type(main_type_str)
 
-        # Literal arguments are values, not types. Parse them with ast.literal_eval, which safely handles
+        # Parse literal args with ast.literal_eval, which safely handles
         # str/int/bool/None/bytes and is quote-aware, so a comma inside a string value does not split the
-        # arguments the way _parse_generic_args would.
+        # arguments.
         if main_type is typing.Literal:
             return typing.Literal[ast.literal_eval(f"({generics_str},)")]
 

--- a/releasenotes/notes/fix-serialize-literal-0b79f23f2a1ca883.yaml
+++ b/releasenotes/notes/fix-serialize-literal-0b79f23f2a1ca883.yaml
@@ -1,9 +1,9 @@
 ---
 fixes:
   - |
-    Fixed `serialize_type`/`deserialize_type` for `typing.Literal`. Previously a `Literal` type hint was
-    serialized with its values rendered as bare tokens (e.g. `typing.Literal[yes, no]`), which failed to
-    deserialize, and values that looked like type names (e.g. `Literal["int", "str"]`) were silently turned
-    into types on the round-trip. The values are now serialized with `repr()` and read back with
-    `ast.literal_eval`, so a `Literal` type used by a component (such as `OutputAdapter` or `ConditionalRouter`)
+    Fixed ``serialize_type``/``deserialize_type`` for ``typing.Literal``. Previously a ``Literal`` type hint was
+    serialized with its values rendered as bare tokens (e.g. ``typing.Literal[yes, no]``), which failed to
+    deserialize, and values that looked like type names (e.g. ``Literal["int", "str"]``) were silently turned
+    into types on the round-trip. The values are now serialized with ``repr()`` and read back with
+    ``ast.literal_eval``, so a ``Literal`` type used by a component (such as ``OutputAdapter`` or ``ConditionalRouter``)
     round-trips correctly through pipeline serialization.

--- a/releasenotes/notes/fix-serialize-literal-0b79f23f2a1ca883.yaml
+++ b/releasenotes/notes/fix-serialize-literal-0b79f23f2a1ca883.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed `serialize_type`/`deserialize_type` for `typing.Literal`. Previously a `Literal` type hint was
+    serialized with its values rendered as bare tokens (e.g. `typing.Literal[yes, no]`), which failed to
+    deserialize, and values that looked like type names (e.g. `Literal["int", "str"]`) were silently turned
+    into types on the round-trip. The values are now serialized with `repr()` and read back with
+    `ast.literal_eval`, so a `Literal` type used by a component (such as `OutputAdapter` or `ConditionalRouter`)
+    round-trips correctly through pipeline serialization.

--- a/test/utils/test_type_serialization.py
+++ b/test/utils/test_type_serialization.py
@@ -296,8 +296,6 @@ def test_output_type_round_trip_callable_with_parameter_list():
 
 
 def test_output_type_serialization_literal():
-    # `Literal` holds values (e.g. Literal["yes", "no"]), not types, so each value is serialized with
-    # repr() rather than as a bare token. See https://github.com/deepset-ai/haystack/issues/12285.
     assert serialize_type(Literal["yes", "no"]) == "typing.Literal['yes', 'no']"
     assert serialize_type(Literal[1, 2, 3]) == "typing.Literal[1, 2, 3]"
     assert serialize_type(Literal[True, False]) == "typing.Literal[True, False]"

--- a/test/utils/test_type_serialization.py
+++ b/test/utils/test_type_serialization.py
@@ -7,7 +7,7 @@ import sys
 import typing
 from collections import deque
 from types import UnionType
-from typing import Any, Callable, Deque, Dict, FrozenSet, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Deque, Dict, FrozenSet, List, Literal, Optional, Set, Tuple, Union
 
 import pytest
 
@@ -291,6 +291,39 @@ def test_output_type_round_trip_callable_with_parameter_list():
         # so `...` still falls through to the existing Ellipsis handling in serialize_type/deserialize_type.
         Callable[..., int],
         Callable[[int], Callable[..., str]],
+    ]:
+        assert deserialize_type(serialize_type(type_)) == type_
+
+
+def test_output_type_serialization_literal():
+    # `Literal` holds values (e.g. Literal["yes", "no"]), not types, so each value is serialized with
+    # repr() rather than as a bare token. See https://github.com/deepset-ai/haystack/issues/12285.
+    assert serialize_type(Literal["yes", "no"]) == "typing.Literal['yes', 'no']"
+    assert serialize_type(Literal[1, 2, 3]) == "typing.Literal[1, 2, 3]"
+    assert serialize_type(Literal[True, False]) == "typing.Literal[True, False]"
+    # A value that happens to look like a type name must stay a string, not be rendered as that type.
+    assert serialize_type(Literal["int", "str"]) == "typing.Literal['int', 'str']"
+
+
+def test_output_type_deserialization_literal():
+    assert deserialize_type("typing.Literal['yes', 'no']") == Literal["yes", "no"]
+    assert deserialize_type("typing.Literal[1, 2, 3]") == Literal[1, 2, 3]
+    assert deserialize_type("typing.Literal[True, False]") == Literal[True, False]
+    assert deserialize_type("typing.Literal['int', 'str']") == Literal["int", "str"]
+
+
+def test_output_type_round_trip_literal():
+    for type_ in [
+        Literal["yes", "no"],
+        Literal["int", "str"],  # values that look like type names must round-trip as strings, not types
+        Literal[1, 2, 3],
+        Literal[True, False],
+        Literal["None"],  # the string "None", not the NoneType singleton
+        Literal["a, b", "c"],  # a comma inside a value must not split the arguments
+        Literal["x"],
+        Literal[b"bytes"],
+        Optional[Literal["a", "b"]],
+        Union[Literal["a"], int],
     ]:
         assert deserialize_type(serialize_type(type_)) == type_
 


### PR DESCRIPTION
### Related Issues

- fixes #12285

### Proposed Changes:

`serialize_type` had no handling for `typing.Literal`, so it fell through to the generic-path logic and rendered the literal's *values* as if they were type names:

```python
serialize_type(Literal["yes", "no"])   # -> "typing.Literal[yes, no]"
```

`deserialize_type` then tried to resolve `yes` and `no` as types and raised `DeserializationError`. A value that happened to look like a real type name silently corrupted instead of raising: `Literal["int", "str"]` round-tripped to `Literal[int, str]` (two types).

The fix special-cases `typing.Literal` on both sides:

- **serialize:** render each value with `repr()`, so strings keep their quotes and non-string values (`int`, `bool`, `bytes`, `None`) are emitted as valid Python literals.
- **deserialize:** parse the arguments with `ast.literal_eval` instead of the type-resolving generic path. `ast.literal_eval` is quote-aware, so a comma inside a string value (`Literal["a, b", "c"]`) no longer splits the arguments, and it is limited to safe literals (`str`/`int`/`bool`/`None`/`bytes`/tuples).

Scope note: this covers the literal value kinds Python's own `Literal` accepts and that survive a text round-trip (str, bytes, int, bool, None). Enum members as `Literal` values are out of scope — they can't be reconstructed from `repr()` alone and would need import-path handling; I left that out rather than half-support it. Happy to follow up if you want it.

### How did you test it?

Unit tests in `test/utils/test_type_serialization.py` (`serialization`, `deserialization`, and `round_trip` for Literal, mirroring the existing `Callable` trio), covering the failing case, the silent-corruption case (`Literal["int", "str"]`), non-string values, a comma inside a value, and `Literal` nested in `Optional`/`Union`. Proven fail-without/pass-with: with the source change stashed the three new tests fail with `DeserializationError`; with it applied they pass.

Full file green (`195 passed`), plus the consumer suites: `test_output_adapter.py`, `test_conditional_router.py`, `test_pipeline.py` (`80 passed`). `ruff check` / `ruff format --check` clean, `mypy` clean on the changed module.

End-to-end check — this previously crashed on load, now round-trips:

```python
p = Pipeline()
p.add_component("oa", OutputAdapter(template="{{ x }}", output_type=Literal["yes", "no"]))
Pipeline.loads(p.dumps())   # OK
```

### Notes for the reviewer

The `Literal` branch is placed before the generic-args parsing on both sides on purpose: `typing.get_origin(Literal[...])` is `typing.Literal`, and its args are values, so they must not go through the type-resolving path (`_parse_generic_args` / `deserialize_type` per arg).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
