### PR TITLE
fix: keep title keys inside OpenAPI singular example values

### DIFF
--- a/haystack/tools/from_function.py
+++ b/haystack/tools/from_function.py
@@ -346,7 +346,7 @@ _NAME_KEYED_SCHEMA_MAPS = frozenset(
 
 # Keywords whose value is instance *data*, not a sub-schema. A 'title' key inside a
 # default value is part of that value, so removing it would change the tool's contract.
-_DATA_SCHEMA_KEYWORDS = frozenset({"default", "const", "enum", "examples"})
+_DATA_SCHEMA_KEYWORDS = frozenset({"default", "const", "enum", "examples", "example"})
 
 
 def _remove_title_from_schema(schema: dict[str, Any]) -> None:

--- a/releasenotes/notes/fix-tool-schema-title-inside-openapi-example-7c2a9e1b4d80f3a1.yaml
+++ b/releasenotes/notes/fix-tool-schema-title-inside-openapi-example-7c2a9e1b4d80f3a1.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed ``create_tool_from_function``, the ``@tool`` decorator, and ``ComponentTool`` stripping
+    ``title`` keys inside OpenAPI 3.0 singular ``example`` values when building a tool's JSON schema.
+    ``example`` is now treated as instance data alongside ``default``, ``const``, ``enum`` and
+    ``examples``, so a ``title`` key carried via Pydantic ``json_schema_extra`` stays part of the
+    tool contract.

--- a/test/tools/test_from_function.py
+++ b/test/tools/test_from_function.py
@@ -539,8 +539,7 @@ def test_from_function_with_openapi_example_containing_title_key():
 
     def render(
         options: Annotated[dict, "rendering options"] = Field(  # noqa: B008
-            default={},
-            json_schema_extra={"example": {"title": "Untitled", "width": "80"}},
+            default={}, json_schema_extra={"example": {"title": "Untitled", "width": "80"}}
         ),
     ) -> str:
         """Render a document."""

--- a/test/tools/test_from_function.py
+++ b/test/tools/test_from_function.py
@@ -7,7 +7,7 @@ from typing import Annotated, Literal
 
 import jsonschema
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from haystack.components.agents.state import State
 from haystack.tools.errors import SchemaGenerationError
@@ -424,13 +424,22 @@ def test_remove_title_from_schema_definition_named_title_draft_07_spelling():
 
 
 def test_remove_title_from_schema_keeps_instance_data():
-    """Test that 'title' keys inside instance data are left untouched."""
+    """Test that 'title' keys inside instance data are left untouched.
+
+    Covers JSON Schema ``default``/``const``/``enum``/``examples`` and the OpenAPI 3.0
+    singular ``example`` spelling (Pydantic ``json_schema_extra={"example": ...}``).
+    """
     schema = {
         "properties": {
             "cfg": {"type": "object", "default": {"title": "Untitled", "width": 80}, "title": "Cfg"},
             "mode": {"const": {"title": "fast", "workers": 2}, "title": "Mode"},
             "choice": {"enum": [{"title": "A", "id": 1}, {"title": "B", "id": 2}], "title": "Choice"},
-            "example": {"examples": [{"title": "Example", "id": 1}], "title": "Example"},
+            "sample": {
+                "type": "object",
+                "examples": [{"title": "Example", "id": 1}],
+                "example": {"title": "Untitled", "width": "80"},
+                "title": "Sample",
+            },
         },
         "title": "configure",
         "type": "object",
@@ -438,14 +447,18 @@ def test_remove_title_from_schema_keeps_instance_data():
 
     _remove_title_from_schema(schema)
 
-    # A 'title' key in a default/const/enum/examples is part of the *value*, not a schema keyword:
-    # removing it would silently change the tool's contract.
+    # A 'title' key in a default/const/enum/examples/example is part of the *value*, not a
+    # schema keyword: removing it would silently change the tool's contract.
     assert schema == {
         "properties": {
             "cfg": {"type": "object", "default": {"title": "Untitled", "width": 80}},
             "mode": {"const": {"title": "fast", "workers": 2}},
             "choice": {"enum": [{"title": "A", "id": 1}, {"title": "B", "id": 2}]},
-            "example": {"examples": [{"title": "Example", "id": 1}]},
+            "sample": {
+                "type": "object",
+                "examples": [{"title": "Example", "id": 1}],
+                "example": {"title": "Untitled", "width": "80"},
+            },
         },
         "type": "object",
     }
@@ -519,6 +532,23 @@ def test_from_function_with_default_containing_title_key():
     tool = create_tool_from_function(function=render)
 
     assert tool.parameters["properties"]["options"]["default"] == {"title": "Untitled", "width": 80}
+
+
+def test_from_function_with_openapi_example_containing_title_key():
+    """OpenAPI 3.0 singular ``example`` values must keep nested ``title`` keys."""
+
+    def render(
+        options: Annotated[dict, "rendering options"] = Field(  # noqa: B008
+            default={},
+            json_schema_extra={"example": {"title": "Untitled", "width": "80"}},
+        ),
+    ) -> str:
+        """Render a document."""
+        return ""
+
+    tool = create_tool_from_function(function=render)
+
+    assert tool.parameters["properties"]["options"]["example"] == {"title": "Untitled", "width": "80"}
 
 
 def test_remove_title_from_schema_handle_no_title_in_top_level():


### PR DESCRIPTION
## Summary
- Follow-up to #12219: treat OpenAPI 3.0 singular `example` as instance data in `_DATA_SCHEMA_KEYWORDS`, same as `examples` / `default` / `const` / `enum`.
- Keeps nested `title` keys carried via Pydantic `json_schema_extra={example: ...}` when building tool schemas.
- Adds a unit fixture that discriminates singular `example` and a public-API regression through `create_tool_from_function`.

## Context
Flagged by @percymcn on #12219 after re-checking the post-merge `3.1.0.dev` build.

## Test plan
- [ ] `test_remove_title_from_schema_keeps_instance_data` passes with singular `example`
- [ ] `test_from_function_with_openapi_example_containing_title_key` passes
- [ ] Existing title-stripping controls (`items` / `propertyNames`) still remove schema-level `title`