### PR TITLE
feat: add `Agent.clone`

### DIFF
--- a/docs-website/docs/pipeline-components/agents-1/agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent.mdx
@@ -112,6 +112,14 @@ def fallback_on_max_steps(state: State) -> None:
 For the full parameter reference, see the [Agents API Documentation](/reference/agents-api).
 :::
 
+### Cloning
+
+`clone()` returns a new agent with the same configuration, optionally replacing some init parameters. This is useful for creating a variant of an agent you did not build yourself, such as one returned by a factory function of the [Agent Pack](./agent-pack.mdx).
+
+```python
+variant = agent.clone(system_prompt="Answer in German.", max_agent_steps=20)
+```
+
 ## Usage
 
 ### On its own

--- a/docs-website/docs/pipeline-components/agents-1/agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent.mdx
@@ -112,12 +112,24 @@ def fallback_on_max_steps(state: State) -> None:
 For the full parameter reference, see the [Agents API Documentation](/reference/agents-api).
 :::
 
-### Cloning
+### Cloning and modifying an agent
+
+Agent attributes are not meant to be reassigned after initialization: several parameters are processed at init time, so setting an attribute on a built agent does not reliably take effect. The recommended way to get a modified version of an existing agent is `clone()`.
 
 `clone()` returns a new agent with the same configuration, optionally replacing some init parameters. This is useful for creating a variant of an agent you did not build yourself, such as one returned by a factory function of the [Agent Pack](./agent-pack.mdx).
 
 ```python
 variant = agent.clone(system_prompt="Answer in German.", max_agent_steps=20)
+```
+
+Overrides replace the original values. To extend a list or dictionary instead, unpack the existing value and add your entries:
+
+```python
+extended = agent.clone(
+    tools=[*agent.tools, my_new_tool],
+    state_schema={**agent.state_schema, "notes": {"type": str}},
+    hooks={**agent.hooks, "before_llm": [my_hook]},
+)
 ```
 
 ## Usage

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -481,17 +481,17 @@ class Agent:
 
         # --- State schema ---
         # shallow copy is sufficient: we only add a top-level "messages" key, never mutate nested values
-        self._state_schema = state_schema or {}
-        self.state_schema = dict(self._state_schema)
-        if self.state_schema.get("messages") is None:
-            self.state_schema["messages"] = {"type": list[ChatMessage], "handler": merge_lists}
+        self.state_schema = state_schema or {}
+        self.resolved_state_schema = dict(self.state_schema)
+        if self.resolved_state_schema.get("messages") is None:
+            self.resolved_state_schema["messages"] = {"type": list[ChatMessage], "handler": merge_lists}
         for key, config in {**_RUN_METADATA_STATE_KEYS, **_INTERNAL_STATE_KEYS}.items():
-            self.state_schema[key] = dict(config)
+            self.resolved_state_schema[key] = dict(config)
 
         # --- Component I/O ---
         self._run_method_params = _get_run_method_params(self)
         output_types: dict[str, Any] = {"last_message": ChatMessage}
-        for param, config in self.state_schema.items():
+        for param, config in self.resolved_state_schema.items():
             # Internal keys are run-control / hook-facing state, not exposed as inputs or outputs.
             if param in _INTERNAL_STATE_KEYS:
                 continue
@@ -552,7 +552,7 @@ class Agent:
 
         for var_name, sources in all_variables.items():
             prompt_source = " and ".join(sources)
-            if var_name in self.state_schema:
+            if var_name in self.resolved_state_schema:
                 raise ValueError(
                     f"Variable '{var_name}' from {prompt_source} is already defined in the state schema. "
                     "Please rename the variable or remove it from the prompt to avoid conflicts."
@@ -618,9 +618,6 @@ class Agent:
         """
         init_params = inspect.signature(type(self).__init__).parameters
         params: dict[str, Any] = {name: getattr(self, name) for name in init_params if name != "self"}
-        # self.state_schema is the resolved schema including reserved keys, which __init__ rejects
-        # we pass the original user-provided schema instead
-        params["state_schema"] = self._state_schema
         return type(self)(**{**params, **overrides})
 
     def to_dict(self) -> dict[str, Any]:
@@ -637,8 +634,7 @@ class Agent:
             user_prompt=self.user_prompt,
             required_variables=self.required_variables,
             exit_conditions=self.exit_conditions,
-            # We serialize the original state schema, not the resolved one to reflect the original user input
-            state_schema=_schema_to_dict(self._state_schema),
+            state_schema=_schema_to_dict(self.state_schema),
             max_agent_steps=self.max_agent_steps,
             streaming_callback=serialize_callable(self.streaming_callback) if self.streaming_callback else None,
             raise_on_tool_invocation_failure=self.raise_on_tool_invocation_failure,
@@ -689,7 +685,7 @@ class Agent:
                 "haystack.agent.max_steps": self.max_agent_steps,
                 "haystack.agent.tools": tools,
                 "haystack.agent.exit_conditions": self.exit_conditions,
-                "haystack.agent.state_schema": _schema_to_dict(self.state_schema),
+                "haystack.agent.state_schema": _schema_to_dict(self.resolved_state_schema),
             },
             parent_span=parent_span,
         )
@@ -751,8 +747,8 @@ class Agent:
                 "The Agent component requires a chat generator that supports tools when tools are provided."
             )
 
-        state_kwargs: dict[str, Any] = {key: kwargs[key] for key in self.state_schema.keys() if key in kwargs}
-        state = State(schema=self.state_schema, data=state_kwargs)
+        state_kwargs: dict[str, Any] = {key: kwargs[key] for key in self.resolved_state_schema.keys() if key in kwargs}
+        state = State(schema=self.resolved_state_schema, data=state_kwargs)
         state.set("messages", messages)
         state.set("step_count", 0)
         state.set("token_usage", {})

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -609,6 +609,20 @@ class Agent:
         elif hasattr(self.chat_generator, "close"):
             self.chat_generator.close()
 
+    def clone(self, **overrides: Any) -> "Agent":
+        """
+        Return a new Agent configured like this one, with the given init parameters replaced.
+
+        :param overrides: Init parameters to replace, e.g. `agent.clone(system_prompt="...")`.
+        :returns: The new Agent.
+        """
+        init_params = inspect.signature(type(self).__init__).parameters
+        params: dict[str, Any] = {name: getattr(self, name) for name in init_params if name != "self"}
+        # self.state_schema is the resolved schema including reserved keys, which __init__ rejects
+        # we pass the original user-provided schema instead
+        params["state_schema"] = self._state_schema
+        return type(self)(**{**params, **overrides})
+
     def to_dict(self) -> dict[str, Any]:
         """
         Serialize the component to a dictionary.

--- a/releasenotes/notes/agent-clone-a311b5fa481395f8.yaml
+++ b/releasenotes/notes/agent-clone-a311b5fa481395f8.yaml
@@ -3,3 +3,10 @@ features:
   - |
     Add an ``Agent.clone()`` method that returns a new Agent with the same configuration, optionally
     replacing some init parameters: ``variant = agent.clone(system_prompt="Answer in German.")``.
+upgrade:
+  - |
+    ``Agent.state_schema`` now contains the user-provided state schema, exactly as passed to
+    ``__init__``. Previously it contained the resolved schema, which also included ``messages``
+    and the keys the Agent manages internally (``step_count``, ``token_usage``, ``exit_reason``, ...).
+    If you were reading ``agent.state_schema`` to inspect the effective runtime schema, use the
+    new public attribute ``agent.resolved_state_schema`` instead.

--- a/releasenotes/notes/agent-clone-a311b5fa481395f8.yaml
+++ b/releasenotes/notes/agent-clone-a311b5fa481395f8.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add an ``Agent.clone()`` method that returns a new Agent with the same configuration, optionally
+    replacing some init parameters: ``variant = agent.clone(system_prompt="Answer in German.")``.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -481,7 +481,8 @@ class TestAgent:
         assert agent.tools[0].function is weather_function
         assert isinstance(agent.tools[1]._component, PromptBuilder)
         assert agent.exit_conditions == ["text", "weather_tool"]
-        assert agent.state_schema == {
+        assert agent.state_schema == {"foo": {"type": str}}
+        assert agent.resolved_state_schema == {
             "foo": {"type": str},
             "messages": {"handler": merge_lists, "type": list[ChatMessage]},
             "step_count": {"type": int, "handler": replace_values},
@@ -594,7 +595,8 @@ class TestAgent:
             },
         }
         agent = Agent.from_dict(data)
-        assert agent.state_schema == {
+        assert agent.state_schema == {}
+        assert agent.resolved_state_schema == {
             "messages": {"type": list[ChatMessage], "handler": merge_lists},
             "step_count": {"type": int, "handler": replace_values},
             "token_usage": {"type": dict[str, Any], "handler": replace_values},
@@ -639,7 +641,8 @@ class TestAgent:
         assert deserialized_agent.tools[0].function is weather_function
         assert isinstance(deserialized_agent.tools[1]._component, PromptBuilder)
         assert deserialized_agent.exit_conditions == ["text", "weather_tool"]
-        assert deserialized_agent.state_schema == {
+        assert deserialized_agent.state_schema == {"foo": {"type": str}}
+        assert deserialized_agent.resolved_state_schema == {
             "foo": {"type": str},
             "messages": {"handler": merge_lists, "type": list[ChatMessage]},
             "step_count": {"type": int, "handler": replace_values},
@@ -667,19 +670,17 @@ class TestAgent:
 
         assert clone is not agent
         assert clone.to_dict() == agent.to_dict()
-        assert clone._state_schema == {"foo": {"type": str}}
-        assert clone.state_schema == agent.state_schema
 
     @pytest.mark.parametrize(
-        "name, value, attr",
+        "name, value",
         [
-            ("system_prompt", "A nice system prompt", "system_prompt"),
-            ("max_agent_steps", 3, "max_agent_steps"),
-            ("exit_conditions", ["weather_tool"], "exit_conditions"),
-            ("state_schema", {"bar": {"type": int}}, "_state_schema"),
+            ("system_prompt", "A nice system prompt"),
+            ("max_agent_steps", 3),
+            ("exit_conditions", ["weather_tool"]),
+            ("state_schema", {"bar": {"type": int}}),
         ],
     )
-    def test_clone_with_overrides(self, weather_tool, name, value, attr):
+    def test_clone_with_overrides(self, weather_tool, name, value):
         agent = Agent(
             chat_generator=MockChatGenerator("Hello"),
             tools=[weather_tool],
@@ -689,7 +690,7 @@ class TestAgent:
 
         clone = agent.clone(**{name: value})
 
-        assert getattr(clone, attr) == value
+        assert getattr(clone, name) == value
 
         # only the overridden init parameter differs
         original_params = agent.to_dict()["init_parameters"]
@@ -700,6 +701,18 @@ class TestAgent:
                 assert clone_params[key] != original_params[key]
             else:
                 assert clone_params[key] == original_params[key]
+
+    def test_clone_with_additional_state_schema_and_tools(self, weather_tool, component_tool):
+        agent = Agent(
+            chat_generator=MockChatGenerator("Hello"), tools=[weather_tool], state_schema={"foo": {"type": str}}
+        )
+
+        clone = agent.clone(
+            tools=[*agent.tools, component_tool], state_schema={**agent.state_schema, "notes": {"type": str}}
+        )
+
+        assert clone.tools == [weather_tool, component_tool]
+        assert clone.state_schema == {"foo": {"type": str}, "notes": {"type": str}}
 
     def test_exit_conditions(self, weather_tool, component_tool, monkeypatch):
         monkeypatch.setenv("FAKE_OPENAI_KEY", "fake-key")

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -653,6 +653,54 @@ class TestAgent:
         }
         assert deserialized_agent.streaming_callback is sync_streaming_callback
 
+    def test_clone(self, weather_tool):
+        agent = Agent(
+            chat_generator=MockChatGenerator("Hello"),
+            tools=[weather_tool],
+            system_prompt="You are helpful",
+            exit_conditions=["text", "weather_tool"],
+            state_schema={"foo": {"type": str}},
+            max_agent_steps=7,
+        )
+
+        clone = agent.clone()
+
+        assert clone is not agent
+        assert clone.to_dict() == agent.to_dict()
+        assert clone._state_schema == {"foo": {"type": str}}
+        assert clone.state_schema == agent.state_schema
+
+    @pytest.mark.parametrize(
+        "name, value, attr",
+        [
+            ("system_prompt", "A nice system prompt", "system_prompt"),
+            ("max_agent_steps", 3, "max_agent_steps"),
+            ("exit_conditions", ["weather_tool"], "exit_conditions"),
+            ("state_schema", {"bar": {"type": int}}, "_state_schema"),
+        ],
+    )
+    def test_clone_with_overrides(self, weather_tool, name, value, attr):
+        agent = Agent(
+            chat_generator=MockChatGenerator("Hello"),
+            tools=[weather_tool],
+            system_prompt="You are helpful",
+            state_schema={"foo": {"type": str}},
+        )
+
+        clone = agent.clone(**{name: value})
+
+        assert getattr(clone, attr) == value
+
+        # only the overridden init parameter differs
+        original_params = agent.to_dict()["init_parameters"]
+        clone_params = clone.to_dict()["init_parameters"]
+        assert clone_params.keys() == original_params.keys()
+        for key in original_params:
+            if key == name:
+                assert clone_params[key] != original_params[key]
+            else:
+                assert clone_params[key] == original_params[key]
+
     def test_exit_conditions(self, weather_tool, component_tool, monkeypatch):
         monkeypatch.setenv("FAKE_OPENAI_KEY", "fake-key")
         generator = OpenAIChatGenerator(api_key=Secret.from_env_var("FAKE_OPENAI_KEY"))


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/527

I first tried making the Agent attributes editable (`my_agent.system_prompt="new"`). It is feasible but I ended up changing hundreds of lines and introducing potentially fragile and unexpected behaviors: what if the Agent is already part of a Pipeline? Why is this component editable after initialization while the others are not? 

So I took a lighter and more radical idea: just expose a way to clone the Agent with overrides. It is useful for editing already created Agents, like those coming from the Agent Pack.

### Proposed Changes:
- add `Agent.clone`: a method that copies an Agent with optional parameter overrides

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
