### PR TITLE
fix: ambiguity guard for duplicate tool call names missed mixed-id batches

### DIFF
--- a/haystack/hooks/human_in_the_loop/strategies.py
+++ b/haystack/hooks/human_in_the_loop/strategies.py
@@ -481,8 +481,25 @@ def _apply_tool_execution_decisions(
     decision_by_name = {d.tool_name: d for d in tool_execution_decisions if d.tool_name}
 
     # Known limitation: If tool calls are missing IDs, we rely on tool names to match decisions to tool calls.
-    # This can lead to incorrect matches if there are multiple tool calls in the provided messages with duplicate names.
-    if not decision_by_id and len(decision_by_name) < len(tool_execution_decisions):
+    # This can lead to incorrect matches if there are multiple tool calls in the provided messages with duplicate
+    # names: decision_by_name only keeps one decision per name, so every such tool call whose own id isn't in
+    # decision_by_id would silently match that same single decision.
+    #
+    # The ambiguity has to be checked against the actual tool calls (not just the decisions): a single decision
+    # without a tool_call_id can still be applied to two tool calls that share a name, so counting duplicate names
+    # only among tool_execution_decisions misses the case where there are fewer decisions than matching tool calls.
+    tool_call_name_counts: dict[str, int] = {}
+    for chat_msg in tool_call_messages:
+        for tc in chat_msg.tool_calls or []:
+            if tc.tool_name:
+                tool_call_name_counts[tc.tool_name] = tool_call_name_counts.get(tc.tool_name, 0) + 1
+
+    ambiguous = any(
+        tc.tool_name and tool_call_name_counts.get(tc.tool_name, 0) > 1 and (tc.id or "") not in decision_by_id
+        for chat_msg in tool_call_messages
+        for tc in (chat_msg.tool_calls or [])
+    )
+    if ambiguous:
         raise ValueError(
             "ToolExecutionDecisions are missing tool_call_id fields and there are multiple tool calls with the same "
             "name. When multiple tool calls with the same name are present, tool_call_id is required to correctly "

--- a/releasenotes/notes/fix-hitl-duplicate-tool-name-ambiguity-guard-df9b0f4fcebe6e57.yaml
+++ b/releasenotes/notes/fix-hitl-duplicate-tool-name-ambiguity-guard-df9b0f4fcebe6e57.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed ``_apply_tool_execution_decisions`` in the human-in-the-loop hooks silently applying the wrong
+    ``ToolExecutionDecision`` when multiple tool calls shared the same name. The ambiguity guard only raised
+    when *every* decision was missing a ``tool_call_id``; if just one decision in the batch had an id (even
+    for an unrelated tool call), the guard was skipped entirely. Duplicate-named tool calls whose own decision
+    lacked an id would then fall back to name-based matching, which keeps only one decision per name, so the
+    same decision (and its ``final_tool_params``) could get silently applied to the wrong tool call. A
+    ``ValueError`` is now raised whenever any tool call with a duplicated name can't be matched by id, regardless
+    of whether other decisions in the same batch have one.

--- a/test/hooks/human_in_the_loop/test_strategies.py
+++ b/test/hooks/human_in_the_loop/test_strategies.py
@@ -356,6 +356,64 @@ class TestApplyToolExecutionDecisions:
                 ],
             )
 
+    def test_two_teds_same_name_mixed_ids_raises(self):
+        """
+        Regression test: even when *some* decisions carry a tool_call_id, a duplicate-named tool call whose
+        own decision is missing an id is still ambiguous and must raise, rather than silently falling back
+        to whichever decision happens to be last in decision_by_name.
+        """
+        message_with_tool_calls = ChatMessage.from_assistant(
+            text="I'll extract the information about the people mentioned in the context.",
+            tool_calls=[
+                ToolCall(tool_name="add_database_tool", arguments={"name": "Malte"}, id="1"),
+                ToolCall(tool_name="add_database_tool", arguments={"name": "Milos"}, id="2"),
+                ToolCall(tool_name="unrelated_tool", arguments={"path": "f.txt"}, id="3"),
+            ],
+        )
+        with pytest.raises(
+            ValueError,
+            match="ToolExecutionDecisions are missing tool_call_id fields and there are multiple tool calls with the "
+            "same name",
+        ):
+            _apply_tool_execution_decisions(
+                tool_call_messages=[message_with_tool_calls],
+                tool_execution_decisions=[
+                    ToolExecutionDecision(
+                        tool_name="unrelated_tool", execute=True, tool_call_id="3", final_tool_params={"path": "f.txt"}
+                    ),
+                    # Missing tool_call_id: ambiguous against the two "add_database_tool" calls above, even though
+                    # another decision in this same batch does have an id.
+                    ToolExecutionDecision(
+                        tool_name="add_database_tool", execute=True, final_tool_params={"name": "Milos"}
+                    ),
+                ],
+            )
+
+    def test_two_teds_same_name_all_ids_present(self):
+        """When every tool call sharing a name has its own id-matched decision, matching is unambiguous."""
+        message_with_tool_calls = ChatMessage.from_assistant(
+            text="I'll extract the information about the people mentioned in the context.",
+            tool_calls=[
+                ToolCall(tool_name="add_database_tool", arguments={"name": "Malte"}, id="1"),
+                ToolCall(tool_name="add_database_tool", arguments={"name": "Milos"}, id="2"),
+            ],
+        )
+        rejection_messages, tool_call_messages = _apply_tool_execution_decisions(
+            tool_call_messages=[message_with_tool_calls],
+            tool_execution_decisions=[
+                ToolExecutionDecision(
+                    tool_name="add_database_tool", execute=True, tool_call_id="1", final_tool_params={"name": "Malte"}
+                ),
+                ToolExecutionDecision(
+                    tool_name="add_database_tool", execute=True, tool_call_id="2", final_tool_params={"name": "Milos"}
+                ),
+            ],
+        )
+        assert rejection_messages == []
+        applied_tool_calls = tool_call_messages[0].tool_calls
+        assert applied_tool_calls[0].arguments == {"name": "Malte"}
+        assert applied_tool_calls[1].arguments == {"name": "Milos"}
+
 
 class TestUpdateChatHistory:
     @pytest.fixture


### PR DESCRIPTION
Fixes #11756

_apply_tool_execution_decisions() only raised its duplicate-tool-call-name
ValueError when **every** decision in the batch was missing a
tool_call_id. If a batch mixed id-matched decisions for some tools with a
name-only decision for a duplicated tool name, the guard was skipped
entirely — the name-only decision silently overwrote every tool call
sharing that name via decision_by_name, applying the wrong
final_tool_params with no error raised.

The guard now checks ambiguity per tool call: any tool call whose name is
shared by another tool call in the same messages, and whose own id isn't
in decision_by_id, is ambiguous and raises — regardless of whether other
decisions in the batch happen to carry an id.

Includes two new regression tests and a release note.