### PR TITLE
test: type-check agent state tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ all = 'pytest {args:test}'
 e2e = 'pytest {args:e2e}'
 
 # TODO We want to eventually type the whole test folder
-types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/components/caching/ test/components/embedders/ test/components/generators/ test/components/joiners/ test/components/writers/}"
+types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/components/agents/test_state_class.py test/components/caching/ test/components/embedders/ test/components/generators/ test/components/joiners/ test/components/writers/}"
 
 [project.urls]
 "CI: GitHub" = "https://github.com/deepset-ai/haystack/actions"

--- a/test/components/agents/test_state_class.py
+++ b/test/components/agents/test_state_class.py
@@ -52,7 +52,7 @@ class TestMergeLists:
     def test_merge_two_lists(self):
         current = [1, 2, 3]
         new = [4, 5, 6]
-        result = merge_lists(current, new)
+        result: list[int] = merge_lists(current, new)
         assert result == [1, 2, 3, 4, 5, 6]
         # Ensure original lists weren't modified
         assert current == [1, 2, 3]


### PR DESCRIPTION
### Why:

Continue #10396 with a small, reviewable increment by adding the Agent state tests to the repository's mypy target.

The file had three related errors because mypy inferred the generic type parameter of `merge_lists()` as `Never` when both arguments were lists. An explicit result type supplies the intended `int` context without changing runtime behavior.

### What:

- add `test/components/agents/test_state_class.py` to the `test:types` mypy allowlist
- annotate the merged list result as `list[int]`

### How can it be used:

This runs automatically as part of the existing `hatch run test:types` command.

### How did you test it:

- `uv run --with mypy mypy --install-types --non-interactive --cache-dir=.mypy_cache test/components/agents/test_state_class.py`: no issues
- `uv run --with pytest pytest test/components/agents/test_state_class.py -q`: 52 passed
- `uvx ruff check test/components/agents/test_state_class.py pyproject.toml`: passed
- `uvx ruff format --check test/components/agents/test_state_class.py`: passed

Before the annotation, the focused mypy command reported three errors at the `merge_lists` call; after the annotation it reports none.

### Checklist:

- [x] I have read the contribution guidelines
- [x] I have added or updated tests where needed
- [x] I have run the relevant tests and quality checks
- [x] This is a test/type-checking-only change; no release note is needed
- [x] The commit includes DCO sign-off

### AI assistance

Codex assisted with candidate screening, type-check diagnosis, and validation. I reviewed and understand the submitted change and all reported test results.