### PR TITLE
feat: allow skipping serialization of certain keys in `State.to_dict`

### DIFF
--- a/haystack/components/agents/state/state.py
+++ b/haystack/components/agents/state/state.py
@@ -189,15 +189,23 @@ class State:
         """
         return key in self._data
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self, skip_keys: list[str] | None = None) -> dict[str, Any]:
         """
         Convert the State object to a dictionary.
+
+        :param skip_keys: List of keys to skip during serialization
+        :returns: Dictionary representation of the State object
         """
+        skipped = set(skip_keys or [])
+        schema = {key: definition for key, definition in self.schema.items() if key not in skipped}
+        data = {key: value for key, value in self._data.items() if key not in skipped}
+
         serialized = {}
-        serialized["schema"] = _schema_to_dict(self.schema)
+        serialized["schema"] = _schema_to_dict(schema=schema)
         # Field-level fallback so a single non-serializable value omits only that field instead of
         # failing the whole State serialization.
-        serialized["data"] = _serialize_with_field_fallback(self._data, description="the agent's State data")
+        serialized["data"] = _serialize_with_field_fallback(data, description="the agent's State data")
+
         return serialized
 
     @classmethod

--- a/haystack/components/agents/state/state.py
+++ b/haystack/components/agents/state/state.py
@@ -196,15 +196,15 @@ class State:
         :param skip_keys: List of keys to skip during serialization
         :returns: Dictionary representation of the State object
         """
-        skipped = set(skip_keys or [])
-        schema = {key: definition for key, definition in self.schema.items() if key not in skipped}
-        data = {key: value for key, value in self._data.items() if key not in skipped}
+        skip_keys = skip_keys or []
+        schema = {key: definition for key, definition in self.schema.items() if key not in skip_keys}
+        data = {key: value for key, value in self._data.items() if key not in skip_keys}
 
         serialized = {}
         serialized["schema"] = _schema_to_dict(schema=schema)
         # Field-level fallback so a single non-serializable value omits only that field instead of
         # failing the whole State serialization.
-        serialized["data"] = _serialize_with_field_fallback(data, description="the agent's State data")
+        serialized["data"] = _serialize_with_field_fallback(payload=data, description="the agent's State data")
 
         return serialized
 

--- a/releasenotes/notes/state-todict-skipkeys-ec8c5dc61354c015.yaml
+++ b/releasenotes/notes/state-todict-skipkeys-ec8c5dc61354c015.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    ``State.to_dict`` now accepts a ``skip_keys`` parameter to exclude specific keys from the output.

--- a/test/components/agents/test_state_class.py
+++ b/test/components/agents/test_state_class.py
@@ -424,6 +424,30 @@ class TestState:
             },
         }
 
+    def test_state_to_dict_skip_keys(self):
+        state_schema = {"numbers": {"type": int}, "messages": {"type": list[ChatMessage]}}
+
+        data = {"numbers": 1, "messages": [ChatMessage.from_user(text="Hello, world!")]}
+        state = State(state_schema, data)
+        state_dict = state.to_dict(skip_keys=["numbers"])
+        assert state_dict["schema"] == {
+            "messages": {
+                "type": "list[haystack.dataclasses.chat_message.ChatMessage]",
+                "handler": "haystack.components.agents.state.state_utils.merge_lists",
+            }
+        }
+        assert state_dict["data"] == {
+            "serialization_schema": {
+                "type": "object",
+                "properties": {
+                    "messages": {"type": "array", "items": {"type": "haystack.dataclasses.chat_message.ChatMessage"}}
+                },
+            },
+            "serialized_data": {
+                "messages": [{"role": "user", "meta": {}, "name": None, "content": [{"text": "Hello, world!"}]}]
+            },
+        }
+
     def test_state_from_dict(self):
         state_dict = {
             "schema": {


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/522

### Proposed Changes:
- add `skip_keys` parameter to `State.to_dict` to allow skipping serialization of keys

### How did you test it?
CI, new test

### Notes for the reviewer
I verified that it achieves the same effect as the `_without_live_agent_resources` utility function in https://github.com/deepset-ai/hayhooks/pull/253

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
