### PR TITLE
test: enable mypy typing checks for four already-clean test directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ all = 'pytest {args:test}'
 e2e = 'pytest {args:e2e}'
 
 # TODO We want to eventually type the whole test folder
-types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/components/caching/ test/components/embedders/ test/components/generators/ test/components/joiners/ test/components/writers/}"
+types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/fuzz/ test/skill_stores/ test/components/caching/ test/components/embedders/ test/components/generators/ test/components/joiners/ test/components/query/ test/components/validators/ test/components/writers/}"
 
 [project.urls]
 "CI: GitHub" = "https://github.com/deepset-ai/haystack/actions"


### PR DESCRIPTION
### Related Issues

- Part of #10396

### Proposed Changes:

`test/components/query/`, `test/components/validators/`, `test/fuzz/` and `test/skill_stores/` already pass mypy under the current settings. This adds them to the `types` target, with no code changes at all.

Adding them is not a no-op: until a directory is in the target, nothing stops a later change from introducing type errors there. This locks in the state those four are already in, and takes four directories off the list in #10396 in one line.

I bundled them rather than opening four PRs, since the diff is the same single line either way. Happy to split them if you would rather have one directory per PR to match the checklist.

`test/fuzz/` holds fuzz harnesses rather than tests, so it is slightly different in kind from the rest, but it is on the checklist in #10396 and it passes clean, so I included it. Easy to drop if you would rather leave it out.

### How did you test it?

All through hatch, on Python 3.10:

- `hatch run test:types` gives `Success: no issues found in 425 source files`
- `hatch run fmt-check` gives `All checks passed!`
- `hatch run test:unit` on the four directories gives `84 passed, 1 skipped`
- `pre-commit run` on `pyproject.toml`: all applicable hooks pass

### Notes for the reviewer

This edits the same `types` line as #12319, so whichever merges second will need a one-line update. Happy to handle that on my side rather than have you hit "Update branch" again.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `test:`.
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
- n/a Unit tests and docstrings: no code changes, this only extends the mypy target.
- n/a Release note: test-only change, not user-facing.
