### PR TITLE
feat: add confirmation-gated TaskMarket toolset

### DIFF
--- a/docs-website/docs/tools/taskmarkettoolset.mdx
+++ b/docs-website/docs/tools/taskmarkettoolset.mdx
@@ -1,0 +1,92 @@
+---
+title: "TaskMarketToolset"
+id: taskmarkettoolset
+slug: "/taskmarkettoolset"
+description: "Expose confirmation-gated TaskMarket discovery and task-request tools to Haystack agents."
+---
+
+# TaskMarketToolset
+
+`TaskMarketToolset` exposes TaskMarket discovery and task-request operations as Haystack tools. It is intended for agents that need to find or request work through the TaskMarket API while keeping spending and submission decisions under application control.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Mandatory init variables** | None for read-only operation; provide `approval` to enable task creation |
+| **API reference**            | [TaskMarketToolset](/reference/tools-api#taskmarkettoolset) |
+| **GitHub link**              | https://github.com/deepset-ai/haystack/blob/main/haystack/tools/taskmarket.py |
+| **Package name**             | `haystack-ai` |
+
+</div>
+
+## Overview
+
+The toolset provides five tools:
+
+- `taskmarket_list_tasks`: list public tasks without spending funds.
+- `taskmarket_get_task`: retrieve the current status of a task.
+- `taskmarket_list_submissions`: retrieve submissions for application-level review.
+- `taskmarket_preview_task`: normalize a proposed request and calculate its maximum Base USDC spend without writing anything.
+- `taskmarket_create_task`: create a task only after a matching preview, `confirm=True`, an application-provided approval callback, and a Base USDC balance check.
+
+The write path calls the first-party `taskmarket` CLI exactly once after preflight. It does not accept or reject submissions, does not receive wallet private keys, and does not retry an ambiguous write. If a write times out, inspect TaskMarket before deciding whether any follow-up is appropriate.
+
+## Installation
+
+Install the TaskMarket CLI separately when task creation is needed:
+
+```shell
+npm install -g @lucid-agents/taskmarket
+```
+
+Read-only tools use the public TaskMarket HTTP API and do not require the CLI.
+
+## Usage
+
+```python
+from typing import Any
+
+from haystack.tools import TaskMarketToolset
+
+
+def approve_task(preview: dict[str, Any]) -> bool:
+    """Connect this callback to the application's human or policy approval flow."""
+    print(f"Review {preview['rewardUsdc']} USDC: {preview['description']}")
+    return application_policy_allows(preview)  # Replace with your approval flow.
+
+
+toolset = TaskMarketToolset(approval=approve_task)
+```
+
+Without an `approval` callback, the toolset remains safe for discovery and preview but blocks task creation.
+
+### Preview before creating
+
+Call `taskmarket_preview_task` first. The result contains the canonical request, Base chain ID, USDC contract, deadline, maximum spend, and a short-lived confirmation token. The maximum spend includes the configured platform and relay fees, so the approval flow can show the full amount before any CLI write.
+
+```python
+preview = next(t for t in toolset if t.name == "taskmarket_preview_task").invoke(
+    description="Build and test a small Haystack component",
+    reward_usdc="1.00",
+    duration_hours=24,
+    mode="bounty",
+)
+
+created = next(t for t in toolset if t.name == "taskmarket_create_task").invoke(
+    description="Build and test a small Haystack component",
+    reward_usdc="1.00",
+    duration_hours=24,
+    confirmation_token=preview["confirmationToken"],
+    confirm=True,
+    mode="bounty",
+)
+```
+
+The application should treat a result with `status="unknown"` as an indeterminate write and reconcile it through `taskmarket_get_task` or the TaskMarket CLI before attempting anything else.
+
+:::warning
+
+Task creation spends USDC. Use a real approval callback, keep the CLI wallet configured for Base USDC, and never put a private key in a Haystack pipeline or tool argument.
+
+:::

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -733,6 +733,7 @@ export default {
         'tools/componenttool',
         'tools/pipelinetool',
         'tools/toolset',
+        'tools/taskmarkettoolset',
         'tools/mcptool',
         'tools/mcptoolset',
         'tools/searchabletoolset',

--- a/haystack/tools/__init__.py
+++ b/haystack/tools/__init__.py
@@ -24,6 +24,7 @@ from haystack.tools.from_function import create_tool_from_function, tool
 from haystack.tools.tool import Tool, _check_duplicate_tool_names
 
 _import_structure = {
+    "taskmarket": ["TaskMarketToolset"],
     "toolset": ["Toolset"],
     "searchable_toolset": ["SearchableToolset"],
     "skills": ["SkillToolset"],
@@ -43,6 +44,7 @@ if TYPE_CHECKING:
     from haystack.tools.serde_utils import deserialize_tools_or_toolset_inplace as deserialize_tools_or_toolset_inplace
     from haystack.tools.serde_utils import serialize_tools_or_toolset as serialize_tools_or_toolset
     from haystack.tools.skills import SkillToolset as SkillToolset
+    from haystack.tools.taskmarket import TaskMarketToolset as TaskMarketToolset
     from haystack.tools.tool_types import ToolsType as ToolsType
     from haystack.tools.toolset import Toolset as Toolset
     from haystack.tools.utils import flatten_tools_or_toolsets as flatten_tools_or_toolsets

--- a/haystack/tools/taskmarket.py
+++ b/haystack/tools/taskmarket.py
@@ -1,0 +1,519 @@
+# SPDX-FileCopyrightText: 2026-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""TaskMarket requester tools for Haystack agents."""
+
+import hashlib
+import json
+import math
+import re
+import shutil
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import ROUND_CEILING, Decimal, InvalidOperation
+from typing import Annotated, Any, Literal
+
+import httpx
+
+from haystack.core.serialization import generate_qualified_class_name
+
+from .from_function import create_tool_from_function
+from .toolset import Toolset
+
+DEFAULT_API_URL = "https://api.taskmarket.dev"
+DEFAULT_CLI = "taskmarket"
+BASE_CHAIN_ID = 8453
+USDC_CONTRACT = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+PLATFORM_FEE_BPS = Decimal("750")
+RELAY_FEE_USDC = Decimal("0.001")
+USDC_QUANTUM = Decimal("0.000001")
+PREVIEW_TTL = timedelta(minutes=15)
+TaskMode = Literal["bounty", "claim", "pitch", "benchmark"]
+SUPPORTED_MODES = frozenset({"bounty", "claim", "pitch", "benchmark"})
+JsonTransport = Callable[[str, str, dict[str, str], dict[str, Any] | None], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class _PendingPreview:
+    request: dict[str, Any]
+    deadline: datetime
+    expires_at: datetime
+    maximum_spend: Decimal
+
+
+@dataclass(frozen=True)
+class _CliResult:
+    succeeded: bool
+    data: dict[str, Any] | None = None
+    error: str | None = None
+    ambiguous: bool = False
+
+
+@dataclass(frozen=True)
+class _CreationContext:
+    pending: _PendingPreview
+    request: dict[str, Any]
+    confirmation_token: str
+
+
+class TaskMarketToolset(Toolset):
+    """
+    A confirmation-gated TaskMarket requester toolset.
+
+    Read tools use TaskMarket's public HTTP API. The write path requires a
+    matching preview, ``confirm=True``, and an application-provided approval
+    callback. Before calling the first-party CLI once, it checks Base/USDC
+    configuration and balance. The toolset never receives wallet keys and has
+    no operation for accepting or rejecting submissions.
+
+    :param api_url: TaskMarket API origin.
+    :param cli_path: First-party ``taskmarket`` executable name or path.
+    :param timeout: HTTP and CLI timeout in seconds.
+    :param approval: Callback that presents the exact preview to a human and
+        returns whether task creation is authorized.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_url: str = DEFAULT_API_URL,
+        cli_path: str = DEFAULT_CLI,
+        timeout: float = 15.0,
+        approval: Callable[[dict[str, Any]], bool] | None = None,
+        transport: JsonTransport | None = None,
+        cli_runner: Callable[[list[str], bool], _CliResult] | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        if not api_url.strip():
+            raise ValueError("`api_url` must not be empty")
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError("`timeout` must be a positive finite number")
+
+        self.api_url = api_url.rstrip("/")
+        self.cli_path = cli_path
+        self.timeout = timeout
+        self._approval = approval
+        self._transport = transport
+        self._cli_runner = cli_runner
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._pending_previews: dict[str, _PendingPreview] = {}
+
+        super().__init__(
+            tools=[
+                create_tool_from_function(
+                    self.list_tasks,
+                    name="taskmarket_list_tasks",
+                    description="List live TaskMarket tasks without spending funds.",
+                ),
+                create_tool_from_function(
+                    self.get_task, name="taskmarket_get_task", description="Retrieve live status for a TaskMarket task."
+                ),
+                create_tool_from_function(
+                    self.list_submissions,
+                    name="taskmarket_list_submissions",
+                    description="List TaskMarket submissions for human review only.",
+                ),
+                create_tool_from_function(
+                    self.preview_task,
+                    name="taskmarket_preview_task",
+                    description="Prepare an exact TaskMarket request for review without spending funds.",
+                ),
+                create_tool_from_function(
+                    self.create_task,
+                    name="taskmarket_create_task",
+                    description=(
+                        "Create a TaskMarket task only after a matching preview and human approval. "
+                        "Never accept or reject submissions automatically."
+                    ),
+                ),
+            ]
+        )
+
+    def list_tasks(
+        self,
+        status: Annotated[str, "Task status to list"] = "open",
+        mode: Annotated[str | None, "Optional task mode"] = None,
+        tags: Annotated[list[str] | None, "Optional tags that must match"] = None,
+        limit: Annotated[int, "Maximum number of tasks to return"] = 20,
+    ) -> dict[str, Any]:
+        """List live public tasks."""
+        if not 1 <= limit <= 100:
+            return {"error": "`limit` must be between 1 and 100", "retry": False}
+        params = {"status": status, "limit": str(limit)}
+        if mode:
+            params["mode"] = mode
+        if tags:
+            params["tags"] = ",".join(tag.strip() for tag in tags if tag.strip())
+        return self._request_json("GET", "/api/tasks", params=params)
+
+    def get_task(self, task_id: Annotated[str, "0x-prefixed TaskMarket task ID"]) -> dict[str, Any]:
+        """Retrieve a live task without changing it."""
+        error = _validate_task_id(task_id)
+        if error:
+            return {"error": error, "retry": False}
+        return self._request_json("GET", f"/api/tasks/{task_id}")
+
+    def list_submissions(self, task_id: Annotated[str, "0x-prefixed TaskMarket task ID"]) -> dict[str, Any]:
+        """Return submissions for human review without accepting work."""
+        error = _validate_task_id(task_id)
+        if error:
+            return {"error": error, "retry": False}
+        return self._request_json("GET", f"/api/tasks/{task_id}/submissions")
+
+    def preview_task(
+        self,
+        description: Annotated[str, "Complete task deliverable description"],
+        reward_usdc: Annotated[str, "Positive USDC reward with at most 6 decimals"],
+        duration_hours: Annotated[float, "How long the task should remain open"],
+        mode: Annotated[TaskMode, "TaskMarket task mode"] = "bounty",
+        tags: Annotated[list[str] | None, "Optional task tags"] = None,
+    ) -> dict[str, Any]:
+        """Prepare an exact, reviewable request without spending funds."""
+        try:
+            request = self._normalise_request(
+                description=description, reward_usdc=reward_usdc, duration_hours=duration_hours, mode=mode, tags=tags
+            )
+        except ValueError as exc:
+            return {"error": str(exc), "retry": False}
+
+        now = self._utc_now()
+        try:
+            deadline = now + timedelta(hours=float(request["durationHours"]))
+        except (OverflowError, ValueError) as exc:
+            return {"error": f"`duration_hours` is too large: {exc}", "retry": False}
+        if deadline <= now:
+            return {"error": "`duration_hours` must produce a future deadline", "retry": False}
+
+        request["deadline"] = _format_datetime(deadline)
+        maximum_spend = _maximum_spend(Decimal(request["rewardUsdc"]))
+        request["maximumSpendUsdc"] = _format_usdc(maximum_spend)
+        token = _confirmation_digest(request)
+        expires_at = min(deadline, now + PREVIEW_TTL)
+        self._pending_previews[token] = _PendingPreview(
+            request=request, deadline=deadline, expires_at=expires_at, maximum_spend=maximum_spend
+        )
+        return {
+            **request,
+            "network": "Base",
+            "chainId": BASE_CHAIN_ID,
+            "currency": "USDC",
+            "usdcContract": USDC_CONTRACT,
+            "confirmationToken": token,
+            "expiresAt": _format_datetime(expires_at),
+        }
+
+    def create_task(
+        self,
+        description: Annotated[str, "Complete task deliverable description"],
+        reward_usdc: Annotated[str, "Positive USDC reward with at most 6 decimals"],
+        duration_hours: Annotated[float, "How long the task should remain open"],
+        confirmation_token: Annotated[str, "Unchanged token from taskmarket_preview_task"],
+        confirm: Annotated[bool, "Must be true in addition to the approval callback"] = False,
+        mode: Annotated[TaskMode, "TaskMarket task mode"] = "bounty",
+        tags: Annotated[list[str] | None, "Optional task tags"] = None,
+    ) -> dict[str, Any]:
+        """Create one task after matching preview, approval, and wallet checks."""
+        if not confirm:
+            return {
+                "error": (
+                    "Creation is confirmation-gated. Review `taskmarket_preview_task` first, "
+                    "then call `taskmarket_create_task` with `confirm=True`."
+                ),
+                "retry": False,
+            }
+        context = self._prepare_creation_context(
+            description=description,
+            reward_usdc=reward_usdc,
+            duration_hours=duration_hours,
+            confirmation_token=confirmation_token,
+            mode=mode,
+            tags=tags,
+        )
+        if isinstance(context, dict):
+            return context
+
+        approval_error = self._request_approval(context)
+        if approval_error is not None:
+            return approval_error
+
+        preflight = self._preflight_cli(context.pending.maximum_spend)
+        if not preflight.succeeded:
+            return {
+                "error": preflight.error or "TaskMarket wallet preflight failed.",
+                "retry": False,
+                "status": "blocked",
+            }
+
+        cli_args = self._build_create_args(context)
+        if isinstance(cli_args, dict):
+            return cli_args
+
+        result = self._run_cli(cli_args, True)
+        task_id = _task_id_from_cli_result(result.data)
+        if not result.succeeded or task_id is None:
+            if not result.succeeded:
+                error = result.error or "Task creation failed; inspect live status before retrying."
+                status = "unknown" if result.ambiguous else "failed"
+            else:
+                error = "The CLI returned no task ID. Inspect live status before retrying."
+                status = "unknown"
+            return {"error": error, "retry": False, "status": status}
+
+        self._pending_previews.pop(context.confirmation_token, None)
+        return {
+            "taskId": task_id,
+            "taskUrl": f"{self.api_url}/api/tasks/{task_id}",
+            "status": "created",
+            "retry": False,
+        }
+
+    def _prepare_creation_context(
+        self,
+        *,
+        description: str,
+        reward_usdc: str,
+        duration_hours: float,
+        confirmation_token: str,
+        mode: TaskMode,
+        tags: list[str] | None,
+    ) -> dict[str, Any] | _CreationContext:
+        if not confirmation_token:
+            return {"error": "A `confirmation_token` from `taskmarket_preview_task` is required.", "retry": False}
+
+        pending = self._pending_previews.get(confirmation_token)
+        if pending is None:
+            return {"error": "The preview is missing or has already been used.", "retry": False}
+        now = self._utc_now()
+        if now >= pending.expires_at or now >= pending.deadline:
+            self._pending_previews.pop(confirmation_token, None)
+            return {"error": "The preview expired. Run `taskmarket_preview_task` again.", "retry": False}
+
+        try:
+            request = self._normalise_request(
+                description=description, reward_usdc=reward_usdc, duration_hours=duration_hours, mode=mode, tags=tags
+            )
+        except ValueError as exc:
+            return {"error": str(exc), "retry": False}
+        reviewed_request = {key: pending.request[key] for key in request}
+        if request != reviewed_request:
+            return {
+                "error": (
+                    "The creation arguments differ from the reviewed preview. "
+                    "Run `taskmarket_preview_task` again and review the new record."
+                ),
+                "retry": False,
+            }
+        return _CreationContext(pending=pending, request=request, confirmation_token=confirmation_token)
+
+    def _request_approval(self, context: _CreationContext) -> dict[str, Any] | None:
+        if self._approval is None:
+            return {
+                "error": "No approval callback is configured; task creation is blocked.",
+                "retry": False,
+                "status": "blocked",
+            }
+        preview = {
+            **context.pending.request,
+            "network": "Base",
+            "chainId": BASE_CHAIN_ID,
+            "currency": "USDC",
+            "usdcContract": USDC_CONTRACT,
+            "confirmationToken": context.confirmation_token,
+            "expiresAt": _format_datetime(context.pending.expires_at),
+        }
+        try:
+            approved = self._approval(preview)
+        except Exception as exc:  # noqa: BLE001
+            return {"error": f"The approval callback failed: {exc}", "retry": False, "status": "blocked"}
+        if not approved:
+            return {
+                "error": "The approval callback did not authorize task creation.",
+                "retry": False,
+                "status": "denied",
+            }
+        return None
+
+    def _build_create_args(self, context: _CreationContext) -> list[str] | dict[str, Any]:
+        remaining_hours = (context.pending.deadline - self._utc_now()).total_seconds() / 3600
+        if remaining_hours <= 0:
+            self._pending_previews.pop(context.confirmation_token, None)
+            return {"error": "The reviewed deadline has passed. Run `taskmarket_preview_task` again.", "retry": False}
+
+        cli_args = [
+            "task",
+            "create",
+            "--description",
+            context.request["description"],
+            "--reward",
+            context.request["rewardUsdc"],
+            "--duration",
+            f"{remaining_hours:.9f}",
+            "--mode",
+            context.request["mode"],
+        ]
+        if context.request["tags"]:
+            cli_args.extend(["--tags", ",".join(context.request["tags"])])
+        return cli_args
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize configuration, not runtime callbacks or wallet state."""
+        return {
+            "type": generate_qualified_class_name(type(self)),
+            "data": {"api_url": self.api_url, "cli_path": self.cli_path, "timeout": self.timeout},
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TaskMarketToolset":
+        """Recreate a safe, read-capable toolset from serialized configuration."""
+        config = data["data"]
+        return cls(api_url=config["api_url"], cli_path=config["cli_path"], timeout=config["timeout"])
+
+    def _preflight_cli(self, maximum_spend: Decimal) -> _CliResult:
+        if self._cli_runner is None and shutil.which(self.cli_path) is None:
+            return _CliResult(
+                succeeded=False,
+                error=("The first-party `taskmarket` CLI was not found. Install `@lucid-agents/taskmarket` and retry."),
+            )
+        deposit = self._run_cli(["deposit"], False)
+        if not deposit.succeeded or deposit.data is None:
+            return _CliResult(succeeded=False, error=deposit.error or "Could not verify TaskMarket wallet network.")
+        expected = {"network": "Base", "chainId": BASE_CHAIN_ID, "currency": "USDC", "usdcContract": USDC_CONTRACT}
+        if any(deposit.data.get(key) != value for key, value in expected.items()):
+            return _CliResult(succeeded=False, error="TaskMarket wallet is not configured for Base USDC.")
+
+        stats = self._run_cli(["stats"], False)
+        if not stats.succeeded or stats.data is None:
+            return _CliResult(succeeded=False, error=stats.error or "Could not verify available USDC balance.")
+        try:
+            balance = Decimal(str(stats.data["balanceUsdc"]))
+        except (KeyError, InvalidOperation, TypeError, ValueError):
+            return _CliResult(succeeded=False, error="TaskMarket CLI returned an unreadable USDC balance.")
+        if not balance.is_finite() or balance < maximum_spend:
+            return _CliResult(
+                succeeded=False,
+                error=f"Insufficient USDC balance for the reviewed maximum spend ({_format_usdc(maximum_spend)} USDC).",
+            )
+        return _CliResult(succeeded=True, data=stats.data)
+
+    def _run_cli(self, args: list[str], is_write: bool) -> _CliResult:
+        if self._cli_runner is not None:
+            return self._cli_runner(args, is_write)
+        try:
+            completed = subprocess.run(
+                [self.cli_path, *args], capture_output=True, check=False, text=True, timeout=self.timeout
+            )
+        except FileNotFoundError:
+            return _CliResult(succeeded=False, error="The first-party `taskmarket` CLI was not found.")
+        except subprocess.TimeoutExpired:
+            return _CliResult(
+                succeeded=False,
+                error=("TaskMarket CLI timed out. Inspect live status before retrying; the command was not retried."),
+                ambiguous=is_write,
+            )
+        parsed: Any = None
+        if completed.stdout.strip():
+            try:
+                parsed = json.loads(completed.stdout)
+            except json.JSONDecodeError:
+                parsed = None
+        if completed.returncode == 0 and isinstance(parsed, dict):
+            if parsed.get("ok") is False:
+                return _CliResult(succeeded=False, error="TaskMarket CLI rejected the command.", ambiguous=is_write)
+            data = parsed.get("data", parsed)
+            return _CliResult(succeeded=isinstance(data, dict), data=data if isinstance(data, dict) else None)
+        return _CliResult(succeeded=False, error="TaskMarket CLI rejected the command.", ambiguous=is_write)
+
+    def _request_json(
+        self, method: str, path: str, *, params: dict[str, str] | None = None, body: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        if self._transport is not None:
+            return self._transport(method, path, params or {}, body)
+        try:
+            with httpx.Client(base_url=self.api_url, timeout=self.timeout, follow_redirects=False) as client:
+                response = client.request(method, path, params=params, json=body)
+                response.raise_for_status()
+                payload = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            return {"error": f"TaskMarket request failed: {exc}", "retry": True}
+        if not isinstance(payload, dict):
+            return {"error": "TaskMarket returned a non-object JSON response.", "retry": True}
+        return payload
+
+    def _utc_now(self) -> datetime:
+        now = self._clock()
+        if now.tzinfo is None:
+            return now.replace(tzinfo=timezone.utc)
+        return now.astimezone(timezone.utc)
+
+    @staticmethod
+    def _normalise_request(
+        *, description: str, reward_usdc: str, duration_hours: float, mode: TaskMode, tags: list[str] | None
+    ) -> dict[str, Any]:
+        if not isinstance(description, str) or not description.strip():
+            raise ValueError("`description` must not be empty")
+        try:
+            reward = Decimal(str(reward_usdc).strip())
+        except (InvalidOperation, ValueError):
+            raise ValueError("`reward_usdc` must be a positive USDC amount") from None
+        if not reward.is_finite() or reward <= 0:
+            raise ValueError("`reward_usdc` must be a positive USDC amount")
+        exponent = reward.as_tuple().exponent
+        if isinstance(exponent, str) or exponent < -6:
+            raise ValueError("`reward_usdc` supports at most 6 decimal places")
+        reward = reward.quantize(USDC_QUANTUM)
+        try:
+            duration = Decimal(str(duration_hours))
+        except (InvalidOperation, ValueError):
+            raise ValueError("`duration_hours` must be a positive finite number") from None
+        if not duration.is_finite() or duration <= 0:
+            raise ValueError("`duration_hours` must be a positive finite number")
+        if not isinstance(mode, str) or mode not in SUPPORTED_MODES:
+            raise ValueError("`mode` must be one of: bounty, claim, pitch, benchmark")
+        return {
+            "description": description.strip(),
+            "rewardUsdc": _format_usdc(reward),
+            "durationHours": _format_decimal(duration),
+            "mode": mode,
+            "tags": [tag.strip() for tag in tags or [] if tag.strip()],
+        }
+
+
+def _validate_task_id(task_id: str) -> str | None:
+    if not isinstance(task_id, str) or re.fullmatch(r"0x[0-9a-fA-F]{64}", task_id) is None:
+        return "`task_id` must be a 0x-prefixed 32-byte TaskMarket task ID"
+    return None
+
+
+def _format_usdc(value: Decimal) -> str:
+    return f"{value.quantize(USDC_QUANTUM):.6f}"
+
+
+def _format_decimal(value: Decimal) -> str:
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _format_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _maximum_spend(reward: Decimal) -> Decimal:
+    fee = reward * PLATFORM_FEE_BPS / Decimal("10000")
+    return (reward + fee + RELAY_FEE_USDC).quantize(USDC_QUANTUM, rounding=ROUND_CEILING)
+
+
+def _confirmation_digest(request: dict[str, Any]) -> str:
+    encoded = json.dumps(request, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _task_id_from_cli_result(data: dict[str, Any] | None) -> str | None:
+    if data is None:
+        return None
+    task_id = data.get("taskId")
+    return task_id if isinstance(task_id, str) and re.fullmatch(r"0x[0-9a-fA-F]{64}", task_id) else None

--- a/releasenotes/notes/add-taskmarket-toolset-e43a3ec3048cee6d.yaml
+++ b/releasenotes/notes/add-taskmarket-toolset-e43a3ec3048cee6d.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add `TaskMarketToolset` for confirmation-gated TaskMarket discovery,
+    preview, and task creation from Haystack agents. Task creation validates
+    Base USDC configuration and balance, requires an application approval
+    callback, and does not retry ambiguous CLI writes.

--- a/test/tools/test_taskmarket.py
+++ b/test/tools/test_taskmarket.py
@@ -1,0 +1,202 @@
+from datetime import datetime, timezone
+from typing import Any
+
+from haystack.tools import TaskMarketToolset
+from haystack.tools.taskmarket import USDC_CONTRACT, _CliResult
+
+TASK_ID = "0x" + "a" * 64
+
+
+def _tool(toolset: TaskMarketToolset, name: str) -> Any:
+    return next(tool for tool in toolset.get_selectable_tools() if tool.name == name)
+
+
+def test_taskmarket_toolset_lists_live_tasks() -> None:
+    calls: list[tuple[str, str, dict[str, str], Any]] = []
+
+    def transport(method: str, path: str, params: dict[str, str], body: Any) -> dict[str, Any]:
+        calls.append((method, path, params, body))
+        return {"tasks": [{"id": "0xabc", "status": "open"}]}
+
+    toolset = TaskMarketToolset(transport=transport)
+    list_tasks = _tool(toolset, "taskmarket_list_tasks")
+
+    result = list_tasks.invoke(status="open", limit=1)
+
+    assert result == {"tasks": [{"id": "0xabc", "status": "open"}]}
+    assert calls == [("GET", "/api/tasks", {"status": "open", "limit": "1"}, None)]
+
+
+def test_taskmarket_toolset_reads_task_and_submissions() -> None:
+    calls: list[tuple[str, str, dict[str, str], Any]] = []
+
+    def transport(method: str, path: str, params: dict[str, str], body: Any) -> dict[str, Any]:
+        calls.append((method, path, params, body))
+        return {"path": path}
+
+    toolset = TaskMarketToolset(transport=transport)
+
+    assert _tool(toolset, "taskmarket_get_task").invoke(task_id=TASK_ID) == {"path": f"/api/tasks/{TASK_ID}"}
+    assert _tool(toolset, "taskmarket_list_submissions").invoke(task_id=TASK_ID) == {
+        "path": f"/api/tasks/{TASK_ID}/submissions"
+    }
+    assert calls == [("GET", f"/api/tasks/{TASK_ID}", {}, None), ("GET", f"/api/tasks/{TASK_ID}/submissions", {}, None)]
+
+
+def test_taskmarket_toolset_rejects_noncanonical_task_ids() -> None:
+    calls: list[tuple[str, str, dict[str, str], Any]] = []
+
+    def transport(method: str, path: str, params: dict[str, str], body: Any) -> dict[str, Any]:
+        calls.append((method, path, params, body))
+        return {}
+
+    result = _tool(TaskMarketToolset(transport=transport), "taskmarket_get_task").invoke(task_id="0x../secret")
+
+    assert "32-byte" in result["error"]
+    assert result["retry"] is False
+    assert calls == []
+
+
+def test_taskmarket_preview_contains_exact_base_usdc_budget() -> None:
+    now = datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)
+    toolset = TaskMarketToolset(clock=lambda: now)
+
+    result = _tool(toolset, "taskmarket_preview_task").invoke(
+        description="Deliver a tested data connector",
+        reward_usdc="1.00",
+        duration_hours=4,
+        mode="bounty",
+        tags=["python", "  ", "agents"],
+    )
+
+    assert result["rewardUsdc"] == "1.000000"
+    assert result["durationHours"] == "4"
+    assert result["deadline"] == "2026-08-13T16:00:00Z"
+    assert result["maximumSpendUsdc"] == "1.076000"
+    assert result["expiresAt"] == "2026-08-13T12:15:00Z"
+    assert result["network"] == "Base"
+    assert result["chainId"] == 8453
+    assert result["currency"] == "USDC"
+    assert result["usdcContract"] == USDC_CONTRACT
+    assert result["tags"] == ["python", "agents"]
+    assert len(result["confirmationToken"]) == 64
+
+
+def test_taskmarket_create_requires_confirmation_before_any_side_effect() -> None:
+    calls: list[tuple[list[str], bool]] = []
+
+    def cli_runner(args: list[str], is_write: bool) -> _CliResult:
+        calls.append((args, is_write))
+        return _CliResult(succeeded=True, data={"taskId": TASK_ID})
+
+    approvals: list[dict[str, Any]] = []
+
+    def approve(preview: dict[str, Any]) -> bool:
+        approvals.append(preview)
+        return True
+
+    toolset = TaskMarketToolset(cli_runner=cli_runner, approval=approve)
+
+    result = _tool(toolset, "taskmarket_create_task").invoke(
+        description="Deliver a tested data connector",
+        reward_usdc="1",
+        duration_hours=4,
+        confirmation_token="not-previewed",
+        confirm=False,
+    )
+
+    assert result["retry"] is False
+    assert "confirmation-gated" in result["error"]
+    assert calls == []
+    assert approvals == []
+
+
+def test_taskmarket_create_runs_one_approved_cli_flow() -> None:
+    now = datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)
+    calls: list[tuple[list[str], bool]] = []
+
+    def cli_runner(args: list[str], is_write: bool) -> _CliResult:
+        calls.append((args, is_write))
+        if args == ["deposit"]:
+            return _CliResult(
+                succeeded=True,
+                data={"network": "Base", "chainId": 8453, "currency": "USDC", "usdcContract": USDC_CONTRACT},
+            )
+        if args == ["stats"]:
+            return _CliResult(succeeded=True, data={"balanceUsdc": "5"})
+        return _CliResult(succeeded=True, data={"taskId": TASK_ID})
+
+    approvals: list[dict[str, Any]] = []
+
+    def approve(preview: dict[str, Any]) -> bool:
+        approvals.append(preview)
+        return True
+
+    toolset = TaskMarketToolset(clock=lambda: now, cli_runner=cli_runner, approval=approve)
+    preview = _tool(toolset, "taskmarket_preview_task").invoke(
+        description="Deliver a tested data connector", reward_usdc="1", duration_hours=4
+    )
+
+    result = _tool(toolset, "taskmarket_create_task").invoke(
+        description="Deliver a tested data connector",
+        reward_usdc="1",
+        duration_hours=4,
+        confirmation_token=preview["confirmationToken"],
+        confirm=True,
+    )
+
+    assert result == {
+        "taskId": TASK_ID,
+        "taskUrl": f"https://api.taskmarket.dev/api/tasks/{TASK_ID}",
+        "status": "created",
+        "retry": False,
+    }
+    assert len(approvals) == 1
+    assert calls[0] == (["deposit"], False)
+    assert calls[1] == (["stats"], False)
+    assert calls[2][0][:2] == ["task", "create"]
+    assert calls[2][1] is True
+
+
+def test_taskmarket_create_does_not_retry_ambiguous_cli_write() -> None:
+    calls: list[tuple[list[str], bool]] = []
+
+    def cli_runner(args: list[str], is_write: bool) -> _CliResult:
+        calls.append((args, is_write))
+        if args == ["deposit"]:
+            return _CliResult(
+                succeeded=True,
+                data={"network": "Base", "chainId": 8453, "currency": "USDC", "usdcContract": USDC_CONTRACT},
+            )
+        if args == ["stats"]:
+            return _CliResult(succeeded=True, data={"balanceUsdc": "5"})
+        return _CliResult(succeeded=False, error="timed out", ambiguous=True)
+
+    toolset = TaskMarketToolset(cli_runner=cli_runner, approval=lambda _preview: True)
+    preview = _tool(toolset, "taskmarket_preview_task").invoke(
+        description="Deliver a tested data connector", reward_usdc="1", duration_hours=4
+    )
+
+    result = _tool(toolset, "taskmarket_create_task").invoke(
+        description="Deliver a tested data connector",
+        reward_usdc="1",
+        duration_hours=4,
+        confirmation_token=preview["confirmationToken"],
+        confirm=True,
+    )
+
+    assert result["status"] == "unknown"
+    assert result["retry"] is False
+    assert len(calls) == 3
+    assert calls[-1][1] is True
+
+
+def test_taskmarket_rejects_unknown_mode() -> None:
+    toolset = TaskMarketToolset()
+
+    result = _tool(toolset, "taskmarket_preview_task").invoke(
+        description="Deliver a tested data connector", reward_usdc="1", duration_hours=4, mode="unknown"
+    )
+
+    assert "mode" in result["error"]
+    assert result["retry"] is False


### PR DESCRIPTION
### Related Issues

- fixes #12341

### Proposed Changes

This PR adds `TaskMarketToolset`, a first-party Haystack `Toolset` for discovering and requesting external TaskMarket work from an agent workflow.

- Adds read-only tools for listing tasks, retrieving task status, and reviewing submissions through the public API.
- Adds a preview tool that canonicalizes the request, calculates the Base USDC maximum spend including platform and relay fees, and returns a short-lived confirmation token.
- Adds a confirmation-gated create tool. It requires `confirm=True`, a matching preview, an application-provided approval callback, Base/USDC wallet preflight, and sufficient USDC balance.
- Uses the first-party `taskmarket` CLI without accepting private keys, shell interpolation, automatic submission acceptance/rejection, or retries of ambiguous writes.
- Adds serialization that preserves only safe read-capable configuration; runtime approval callbacks and wallet state are never serialized.
- Adds user documentation and a release note.

### How did you test it?

- `hatch run fmt`
- `hatch run test:types`
- `hatch run test:unit test/tools -q` — 294 passed, 12 deselected
- `hatch -e test run python -c 'from haystack.tools import TaskMarketToolset; ...'` against the live public TaskMarket API — read-only listing succeeded.
- Manual `taskmarket deposit` and `taskmarket stats` output checks confirmed the Base chain, USDC contract, and `balanceUsdc` fields consumed by the preflight path.

### Notes for the reviewer

The write path intentionally stops at an application approval callback and never handles private keys. A CLI timeout is reported as `status="unknown"` so callers reconcile live status before deciding whether to do anything else.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with the implementation and test evidence.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used a conventional commit type for the PR title.
- [x] I have documented the code and user-facing behavior.
- [x] I have added a release note file.
- [x] I have run the repository formatter and type checks.
