### PR TITLE
refactor: stop guarding warmed hooks

### DIFF
--- a/docs-website/docs/pipeline-components/agents-1/hooks.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/hooks.mdx
@@ -151,7 +151,8 @@ class GradeFinalAnswer:
         self._judge = OpenAIChatGenerator(model=self.model)
 
     def warm_up(self) -> None:
-        # Warm up the judge's own client during the Agent's warm-up.
+        # The Agent calls this before every run, but OpenAIChatGenerator.warm_up
+        # creates its client only on the first call, so repeating it is safe and cheap.
         self._judge.warm_up()
 
     def close(self) -> None:

--- a/docs-website/docs/pipeline-components/agents-1/hooks.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/hooks.mdx
@@ -127,7 +127,7 @@ print(result["last_message"].text)
 
 ### Class-based hooks
 
-A hook is any object with a `run(state)` method; it may additionally define `run_async(state)` for true async behavior. Class-based hooks may also implement the optional lifecycle methods `warm_up` / `warm_up_async` and `close` / `close_async`. The Agent calls them from its own `warm_up` / `close`, so a hook can defer opening clients or reading credentials until warm-up and release them on close.
+A hook is any object with a `run(state)` method; it may additionally define `run_async(state)` for true async behavior. Class-based hooks may also implement the optional lifecycle methods `warm_up` / `warm_up_async` and `close` / `close_async`. The Agent calls them from its own `warm_up` / `close`, so a hook can defer opening clients or reading credentials until warm-up and release them on close. Because warm-up runs before every Agent run, a hook should not repeat expensive initialization: return early if the work is already done, as in `if self._client is not None: return`.
 
 When a class-based hook should be serializable (so an Agent using it can be serialized), implement `to_dict` / `from_dict`: store serializable constructor arguments on the hook and rebuild runtime clients from those values.
 

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -477,7 +477,6 @@ class Agent:
         self.tool_concurrency_limit = tool_concurrency_limit
         self.tool_streaming_callback_passthrough = tool_streaming_callback_passthrough
         self.hooks = hooks
-        self._hooks_warmed_up = False
 
         # --- State schema ---
         # shallow copy is sufficient: we only add a top-level "messages" key, never mutate nested values
@@ -567,29 +566,17 @@ class Agent:
             else:
                 component.set_input_type(self, name=var_name, type=Any, default=None)
 
-    def _warm_up_hooks(self) -> None:
-        """Warm up the configured hooks once."""
-        if not self._hooks_warmed_up:
-            warm_up_hooks(self.hooks)
-            self._hooks_warmed_up = True
-
-    async def _warm_up_hooks_async(self) -> None:
-        """Warm up the configured hooks once, preferring each hook's async warm-up."""
-        if not self._hooks_warmed_up:
-            await warm_up_hooks_async(self.hooks)
-            self._hooks_warmed_up = True
-
     def warm_up(self) -> None:
         """Warm up the tools, hooks, and the underlying chat generator."""
         warm_up_tools(tools=self.tools)
-        self._warm_up_hooks()
+        warm_up_hooks(self.hooks)
         if hasattr(self.chat_generator, "warm_up"):
             self.chat_generator.warm_up()
 
     async def warm_up_async(self) -> None:
         """Warm up the tools, hooks, and the underlying chat generator on the serving event loop."""
         warm_up_tools(tools=self.tools)
-        await self._warm_up_hooks_async()
+        await warm_up_hooks_async(self.hooks)
         if hasattr(self.chat_generator, "warm_up_async"):
             await self.chat_generator.warm_up_async()
         elif hasattr(self.chat_generator, "warm_up"):

--- a/haystack/hooks/protocol.py
+++ b/haystack/hooks/protocol.py
@@ -35,7 +35,9 @@ class Hook(Protocol):
 
     A hook may also implement the optional lifecycle methods `warm_up` / `warm_up_async` and `close` / `close_async`.
     The Agent calls them from its own `warm_up` / `warm_up_async` and `close` / `close_async`, so a hook can defer
-    opening clients or reading credentials until warm-up and release them on close.
+    opening clients or reading credentials until warm-up and release them on close. Because warm-up runs before every
+    Agent run, hooks should avoid repeating expensive initialization, for example by returning early if a client has
+    already been initialized.
     """
 
     def run(self, state: State) -> None:

--- a/releasenotes/notes/rm-agent-hooks-warmup-guard-8f3c1d2a4b5e6f70.yaml
+++ b/releasenotes/notes/rm-agent-hooks-warmup-guard-8f3c1d2a4b5e6f70.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The Agent now warms up its hooks before every run, not only the first one, as it already does for Tools and
+    Toolsets. If your hook has a ``warm_up()`` that does expensive setup (opening a client, loading a model),
+    make it return early once done, for example ``if self._client is not None: return``.

--- a/test/components/agents/test_agent_hooks.py
+++ b/test/components/agents/test_agent_hooks.py
@@ -643,12 +643,12 @@ class TestAgentHookLifecycle:
         Agent(chat_generator=MockChatGenerator(), hooks={"before_llm": [h]})
         assert h.warmed == 0
 
-    def test_warm_up_warms_hooks_once(self):
+    def test_warm_up_warms_hooks_each_call(self):
         h = LifecycleHook()
         agent = Agent(chat_generator=MockChatGenerator(), hooks={"before_llm": [h]})
         agent.warm_up()
         agent.warm_up()
-        assert h.warmed == 1
+        assert h.warmed == 2
 
     def test_reused_hook_warmed_once(self):
         h = LifecycleHook()


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/535

### Proposed Changes:
- the Agent now warms Hooks at every run. As we do for Tools, it's the Hook responsibility to avoid repeating expensive work
- update Hook protocol definition and docs to communicate this

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
