### PR TITLE
test: enable mypy typing checks for test/components/rankers/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ all = 'pytest {args:test}'
 e2e = 'pytest {args:e2e}'
 
 # TODO We want to eventually type the whole test folder
-types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/components/caching/ test/components/embedders/ test/components/generators/ test/components/writers/}"
+types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/components/caching/ test/components/embedders/ test/components/generators/ test/components/rankers/ test/components/writers/}"
 
 [project.urls]
 "CI: GitHub" = "https://github.com/deepset-ai/haystack/actions"

--- a/test/components/rankers/test_llm_ranker.py
+++ b/test/components/rankers/test_llm_ranker.py
@@ -85,6 +85,7 @@ def test_from_dict(monkeypatch):
     assert ranker.top_k == 3
     assert ranker.raise_on_failure is True
     assert ranker.prompt == "Rank {{ documents|length }} docs for {{ query }}"
+    assert isinstance(ranker._chat_generator, OpenAIChatGenerator)
     assert ranker._chat_generator.to_dict() == chat_generator.to_dict()
 
 

--- a/test/components/rankers/test_lost_in_the_middle.py
+++ b/test/components/rankers/test_lost_in_the_middle.py
@@ -121,7 +121,7 @@ class TestLostInTheMiddleRanker:
         assert result["documents"][1].content == "unique"
 
     @pytest.mark.parametrize("top_k", [1, 2, 3, 4, 5, 6, 7, 8, 12, 20])
-    def test_lost_in_the_middle_order_with_top_k(self, top_k: int):
+    def test_lost_in_the_middle_order_with_top_k(self, top_k: int) -> None:
         # tests that lost_in_the_middle order works with an odd number of documents and a top_k parameter
         docs = [Document(content=str(i)) for i in range(1, 10)]
         ranker = LostInTheMiddleRanker()

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -185,7 +185,7 @@ class TestMetaFieldRanker:
 
     def test_raises_value_error_if_wrong_ranking_mode(self):
         with pytest.raises(ValueError):
-            MetaFieldRanker(meta_field="rating", ranking_mode="wrong_mode")
+            MetaFieldRanker(meta_field="rating", ranking_mode="wrong_mode")  # type: ignore[arg-type]
 
     @pytest.mark.parametrize("top_k", [0, -1])
     def test_raises_value_error_if_wrong_top_k(self, top_k):
@@ -207,15 +207,15 @@ class TestMetaFieldRanker:
 
     def test_raises_value_error_if_wrong_sort_order(self):
         with pytest.raises(ValueError):
-            MetaFieldRanker(meta_field="rating", sort_order="wrong_order")
+            MetaFieldRanker(meta_field="rating", sort_order="wrong_order")  # type: ignore[arg-type]
 
     def test_raises_value_error_if_wrong_missing_meta(self):
         with pytest.raises(ValueError):
-            MetaFieldRanker(meta_field="rating", missing_meta="wrong_missing_meta")
+            MetaFieldRanker(meta_field="rating", missing_meta="wrong_missing_meta")  # type: ignore[arg-type]
 
     def test_raises_value_error_if_wrong_meta_value_type(self):
         with pytest.raises(ValueError):
-            MetaFieldRanker(meta_field="rating", meta_value_type="wrong_type")
+            MetaFieldRanker(meta_field="rating", meta_value_type="wrong_type")  # type: ignore[arg-type]
 
     def test_linear_score(self):
         ranker = MetaFieldRanker(meta_field="rating", ranking_mode="linear_score", weight=0.5)


### PR DESCRIPTION
### Related Issues

- Part of #10396

### Proposed Changes:

Adds `test/components/rankers/` to the mypy target and fixes the 6 errors that surfaced.

Four of them are deliberate invalid-input tests. `MetaFieldRanker` takes `Literal` parameters, and these tests pass values outside those literals to assert the constructor raises `ValueError`. They get a narrow `# type: ignore[arg-type]`, since the invalid value is the point of the test.

`test_from_dict` called `to_dict()` on `ranker._chat_generator`, which is typed as the `ChatGenerator` protocol. That protocol deliberately declares only `run()`, so `to_dict()` is not part of it. Rather than suppress that one, the test now asserts the reconstructed generator is an `OpenAIChatGenerator`. That narrows the type for mypy and also covers something the test did not check before, namely that `from_dict` restores the concrete generator class.

The remaining error is a missing return annotation on a function that already annotates `top_k`, which is what `disallow_incomplete_defs` requires.

### How did you test it?

All through hatch, on Python 3.10:

- `hatch run test:types` gives `Success: no issues found in 415 source files`
- `hatch run fmt-check` gives `All checks passed!`
- `hatch run test:unit test/components/rankers` gives `125 passed, 3 deselected`
- `pre-commit run` over the changed files: all applicable hooks pass

No behavior changes, so no new tests and no release note.

### Notes for the reviewer

This edits the same `types` line in `pyproject.toml` as #12318, so whichever merges second will need a one-line rebase. Happy to do that as soon as the first one lands.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `test:`.
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
- n/a Unit tests and docstrings: this only adds type annotations and one assertion to existing tests, there is no new behavior to cover.
- n/a Release note: test-only change, not user-facing.
