### PR TITLE
feat: Add new class variable to chat generators for generation kwarg conversion

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -97,6 +97,12 @@ class OpenAIChatGenerator:
     ```
     """
 
+    _HAYSTACK_TO_PROVIDER_GENERATION_KWARGS: ClassVar[dict[str, str]] = {
+        "max_output_tokens": "max_completion_tokens",
+        "temperature": "temperature",
+        "top_p": "top_p",
+    }
+
     SUPPORTED_MODELS: ClassVar[list[str]] = [
         "gpt-5-mini",
         "gpt-5-nano",

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -97,11 +97,7 @@ class OpenAIChatGenerator:
     ```
     """
 
-    _HAYSTACK_TO_PROVIDER_GENERATION_KWARGS: ClassVar[dict[str, str]] = {
-        "max_output_tokens": "max_completion_tokens",
-        "temperature": "temperature",
-        "top_p": "top_p",
-    }
+    _HAYSTACK_TO_PROVIDER_GENERATION_KWARGS: ClassVar[dict[str, str]] = {"max_output_tokens": "max_completion_tokens"}
 
     SUPPORTED_MODELS: ClassVar[list[str]] = [
         "gpt-5-mini",

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -74,6 +74,12 @@ class OpenAIResponsesChatGenerator:
     ```
     """
 
+    _HAYSTACK_TO_PROVIDER_GENERATION_KWARGS: ClassVar[dict[str, str]] = {
+        "max_output_tokens": "max_output_tokens",
+        "temperature": "temperature",
+        "top_p": "top_p",
+    }
+
     SUPPORTED_MODELS: ClassVar[list[str]] = [
         "gpt-5-mini",
         "gpt-5-nano",

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -74,11 +74,7 @@ class OpenAIResponsesChatGenerator:
     ```
     """
 
-    _HAYSTACK_TO_PROVIDER_GENERATION_KWARGS: ClassVar[dict[str, str]] = {
-        "max_output_tokens": "max_output_tokens",
-        "temperature": "temperature",
-        "top_p": "top_p",
-    }
+    _HAYSTACK_TO_PROVIDER_GENERATION_KWARGS: ClassVar[dict[str, str]] = {"max_output_tokens": "max_output_tokens"}
 
     SUPPORTED_MODELS: ClassVar[list[str]] = [
         "gpt-5-mini",

--- a/haystack/components/generators/chat/utils.py
+++ b/haystack/components/generators/chat/utils.py
@@ -6,11 +6,9 @@ from typing import Any
 
 from haystack.components.generators.chat.types import ChatGenerator
 
-# The provider-neutral generation parameters that Haystack components can request from Chat Generators. These names
-# follow the OpenAI Responses API.
-_HAYSTACK_GENERATION_PARAMETERS = frozenset({"max_output_tokens", "temperature", "top_p"})
-
-_HAYSTACK_TO_PROVIDER_GENERATION_KWARGS = "_HAYSTACK_TO_PROVIDER_GENERATION_KWARGS"
+# The provider-neutral generation parameters that Haystack components can request from Chat Generators.
+# The chosen name is based on OpenAI's Responses API.
+_HAYSTACK_GENERATION_PARAMETERS = frozenset({"max_output_tokens"})
 
 
 def _convert_haystack_generation_kwargs(
@@ -34,9 +32,7 @@ def _convert_haystack_generation_kwargs(
         msg = f"Unknown Haystack generation parameter(s): {unknown}"
         raise ValueError(msg)
 
-    parameter_mapping = getattr(chat_generator, _HAYSTACK_TO_PROVIDER_GENERATION_KWARGS, {})
-    if not isinstance(parameter_mapping, dict):
-        return {}
+    parameter_mapping = getattr(chat_generator, "_HAYSTACK_TO_PROVIDER_GENERATION_KWARGS", {})
 
     return {
         provider_name: haystack_generation_kwargs[haystack_name]

--- a/haystack/components/generators/chat/utils.py
+++ b/haystack/components/generators/chat/utils.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from haystack.components.generators.chat.types import ChatGenerator
+
+# The provider-neutral generation parameters that Haystack components can request from Chat Generators. These names
+# follow the OpenAI Responses API.
+_HAYSTACK_GENERATION_PARAMETERS = frozenset({"max_output_tokens", "temperature", "top_p"})
+
+_HAYSTACK_TO_PROVIDER_GENERATION_KWARGS = "_HAYSTACK_TO_PROVIDER_GENERATION_KWARGS"
+
+
+def _convert_haystack_generation_kwargs(
+    chat_generator: ChatGenerator, haystack_generation_kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    """
+    Convert provider-neutral Haystack generation parameters for a Chat Generator.
+
+    Chat Generators advertise supported parameters through a private class-level mapping from the canonical Haystack
+    name to the provider-specific name. Parameters not advertised by the generator are omitted, allowing callers to
+    provide a fallback for generators that do not expose this optional capability.
+
+    :param chat_generator: The Chat Generator that will receive the converted parameters.
+    :param haystack_generation_kwargs: Generation parameters using Haystack's canonical names.
+    :returns: The supported parameters converted to their provider-specific names.
+    :raises ValueError: If a parameter is not part of Haystack's canonical vocabulary.
+    """
+    unknown_parameters = haystack_generation_kwargs.keys() - _HAYSTACK_GENERATION_PARAMETERS
+    if unknown_parameters:
+        unknown = ", ".join(sorted(unknown_parameters))
+        msg = f"Unknown Haystack generation parameter(s): {unknown}"
+        raise ValueError(msg)
+
+    parameter_mapping = getattr(chat_generator, _HAYSTACK_TO_PROVIDER_GENERATION_KWARGS, {})
+    if not isinstance(parameter_mapping, dict):
+        return {}
+
+    return {
+        provider_name: haystack_generation_kwargs[haystack_name]
+        for haystack_name, provider_name in parameter_mapping.items()
+        if haystack_name in haystack_generation_kwargs
+    }

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 
 import haystack.components.generators.chat.azure as azure_chat_module
 from haystack import Pipeline, component
-from haystack.components.generators.chat import AzureOpenAIChatGenerator
+from haystack.components.generators.chat import AzureOpenAIChatGenerator, OpenAIChatGenerator
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.tools import ComponentTool, Tool
@@ -78,6 +78,12 @@ def tools():
 
 
 class TestAzureOpenAIChatGenerator:
+    def test_haystack_to_provider_generation_kwargs(self) -> None:
+        assert (
+            AzureOpenAIChatGenerator._HAYSTACK_TO_PROVIDER_GENERATION_KWARGS
+            is OpenAIChatGenerator._HAYSTACK_TO_PROVIDER_GENERATION_KWARGS
+        )
+
     def test_supported_models(self) -> None:
         """SUPPORTED_MODELS is a non-empty list of strings."""
         models = AzureOpenAIChatGenerator.SUPPORTED_MODELS

--- a/test/components/generators/chat/test_azure_responses.py
+++ b/test/components/generators/chat/test_azure_responses.py
@@ -11,7 +11,7 @@ import pytest
 from pydantic import BaseModel
 
 from haystack import Pipeline, component
-from haystack.components.generators.chat import AzureOpenAIResponsesChatGenerator
+from haystack.components.generators.chat import AzureOpenAIResponsesChatGenerator, OpenAIResponsesChatGenerator
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import ChatMessage, ToolCall
 from haystack.tools import ComponentTool, Tool
@@ -75,6 +75,12 @@ def tools():
 
 
 class TestInitialization:
+    def test_haystack_to_provider_generation_kwargs(self) -> None:
+        assert (
+            AzureOpenAIResponsesChatGenerator._HAYSTACK_TO_PROVIDER_GENERATION_KWARGS
+            is OpenAIResponsesChatGenerator._HAYSTACK_TO_PROVIDER_GENERATION_KWARGS
+        )
+
     def test_supported_models(self) -> None:
         """SUPPORTED_MODELS is a non-empty list of strings."""
         models = AzureOpenAIResponsesChatGenerator.SUPPORTED_MODELS

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -189,6 +189,11 @@ def tools():
 
 
 class TestOpenAIChatGenerator:
+    def test_haystack_to_provider_generation_kwargs(self) -> None:
+        assert OpenAIChatGenerator._HAYSTACK_TO_PROVIDER_GENERATION_KWARGS == {
+            "max_output_tokens": "max_completion_tokens"
+        }
+
     def test_supported_models(self) -> None:
         """SUPPORTED_MODELS is a non-empty list of strings."""
         models = OpenAIChatGenerator.SUPPORTED_MODELS

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -104,6 +104,11 @@ class RecordingCallback:
 
 
 class TestInitialization:
+    def test_haystack_to_provider_generation_kwargs(self) -> None:
+        assert OpenAIResponsesChatGenerator._HAYSTACK_TO_PROVIDER_GENERATION_KWARGS == {
+            "max_output_tokens": "max_output_tokens"
+        }
+
     def test_supported_models(self) -> None:
         """SUPPORTED_MODELS is a non-empty list of strings."""
         models = OpenAIResponsesChatGenerator.SUPPORTED_MODELS

--- a/test/components/generators/chat/test_utils.py
+++ b/test/components/generators/chat/test_utils.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack.components.generators.chat import MockChatGenerator, OpenAIChatGenerator, OpenAIResponsesChatGenerator
+from haystack.components.generators.chat.utils import (
+    _HAYSTACK_GENERATION_PARAMETERS,
+    _convert_haystack_generation_kwargs,
+)
+
+
+class TestConvertHaystackGenerationKwargs:
+    def test_haystack_generation_parameters(self) -> None:
+        assert {"max_output_tokens", "temperature", "top_p"} == _HAYSTACK_GENERATION_PARAMETERS
+
+    def test_openai_kwargs(self) -> None:
+        converted = _convert_haystack_generation_kwargs(
+            OpenAIChatGenerator.__new__(OpenAIChatGenerator),
+            {"max_output_tokens": 100, "temperature": 0.2, "top_p": 0.9},
+        )
+        assert converted == {"max_completion_tokens": 100, "temperature": 0.2, "top_p": 0.9}
+
+    def test_openai_responses_kwargs(self) -> None:
+        converted = _convert_haystack_generation_kwargs(
+            OpenAIResponsesChatGenerator.__new__(OpenAIResponsesChatGenerator),
+            {"max_output_tokens": 100, "temperature": 0.2, "top_p": 0.9},
+        )
+        assert converted == {"max_output_tokens": 100, "temperature": 0.2, "top_p": 0.9}
+
+    def test_no_mapping(self) -> None:
+        assert _convert_haystack_generation_kwargs(MockChatGenerator(), {"max_output_tokens": 100}) == {}
+
+    def test_invalid_parameter(self) -> None:
+        with pytest.raises(ValueError, match="Unknown Haystack generation parameter\\(s\\): max_tokens"):
+            _convert_haystack_generation_kwargs(MockChatGenerator(), {"max_tokens": 100})

--- a/test/components/generators/chat/test_utils.py
+++ b/test/components/generators/chat/test_utils.py
@@ -2,32 +2,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import ClassVar
+
 import pytest
 
-from haystack.components.generators.chat import MockChatGenerator, OpenAIChatGenerator, OpenAIResponsesChatGenerator
+from haystack.components.generators.chat import MockChatGenerator
 from haystack.components.generators.chat.utils import (
     _HAYSTACK_GENERATION_PARAMETERS,
     _convert_haystack_generation_kwargs,
 )
 
 
+class MappedMockChatGenerator(MockChatGenerator):
+    _HAYSTACK_TO_PROVIDER_GENERATION_KWARGS: ClassVar[dict[str, str]] = {"max_output_tokens": "provider_max_tokens"}
+
+
 class TestConvertHaystackGenerationKwargs:
     def test_haystack_generation_parameters(self) -> None:
-        assert {"max_output_tokens", "temperature", "top_p"} == _HAYSTACK_GENERATION_PARAMETERS
+        assert {"max_output_tokens"} == _HAYSTACK_GENERATION_PARAMETERS
 
-    def test_openai_kwargs(self) -> None:
-        converted = _convert_haystack_generation_kwargs(
-            OpenAIChatGenerator.__new__(OpenAIChatGenerator),
-            {"max_output_tokens": 100, "temperature": 0.2, "top_p": 0.9},
-        )
-        assert converted == {"max_completion_tokens": 100, "temperature": 0.2, "top_p": 0.9}
-
-    def test_openai_responses_kwargs(self) -> None:
-        converted = _convert_haystack_generation_kwargs(
-            OpenAIResponsesChatGenerator.__new__(OpenAIResponsesChatGenerator),
-            {"max_output_tokens": 100, "temperature": 0.2, "top_p": 0.9},
-        )
-        assert converted == {"max_output_tokens": 100, "temperature": 0.2, "top_p": 0.9}
+    def test_conversion(self) -> None:
+        converted = _convert_haystack_generation_kwargs(MappedMockChatGenerator(), {"max_output_tokens": 100})
+        assert converted == {"provider_max_tokens": 100}
 
     def test_no_mapping(self) -> None:
         assert _convert_haystack_generation_kwargs(MockChatGenerator(), {"max_output_tokens": 100}) == {}


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/536

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add a new class variable `_HAYSTACK_TO_PROVIDER_GENERATION_KWARGS` to chat generators containing some common generation kwargs we would like to standardize. The shape is `{"haystack_key": "provider_key"}`. We purposefully keep it private for now to see how well it works in practice. If we like the strategy we will make it public in the future.  

Add private util methods to help auto convert haystack key-ed generation kwargs into the provider specific ones. The plan is to use this method in the Summarization Compactor (POC https://github.com/deepset-ai/haystack/pull/12296) instead of needing to build a provider specific mapping like was done here https://github.com/deepset-ai/haystack/pull/12305

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added new tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

I didn't add a reno since none of the additions are public. 

Also I purposefully limited the number of keys to a small number for now and we can see if want to expand this list in the future. The main key I need for the summarization compactor is the max output tokens. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
