### PR TITLE
fix(generators): serialize timeout and max_retries in OpenAIImageGenerator.to_dict

### DIFF
--- a/haystack/components/generators/openai_image_generator.py
+++ b/haystack/components/generators/openai_image_generator.py
@@ -230,6 +230,8 @@ class OpenAIImageGenerator:
             api_key=self.api_key,
             api_base_url=self.api_base_url,
             organization=self.organization,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
             http_client_kwargs=self.http_client_kwargs,
         )
 

--- a/releasenotes/notes/openai-image-generator-serialize-client-settings-3d7c1a9e5b40f286.yaml
+++ b/releasenotes/notes/openai-image-generator-serialize-client-settings-3d7c1a9e5b40f286.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    ``OpenAIImageGenerator.to_dict()`` now serializes ``timeout`` and ``max_retries``, like the other OpenAI-backed
+    components already do. Previously both were dropped, so a pipeline that was serialized and loaded back silently
+    fell back to the ``OPENAI_TIMEOUT``/``OPENAI_MAX_RETRIES`` environment variables or to the 30 seconds and 5
+    retries defaults.

--- a/test/components/generators/test_openai_image_generator.py
+++ b/test/components/generators/test_openai_image_generator.py
@@ -88,6 +88,8 @@ class TestOpenAIImageGenerator:
                 "api_key": {"type": "env_var", "env_vars": ["OPENAI_API_KEY"], "strict": True},
                 "api_base_url": None,
                 "organization": None,
+                "timeout": None,
+                "max_retries": None,
                 "http_client_kwargs": None,
             },
         }
@@ -114,6 +116,8 @@ class TestOpenAIImageGenerator:
                 "api_key": {"type": "env_var", "env_vars": ["EXAMPLE_API_KEY"], "strict": True},
                 "api_base_url": "https://api.openai.com",
                 "organization": "test-org",
+                "timeout": 60.0,
+                "max_retries": 10,
                 "http_client_kwargs": {"proxy": "http://localhost:8080"},
             },
         }
@@ -128,6 +132,8 @@ class TestOpenAIImageGenerator:
                 "api_key": {"type": "env_var", "env_vars": ["OPENAI_API_KEY"], "strict": True},
                 "api_base_url": None,
                 "organization": None,
+                "timeout": 60.0,
+                "max_retries": 10,
                 "http_client_kwargs": None,
             },
         }
@@ -136,6 +142,8 @@ class TestOpenAIImageGenerator:
         assert generator.quality == "auto"
         assert generator.size == "1024x1024"
         assert generator.api_key.to_dict() == {"type": "env_var", "env_vars": ["OPENAI_API_KEY"], "strict": True}
+        assert pytest.approx(generator.timeout) == 60.0
+        assert generator.max_retries == 10
         assert generator.http_client_kwargs is None
 
     def test_from_dict_default_params(self):
@@ -162,6 +170,12 @@ class TestOpenAIImageGenerator:
         assert "images" in response and "revised_prompt" in response
         assert response["images"] == ["test-b64-json"]
         assert response["revised_prompt"] == "test-prompt"
+
+    def test_to_dict_from_dict_roundtrip_keeps_client_kwargs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        generator = OpenAIImageGenerator(timeout=60.0, max_retries=10)
+        deserialized = OpenAIImageGenerator.from_dict(generator.to_dict())
+        assert deserialized._client_kwargs() == generator._client_kwargs()
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),


### PR DESCRIPTION
### Related Issues

- No open issue; found while auditing `to_dict()` coverage across components.

### Proposed Changes:

`OpenAIImageGenerator.__init__` takes `timeout` and `max_retries`, stores both on the instance, and `_client_kwargs()` passes them to `OpenAI`/`AsyncOpenAI`. `to_dict()` never emitted them, so they were lost on the way through a serialized pipeline:

```python
g = OpenAIImageGenerator(timeout=60.0, max_retries=10)
g2 = OpenAIImageGenerator.from_dict(g.to_dict())

g._client_kwargs()   # {'timeout': 60.0, 'max_retries': 10}
g2._client_kwargs()  # {'timeout': 30.0, 'max_retries': 5}   <- silently back to the defaults
```

The fallback is silent: `_client_kwargs()` reads `OPENAI_TIMEOUT`/`OPENAI_MAX_RETRIES` or defaults to 30s / 5 retries whenever the attribute is `None`, so a deserialized pipeline just runs with different client settings than the one that was saved.

This is the only OpenAI-backed component with the gap — `OpenAIChatGenerator`, `OpenAIGenerator`, `AzureOpenAIChatGenerator`, `AzureOpenAIResponsesChatGenerator`, `OpenAIResponsesChatGenerator`, `OpenAI{Text,Document}Embedder`, `AzureOpenAI{Text,Document}Embedder` and `OpenAITokenCounter` all serialize both fields already.

`response_format` is deliberately left out: it is documented as ignored and only kept for backward compatibility, and `__init__` warns when it is set to anything other than `"b64_json"`.

### How did you test it?

`hatch run test:unit -k openai_image_generator` equivalent (`pytest test/components/generators/test_openai_image_generator.py`):

- before the fix: `3 failed, 20 passed, 2 skipped` — the two updated `to_dict` expectations plus the new round-trip test
- after the fix: `23 passed, 2 skipped`

Updated `test_to_dict`, `test_to_dict_with_params` and `test_from_dict` to cover the two fields (`test_to_dict_with_params` already passed `timeout=60, max_retries=10` into the constructor but asserted they were dropped), and added `test_to_dict_from_dict_roundtrip_keeps_client_kwargs`, which asserts `_client_kwargs()` is identical across a `to_dict()`/`from_dict()` round trip.

`ruff check` and `ruff format --check` are clean on both touched files.

### Notes for the reviewer

The branch is cut from an older `main` because my fork cannot be fast-forwarded (my token has no `workflow` scope and syncing touches `.github/workflows/`). The three hunks are pure additions and merge cleanly onto current `main`; happy to rebase if you prefer.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

---

This PR was written with an AI assistant (Claude Code). I have reviewed the changes and run the relevant tests locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
