### PR TITLE
docs: document four undocumented parameters in pipeline internals

### DIFF
--- a/haystack/components/preprocessors/document_cleaner.py
+++ b/haystack/components/preprocessors/document_cleaner.py
@@ -270,6 +270,8 @@ class DocumentCleaner:
         Note: This heuristic uses exact matches and therefore works well for footers like "Copyright 2019 by XXX",
          but won't detect "Page 3 of 4" or similar.
 
+        :param text: The text to remove headers and footers from, with pages separated by the
+            form feed character described above.
         :param n_chars: The number of first/last characters where the header/footer shall be searched in.
         :param n_first_pages_to_ignore: The number of first pages to ignore
             (e.g. TOCs often don't contain footer/header).

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1226,6 +1226,8 @@ class PipelineBase:  # noqa: PLW1641
         :param component_name: The name of a component.
         :param component: Component with component metadata.
         :param inputs: Global inputs state.
+        :param is_resume: Whether the component is being resumed from a breakpoint. If True, the inputs
+            have already been consumed, so the first available value is returned for each socket.
         :returns: The inputs for the component.
         """
         component_inputs = inputs.get(component_name, {})

--- a/haystack/core/pipeline/draw.py
+++ b/haystack/core/pipeline/draw.py
@@ -262,6 +262,9 @@ def _to_mermaid_image(
         Dictionary of customization parameters. See `validate_mermaid_params` for valid keys.
     :param timeout:
         Timeout in seconds for the request to the Mermaid server.
+    :param super_component_mapping:
+        Mapping of component names to the SuperComponent that contains them, used to group
+        those components visually in the rendered diagram.
     :returns:
         The image, SVG, or PDF data returned by the Mermaid server as bytes.
     :raises ValueError:

--- a/haystack/core/pipeline/draw.py
+++ b/haystack/core/pipeline/draw.py
@@ -263,8 +263,8 @@ def _to_mermaid_image(
     :param timeout:
         Timeout in seconds for the request to the Mermaid server.
     :param super_component_mapping:
-        Mapping of component names to the SuperComponent that contains them, used to group
-        those components visually in the rendered diagram.
+        Mapping of component names to the name of the SuperComponent that contains them, used to
+        group those components visually in the rendered diagram.
     :returns:
         The image, SVG, or PDF data returned by the Mermaid server as bytes.
     :raises ValueError:

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -141,6 +141,8 @@ class Pipeline(PipelineBase):
         :param component_visits: Current state of component visits.
         :param parent_span: The parent span to use for the newly created span.
             This is to allow tracing to be correctly linked to the pipeline run.
+        :param break_point: An optional breakpoint. If it targets this component and its visit
+            count matches the current one, a `BreakpointException` is raised before the Component runs.
         :raises PipelineRuntimeError: If Component doesn't return a dictionary.
         :return: The output of the Component.
         """


### PR DESCRIPTION
Follow-up to #12204 (merged), same defect class, different four sites.

## What changed

Four functions each document **every** parameter except one. Added the missing `:param:` entry in
each case — docstrings only, no behavior change.

| Location | Missing | Why it reads as an oversight, not a style choice |
|---|---|---|
| `haystack/components/preprocessors/document_cleaner.py:262` | `text` | The other three params (`n_chars`, `n_first_pages_to_ignore`, `n_last_pages_to_ignore`) are all documented, and the prose above already explains that pages in `text` must be form-feed separated — so the constraint was known, it just never became a param entry. |
| `haystack/core/pipeline/base.py:1220` | `is_resume` | `component_name`, `component`, `inputs` all documented. `is_resume` is load-bearing: at `base.py:1241` it takes a different branch that returns the first available socket value instead of consuming inputs. |
| `haystack/core/pipeline/draw.py:247` | `super_component_mapping` | `graph`, `server_url`, `params`, `timeout` documented, plus both `:raises:` entries — only the last parameter is missing. |
| `haystack/core/pipeline/pipeline.py:126` | `break_point` | First five params documented plus `:raises:` and `:return:`. `break_point` is keyword-only, which is likely why it was missed when added. |

## How these were found

An `ast` pass comparing each function's signature against the names its docstring documents,
reporting only where the docstring is *mostly* complete (≥70% of params documented, ≤2 missing).
That threshold is the point: a function documenting nothing is a style choice, one or two
stragglers in an otherwise-complete list is an oversight.

Same method as #12204, which `sjrl` merged. Recall-checked before use: rolled the repo back to
`5add74ec` (the parent of #12204) and confirmed the scanner re-finds
`LinkContentFetcher.__init__ missing ['request_headers']`, one of the defects that PR fixed.

Scanning current `main` (`5b791afa`) reports exactly these four and nothing else; after this
change it reports zero.

## Accuracy note

I verified each parameter's behavior in the function body rather than paraphrasing its name. One
draft was wrong and got corrected: I first wrote that `break_point` "saves a snapshot and raises",
but `pipeline.py:150-154` only raises `BreakpointException.from_triggered_breakpoint(...)` before
the component runs — no snapshot is written there. The committed text says what the code does.

I also avoided putting a literal `"\f"` in the `document_cleaner` docstring: that docstring is not
raw, so the escape would embed an actual form-feed control character. The added line refers to the
form feed described in the prose above instead.

## Validation

```
$ hatch run fmt
All checks passed!
549 files left unchanged

$ hatch run test:types
Success: no issues found in 408 source files

$ hatch run test:unit -k "document_cleaner or pipeline or draw"
540 passed, 5843 deselected, 3 warnings in 19.96s
```

No release note: the commit is prefixed `docs:`, which `release_notes.yml` exempts via its
`git log --pretty=%s origin/main..HEAD | grep -E '^(ci:|docs:|test:)'` check.

All four are private methods, so no public API surface changes.

---

🤖 Written with [Claude Code](https://claude.com/claude-code). Every site was opened and read
individually; the commands above were run locally with the output shown.
