### PR TITLE
feat: add Agent Hook tracing

### DIFF
--- a/haystack/hooks/compaction/hooks.py
+++ b/haystack/hooks/compaction/hooks.py
@@ -4,10 +4,15 @@
 
 from typing import Any
 
-from haystack import logging
+from haystack import logging, tracing
 from haystack.components.agents.state.state import State
 from haystack.components.agents.state.state_utils import replace_values
-from haystack.core.serialization import component_to_dict, default_from_dict, default_to_dict
+from haystack.core.serialization import (
+    component_to_dict,
+    default_from_dict,
+    default_to_dict,
+    generate_qualified_class_name,
+)
 from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction.types import Compactor
 from haystack.hooks.compaction.utils import _estimated_context_tokens, _last_assistant_index
@@ -164,9 +169,22 @@ class CompactionHook:
         estimated = _estimated_context_tokens(
             messages=messages, context_tokens=context_tokens, token_counter=self.token_counter, tools=tools
         )
-        if estimated < self.context_window * self.compact_at:
-            # The conversation is not yet large enough to compact, so leave it alone.
+        triggered = estimated >= self.context_window * self.compact_at
+
+        span = tracing.tracer.current_span()
+        if span is not None:
+            span.set_tags(
+                tags={
+                    "haystack.agent.hook.compaction.strategy": generate_qualified_class_name(cls=type(self.compactor)),
+                    "haystack.agent.hook.compaction.estimated_context_tokens": estimated,
+                    "haystack.agent.hook.compaction.triggered": triggered,
+                }
+            )
+
+        # The conversation is not yet large enough to compact, so leave it alone.
+        if not triggered:
             return None
+
         # Calculate the non-message overhead, such as tool schemas and the provider's chat-template overhead.
         message_tokens = self.token_counter.count(messages=messages)
         overhead = estimated - message_tokens
@@ -178,9 +196,14 @@ class CompactionHook:
                 message_tokens=message_tokens,
                 estimated=estimated,
             )
+        target_tokens = max(int(self.context_window * self.compact_to) - overhead, 0)
+
+        if span is not None:
+            span.set_tag(key="haystack.agent.hook.compaction.target_tokens", value=target_tokens)
+
         # Return the target token amount the messages should be compacted to and the overhead needed to re-estimate the
         # context size after compaction.
-        return max(int(self.context_window * self.compact_to) - overhead, 0), overhead
+        return target_tokens, overhead
 
     def _apply(
         self,
@@ -201,8 +224,14 @@ class CompactionHook:
         :param original_context_tokens: The provider-reported context count before compaction, or 0 when unavailable.
         :param estimated_overhead: The estimated non-message overhead to include in the updated context count.
         """
+        span = tracing.tracer.current_span()
+        if span is not None:
+            span.set_tag(key="haystack.agent.hook.compaction.compacted", value=compacted is not None)
+
+        # If the compactor returned None, it declined to compact. Leave the conversation alone.
         if compacted is None:
             return
+
         state.set("messages", compacted, handler_override=replace_values)
         # If the original value was 0, leave it unchanged so later steps keep recounting the full request locally.
         if original_context_tokens != 0:

--- a/haystack/hooks/invocation.py
+++ b/haystack/hooks/invocation.py
@@ -2,9 +2,45 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any
+
+from haystack import tracing
 from haystack.components.agents.state.state import State
+from haystack.core.errors import SerializationError
+from haystack.core.serialization import generate_qualified_class_name
+from haystack.hooks.from_function import FunctionHook
 from haystack.hooks.protocol import Hook, HookPoint
+from haystack.tracing import Span
 from haystack.utils.async_utils import _execute_component_async
+from haystack.utils.callable_serialization import serialize_callable
+
+
+def _hook_name(hook: Hook) -> str:
+    """Return a human-readable identifier for a hook."""
+    if isinstance(hook, FunctionHook):
+        # FunctionHook is a generic wrapper, so identify it by its wrapped callable instead.
+        function = hook.function or hook.async_function
+        if function is not None:
+            try:
+                return serialize_callable(callable_handle=function)
+            except SerializationError:
+                # Tracing must not prevent an otherwise runnable hook from executing. Nested functions and lambdas are
+                # unsupported by serialization, but their qualified names are still useful within the current process.
+                return f"{function.__module__}.{function.__qualname__}"
+    return type(hook).__name__
+
+
+def _create_hook_span(hook: Hook, hook_point: HookPoint, parent_span: Span | None) -> Any:
+    """Create a content-free tracing span for one hook invocation."""
+    return tracing.tracer.trace(
+        "haystack.agent.hook",
+        tags={
+            "haystack.agent.hook.point": hook_point,
+            "haystack.agent.hook.name": _hook_name(hook=hook),
+            "haystack.agent.hook.type": generate_qualified_class_name(cls=type(hook)),
+        },
+        parent_span=parent_span,
+    )
 
 
 def _run_hooks(hooks: dict[HookPoint, list[Hook]], hook_point: HookPoint, state: State) -> None:
@@ -15,8 +51,14 @@ def _run_hooks(hooks: dict[HookPoint, list[Hook]], hook_point: HookPoint, state:
     :param hook_point: The hook point whose hooks to run; hooks registered under other hook points are skipped.
     :param state: The Agent's live `State`, passed to each hook and mutated in place.
     """
-    for h in hooks.get(hook_point, []):
-        h.run(state)
+    hooks_to_run = hooks.get(hook_point, [])
+    if not hooks_to_run:
+        return
+
+    parent_span = tracing.tracer.current_span()
+    for h in hooks_to_run:
+        with _create_hook_span(hook=h, hook_point=hook_point, parent_span=parent_span):
+            h.run(state)
 
 
 async def _run_hooks_async(hooks: dict[HookPoint, list[Hook]], hook_point: HookPoint, state: State) -> None:
@@ -27,5 +69,11 @@ async def _run_hooks_async(hooks: dict[HookPoint, list[Hook]], hook_point: HookP
     :param hook_point: The hook point whose hooks to run; hooks registered under other hook points are skipped.
     :param state: The Agent's live `State`, passed to each hook and mutated in place.
     """
-    for h in hooks.get(hook_point, []):
-        await _execute_component_async(h, state=state)
+    hooks_to_run = hooks.get(hook_point, [])
+    if not hooks_to_run:
+        return
+
+    parent_span = tracing.tracer.current_span()
+    for h in hooks_to_run:
+        with _create_hook_span(hook=h, hook_point=hook_point, parent_span=parent_span):
+            await _execute_component_async(h, state=state)

--- a/haystack/hooks/invocation.py
+++ b/haystack/hooks/invocation.py
@@ -22,11 +22,15 @@ def _hook_name(hook: Hook) -> str:
         function = hook.function or hook.async_function
         if function is not None:
             try:
-                return serialize_callable(callable_handle=function)
-            except SerializationError:
-                # Tracing must not prevent an otherwise runnable hook from executing. Nested functions and lambdas are
-                # unsupported by serialization, but their qualified names are still useful within the current process.
-                return f"{function.__module__}.{function.__qualname__}"
+                try:
+                    return serialize_callable(callable_handle=function)
+                except SerializationError:
+                    # Nested functions and lambdas are unsupported by serialization, but their qualified names are still
+                    # useful.
+                    return f"{function.__module__}.{function.__qualname__}"
+            # functools.partial and callable-object instances may not expose __module__, __qualname__, or __name__.
+            except Exception:
+                pass
     return type(hook).__name__
 
 

--- a/releasenotes/notes/trace-agent-hook-invocations-dd947a6eb6f1ad47.yaml
+++ b/releasenotes/notes/trace-agent-hook-invocations-dd947a6eb6f1ad47.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add a content-free ``haystack.agent.hook`` tracing span for every Agent hook invocation. Each span identifies the
+    hook point, hook name, and hook type, allowing hook latency and failures to be attributed without tracing the
+    potentially large Agent ``State``.

--- a/releasenotes/notes/trace-agent-hook-invocations-dd947a6eb6f1ad47.yaml
+++ b/releasenotes/notes/trace-agent-hook-invocations-dd947a6eb6f1ad47.yaml
@@ -3,4 +3,5 @@ features:
   - |
     Add a content-free ``haystack.agent.hook`` tracing span for every Agent hook invocation. Each span identifies the
     hook point, hook name, and hook type, allowing hook latency and failures to be attributed without tracing the
-    potentially large Agent ``State``.
+    potentially large Agent ``State``. ``CompactionHook`` also adds its configured compaction strategy, estimated
+    context size, whether compaction was triggered, its token target, and whether the compactor returned a replacement.

--- a/test/hooks/compaction/test_hooks.py
+++ b/test/hooks/compaction/test_hooks.py
@@ -12,6 +12,7 @@ from haystack.components.generators.chat import MockChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction import CompactionHook, Compactor, SlidingWindowCompactor, ToolResultPruningCompactor
 from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _estimated_context_tokens, _last_assistant_index
+from haystack.hooks.invocation import _run_hooks, _run_hooks_async
 from haystack.token_counters import TokenCounter
 from haystack.tools import tool
 from haystack.utils.experimental import ExperimentalWarning
@@ -328,3 +329,66 @@ class TestCompactionHookAsync:
         result = await _agent({"before_llm": [_hook()]}).run_async(messages=[ChatMessage.from_user("start")])
         assert count_markers(result["messages"]) == 1
         _assert_every_tool_result_is_answered(result["messages"])
+
+
+class TestCompactionHookTracing:
+    def test_adds_compaction_tags_to_hook_span(self, spying_tracer):
+        compacted = [ChatMessage.from_assistant(text="kept")]
+        hook = _hook(compactor=_RecordingCompactor(result=compacted))
+        state = make_state(messages=[ChatMessage.from_assistant(text="original")], context_tokens=800)
+        _run_hooks(hooks={"before_llm": [hook]}, hook_point="before_llm", state=state)
+        span = spying_tracer.spans[0]
+        assert span.operation_name == "haystack.agent.hook"
+        assert span.parent_span is None
+        assert span.tags == {
+            # From _run_hooks
+            "haystack.agent.hook.point": "before_llm",
+            "haystack.agent.hook.name": "CompactionHook",
+            "haystack.agent.hook.type": "haystack.hooks.compaction.hooks.CompactionHook",
+            # From CompactionHook
+            "haystack.agent.hook.compaction.strategy": "test.hooks.compaction.test_hooks._RecordingCompactor",
+            "haystack.agent.hook.compaction.estimated_context_tokens": 800,
+            "haystack.agent.hook.compaction.triggered": True,
+            "haystack.agent.hook.compaction.target_tokens": 0,
+            "haystack.agent.hook.compaction.compacted": True,
+        }
+
+    def test_traces_when_compaction_is_not_triggered(self, spying_tracer):
+        hook = _hook(compactor=_RecordingCompactor())
+        state = make_state(messages=[ChatMessage.from_assistant(text="original")], context_tokens=300)
+        _run_hooks(hooks={"before_llm": [hook]}, hook_point="before_llm", state=state)
+        span = spying_tracer.spans[0]
+        assert span.operation_name == "haystack.agent.hook"
+        assert span.parent_span is None
+        assert span.tags == {
+            # From _run_hooks
+            "haystack.agent.hook.point": "before_llm",
+            "haystack.agent.hook.name": "CompactionHook",
+            "haystack.agent.hook.type": "haystack.hooks.compaction.hooks.CompactionHook",
+            # From CompactionHook
+            "haystack.agent.hook.compaction.strategy": "test.hooks.compaction.test_hooks._RecordingCompactor",
+            "haystack.agent.hook.compaction.estimated_context_tokens": 300,
+            "haystack.agent.hook.compaction.triggered": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_adds_compaction_tags_to_hook_span_async(self, spying_tracer):
+        compacted = [ChatMessage.from_assistant(text="kept")]
+        hook = _hook(compactor=_RecordingCompactor(result=compacted))
+        state = make_state(messages=[ChatMessage.from_assistant(text="original")], context_tokens=800)
+        await _run_hooks_async(hooks={"before_llm": [hook]}, hook_point="before_llm", state=state)
+        span = spying_tracer.spans[0]
+        assert span.operation_name == "haystack.agent.hook"
+        assert span.parent_span is None
+        assert span.tags == {
+            # From _run_hooks_async
+            "haystack.agent.hook.point": "before_llm",
+            "haystack.agent.hook.name": "CompactionHook",
+            "haystack.agent.hook.type": "haystack.hooks.compaction.hooks.CompactionHook",
+            # From CompactionHook
+            "haystack.agent.hook.compaction.strategy": "test.hooks.compaction.test_hooks._RecordingCompactor",
+            "haystack.agent.hook.compaction.estimated_context_tokens": 800,
+            "haystack.agent.hook.compaction.triggered": True,
+            "haystack.agent.hook.compaction.target_tokens": 0,
+            "haystack.agent.hook.compaction.compacted": True,
+        }

--- a/test/hooks/test_invocation.py
+++ b/test/hooks/test_invocation.py
@@ -2,18 +2,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import functools
 import threading
 
 import pytest
 
 from haystack.components.agents.state import State
-from haystack.hooks import hook
+from haystack.hooks import FunctionHook, hook
 from haystack.hooks.invocation import _run_hooks, _run_hooks_async
 
 
 @hook
 def traced_function_hook(state: State) -> None:
     state.set(key="messages", value=[])
+
+
+def plain_function_hook(state: State) -> None:
+    pass
+
+
+class CallableFunctionHook:
+    def __call__(self, state: State) -> None:
+        pass
 
 
 class RecordingHook:
@@ -90,6 +100,16 @@ class TestRunHooks:
             "haystack.agent.hook.name": "test.hooks.test_invocation.traced_function_hook",
             "haystack.agent.hook.type": "haystack.hooks.from_function.FunctionHook",
         }
+
+    @pytest.mark.parametrize(
+        "function", [functools.partial(plain_function_hook), CallableFunctionHook()], ids=["partial", "callable-object"]
+    )
+    def test_function_hook_name_falls_back_when_callable_has_no_name(self, spying_tracer, function):
+        # We don't support serialization of partials or callable-object instances, so the span name falls back to the
+        # class name.
+        function_hook = FunctionHook(function=function)
+        _run_hooks(hooks={"before_run": [function_hook]}, hook_point="before_run", state=State(schema={}))
+        assert spying_tracer.spans[0].tags["haystack.agent.hook.name"] == "FunctionHook"
 
     def test_no_hooks_does_not_create_span(self, spying_tracer):
         _run_hooks(hooks={}, hook_point="before_llm", state=State(schema={}))

--- a/test/hooks/test_invocation.py
+++ b/test/hooks/test_invocation.py
@@ -7,7 +7,13 @@ import threading
 import pytest
 
 from haystack.components.agents.state import State
+from haystack.hooks import hook
 from haystack.hooks.invocation import _run_hooks, _run_hooks_async
+
+
+@hook
+def traced_function_hook(state: State) -> None:
+    state.set(key="messages", value=[])
 
 
 class RecordingHook:
@@ -57,6 +63,38 @@ class TestRunHooks:
     def test_no_hooks_for_hook_point_is_noop(self):
         _run_hooks(hooks={}, hook_point="before_llm", state=State(schema={}))  # does not raise
 
+    def test_traces_each_hook_invocation_as_a_sibling(self, spying_tracer):
+        log: list = []
+        hooks = {"before_llm": [RecordingHook(label="a", log=log), RecordingHook(label="b", log=log)]}
+        with spying_tracer.trace(operation_name="parent") as parent_span:
+            _run_hooks(hooks=hooks, hook_point="before_llm", state=State(schema={}))
+        hook_spans = [span for span in spying_tracer.spans if span.operation_name == "haystack.agent.hook"]
+        assert len(hook_spans) == 2
+        assert all(span.parent_span is parent_span for span in hook_spans)
+        assert all(
+            span.tags
+            == {
+                "haystack.agent.hook.point": "before_llm",
+                "haystack.agent.hook.name": "RecordingHook",
+                "haystack.agent.hook.type": "test.hooks.test_invocation.RecordingHook",
+            }
+            for span in hook_spans
+        )
+
+    def test_function_hook_span_identifies_wrapped_function(self, spying_tracer):
+        _run_hooks(hooks={"before_run": [traced_function_hook]}, hook_point="before_run", state=State(schema={}))
+        span = spying_tracer.spans[0]
+        assert span.operation_name == "haystack.agent.hook"
+        assert span.tags == {
+            "haystack.agent.hook.point": "before_run",
+            "haystack.agent.hook.name": "test.hooks.test_invocation.traced_function_hook",
+            "haystack.agent.hook.type": "haystack.hooks.from_function.FunctionHook",
+        }
+
+    def test_no_hooks_does_not_create_span(self, spying_tracer):
+        _run_hooks(hooks={}, hook_point="before_llm", state=State(schema={}))
+        assert spying_tracer.spans == []
+
 
 class TestRunHooksAsync:
     @pytest.mark.asyncio
@@ -89,3 +127,20 @@ class TestRunHooksAsync:
         hooks = {"before_llm": [AsyncRecordingHook("a", log), RecordingHook("b", log)]}
         await _run_hooks_async(hooks=hooks, hook_point="before_llm", state=State(schema={}))
         assert log == [("run_async", "a"), ("run", "b")]
+
+    @pytest.mark.asyncio
+    async def test_traces_async_hook_invocation(self, spying_tracer):
+        log: list = []
+        hook_instance = AsyncRecordingHook(label="a", log=log)
+        with spying_tracer.trace(operation_name="parent") as parent_span:
+            await _run_hooks_async(
+                hooks={"after_tool": [hook_instance]}, hook_point="after_tool", state=State(schema={})
+            )
+        hook_span = spying_tracer.spans[1]
+        assert hook_span.operation_name == "haystack.agent.hook"
+        assert hook_span.parent_span is parent_span
+        assert hook_span.tags == {
+            "haystack.agent.hook.point": "after_tool",
+            "haystack.agent.hook.name": "AsyncRecordingHook",
+            "haystack.agent.hook.type": "test.hooks.test_invocation.AsyncRecordingHook",
+        }


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/464

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add a content-free ``haystack.agent.hook`` tracing span for every Agent hook invocation. Each span identifies the hook point, hook name, and hook type, allowing hook latency and failures to be attributed without tracing the potentially large Agent ``State``. ``CompactionHook`` also adds its configured compaction strategy, estimated context size, whether compaction was triggered, its token target, and whether the compactor returned a replacement.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

I will create follow up issues to add tracing inside of our other pre-made hooks. I only added it for `CompactionHook` now to serve as an example. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
