### PR TITLE
fix: PythonCodeSplitter emits invalid code for docstring-only bodies

### DIFF
--- a/haystack/components/preprocessors/python_code_splitter.py
+++ b/haystack/components/preprocessors/python_code_splitter.py
@@ -190,10 +190,11 @@ class PythonCodeSplitter:
             return self._slice_lines(source_lines, unit_start, unit_end), None
 
         # Skip stripping when the docstring shares a line with the def/class (would
-        # leave broken syntax) or extends past the caller's slice (e.g. class_header).
+        # leave broken syntax), extends past the caller's slice (e.g. class_header), or
+        # is the body's only statement (stripping it would leave no body at all).
         ds_start = first.lineno
         ds_end = first.end_lineno or first.lineno
-        if ds_start <= node.lineno or ds_end > unit_end:
+        if len(body) == 1 or ds_start <= node.lineno or ds_end > unit_end:
             return self._slice_lines(source_lines, unit_start, unit_end), None
 
         before = source_lines[unit_start - 1 : ds_start - 1]

--- a/releasenotes/notes/python-code-splitter-docstring-only-body-410e6c2a66da1bbf.yaml
+++ b/releasenotes/notes/python-code-splitter-docstring-only-body-410e6c2a66da1bbf.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix ``PythonCodeSplitter`` with ``strip_docstrings=True`` emitting a syntactically
+    invalid chunk for any function, method, or class whose body consists solely of a
+    docstring (for example a one-line custom exception class). Such units are now left
+    unstripped instead of being reduced to a header with no body.

--- a/test/components/preprocessors/test_python_code_splitter.py
+++ b/test/components/preprocessors/test_python_code_splitter.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import ast
 import textwrap
 
 import pytest
@@ -686,6 +687,46 @@ class TestDocstringStripping:
         header = header_chunks[0]
         assert "Class-level docstring." not in (header.content or "")
         assert "Class-level docstring." in " | ".join(header.meta.get("docstrings") or [])
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param(
+                textwrap.dedent(
+                    '''
+                    class MyError(Exception):
+                        """Custom error raised when the widget explodes."""
+                    '''
+                ).lstrip(),
+                id="docstring_only_class",
+            ),
+            pytest.param(
+                textwrap.dedent(
+                    '''
+                    def foo():
+                        """This function intentionally does nothing yet."""
+                    '''
+                ).lstrip(),
+                id="docstring_only_function",
+            ),
+            pytest.param(
+                textwrap.dedent(
+                    '''
+                    class Widget:
+                        def explode(self):
+                            """Explode the widget."""
+                    '''
+                ).lstrip(),
+                id="docstring_only_method",
+            ),
+        ],
+    )
+    def test_strip_docstrings_skips_body_that_is_only_a_docstring(self, source):
+        """A def/class whose sole body statement is the docstring must not be stripped down to an empty body."""
+        splitter = PythonCodeSplitter(min_effective_lines=1, max_effective_lines=10, strip_docstrings=True)
+        result = splitter.run(documents=[Document(content=source)])
+        for chunk in result["documents"]:
+            ast.parse(chunk.content)  # raises SyntaxError if the body was stripped down to nothing
 
 
 class TestTopLevelStatements:


### PR DESCRIPTION
### Related Issues

- fixes #12330

### Proposed Changes:

`_strip_docstring` only refuses to strip a docstring when it shares a line with the `def`/`class` header or extends past the caller's slice. It never checks whether the docstring is the unit's only body statement. When it is, the `before`/`after` slices it composes leave just the header with no body, which is invalid Python.

This adds a third guard, `len(body) == 1`, to the existing bail-out check, so a docstring-only unit is left untouched (docstring kept in the chunk content, nothing added to `meta["docstrings"]`) instead of being reduced to an empty body.

### How did you test it?

- New parametrized test, `TestDocstringStripping::test_strip_docstrings_skips_body_that_is_only_a_docstring` (docstring-only class, function, and method): fails on main with a `SyntaxError` from `ast.parse`, passes on this branch.
- Full `test/components/preprocessors/test_python_code_splitter.py` suite: 72 passed.
- `ruff check` / `ruff format --check` and `check_imports.py` clean on the changed files.
- Not checked: whether the same class of bug exists elsewhere in the splitter for units this fix does not touch.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file.
- [x] I have run pre-commit hooks and fixed any issue.
