### PR TITLE
ci: skip the linked-issue release when there is nobody to unassign

### DIFF
--- a/.github/workflows/cla_draft_gate.yml
+++ b/.github/workflows/cla_draft_gate.yml
@@ -129,6 +129,12 @@ jobs:
             // e.g. a maintainer who deliberately assigned themselves) and remember
             // the issue for the board step.
             async function releaseLinkedIssues(pr, meta) {
+              const assignees = meta.reviewers ?? [];
+              // linked_issue_review only claims an issue when it has individual
+              // reviewers to assign, so with nobody to unassign there is nothing to
+              // hand back -- and no reason to move the board item either.
+              if (!assignees.length) return;
+
               const result = await github.graphql(
                 `query($owner: String!, $repo: String!, $number: Int!) {
                   repository(owner: $owner, name: $repo) {
@@ -144,14 +150,11 @@ jobs:
               const issues = result.repository.pullRequest.closingIssuesReferences.nodes.filter(
                 (issue) => issue.repository.nameWithOwner === `${owner}/${repo}`,
               );
-              const assignees = meta.reviewers ?? [];
               for (const issue of issues) {
-                if (assignees.length) {
-                  // Logins that aren't assigned are ignored, so this is idempotent.
-                  await github.rest.issues.removeAssignees({
-                    owner, repo, issue_number: issue.number, assignees,
-                  });
-                }
+                // Logins that aren't assigned are ignored, so this is idempotent.
+                await github.rest.issues.removeAssignees({
+                  owner, repo, issue_number: issue.number, assignees,
+                });
                 parkedIssueIds.add(issue.id);
                 core.info(`Released linked issue #${issue.number} of PR #${pr.number}`);
               }


### PR DESCRIPTION
### Related Issues

- Follow-up to #12304

### Proposed Changes:

`releaseLinkedIssues()` now returns early when the marker comment holds no reviewers.

[`linked_issue_review.yml`](https://github.com/deepset-ai/haystack/blob/main/.github/workflows/linked_issue_review.yml) only claims an issue when the PR has individual reviewers to assign. With no reviewers it logs `No individual reviewers requested yet` and returns. So when the gate's marker holds no reviewers, there is nothing to hand back.

Without this early return, an issue owned by somebody else can be sitting in the review column and get demoted to `Backlog` by the gate even though the gate removed no assignee from it. 

### How did you test it?

### Notes for the reviewer

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes. — n/a, no linked issue
- [x] I have added unit tests and updated the docstrings. — n/a, CI-workflow-only change; validated with `actionlint` and `node --check`
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- [x] I have documented my code. — the early return carries a comment explaining why
- [x] I have added a release note file. — n/a, no `**.py` or `pyproject.toml` changed
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)