### PR TITLE
fix: keep docstring-only Python chunks valid

### DIFF
--- a/haystack/components/preprocessors/python_code_splitter.py
+++ b/haystack/components/preprocessors/python_code_splitter.py
@@ -198,6 +198,12 @@ class PythonCodeSplitter:
 
         before = source_lines[unit_start - 1 : ds_start - 1]
         after = source_lines[ds_end:unit_end]
+        # Removing the only statement from a function or class would leave an
+        # invalid suite. Keep the generated chunk syntactically valid.
+        if len(body) == 1:
+            docstring_line = source_lines[ds_start - 1]
+            indentation = docstring_line[: len(docstring_line) - len(docstring_line.lstrip())]
+            after.insert(0, f"{indentation}pass\n")
         return "".join(before + after), docstring
 
     def _emit_class_units(self, cls: ast.ClassDef, source_lines: list[str], cursor: int, units: list[_CodeUnit]) -> int:

--- a/releasenotes/notes/fix-python-code-splitter-docstring-only-20260814.yaml
+++ b/releasenotes/notes/fix-python-code-splitter-docstring-only-20260814.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Ensures ``PythonCodeSplitter`` emits syntactically valid chunks when ``strip_docstrings=True`` is used on a function or class whose docstring is its only statement.

--- a/test/components/preprocessors/test_python_code_splitter.py
+++ b/test/components/preprocessors/test_python_code_splitter.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import ast
 import textwrap
 
 import pytest
@@ -686,6 +687,21 @@ class TestDocstringStripping:
         header = header_chunks[0]
         assert "Class-level docstring." not in (header.content or "")
         assert "Class-level docstring." in " | ".join(header.meta.get("docstrings") or [])
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            'def only_docstring():\n    """Function docs."""\n',
+            'class OnlyDocstring:\n    """Class docs."""\n',
+        ],
+    )
+    def test_strip_docstrings_keeps_docstring_only_units_valid(self, source):
+        splitter = PythonCodeSplitter(min_effective_lines=1, max_effective_lines=10, strip_docstrings=True)
+        result = splitter.run(documents=[Document(content=source)])
+
+        assert result["documents"]
+        for chunk in result["documents"]:
+            ast.parse(chunk.content or "")
 
 
 class TestTopLevelStatements:


### PR DESCRIPTION
## Summary

Fixes #12330.

When strip_docstrings=True removes the only statement in a function or class, keep the generated chunk valid by inserting an indented pass. Add a regression test that parses docstring-only functions and classes with ast.parse, plus the required release note.

## Validation

- hatch run test:unit --no-cov test/components/preprocessors/test_python_code_splitter.py -q — 71 passed.
- git diff --check

I used an AI assistant to help prepare this PR, reviewed the changes, and ran the relevant tests.