### PR TITLE
fix: pinning openai and numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
   "tqdm",
   "tenacity!=8.4.0",
   "lazy-imports",
-  "openai>=2.6.0",
+  # openai 3.x builds on httpx2, while the clients we pass to `http_client` are httpx ones
+  "openai>=2.6.0,<3",
   "pydantic",
   "Jinja2",
   "MarkupSafe",             # already required by Jinja2 but used directly in templatize_part
@@ -86,7 +87,9 @@ docs = "haystack-pydoc pydoc tmp_api_reference"
 
 # we override dependencies from the default environment
 dependencies = [
-  "numpy>=2", # Haystack is compatible both with numpy 1.x and 2.x, but we test with 2.x
+  # Haystack is compatible both with numpy 1.x and 2.x, but we test with 2.x.
+  # numpy 2.5 stubs use PEP 695 `type` statements, which mypy rejects under python_version = "3.10".
+  "numpy>=2,<2.5",
   "numba>=0.54.0", # This pin helps uv resolve the dependency tree. See https://github.com/astral-sh/uv/issues/7881
 
   "pandas",                                           # AzureOCRDocumentConverter, CSVDocumentCleaner, CSVDocumentSplitter,

--- a/releasenotes/notes/pin-openai-below-3-fbc2b95a8fd0b27c.yaml
+++ b/releasenotes/notes/pin-openai-below-3-fbc2b95a8fd0b27c.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Pinned ``openai`` to ``<3``. The OpenAI SDK 3.0 switched its HTTP stack from ``httpx`` to
+    ``httpx2``, and the clients Haystack builds from ``http_client_kwargs`` and passes to
+    ``http_client`` are still ``httpx`` ones. Support for ``openai`` 3.x will be added in a
+    follow-up release.


### PR DESCRIPTION
### Related Issues

- fixes failing mypy tests e.g. https://github.com/deepset-ai/haystack/actions/runs/31675493850/job/94370083742?pr=12328

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Openai just released a version 3 of their sdk that switched to using the httpx2 library instead of httpx. Numpy in version 2.5 added typing stubs that only work with python 3.12

So to get PRs unblocked I've pinned the openai library to less than 3 and the numpy test dep to less than 2.5. 

As a follow up we should see how hard it would be to migrate to openai 3.0 and whether we should update our typing run to run on at least python 3.12 instead of python 3.10

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Existing tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

If we migrate to openai 3.0 before the next haystack release we can delete the reno added in this PR

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
