### PR TITLE
fix: prevent CSVDocumentSplitter recursion on nested splits

### DIFF
--- a/haystack/components/preprocessors/csv_document_splitter.py
+++ b/haystack/components/preprocessors/csv_document_splitter.py
@@ -173,12 +173,12 @@ class CSVDocumentSplitter:
         :param df: DataFrame to split.
         :param split_threshold: Minimum number of consecutive empty rows or columns to trigger a split.
         :param axis: Axis along which to find empty elements. Either "row" or "column".
-        :return: List of indices where consecutive empty rows or columns start.
+        :return: List of zero-based positional indices for consecutive empty rows or columns.
         """
         if axis == "row":
-            empty_elements = df[df.isnull().all(axis=1)].index.tolist()
+            empty_elements = [i for i, is_empty in enumerate(df.isnull().all(axis=1).tolist()) if is_empty]
         else:
-            empty_elements = df.columns[df.isnull().all(axis=0)].tolist()
+            empty_elements = [i for i, is_empty in enumerate(df.isnull().all(axis=0).tolist()) if is_empty]
 
         # If no empty elements found, return empty list
         if len(empty_elements) == 0:

--- a/releasenotes/notes/csv-document-splitter-recursion-c462a9e0822d92cc.yaml
+++ b/releasenotes/notes/csv-document-splitter-recursion-c462a9e0822d92cc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed an infinite recursion in `CSVDocumentSplitter` when nested row and column blocks were split together.

--- a/releasenotes/notes/csv-document-splitter-recursion-c462a9e0822d92cc.yaml
+++ b/releasenotes/notes/csv-document-splitter-recursion-c462a9e0822d92cc.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fixed an infinite recursion in `CSVDocumentSplitter` when nested row and column blocks were split together.
+    Fixed an infinite recursion in ``CSVDocumentSplitter`` when nested row and column blocks were split together.

--- a/test/components/preprocessors/test_csv_document_splitter.py
+++ b/test/components/preprocessors/test_csv_document_splitter.py
@@ -88,6 +88,23 @@ P,Q,R
         result = splitter._find_split_indices(df, split_threshold=2, axis="row")
         assert result == [(2, 3), (6, 7)]
 
+    def test_find_split_indices_returns_positional_indices_for_non_zero_index(
+        self, splitter: CSVDocumentSplitter
+    ) -> None:
+        csv_content = """A,B,C
+1,2,3
+4,5,6
+P,Q,R
+,,
+,,
+X,Y,Z
+"""
+        df = read_csv(StringIO(csv_content), header=None, dtype=object).iloc[3:]
+
+        result = splitter._find_split_indices(df, split_threshold=2, axis="row")
+
+        assert result == [(1, 2)]
+
     def test_find_split_indices_column_two_tables(
         self, splitter: CSVDocumentSplitter, two_tables_sep_by_two_empty_columns: str
     ) -> None:
@@ -210,6 +227,32 @@ P,Q,,,,
         for i, table in enumerate(result):
             assert table.content == expected_tables[i]
             assert table.meta == expected_meta[i]
+
+    def test_recursive_split_with_nested_row_and_column_blocks(self, splitter: CSVDocumentSplitter) -> None:
+        csv_content = """A,B,C,D,E,F
+1,2,3,4,5,6
+,,,,,
+P,Q,,,X,Y
+1,2,,,7,8
+,,,,M,N
+,,,,9,10
+R,S,,,,
+3,4,,,,
+"""
+        splitter = CSVDocumentSplitter(row_split_threshold=1, column_split_threshold=1)
+        doc = Document(content=csv_content, id="test_id")
+
+        result = splitter.run([doc])["documents"]
+
+        assert [(table.content, table.meta) for table in result] == [
+            (
+                "A,B,C,D,E,F\n1,2,3,4,5,6\n",
+                {"source_id": "test_id", "row_idx_start": 0, "col_idx_start": 0, "split_id": 0},
+            ),
+            ("P,Q\n1,2\n", {"source_id": "test_id", "row_idx_start": 3, "col_idx_start": 0, "split_id": 1}),
+            ("X,Y\n7,8\nM,N\n9,10\n", {"source_id": "test_id", "row_idx_start": 3, "col_idx_start": 4, "split_id": 2}),
+            ("R,S\n3,4\n", {"source_id": "test_id", "row_idx_start": 7, "col_idx_start": 0, "split_id": 3}),
+        ]
 
     def test_csv_with_blank_lines(self, splitter: CSVDocumentSplitter) -> None:
         csv_data = """ID,LeftVal,,,RightVal,Extra

--- a/test/components/preprocessors/test_csv_document_splitter.py
+++ b/test/components/preprocessors/test_csv_document_splitter.py
@@ -228,7 +228,7 @@ P,Q,,,,
             assert table.content == expected_tables[i]
             assert table.meta == expected_meta[i]
 
-    def test_recursive_split_with_nested_row_and_column_blocks(self, splitter: CSVDocumentSplitter) -> None:
+    def test_recursive_split_with_nested_row_and_column_blocks(self) -> None:
         csv_content = """A,B,C,D,E,F
 1,2,3,4,5,6
 ,,,,,


### PR DESCRIPTION
## Summary

Fixes #12190.

`CSVDocumentSplitter._find_split_indices()` previously returned DataFrame index/column labels, while `_split_dataframe()` interpreted them as zero-based positions with `iloc`. After an earlier `iloc` slice retained a non-zero index, nested row/column splitting could repeatedly process the same subtable and eventually raise `RecursionError`.

This change makes `_find_split_indices()` return zero-based positional indices for both axes. The DataFrame's original row and column labels remain unchanged, so `row_idx_start` and `col_idx_start` metadata stay intact. No public API or behavior expansion is introduced.

## Tests

- Added a regression test for non-zero DataFrame indices.
- Added an end-to-end regression test covering nested row and column blocks, including output content and metadata.
- Verified the new tests fail on the unfixed code: 2 regression failures, including `RecursionError`; the other 26 tests passed.

## Validation

- `hatch run test:unit test/components/preprocessors/test_csv_document_splitter.py` — 28 passed.
- Ruff check and format check passed for the changed source and test files.
- `git diff --check` passed.
- `hatch run test:types` is currently blocked by the environment's NumPy 2.5.2 stubs using Python 3.12 syntax while the project's mypy target is Python 3.10; a Python 3.12 compatibility run reports existing OpenAI/httpx type mismatches outside this change.
- `hatch run fmt-check` reports a pre-existing formatting issue in `haystack/components/retrievers/sentence_window_retriever.py`; the changed files pass formatting checks.

No public API was added or changed.