### PR TITLE
test: enable mypy typing checks for test/components/joiners/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ all = 'pytest {args:test}'
 e2e = 'pytest {args:e2e}'
 
 # TODO We want to eventually type the whole test folder
-types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/components/caching/ test/components/embedders/ test/components/generators/ test/components/writers/}"
+types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/components/caching/ test/components/embedders/ test/components/generators/ test/components/joiners/ test/components/writers/}"
 
 [project.urls]
 "CI: GitHub" = "https://github.com/deepset-ai/haystack/actions"

--- a/test/components/joiners/test_answer_joiner.py
+++ b/test/components/joiners/test_answer_joiner.py
@@ -5,7 +5,7 @@
 import pytest
 
 from haystack import Document
-from haystack.components.joiners.answer_joiner import AnswerJoiner, JoinMode
+from haystack.components.joiners.answer_joiner import AnswerJoiner, AnswerType, JoinMode
 from haystack.dataclasses.answer import ExtractedAnswer, GeneratedAnswer
 
 
@@ -86,7 +86,7 @@ class TestAnswerJoiner:
 
     def test_list_of_single_answer(self):
         joiner = AnswerJoiner()
-        answers = [
+        answers: list[AnswerType] = [
             GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")]),
             GeneratedAnswer(query="b", data="b", meta={}, documents=[Document(content="b")]),
             GeneratedAnswer(query="c", data="c", meta={}, documents=[Document(content="c")]),
@@ -96,17 +96,17 @@ class TestAnswerJoiner:
 
     def test_two_lists_of_generated_answers(self):
         joiner = AnswerJoiner()
-        answers1 = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
-        answers2 = [GeneratedAnswer(query="d", data="d", meta={}, documents=[Document(content="d")])]
+        answers1: list[AnswerType] = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
+        answers2: list[AnswerType] = [GeneratedAnswer(query="d", data="d", meta={}, documents=[Document(content="d")])]
         result = joiner.run([answers1, answers2])
         assert result == {"answers": answers1 + answers2}
 
     def test_multiple_lists_of_mixed_answers(self):
         joiner = AnswerJoiner()
-        answers1 = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
-        answers2 = [ExtractedAnswer(query="d", score=0.9, meta={}, document=Document(content="d"))]
-        answers3 = [GeneratedAnswer(query="f", data="f", meta={}, documents=[Document(content="f")])]
-        all_answers = answers1 + answers2 + answers3  # type: ignore
+        answers1: list[AnswerType] = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
+        answers2: list[AnswerType] = [ExtractedAnswer(query="d", score=0.9, meta={}, document=Document(content="d"))]
+        answers3: list[AnswerType] = [GeneratedAnswer(query="f", data="f", meta={}, documents=[Document(content="f")])]
+        all_answers = answers1 + answers2 + answers3
         result = joiner.run([answers1, answers2, answers3])
         assert result == {"answers": all_answers}
 
@@ -117,9 +117,9 @@ class TestAnswerJoiner:
 
     def test_run_with_top_k_in_run_method_overrides_init_top_k(self):
         joiner = AnswerJoiner(top_k=5)
-        answers1 = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
-        answers2 = [GeneratedAnswer(query="b", data="b", meta={}, documents=[Document(content="b")])]
-        answers3 = [GeneratedAnswer(query="c", data="c", meta={}, documents=[Document(content="c")])]
+        answers1: list[AnswerType] = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
+        answers2: list[AnswerType] = [GeneratedAnswer(query="b", data="b", meta={}, documents=[Document(content="b")])]
+        answers3: list[AnswerType] = [GeneratedAnswer(query="c", data="c", meta={}, documents=[Document(content="c")])]
         result = joiner.run([answers1, answers2, answers3], top_k=2)
         assert len(result["answers"]) == 2
 
@@ -127,22 +127,22 @@ class TestAnswerJoiner:
         # A run-time top_k=0 must be honored (return no answers), not treated as "unset"
         # and fall back to the instance's top_k.
         joiner = AnswerJoiner(top_k=5)
-        answers1 = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
-        answers2 = [GeneratedAnswer(query="b", data="b", meta={}, documents=[Document(content="b")])]
+        answers1: list[AnswerType] = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
+        answers2: list[AnswerType] = [GeneratedAnswer(query="b", data="b", meta={}, documents=[Document(content="b")])]
         result = joiner.run([answers1, answers2], top_k=0)
         assert len(result["answers"]) == 0
 
     def test_run_with_negative_top_k_in_run_method_raises(self):
         joiner = AnswerJoiner(top_k=5)
-        answers1 = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
-        answers2 = [GeneratedAnswer(query="b", data="b", meta={}, documents=[Document(content="b")])]
+        answers1: list[AnswerType] = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
+        answers2: list[AnswerType] = [GeneratedAnswer(query="b", data="b", meta={}, documents=[Document(content="b")])]
         with pytest.raises(ValueError, match="top_k must not be negative"):
             joiner.run([answers1, answers2], top_k=-1)
 
     def test_sort_by_score(self):
         joiner = AnswerJoiner(sort_by_score=True)
-        answers1 = [ExtractedAnswer(query="a", score=0.3, meta={}, document=Document(content="a"))]
-        answers2 = [ExtractedAnswer(query="b", score=0.9, meta={}, document=Document(content="b"))]
+        answers1: list[AnswerType] = [ExtractedAnswer(query="a", score=0.3, meta={}, document=Document(content="a"))]
+        answers2: list[AnswerType] = [ExtractedAnswer(query="b", score=0.9, meta={}, document=Document(content="b"))]
         result = joiner.run([answers1, answers2])
         scores = [answer.score for answer in result["answers"]]
         assert scores == [0.9, 0.3]
@@ -151,8 +151,10 @@ class TestAnswerJoiner:
         # The docstring promises that an answer with no score is handled as if its score is -infinity.
         # ExtractedAnswer with score=None must not raise a TypeError during sorting and must be sorted last.
         joiner = AnswerJoiner(sort_by_score=True)
-        answers1 = [ExtractedAnswer(query="a", score=0.5, meta={}, document=Document(content="a"))]
-        answers2 = [ExtractedAnswer(query="b", score=None, meta={}, document=Document(content="b"))]  # type: ignore[arg-type]
+        answers1: list[AnswerType] = [ExtractedAnswer(query="a", score=0.5, meta={}, document=Document(content="a"))]
+        answers2: list[AnswerType] = [
+            ExtractedAnswer(query="b", score=None, meta={}, document=Document(content="b"))  # type: ignore[arg-type]
+        ]
         result = joiner.run([answers1, answers2])
         assert [answer.data for answer in result["answers"]] == [None, None]
         assert [answer.score for answer in result["answers"]] == [0.5, None]
@@ -160,8 +162,8 @@ class TestAnswerJoiner:
     def test_sort_by_score_with_answers_missing_score_attribute(self):
         # GeneratedAnswer has no score attribute at all; it must be handled as -infinity and sorted last.
         joiner = AnswerJoiner(sort_by_score=True)
-        answers1 = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
-        answers2 = [ExtractedAnswer(query="b", score=0.9, meta={}, document=Document(content="b"))]
+        answers1: list[AnswerType] = [GeneratedAnswer(query="a", data="a", meta={}, documents=[Document(content="a")])]
+        answers2: list[AnswerType] = [ExtractedAnswer(query="b", score=0.9, meta={}, document=Document(content="b"))]
         result = joiner.run([answers1, answers2])
         # The ExtractedAnswer (score 0.9) comes first, the GeneratedAnswer (no score) comes last.
         assert isinstance(result["answers"][0], ExtractedAnswer)

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -89,7 +89,7 @@ class TestDocumentJoiner:
             JoinMode.DISTRIBUTION_BASED_RANK_FUSION,
         ],
     )
-    def test_empty_list(self, join_mode: JoinMode):
+    def test_empty_list(self, join_mode: JoinMode) -> None:
         joiner = DocumentJoiner(join_mode=join_mode)
         result = joiner.run([])
         assert result == {"documents": []}
@@ -103,7 +103,7 @@ class TestDocumentJoiner:
             JoinMode.DISTRIBUTION_BASED_RANK_FUSION,
         ],
     )
-    def test_list_of_empty_lists(self, join_mode: JoinMode):
+    def test_list_of_empty_lists(self, join_mode: JoinMode) -> None:
         joiner = DocumentJoiner(join_mode=join_mode)
         result = joiner.run([[], []])
         assert result == {"documents": []}
@@ -117,7 +117,7 @@ class TestDocumentJoiner:
             JoinMode.DISTRIBUTION_BASED_RANK_FUSION,
         ],
     )
-    def test_list_with_one_empty_list(self, join_mode: JoinMode):
+    def test_list_with_one_empty_list(self, join_mode: JoinMode) -> None:
         joiner = DocumentJoiner(join_mode=join_mode)
         documents = [Document(content="a"), Document(content="b"), Document(content="c")]
         result = joiner.run([[], documents])


### PR DESCRIPTION
### Related Issues

- Part of #10396

Using "Part of" rather than "fixes" so the umbrella issue stays open for the remaining directories.

### Proposed Changes:

Adds `test/components/joiners/` to the mypy target and fixes the 23 errors that surfaced.

19 of the 23 have a single cause. `AnswerJoiner.run` takes `Variadic[list[AnswerType]]`, which expands to `Iterable[list[AnswerType]]`. The outer container is covariant but the inner `list` is invariant, so a `list[GeneratedAnswer]` is rejected where `list[GeneratedAnswer | ExtractedAnswer]` is expected.

The fix annotates the test locals as `list[AnswerType]` at the construction site, reusing the alias already exported from `haystack.components.joiners.answer_joiner`.

The alternative was widening the parameter to `Sequence[AnswerType]`, which is covariant and would remove the friction at its source rather than at each call site. I left it out because it changes a public component signature, which seemed out of scope for a test-only change. Happy to switch if you would rather fix it there.

Two smaller points:

- The bare `# type: ignore` on the concatenation in `test_multiple_lists_of_mixed_answers` is no longer needed once the operands share a type, so it is removed.
- The narrow `# type: ignore[arg-type]` on the deliberate `score=None` case is kept, since it asserts intentionally invalid input.

The three added return annotations in `test_document_joiner.py` are only on functions that already annotate `join_mode`, which is what `disallow_incomplete_defs` requires. Fully unannotated tests are left alone.

### How did you test it?

All through hatch, on Python 3.10:

- `hatch run test:types` gives `Success: no issues found in 416 source files`
- `hatch run fmt-check` gives `All checks passed!`
- `hatch run test:unit test/components/joiners` gives `94 passed`
- `pre-commit run` over the changed files: all applicable hooks pass

No behavior changes, so no new tests and no release note.

### Notes for the reviewer

The `Sequence[AnswerType]` question above is the only real decision in here. The rest is mechanical.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `test:`.
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
- n/a Unit tests and docstrings: this only adds type annotations to existing tests, there is no new behavior to cover.
- n/a Release note: test-only change, not user-facing.
