### PR TITLE
fix: fix non-deterministic Pipeline conversion for union in receivers

### DIFF
--- a/haystack/core/type_utils.py
+++ b/haystack/core/type_utils.py
@@ -29,6 +29,18 @@ class ConversionStrategy(Enum):
 
 ConversionStrategyType = ConversionStrategy | None
 
+# Priority used to pick a strategy when a Union receiver admits more than one conversion
+_STRATEGY_PRIORITY = (
+    ConversionStrategy.WRAP,
+    ConversionStrategy.UNWRAP,
+    ConversionStrategy.CHAT_MESSAGE_TO_STR,
+    ConversionStrategy.STR_TO_CHAT_MESSAGE,
+    ConversionStrategy.WRAP_CHAT_MESSAGE_TO_STR,
+    ConversionStrategy.WRAP_STR_TO_CHAT_MESSAGE,
+    ConversionStrategy.UNWRAP_CHAT_MESSAGE_TO_STR,
+    ConversionStrategy.UNWRAP_STR_TO_CHAT_MESSAGE,
+)
+
 
 def _resolve_parameter_types(target: Callable) -> dict[str, Any]:
     """
@@ -213,13 +225,13 @@ def _get_conversion_strategy(sender: Any, receiver: Any) -> ConversionStrategyTy
         return None
 
     # If receiver is a Union, it's compatible if ANY of its types are compatible.
-    # We prefer strategies that don't require type conversion if possible.
+    # When several members admit different conversions, decide based on _STRATEGY_PRIORITY.
     if _safe_get_origin(receiver) is Union:
-        strategies = {_get_conversion_strategy(sender, arg) for arg in get_args(receiver)} - {None}
-        for preferred in (ConversionStrategy.WRAP, ConversionStrategy.UNWRAP):
+        strategies = {_get_conversion_strategy(sender, arg) for arg in get_args(receiver)}
+        for preferred in _STRATEGY_PRIORITY:
             if preferred in strategies:
                 return preferred
-        return strategies.pop() if strategies else None
+        return None
 
     # ChatMessage -> str
     if sender is ChatMessage and receiver is str:

--- a/releasenotes/notes/fix-nondeterministic-conversion-strategy-f6ffd9ca15231e18.yaml
+++ b/releasenotes/notes/fix-nondeterministic-conversion-strategy-f6ffd9ca15231e18.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Pipeline connections now always convert values in the same way. Before, when an output was connected to an
+    input accepting multiple types (for example ``ChatMessage`` connected to ``str | list[str]``) and more
+    than one conversion was possible, the choice was not deterministic: the same pipeline could deliver ``"hello"``
+    in one run and ``["hello"]`` in another. Conversion is now chosen using a fixed priority: first, wrapping a value
+    in a list or unwrapping a single-element list; second, converting between ``ChatMessage`` and ``str``; and last,
+    combining both conversions.

--- a/releasenotes/notes/fix-nondeterministic-conversion-strategy-f6ffd9ca15231e18.yaml
+++ b/releasenotes/notes/fix-nondeterministic-conversion-strategy-f6ffd9ca15231e18.yaml
@@ -1,9 +1,11 @@
 ---
 fixes:
   - |
-    Pipeline connections now always convert values in the same way. Before, when an output was connected to an
-    input accepting multiple types (for example ``ChatMessage`` connected to ``str | list[str]``) and more
-    than one conversion was possible, the choice was not deterministic: the same pipeline could deliver ``"hello"``
-    in one run and ``["hello"]`` in another. Conversion is now chosen using a fixed priority: first, wrapping a value
-    in a list or unwrapping a single-element list; second, converting between ``ChatMessage`` and ``str``; and last,
-    combining both conversions.
+    Pipeline connections now always convert values in the same way. When a component output is connected to an
+    input that accepts multiple types, Haystack is sometimes able to automatically convert the value, and more
+    than one conversion may be possible. For example, a ``ChatMessage`` with text "hello" connected to an input
+    annotated ``str | list[str]`` can be delivered either as plain text (``"hello"``) or as a list containing the
+    text (``["hello"]``). Previously the conversion strategy was chosen non-deterministically, so the same
+    pipeline could return a different value across runs. The conversion strategy is now selected using a fixed
+    priority: first, wrapping a value in a list or unwrapping a single-element list; second, converting between
+    ``ChatMessage`` and ``str``; and last, combining both conversions.

--- a/test/core/test_type_utils.py
+++ b/test/core/test_type_utils.py
@@ -13,6 +13,7 @@ import pytest
 
 from haystack.core.component.types import Variadic
 from haystack.core.type_utils import (
+    _STRATEGY_PRIORITY,
     ConversionStrategy,
     _chat_message_to_str,
     _contains_type,
@@ -905,6 +906,9 @@ def test_contains_type():
 
 
 class TestConversion:
+    def test_strategy_priority_covers_all_strategies(self):
+        assert set(_STRATEGY_PRIORITY) == set(ConversionStrategy)
+
     def test_chat_message_to_str(self):
         with pytest.raises(ValueError, match="Cannot convert `ChatMessage` to `str` because it has no text. "):
             _chat_message_to_str(value=ChatMessage.from_assistant())

--- a/test/core/test_type_utils.py
+++ b/test/core/test_type_utils.py
@@ -1022,6 +1022,8 @@ class TestConversion:
             ConversionStrategy.STR_TO_CHAT_MESSAGE,
         )
 
+        assert _types_are_compatible(sender=int, receiver=str | ChatMessage) == (False, None)
+
         assert _types_are_compatible(sender=ChatMessage, receiver=list[ChatMessage] | None) == (
             True,
             ConversionStrategy.WRAP,
@@ -1030,8 +1032,6 @@ class TestConversion:
             True,
             ConversionStrategy.WRAP,
         )
-
-        assert _types_are_compatible(sender=int, receiver=str | ChatMessage) == (False, None)
 
     def test_union_in_receiver_strategy_priority(self):
         assert _types_are_compatible(sender=ChatMessage, receiver=list[str] | list[ChatMessage]) == (
@@ -1042,19 +1042,8 @@ class TestConversion:
             True,
             ConversionStrategy.WRAP,
         )
+
         assert _types_are_compatible(sender=str, receiver=list[str] | list[ChatMessage]) == (
-            True,
-            ConversionStrategy.WRAP,
-        )
-        assert _types_are_compatible(sender=str, receiver=Union[list[str], ChatMessage]) == (
-            True,
-            ConversionStrategy.WRAP,
-        )
-        assert _types_are_compatible(sender=ChatMessage, receiver=str | list[ChatMessage]) == (
-            True,
-            ConversionStrategy.WRAP,
-        )
-        assert _types_are_compatible(sender=ChatMessage, receiver=str | list[str] | list[ChatMessage]) == (
             True,
             ConversionStrategy.WRAP,
         )
@@ -1080,6 +1069,19 @@ class TestConversion:
         assert _types_are_compatible(sender=str, receiver=Union[ChatMessage, list[ChatMessage]]) == (
             True,
             ConversionStrategy.STR_TO_CHAT_MESSAGE,
+        )
+
+        assert _types_are_compatible(sender=ChatMessage, receiver=str | list[ChatMessage]) == (
+            True,
+            ConversionStrategy.WRAP,
+        )
+        assert _types_are_compatible(sender=str, receiver=Union[list[str], ChatMessage]) == (
+            True,
+            ConversionStrategy.WRAP,
+        )
+        assert _types_are_compatible(sender=ChatMessage, receiver=str | list[str] | list[ChatMessage]) == (
+            True,
+            ConversionStrategy.WRAP,
         )
 
     def test_convert_value(self):

--- a/test/core/test_type_utils.py
+++ b/test/core/test_type_utils.py
@@ -1000,47 +1000,6 @@ class TestConversion:
         # multi-level wrap not supported
         assert _types_are_compatible(sender=str, receiver=List[List[str]]) == (False, None)
 
-        ### Handle Union in receiver + conversion
-        assert _types_are_compatible(sender=ChatMessage, receiver=list[str] | list[ChatMessage]) == (
-            True,
-            ConversionStrategy.WRAP,
-        )
-        assert _types_are_compatible(sender=ChatMessage, receiver=Union[list[str], list[ChatMessage]]) == (
-            True,
-            ConversionStrategy.WRAP,
-        )
-
-        assert _types_are_compatible(sender=str, receiver=list[str] | list[ChatMessage]) == (
-            True,
-            ConversionStrategy.WRAP,
-        )
-
-        assert _types_are_compatible(sender=list[ChatMessage], receiver=str | ChatMessage) == (
-            True,
-            ConversionStrategy.UNWRAP,
-        )
-        assert _types_are_compatible(sender=list[str], receiver=str | ChatMessage) == (True, ConversionStrategy.UNWRAP)
-
-        assert _types_are_compatible(sender=ChatMessage, receiver=str | int) == (
-            True,
-            ConversionStrategy.CHAT_MESSAGE_TO_STR,
-        )
-        assert _types_are_compatible(sender=str, receiver=ChatMessage | int) == (
-            True,
-            ConversionStrategy.STR_TO_CHAT_MESSAGE,
-        )
-
-        assert _types_are_compatible(sender=int, receiver=str | ChatMessage) == (False, None)
-
-        assert _types_are_compatible(sender=ChatMessage, receiver=list[ChatMessage] | None) == (
-            True,
-            ConversionStrategy.WRAP,
-        )
-        assert _types_are_compatible(sender=ChatMessage, receiver=Optional[list[ChatMessage]]) == (
-            True,
-            ConversionStrategy.WRAP,
-        )
-
         ### Union inner types in list sender
         assert _types_are_compatible(sender=list[str | int], receiver=ChatMessage) == (False, None)
         assert _types_are_compatible(sender=List[str | int], receiver=ChatMessage) == (False, None)
@@ -1052,6 +1011,76 @@ class TestConversion:
         assert _types_are_compatible(sender=list[str | ChatMessage], receiver=str) == (False, None)
         assert _types_are_compatible(sender=list[str | None], receiver=str) == (False, None)
         assert _types_are_compatible(sender=List[Optional[str]], receiver=str) == (False, None)
+
+    def test_union_in_receiver_conversion(self):
+        assert _types_are_compatible(sender=ChatMessage, receiver=str | int) == (
+            True,
+            ConversionStrategy.CHAT_MESSAGE_TO_STR,
+        )
+        assert _types_are_compatible(sender=str, receiver=ChatMessage | int) == (
+            True,
+            ConversionStrategy.STR_TO_CHAT_MESSAGE,
+        )
+
+        assert _types_are_compatible(sender=ChatMessage, receiver=list[ChatMessage] | None) == (
+            True,
+            ConversionStrategy.WRAP,
+        )
+        assert _types_are_compatible(sender=ChatMessage, receiver=Optional[list[ChatMessage]]) == (
+            True,
+            ConversionStrategy.WRAP,
+        )
+
+        assert _types_are_compatible(sender=int, receiver=str | ChatMessage) == (False, None)
+
+    def test_union_in_receiver_strategy_priority(self):
+        assert _types_are_compatible(sender=ChatMessage, receiver=list[str] | list[ChatMessage]) == (
+            True,
+            ConversionStrategy.WRAP,
+        )
+        assert _types_are_compatible(sender=ChatMessage, receiver=Union[list[str], list[ChatMessage]]) == (
+            True,
+            ConversionStrategy.WRAP,
+        )
+        assert _types_are_compatible(sender=str, receiver=list[str] | list[ChatMessage]) == (
+            True,
+            ConversionStrategy.WRAP,
+        )
+        assert _types_are_compatible(sender=str, receiver=Union[list[str], ChatMessage]) == (
+            True,
+            ConversionStrategy.WRAP,
+        )
+        assert _types_are_compatible(sender=ChatMessage, receiver=str | list[ChatMessage]) == (
+            True,
+            ConversionStrategy.WRAP,
+        )
+        assert _types_are_compatible(sender=ChatMessage, receiver=str | list[str] | list[ChatMessage]) == (
+            True,
+            ConversionStrategy.WRAP,
+        )
+
+        assert _types_are_compatible(sender=list[ChatMessage], receiver=str | ChatMessage) == (
+            True,
+            ConversionStrategy.UNWRAP,
+        )
+        assert _types_are_compatible(sender=list[str], receiver=str | ChatMessage) == (True, ConversionStrategy.UNWRAP)
+
+        assert _types_are_compatible(sender=ChatMessage, receiver=Union[str, list[str]]) == (
+            True,
+            ConversionStrategy.CHAT_MESSAGE_TO_STR,
+        )
+        assert _types_are_compatible(sender=ChatMessage, receiver=str | list[str]) == (
+            True,
+            ConversionStrategy.CHAT_MESSAGE_TO_STR,
+        )
+        assert _types_are_compatible(sender=ChatMessage, receiver=list[str] | str) == (
+            True,
+            ConversionStrategy.CHAT_MESSAGE_TO_STR,
+        )
+        assert _types_are_compatible(sender=str, receiver=Union[ChatMessage, list[ChatMessage]]) == (
+            True,
+            ConversionStrategy.STR_TO_CHAT_MESSAGE,
+        )
 
     def test_convert_value(self):
         with pytest.raises(ValueError, match="Cannot convert `ChatMessage` to `str` because it has no text. "):


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/12282

### Proposed Changes:

- when a union receiver supports more than one conversion strategy, decide based on a fixed strategy priority (as we were already doing for wrap and unwrap)

### How did you test it?
CI + new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
