### PR TITLE
feat: add output token limit utils for chat generators

### DIFF
--- a/haystack/components/generators/chat/utils.py
+++ b/haystack/components/generators/chat/utils.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack.components.generators.chat.types import ChatGenerator
+
+# The `generation_kwargs` key that caps a reply's length, per Chat Generator.
+#
+# Providers do not agree on a name for this setting and the `ChatGenerator` protocol does not standardize it, so a
+# caller that wants to bound a reply has to know which key the generator expects. Generators are matched by class name
+# rather than by `isinstance`, because most of the entries below live in `haystack-core-integrations` and are not
+# importable from here. Only the most derived match is used, so an unlisted subclass resolves through the generator it
+# inherits from: that is what covers the many OpenAI-compatible integrations without naming any of them.
+_OUTPUT_TOKEN_LIMIT_KEYS = {
+    # Haystack
+    "OpenAIChatGenerator": "max_completion_tokens",
+    "AzureOpenAIChatGenerator": "max_completion_tokens",
+    "OpenAIResponsesChatGenerator": "max_output_tokens",
+    "AzureOpenAIResponsesChatGenerator": "max_output_tokens",
+    # haystack-core-integrations
+    "AmazonBedrockChatGenerator": "maxTokens",
+    "AnthropicChatGenerator": "max_tokens",
+    "GoogleAIGeminiChatGenerator": "max_output_tokens",
+    "GoogleGenAIChatGenerator": "max_output_tokens",
+    "HuggingFaceAPIChatGenerator": "max_tokens",
+    "LiteLLMChatGenerator": "max_tokens",
+    "LlamaCppChatGenerator": "max_tokens",
+    "OllamaChatGenerator": "num_predict",
+    "TransformersChatGenerator": "max_new_tokens",
+    "VertexAIGeminiChatGenerator": "max_output_tokens",
+    "VLLMChatGenerator": "max_tokens",
+    "WatsonxChatGenerator": "max_new_tokens",
+}
+
+
+def _generator_output_token_limit_key(chat_generator: ChatGenerator) -> str | None:
+    """
+    Return the `generation_kwargs` key that limits a Chat Generator's output length.
+
+    :param chat_generator: The generator to look up.
+    :returns: The key the generator expects, or None when the generator is not recognized.
+    """
+    # Walk from the most derived class, so a provider's own entry wins over the generator it inherits from.
+    for cls in type(chat_generator).__mro__:
+        key = _OUTPUT_TOKEN_LIMIT_KEYS.get(cls.__name__)
+        if key is not None:
+            return key
+    return None
+
+
+def _resolve_output_token_limit(chat_generator: ChatGenerator, default_limit: int) -> tuple[int, dict[str, Any] | None]:
+    """
+    Resolve an effective output-token limit and the runtime kwargs that hold a Chat Generator to it.
+
+    A recognized limit already configured on the generator wins and is not repeated at runtime. When a recognized
+    generator has no limit configured, the default is returned as that provider's runtime setting. An unrecognized
+    generator receives no runtime setting, because the `ChatGenerator` protocol guarantees nothing beyond
+    `run(messages)` and guessing a key would raise a `TypeError` in the generator.
+
+    :param chat_generator: The generator whose output should be limited.
+    :param default_limit: The positive fallback output-token limit.
+    :returns: The effective limit, and the `generation_kwargs` to pass at runtime, or None when there are none. A
+        caller that gets None can still send the limit as prompt guidance and measure the reply itself.
+    """
+    limit_key = _generator_output_token_limit_key(chat_generator=chat_generator)
+    if limit_key is None:
+        return default_limit, None
+
+    configured = getattr(chat_generator, "generation_kwargs", None)
+    if isinstance(configured, dict) and limit_key in configured:
+        value = configured[limit_key]
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            return value, None
+        # The generator owns this setting. Do not silently replace an invalid value; let it report the problem.
+        return default_limit, None
+    return default_limit, {limit_key: default_limit}

--- a/haystack/components/generators/chat/utils.py
+++ b/haystack/components/generators/chat/utils.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any
-
 from haystack.components.generators.chat.types import ChatGenerator
 
 # The `generation_kwargs` key that caps a reply's length, per Chat Generator. Providers do not agree on a name and the
@@ -16,14 +14,28 @@ _OUTPUT_TOKEN_LIMIT_KEYS = {
     "OpenAIResponsesChatGenerator": "max_output_tokens",
     "AzureOpenAIResponsesChatGenerator": "max_output_tokens",
     # haystack-core-integrations
+    "AIMLAPIChatGenerator": "max_tokens",
     "AmazonBedrockChatGenerator": "maxTokens",
     "AnthropicChatGenerator": "max_tokens",
+    "AnthropicFoundryChatGenerator": "max_tokens",
+    "AnthropicVertexChatGenerator": "max_tokens",
+    "CohereChatGenerator": "max_tokens",
+    "CometAPIChatGenerator": "max_tokens",
+    "EdenAIChatGenerator": "max_tokens",
     "GoogleAIGeminiChatGenerator": "max_output_tokens",
     "GoogleGenAIChatGenerator": "max_output_tokens",
     "HuggingFaceAPIChatGenerator": "max_tokens",
     "LiteLLMChatGenerator": "max_tokens",
     "LlamaCppChatGenerator": "max_tokens",
+    "LlamaStackChatGenerator": "max_tokens",
+    "MistralChatGenerator": "max_tokens",
+    "NvidiaChatGenerator": "max_tokens",
     "OllamaChatGenerator": "num_predict",
+    "OpenRouterChatGenerator": "max_tokens",
+    "OrcaRouterChatGenerator": "max_tokens",
+    "PerplexityChatGenerator": "max_output_tokens",
+    "STACKITChatGenerator": "max_tokens",
+    "TogetherAIChatGenerator": "max_tokens",
     "TransformersChatGenerator": "max_new_tokens",
     "VertexAIGeminiChatGenerator": "max_output_tokens",
     "VLLMChatGenerator": "max_tokens",
@@ -38,25 +50,4 @@ def _generator_output_token_limit_key(chat_generator: ChatGenerator) -> str | No
     :param chat_generator: The generator to look up.
     :returns: The key the generator expects, or None when the generator is not recognized.
     """
-    # `__mro__` is the class followed by its bases, so an unlisted generator still matches through one it inherits
-    # from, such as the integrations built on `OpenAIChatGenerator`. Most derived first, so its own entry wins.
-    for cls in type(chat_generator).__mro__:
-        key = _OUTPUT_TOKEN_LIMIT_KEYS.get(cls.__name__)
-        if key is not None:
-            return key
-    return None
-
-
-def _run_kwargs_with_output_limit(chat_generator: ChatGenerator, limit: int) -> dict[str, Any]:
-    """
-    Return the `run` kwargs that set a Chat Generator's output-token limit to `limit`.
-
-    :param chat_generator: The generator whose output should be limited.
-    :param limit: The positive output-token limit to set.
-    :returns: The kwargs, or an empty dict when the generator is not recognized.
-    """
-    limit_key = _generator_output_token_limit_key(chat_generator=chat_generator)
-    if limit_key is None:
-        # Nothing at all rather than an empty `generation_kwargs`, which an unrecognized generator need not accept.
-        return {}
-    return {"generation_kwargs": {limit_key: limit}}
+    return _OUTPUT_TOKEN_LIMIT_KEYS.get(type(chat_generator).__name__)

--- a/haystack/components/generators/chat/utils.py
+++ b/haystack/components/generators/chat/utils.py
@@ -6,13 +6,9 @@ from typing import Any
 
 from haystack.components.generators.chat.types import ChatGenerator
 
-# The `generation_kwargs` key that caps a reply's length, per Chat Generator.
-#
-# Providers do not agree on a name for this setting and the `ChatGenerator` protocol does not standardize it, so a
-# caller that wants to bound a reply has to know which key the generator expects. Generators are matched by class name
-# rather than by `isinstance`, because most of the entries below live in `haystack-core-integrations` and are not
-# importable from here. Only the most derived match is used, so an unlisted subclass resolves through the generator it
-# inherits from: that is what covers the many OpenAI-compatible integrations without naming any of them.
+# The `generation_kwargs` key that caps a reply's length, per Chat Generator. Providers do not agree on a name and the
+# `ChatGenerator` protocol does not standardize it. Keyed by class name because most of these live in
+# `haystack-core-integrations` and cannot be imported here.
 _OUTPUT_TOKEN_LIMIT_KEYS = {
     # Haystack
     "OpenAIChatGenerator": "max_completion_tokens",
@@ -42,7 +38,8 @@ def _generator_output_token_limit_key(chat_generator: ChatGenerator) -> str | No
     :param chat_generator: The generator to look up.
     :returns: The key the generator expects, or None when the generator is not recognized.
     """
-    # Walk from the most derived class, so a provider's own entry wins over the generator it inherits from.
+    # `__mro__` is the class followed by its bases, so an unlisted generator still matches through one it inherits
+    # from, such as the integrations built on `OpenAIChatGenerator`. Most derived first, so its own entry wins.
     for cls in type(chat_generator).__mro__:
         key = _OUTPUT_TOKEN_LIMIT_KEYS.get(cls.__name__)
         if key is not None:
@@ -50,33 +47,16 @@ def _generator_output_token_limit_key(chat_generator: ChatGenerator) -> str | No
     return None
 
 
-def _resolve_output_token_limit(chat_generator: ChatGenerator, default_limit: int) -> tuple[int, dict[str, Any] | None]:
+def _run_kwargs_with_output_limit(chat_generator: ChatGenerator, limit: int) -> dict[str, Any]:
     """
-    Resolve an effective output-token limit and the runtime kwargs that hold a Chat Generator to it.
-
-    A recognized limit already configured on the generator wins and is not repeated at runtime. This counts a limit the
-    generator set for itself: `HuggingFaceAPIChatGenerator` and `TransformersChatGenerator` both leave a default of 512
-    in their `generation_kwargs`, and reading the dict cannot tell that apart from a deliberate choice, so a caller
-    asking for more than that gets the generator's number back.
-
-    When a recognized generator has no limit configured, the default is returned as that provider's runtime setting. An
-    unrecognized generator receives no runtime setting, because the `ChatGenerator` protocol guarantees nothing beyond
-    `run(messages)` and guessing a key would raise a `TypeError` in the generator.
+    Return the `run` kwargs that set a Chat Generator's output-token limit to `limit`.
 
     :param chat_generator: The generator whose output should be limited.
-    :param default_limit: The positive fallback output-token limit.
-    :returns: The effective limit, and the `generation_kwargs` to pass at runtime, or None when there are none. A
-        caller that gets None can still send the limit as prompt guidance and measure the reply itself.
+    :param limit: The positive output-token limit to set.
+    :returns: The kwargs, or an empty dict when the generator is not recognized.
     """
     limit_key = _generator_output_token_limit_key(chat_generator=chat_generator)
     if limit_key is None:
-        return default_limit, None
-
-    configured = getattr(chat_generator, "generation_kwargs", None)
-    if isinstance(configured, dict) and limit_key in configured:
-        value = configured[limit_key]
-        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
-            return value, None
-        # The generator owns this setting. Do not silently replace an invalid value; let it report the problem.
-        return default_limit, None
-    return default_limit, {limit_key: default_limit}
+        # Nothing at all rather than an empty `generation_kwargs`, which an unrecognized generator need not accept.
+        return {}
+    return {"generation_kwargs": {limit_key: limit}}

--- a/haystack/components/generators/chat/utils.py
+++ b/haystack/components/generators/chat/utils.py
@@ -54,9 +54,13 @@ def _resolve_output_token_limit(chat_generator: ChatGenerator, default_limit: in
     """
     Resolve an effective output-token limit and the runtime kwargs that hold a Chat Generator to it.
 
-    A recognized limit already configured on the generator wins and is not repeated at runtime. When a recognized
-    generator has no limit configured, the default is returned as that provider's runtime setting. An unrecognized
-    generator receives no runtime setting, because the `ChatGenerator` protocol guarantees nothing beyond
+    A recognized limit already configured on the generator wins and is not repeated at runtime. This counts a limit the
+    generator set for itself: `HuggingFaceAPIChatGenerator` and `TransformersChatGenerator` both leave a default of 512
+    in their `generation_kwargs`, and reading the dict cannot tell that apart from a deliberate choice, so a caller
+    asking for more than that gets the generator's number back.
+
+    When a recognized generator has no limit configured, the default is returned as that provider's runtime setting. An
+    unrecognized generator receives no runtime setting, because the `ChatGenerator` protocol guarantees nothing beyond
     `run(messages)` and guessing a key would raise a `TypeError` in the generator.
 
     :param chat_generator: The generator whose output should be limited.

--- a/test/components/generators/chat/test_utils.py
+++ b/test/components/generators/chat/test_utils.py
@@ -13,16 +13,16 @@ from haystack.components.generators.chat import (
     OpenAIResponsesChatGenerator,
 )
 from haystack.components.generators.chat.types import ChatGenerator
-from haystack.components.generators.chat.utils import _generator_output_token_limit_key, _resolve_output_token_limit
+from haystack.components.generators.chat.utils import _generator_output_token_limit_key, _run_kwargs_with_output_limit
 from haystack.dataclasses import ChatMessage
 
 
 def integration_generator(class_name: str) -> ChatGenerator:
     """
-    Stand in for a Chat Generator that lives in `haystack-core-integrations`.
+    Return an object named `class_name` that satisfies `ChatGenerator`.
 
-    Those packages are not importable from here, which is why the lookup matches on class name. A stand-in named the
-    same way is therefore an accurate test of the mechanism, but it cannot catch a rename on the integration side.
+    It stands in for a generator from `haystack-core-integrations`, which cannot be imported here. Lookup is by class
+    name, so the name is the only part that has to match; a rename on the integration side goes unnoticed.
     """
 
     def run(self: Any, messages: list[ChatMessage], **kwargs: Any) -> dict[str, Any]:
@@ -93,27 +93,33 @@ class TestGeneratorOutputTokenLimitKey:
         assert _generator_output_token_limit_key(chat_generator=integration_generator("MysteryChatGenerator")) is None
 
 
-class TestResolveOutputTokenLimit:
-    def test_sends_the_default_as_the_providers_runtime_setting(self):
-        assert _resolve_output_token_limit(chat_generator=OpenAIChatGenerator(), default_limit=100) == (
-            100,
-            {"max_completion_tokens": 100},
-        )
+class TestRunKwargsWithOutputLimit:
+    def test_passes_the_limit_as_the_providers_runtime_setting(self):
+        kwargs = _run_kwargs_with_output_limit(chat_generator=OpenAIChatGenerator(), limit=100)
 
-    def test_a_configured_limit_wins_and_is_not_repeated_at_runtime(self):
+        assert kwargs == {"generation_kwargs": {"max_completion_tokens": 100}}
+
+    def test_overrides_a_limit_the_generator_already_configures(self):
+        # A caller that reserves room for a reply of a given size needs that size honored, so the runtime value wins.
         generator = OpenAIChatGenerator(generation_kwargs={"temperature": 0, "max_completion_tokens": 23})
-        original = dict(generator.generation_kwargs)
 
-        assert _resolve_output_token_limit(chat_generator=generator, default_limit=100) == (23, None)
-        assert generator.generation_kwargs == original
+        kwargs = _run_kwargs_with_output_limit(chat_generator=generator, limit=100)
 
-    @pytest.mark.parametrize("value", [0, -1, True, "512", None], ids=["zero", "negative", "bool", "string", "none"])
-    def test_an_invalid_configured_limit_is_left_for_the_generator_to_report(self, value):
-        generator = OpenAIChatGenerator(generation_kwargs={"max_completion_tokens": value})
-        # The generator owns the setting, so it is neither used nor silently overwritten at runtime.
-        assert _resolve_output_token_limit(chat_generator=generator, default_limit=100) == (100, None)
+        assert kwargs == {"generation_kwargs": {"max_completion_tokens": 100}}
+        # Only this call is affected; the generator keeps its own settings, including the ones it is not asked about.
+        assert generator.generation_kwargs == {"temperature": 0, "max_completion_tokens": 23}
+
+    def test_the_override_reaches_the_generator(self):
+        # Generators merge runtime kwargs over configured ones, which is what makes the override above take effect.
+        generator = OpenAIChatGenerator(generation_kwargs={"temperature": 0, "max_completion_tokens": 23})
+        kwargs = _run_kwargs_with_output_limit(chat_generator=generator, limit=100)
+
+        merged = {**generator.generation_kwargs, **kwargs["generation_kwargs"]}
+
+        assert merged == {"temperature": 0, "max_completion_tokens": 100}
 
     def test_an_unknown_generator_receives_no_guessed_setting(self):
-        # The protocol only guarantees `run(messages)`, so passing a guessed kwarg would raise inside the generator.
+        # The protocol only guarantees `run(messages)`, so even an empty `generation_kwargs` could raise a TypeError.
         generator = integration_generator("MysteryChatGenerator")
-        assert _resolve_output_token_limit(chat_generator=generator, default_limit=100) == (100, None)
+
+        assert _run_kwargs_with_output_limit(chat_generator=generator, limit=100) == {}

--- a/test/components/generators/chat/test_utils.py
+++ b/test/components/generators/chat/test_utils.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import pytest
+
+from haystack.components.generators.chat import (
+    AzureOpenAIChatGenerator,
+    AzureOpenAIResponsesChatGenerator,
+    OpenAIChatGenerator,
+    OpenAIResponsesChatGenerator,
+)
+from haystack.components.generators.chat.types import ChatGenerator
+from haystack.components.generators.chat.utils import _generator_output_token_limit_key, _resolve_output_token_limit
+from haystack.dataclasses import ChatMessage
+
+
+def integration_generator(class_name: str) -> ChatGenerator:
+    """
+    Stand in for a Chat Generator that lives in `haystack-core-integrations`.
+
+    Those packages are not importable from here, which is why the lookup matches on class name. A stand-in named the
+    same way is therefore an accurate test of the mechanism, but it cannot catch a rename on the integration side.
+    """
+
+    def run(self: Any, messages: list[ChatMessage], **kwargs: Any) -> dict[str, Any]:
+        return {"replies": []}
+
+    generator: ChatGenerator = type(class_name, (), {"run": run})()
+    return generator
+
+
+class TestGeneratorOutputTokenLimitKey:
+    @pytest.mark.parametrize(
+        ("generator", "expected"),
+        [
+            pytest.param(OpenAIChatGenerator(), "max_completion_tokens", id="openai"),
+            pytest.param(
+                AzureOpenAIChatGenerator(azure_endpoint="https://test.openai.azure.com"),
+                "max_completion_tokens",
+                id="azure-openai",
+            ),
+            pytest.param(OpenAIResponsesChatGenerator(), "max_output_tokens", id="openai-responses"),
+            pytest.param(
+                AzureOpenAIResponsesChatGenerator(azure_endpoint="https://test.openai.azure.com"),
+                "max_output_tokens",
+                id="azure-openai-responses",
+            ),
+        ],
+    )
+    def test_recognizes_built_in_generators(self, generator, expected):
+        assert _generator_output_token_limit_key(chat_generator=generator) == expected
+
+    @pytest.mark.parametrize(
+        ("class_name", "expected"),
+        [
+            ("AmazonBedrockChatGenerator", "maxTokens"),
+            ("AnthropicChatGenerator", "max_tokens"),
+            ("GoogleAIGeminiChatGenerator", "max_output_tokens"),
+            ("GoogleGenAIChatGenerator", "max_output_tokens"),
+            ("HuggingFaceAPIChatGenerator", "max_tokens"),
+            ("LiteLLMChatGenerator", "max_tokens"),
+            ("LlamaCppChatGenerator", "max_tokens"),
+            ("OllamaChatGenerator", "num_predict"),
+            ("TransformersChatGenerator", "max_new_tokens"),
+            ("VertexAIGeminiChatGenerator", "max_output_tokens"),
+            ("VLLMChatGenerator", "max_tokens"),
+            ("WatsonxChatGenerator", "max_new_tokens"),
+        ],
+    )
+    def test_recognizes_integration_generators(self, class_name, expected):
+        assert _generator_output_token_limit_key(chat_generator=integration_generator(class_name)) == expected
+
+    def test_a_subclass_resolves_through_the_generator_it_inherits_from(self):
+        # This is what covers the OpenAI-compatible integrations, such as Mistral, OpenRouter, and TogetherAI, without
+        # naming any of them.
+        class ProviderChatGenerator(OpenAIChatGenerator):
+            pass
+
+        assert _generator_output_token_limit_key(chat_generator=ProviderChatGenerator()) == "max_completion_tokens"
+
+    def test_the_most_derived_entry_wins(self):
+        # No shipped generator depends on this today, since every subclass that is listed agrees with its base. It is
+        # pinned so that adding an entry for a subclass cannot be silently overridden by the base it inherits from.
+        base = type("OpenAIChatGenerator", (), {})
+        derived = type("OpenAIResponsesChatGenerator", (base,), {})
+
+        assert _generator_output_token_limit_key(chat_generator=derived()) == "max_output_tokens"
+
+    def test_unknown_generator_is_not_recognized(self):
+        assert _generator_output_token_limit_key(chat_generator=integration_generator("MysteryChatGenerator")) is None
+
+
+class TestResolveOutputTokenLimit:
+    def test_sends_the_default_as_the_providers_runtime_setting(self):
+        assert _resolve_output_token_limit(chat_generator=OpenAIChatGenerator(), default_limit=100) == (
+            100,
+            {"max_completion_tokens": 100},
+        )
+
+    def test_a_configured_limit_wins_and_is_not_repeated_at_runtime(self):
+        generator = OpenAIChatGenerator(generation_kwargs={"temperature": 0, "max_completion_tokens": 23})
+        original = dict(generator.generation_kwargs)
+
+        assert _resolve_output_token_limit(chat_generator=generator, default_limit=100) == (23, None)
+        assert generator.generation_kwargs == original
+
+    @pytest.mark.parametrize("value", [0, -1, True, "512", None], ids=["zero", "negative", "bool", "string", "none"])
+    def test_an_invalid_configured_limit_is_left_for_the_generator_to_report(self, value):
+        generator = OpenAIChatGenerator(generation_kwargs={"max_completion_tokens": value})
+        # The generator owns the setting, so it is neither used nor silently overwritten at runtime.
+        assert _resolve_output_token_limit(chat_generator=generator, default_limit=100) == (100, None)
+
+    def test_an_unknown_generator_receives_no_guessed_setting(self):
+        # The protocol only guarantees `run(messages)`, so passing a guessed kwarg would raise inside the generator.
+        generator = integration_generator("MysteryChatGenerator")
+        assert _resolve_output_token_limit(chat_generator=generator, default_limit=100) == (100, None)

--- a/test/components/generators/chat/test_utils.py
+++ b/test/components/generators/chat/test_utils.py
@@ -13,7 +13,7 @@ from haystack.components.generators.chat import (
     OpenAIResponsesChatGenerator,
 )
 from haystack.components.generators.chat.types import ChatGenerator
-from haystack.components.generators.chat.utils import _generator_output_token_limit_key, _run_kwargs_with_output_limit
+from haystack.components.generators.chat.utils import _generator_output_token_limit_key
 from haystack.dataclasses import ChatMessage
 
 
@@ -56,14 +56,28 @@ class TestGeneratorOutputTokenLimitKey:
     @pytest.mark.parametrize(
         ("class_name", "expected"),
         [
+            ("AIMLAPIChatGenerator", "max_tokens"),
             ("AmazonBedrockChatGenerator", "maxTokens"),
             ("AnthropicChatGenerator", "max_tokens"),
+            ("AnthropicFoundryChatGenerator", "max_tokens"),
+            ("AnthropicVertexChatGenerator", "max_tokens"),
+            ("CohereChatGenerator", "max_tokens"),
+            ("CometAPIChatGenerator", "max_tokens"),
+            ("EdenAIChatGenerator", "max_tokens"),
             ("GoogleAIGeminiChatGenerator", "max_output_tokens"),
             ("GoogleGenAIChatGenerator", "max_output_tokens"),
             ("HuggingFaceAPIChatGenerator", "max_tokens"),
             ("LiteLLMChatGenerator", "max_tokens"),
             ("LlamaCppChatGenerator", "max_tokens"),
+            ("LlamaStackChatGenerator", "max_tokens"),
+            ("MistralChatGenerator", "max_tokens"),
+            ("NvidiaChatGenerator", "max_tokens"),
             ("OllamaChatGenerator", "num_predict"),
+            ("OpenRouterChatGenerator", "max_tokens"),
+            ("OrcaRouterChatGenerator", "max_tokens"),
+            ("PerplexityChatGenerator", "max_output_tokens"),
+            ("STACKITChatGenerator", "max_tokens"),
+            ("TogetherAIChatGenerator", "max_tokens"),
             ("TransformersChatGenerator", "max_new_tokens"),
             ("VertexAIGeminiChatGenerator", "max_output_tokens"),
             ("VLLMChatGenerator", "max_tokens"),
@@ -73,53 +87,11 @@ class TestGeneratorOutputTokenLimitKey:
     def test_recognizes_integration_generators(self, class_name, expected):
         assert _generator_output_token_limit_key(chat_generator=integration_generator(class_name)) == expected
 
-    def test_a_subclass_resolves_through_the_generator_it_inherits_from(self):
-        # This is what covers the OpenAI-compatible integrations, such as Mistral, OpenRouter, and TogetherAI, without
-        # naming any of them.
+    def test_an_unlisted_subclass_is_not_recognized(self):
         class ProviderChatGenerator(OpenAIChatGenerator):
             pass
 
-        assert _generator_output_token_limit_key(chat_generator=ProviderChatGenerator()) == "max_completion_tokens"
-
-    def test_the_most_derived_entry_wins(self):
-        # No shipped generator depends on this today, since every subclass that is listed agrees with its base. It is
-        # pinned so that adding an entry for a subclass cannot be silently overridden by the base it inherits from.
-        base = type("OpenAIChatGenerator", (), {})
-        derived = type("OpenAIResponsesChatGenerator", (base,), {})
-
-        assert _generator_output_token_limit_key(chat_generator=derived()) == "max_output_tokens"
+        assert _generator_output_token_limit_key(chat_generator=ProviderChatGenerator()) is None
 
     def test_unknown_generator_is_not_recognized(self):
         assert _generator_output_token_limit_key(chat_generator=integration_generator("MysteryChatGenerator")) is None
-
-
-class TestRunKwargsWithOutputLimit:
-    def test_passes_the_limit_as_the_providers_runtime_setting(self):
-        kwargs = _run_kwargs_with_output_limit(chat_generator=OpenAIChatGenerator(), limit=100)
-
-        assert kwargs == {"generation_kwargs": {"max_completion_tokens": 100}}
-
-    def test_overrides_a_limit_the_generator_already_configures(self):
-        # A caller that reserves room for a reply of a given size needs that size honored, so the runtime value wins.
-        generator = OpenAIChatGenerator(generation_kwargs={"temperature": 0, "max_completion_tokens": 23})
-
-        kwargs = _run_kwargs_with_output_limit(chat_generator=generator, limit=100)
-
-        assert kwargs == {"generation_kwargs": {"max_completion_tokens": 100}}
-        # Only this call is affected; the generator keeps its own settings, including the ones it is not asked about.
-        assert generator.generation_kwargs == {"temperature": 0, "max_completion_tokens": 23}
-
-    def test_the_override_reaches_the_generator(self):
-        # Generators merge runtime kwargs over configured ones, which is what makes the override above take effect.
-        generator = OpenAIChatGenerator(generation_kwargs={"temperature": 0, "max_completion_tokens": 23})
-        kwargs = _run_kwargs_with_output_limit(chat_generator=generator, limit=100)
-
-        merged = {**generator.generation_kwargs, **kwargs["generation_kwargs"]}
-
-        assert merged == {"temperature": 0, "max_completion_tokens": 100}
-
-    def test_an_unknown_generator_receives_no_guessed_setting(self):
-        # The protocol only guarantees `run(messages)`, so even an empty `generation_kwargs` could raise a TypeError.
-        generator = integration_generator("MysteryChatGenerator")
-
-        assert _run_kwargs_with_output_limit(chat_generator=generator, limit=100) == {}


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/512
- POC branch for the full summarization compactor is here https://github.com/deepset-ai/haystack/pull/12296

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add util method for resolving how to pass down a max token limit from the Summarization Compactor down to the Chat Generator. We need to know the token limit at the Compactor level so we can properly account for how large the expected summary is when computing how much of the previous chat history should be summarized. 

The method I chose here is to create a util method that allows us to pass down a max token limit through the `generation_kwargs` runtime params of the ChatGenerator. 

However, I am wondering if a better solution would be to directly expose this as a standardized param name on the ChatGenerators run method instead of needing this util method. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added new tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

I made this a standalone PR so its easier to discuss whether we like this solution and to reduce the PR size of the eventual summarization compactor. 

I'd appreciate your thoughts on whether it makes sense to open issues to update our ChatGenerators to use a standardized param name like `max_output_tokens` instead of needing to maintain/update this dict. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
