### PR TITLE
fix: stop Agent retries after output limit

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -152,12 +152,17 @@ def _is_text_exit(messages: list[ChatMessage]) -> bool:
     Return whether `messages` end in a plain assistant text reply with no tool calls anywhere in the batch.
 
     This is the "no tool call" exit for the model's own replies. The last message must be a non-empty assistant text
-    message, so an invalid response (e.g. one with no tool calls and no text) does not trigger an exit.
+    message or be truncated by its output limit, so an invalid response (e.g. one with no tool calls and no text) does
+    not trigger an exit.
     """
     if not messages:
         return False
     last = messages[-1]
-    return not any(m.tool_call for m in messages) and last.is_from(ChatRole.ASSISTANT) and bool(last.text)
+    return (
+        not any(m.tool_call for m in messages)
+        and last.is_from(ChatRole.ASSISTANT)
+        and (bool(last.text) or last.meta.get("finish_reason") == "length")
+    )
 
 
 def _pending_tool_call_messages_from_state(state: State) -> list[ChatMessage]:

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -28,7 +28,7 @@ from haystack.dataclasses import (
     ToolCallDelta,
     select_streaming_callback,
 )
-from haystack.dataclasses.streaming_chunk import _invoke_streaming_callback
+from haystack.dataclasses.streaming_chunk import FinishReason, _invoke_streaming_callback
 from haystack.tools import (
     ToolsType,
     _check_duplicate_tool_names,
@@ -41,6 +41,26 @@ from haystack.utils import Secret, deserialize_callable, serialize_callable
 from haystack.utils.http_client import init_http_client
 
 logger = logging.getLogger(__name__)
+
+_INCOMPLETE_REASON_MAPPING: dict[str, FinishReason] = {
+    "max_output_tokens": "length",
+    "content_filter": "content_filter",
+}
+
+
+def _get_response_finish_reason(response: Response | ParsedResponse) -> FinishReason:
+    """Return the normalized finish reason for a terminal OpenAI Responses API response."""
+    if (
+        response.status == "incomplete"
+        and response.incomplete_details is not None
+        and response.incomplete_details.reason is not None
+    ):
+        finish_reason = _INCOMPLETE_REASON_MAPPING.get(response.incomplete_details.reason)
+        if finish_reason is not None:
+            return finish_reason
+    if any(output.type == "function_call" for output in response.output):
+        return "tool_calls"
+    return "stop"
 
 
 @component
@@ -690,6 +710,7 @@ def _convert_response_to_chat_message(responses: Response | ParsedResponse) -> C
 
     # remove output from meta because it contains toolcalls, reasoning, text etc.
     meta.pop("output")
+    meta["finish_reason"] = _get_response_finish_reason(responses)
 
     if logprobs:
         meta["logprobs"] = logprobs
@@ -766,14 +787,12 @@ def _convert_response_chunk_to_streaming_chunk(  # noqa: PLR0911
                 meta={"received_at": datetime.now().isoformat()},
             )
 
-    elif chunk.type == "response.completed":
-        # This means a full response is finished
-        # If there are tool_calls present in the final output we mark finish_reason as tool_calls otherwise it's
-        # marked as stop
+    elif chunk.type == "response.completed" or chunk.type == "response.incomplete":
+        # This means a full response is finished.
         return StreamingChunk(
             content="",
             component_info=component_info,
-            finish_reason="tool_calls" if any(o.type == "function_call" for o in chunk.response.output) else "stop",
+            finish_reason=_get_response_finish_reason(chunk.response),
             meta={**chunk.to_dict(), "received_at": datetime.now().isoformat()},
         )
 

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -920,6 +920,8 @@ def _convert_streaming_chunks_to_chat_message(chunks: list[StreamingChunk]) -> C
     # We dump the entire final response into meta to be consistent with non-streaming response
     final_response = chunks[-1].meta.get("response") or {}
     final_response.pop("output", None)
+    if chunks[-1].finish_reason is not None:
+        final_response["finish_reason"] = chunks[-1].finish_reason
     if logprobs:
         final_response["logprobs"] = logprobs
 

--- a/releasenotes/notes/agent-exit-on-output-limit-3ca9a92c399520df.yaml
+++ b/releasenotes/notes/agent-exit-on-output-limit-3ca9a92c399520df.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    Prevent ``Agent`` from retrying an empty response when a chat generator reports
+    ``finish_reason="length"``. This can happen when reasoning tokens exhaust the maximum output token budget.
+    ``OpenAIResponsesChatGenerator`` now maps terminal Responses API events to Haystack ``FinishReason`` values
+    and attaches ``finish_reason`` to the returned ``ChatMessage``.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -1086,6 +1086,19 @@ class TestAgentExitConditions:
         assert result["step_count"] == 2
         assert result["last_message"].text == "The weather is sunny."
 
+    def test_exits_on_empty_assistant_message_truncated_by_output_limit(self, monkeypatch, weather_tool):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        agent = Agent(chat_generator=OpenAIChatGenerator(), tools=[weather_tool], exit_conditions=["text"])
+
+        truncated_reply = {"replies": [ChatMessage.from_assistant(text="", meta={"finish_reason": "length"})]}
+        recovered_reply = {"replies": [ChatMessage.from_assistant(text="The weather is sunny.")]}
+        agent.chat_generator.run = MagicMock(side_effect=[truncated_reply, recovered_reply])
+
+        result = agent.run([ChatMessage.from_user("What's the weather?")])
+
+        assert agent.chat_generator.run.call_count == 1
+        assert result["last_message"].text == ""
+
     @pytest.mark.asyncio
     async def test_does_not_exit_on_empty_assistant_message_async(self, weather_tool):
         replies = [ChatMessage.from_assistant(text=""), "The weather is sunny."]
@@ -1095,6 +1108,20 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 2
         assert result["last_message"].text == "The weather is sunny."
+
+    @pytest.mark.asyncio
+    async def test_exits_on_empty_assistant_message_truncated_by_output_limit_async(self, monkeypatch, weather_tool):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+        agent = Agent(chat_generator=OpenAIChatGenerator(), tools=[weather_tool], exit_conditions=["text"])
+
+        truncated_reply = {"replies": [ChatMessage.from_assistant(text="", meta={"finish_reason": "length"})]}
+        recovered_reply = {"replies": [ChatMessage.from_assistant(text="The weather is sunny.")]}
+        agent.chat_generator.run_async = AsyncMock(side_effect=[truncated_reply, recovered_reply])
+
+        result = await agent.run_async([ChatMessage.from_user("What's the weather?")])
+
+        assert agent.chat_generator.run_async.call_count == 1
+        assert result["last_message"].text == ""
 
     def test_text_exit(self, weather_tool):
         """A plain assistant reply with no tool calls reports the `"text"` exit reason."""

--- a/test/components/generators/chat/test_openai_responses_conversion.py
+++ b/test/components/generators/chat/test_openai_responses_conversion.py
@@ -243,6 +243,8 @@ class TestConversionToStreamingChunks:
         chunk = _convert_response_chunk_to_streaming_chunk(event, previous_chunks=[])
 
         assert chunk.finish_reason == finish_reason
+        message = _convert_streaming_chunks_to_chat_message([chunk])
+        assert message.meta["finish_reason"] == finish_reason
 
     def test_convert_streaming_chunks_to_chat_message_with_tool_call_empty_reasoning(
         self, openai_responses_streaming_chunks_with_tool_call: MagicMock
@@ -298,6 +300,7 @@ class TestConversionToStreamingChunks:
                     "total_tokens": 145,
                 },
                 "store": True,
+                "finish_reason": "tool_calls",
             },
         )
 
@@ -901,6 +904,9 @@ class TestConversionToStreamingChunks:
                 finish_reason="stop",
             ),
         ]
+
+        message = _convert_streaming_chunks_to_chat_message(streaming_chunks)
+        assert message.meta["finish_reason"] == "stop"
 
     def test_convert_only_function_call(self) -> None:
 

--- a/test/components/generators/chat/test_openai_responses_conversion.py
+++ b/test/components/generators/chat/test_openai_responses_conversion.py
@@ -27,11 +27,13 @@ from openai.types.responses import (
     ResponseTextDoneEvent,
     ResponseUsage,
 )
+from openai.types.responses.response import IncompleteDetails
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
 from haystack.components.generators.chat.openai_responses import (
     _convert_chat_message_to_responses_api_format,
     _convert_response_chunk_to_streaming_chunk,
+    _convert_response_to_chat_message,
     _convert_streaming_chunks_to_chat_message,
 )
 from haystack.dataclasses import (
@@ -222,6 +224,22 @@ def openai_responses_streaming_chunks_with_tool_call():
 
 
 class TestConversionToStreamingChunks:
+    @pytest.mark.parametrize(
+        ("incomplete_reason", "finish_reason"), [("max_output_tokens", "length"), ("content_filter", "content_filter")]
+    )
+    def test_convert_incomplete_response_with_finish_reason(self, incomplete_reason: str, finish_reason: str) -> None:
+        response = Response.model_construct(
+            output=[],
+            output_text=None,
+            status="incomplete",
+            incomplete_details=IncompleteDetails(reason=incomplete_reason),
+        )
+        event = ResponseCompletedEvent.model_construct(response=response, type="response.incomplete")
+
+        chunk = _convert_response_chunk_to_streaming_chunk(event, previous_chunks=[])
+
+        assert chunk.finish_reason == finish_reason
+
     def test_convert_streaming_chunks_to_chat_message_with_tool_call_empty_reasoning(
         self, openai_responses_streaming_chunks_with_tool_call: MagicMock
     ) -> None:
@@ -1226,6 +1244,21 @@ class TestConversionToStreamingChunks:
 
 
 class TestResponseToChatMessage:
+    @pytest.mark.parametrize(
+        ("incomplete_reason", "finish_reason"), [("max_output_tokens", "length"), ("content_filter", "content_filter")]
+    )
+    def test_convert_incomplete_response_with_finish_reason(self, incomplete_reason: str, finish_reason: str) -> None:
+        response = Response.model_construct(
+            output=[],
+            output_text=None,
+            status="incomplete",
+            incomplete_details=IncompleteDetails(reason=incomplete_reason),
+        )
+
+        message = _convert_response_to_chat_message(response)
+
+        assert message.meta["finish_reason"] == finish_reason
+
     def test_convert_system_message(self) -> None:
 
         message = ChatMessage.from_system("You are good assistant")

--- a/test/components/generators/chat/test_openai_responses_conversion.py
+++ b/test/components/generators/chat/test_openai_responses_conversion.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Literal
 from unittest.mock import ANY, MagicMock
 
 import pytest
@@ -16,6 +17,7 @@ from openai.types.responses import (
     ResponseFunctionCallArgumentsDeltaEvent,
     ResponseFunctionCallArgumentsDoneEvent,
     ResponseFunctionToolCall,
+    ResponseIncompleteEvent,
     ResponseInProgressEvent,
     ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent,
@@ -227,14 +229,16 @@ class TestConversionToStreamingChunks:
     @pytest.mark.parametrize(
         ("incomplete_reason", "finish_reason"), [("max_output_tokens", "length"), ("content_filter", "content_filter")]
     )
-    def test_convert_incomplete_response_with_finish_reason(self, incomplete_reason: str, finish_reason: str) -> None:
+    def test_convert_incomplete_response_with_finish_reason(
+        self, incomplete_reason: Literal["max_output_tokens", "content_filter"], finish_reason: str
+    ) -> None:
         response = Response.model_construct(
             output=[],
             output_text=None,
             status="incomplete",
             incomplete_details=IncompleteDetails(reason=incomplete_reason),
         )
-        event = ResponseCompletedEvent.model_construct(response=response, type="response.incomplete")
+        event = ResponseIncompleteEvent.model_construct(response=response, type="response.incomplete")
 
         chunk = _convert_response_chunk_to_streaming_chunk(event, previous_chunks=[])
 
@@ -1247,7 +1251,9 @@ class TestResponseToChatMessage:
     @pytest.mark.parametrize(
         ("incomplete_reason", "finish_reason"), [("max_output_tokens", "length"), ("content_filter", "content_filter")]
     )
-    def test_convert_incomplete_response_with_finish_reason(self, incomplete_reason: str, finish_reason: str) -> None:
+    def test_convert_incomplete_response_with_finish_reason(
+        self, incomplete_reason: Literal["max_output_tokens", "content_filter"], finish_reason: str
+    ) -> None:
         response = Response.model_construct(
             output=[],
             output_text=None,


### PR DESCRIPTION
### Related Issues

- fixes #12300

### Proposed Changes:

- Map OpenAI Responses API completions stopped by `max_output_tokens` to Haystack's existing `length` finish reason in both streaming and non-streaming paths.
- Treat a tool-call-free assistant reply with that finish reason as a `text` Agent exit, while retaining the retry behavior for other empty replies such as discarded malformed tool calls.
- Add sync, async, streaming, and non-streaming regression coverage.

### How did you test it?

- `C:\Program Files\Hatch\hatch.exe run test:unit test/components/agents/test_agent.py test/components/generators/chat/test_openai_responses_conversion.py` (121 passed, 4 integration tests deselected)
- `C:\Program Files\Hatch\hatch.exe run test:unit test/components/generators/chat` (251 passed, 43 integration tests deselected)
- `C:\Program Files\Hatch\hatch.exe run test:types`
- `C:\Program Files\Hatch\hatch.exe run ruff check --fix`
- `C:\Program Files\Hatch\hatch.exe run ruff format`
- `C:\Program Files\Hatch\hatch.exe run pre-commit run --files ...` (all scoped hooks passed)

### Notes for the reviewer

The new Agent regression tests fail on `main` because the Agent makes a second model call after a length-truncated empty response. The Responses conversion regressions also fail on `main` because the same condition is exposed as `stop` in streaming mode and has no normalized finish reason in non-streaming mode.

`hatch run fmt` is not directly executable on Windows because the repository script's Unix-style semicolon is passed literally to Ruff; the two configured Ruff commands above were run separately through Hatch.

## AI assistance disclosure

I identified and reproduced the issue, then used OpenAI Codex to assist with the implementation and regression-test work. I personally reviewed the resulting diff and ran the validation commands listed above to verify the fix. Any full-suite or local-environment limitations are documented in the validation section.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md).
- [x] I have updated the related issue with helpful information about this PR.
- [x] I have added unit tests and documentation, if applicable.
- [x] I have followed the [commit conventions](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have documented any new or changed behavior.
- [x] I have added a release note.
- [x] I have run the pre-commit hooks.