### PR TITLE
fix: keep docstring when PythonCodeSplitter would leave an empty body

### DIFF
--- a/haystack/components/preprocessors/python_code_splitter.py
+++ b/haystack/components/preprocessors/python_code_splitter.py
@@ -196,6 +196,20 @@ class PythonCodeSplitter:
         if ds_start <= node.lineno or ds_end > unit_end:
             return self._slice_lines(source_lines, unit_start, unit_end), None
 
+        # If stripping the docstring would leave an empty body, keep it in place. This
+        # happens in two cases:
+        # - The body is just the docstring (e.g. `def foo(): """doc"""`), so removing the
+        #   docstring leaves `def foo():`, which is a SyntaxError.
+        # - The slice is a class_header that contains only the class docstring and the
+        #   class declaration (e.g. `class Foo:\n    """doc"""\n`, followed by methods):
+        #   removing the docstring leaves `class Foo:\n`, which is also a SyntaxError.
+        # In both cases there is no other body statement within the slice to keep the
+        # chunk valid Python, so we leave the docstring in place and do not move it
+        # to ``meta["docstrings"]`` (consistent with returning the original slice and
+        # ``None`` for the docstring when there is nothing to strip).
+        if len(body) <= 1 or body[1].lineno > unit_end:
+            return self._slice_lines(source_lines, unit_start, unit_end), None
+
         before = source_lines[unit_start - 1 : ds_start - 1]
         after = source_lines[ds_end:unit_end]
         return "".join(before + after), docstring

--- a/releasenotes/notes/fix-python-code-splitter-strip-docstring-empty-body-3c1f9a8e4b2d7045.yaml
+++ b/releasenotes/notes/fix-python-code-splitter-strip-docstring-empty-body-3c1f9a8e4b2d7045.yaml
@@ -1,0 +1,15 @@
+---
+fixes:
+  - |
+    Fixed ``PythonCodeSplitter`` (``strip_docstrings=True``) emitting invalid Python
+    when a function, method, class, or nested class body consisted solely of a docstring.
+    Previously, removing the docstring from a unit whose body was only that docstring
+    left a header with no body (``def foo():\n`` or ``class Foo:\n``), which is a
+    ``SyntaxError``. The same bug also affected a class whose class-header slice
+    contained only the class-level docstring and no other body statement before
+    the first method. The docstring is now kept in place in these cases so the
+    emitted chunk remains valid Python, and it is not moved to
+    ``meta["docstrings"]`` (consistent with the existing behaviour for units
+    that have no docstring to strip). A function or class with both a docstring
+    and other body statements is unaffected — the docstring is still stripped
+    and moved to ``meta["docstrings"]`` as before.

--- a/test/components/preprocessors/test_python_code_splitter.py
+++ b/test/components/preprocessors/test_python_code_splitter.py
@@ -687,6 +687,83 @@ class TestDocstringStripping:
         assert "Class-level docstring." not in (header.content or "")
         assert "Class-level docstring." in " | ".join(header.meta.get("docstrings") or [])
 
+    def test_strip_docstrings_keeps_docstring_when_body_is_only_docstring(self):
+        # Issue #12330: a function/method/class whose body consists solely of a
+        # docstring must not be reduced to a header with no body — that would emit
+        # invalid Python (e.g. `def foo():\n`, `class Foo:\n`). The docstring is
+        # kept in place in this case, and is not moved to meta["docstrings"]
+        # (consistent with how we treat units that have no docstring to strip).
+        import ast
+
+        cases = [
+            # function with only a docstring
+            ('def my_helper():\n    """A helper that does nothing."""\n', ["function"]),
+            # class with only a docstring (no methods)
+            ('class MyError(Exception):\n    """Custom error."""\n', ["class"]),
+            # nested class with only a docstring (outer class also has only a docstring,
+            # so the outer class_header is a docstring-only slice and the inner is a
+            # nested_class with its own docstring-only body)
+            ('class Outer:\n    """Outer class."""\n    class Inner:\n        """Inner class."""\n', ["class_header"]),
+            # method with only a docstring
+            (
+                'class Foo:\n    def method(self):\n        """A method that does nothing."""\n',
+                ["class_header", "method"],
+            ),
+        ]
+        for source, expected_kinds in cases:
+            splitter = PythonCodeSplitter(min_effective_lines=1, max_effective_lines=20, strip_docstrings=True)
+            result = splitter.run(documents=[Document(content=source)])
+            # Every emitted chunk must contain the docstring in its content (or be
+            # syntactically valid with no docstring if it is just the trailing-class
+            # body marker) and must parse as valid Python.
+            for chunk in result["documents"]:
+                assert chunk.content, f"empty content for {source!r}"
+                ast.parse(chunk.content)
+            # At least one chunk must still carry the docstring inline (because we
+            # never stripped it from a docstring-only body).
+            joined_content = "\n".join(c.content or "" for c in result["documents"])
+            assert '"""' in joined_content, f"docstring missing from all content for {source!r}"
+            # No chunk should have moved the docstring to meta — stripping was
+            # skipped on docstring-only bodies, so the metadata list is empty.
+            for chunk in result["documents"]:
+                assert not chunk.meta.get("docstrings"), (
+                    f"docstring should not be moved to meta when it is the only body content; "
+                    f"got {chunk.meta!r} for {source!r}"
+                )
+            # The first chunk in the run is the unit we care about; check its kind.
+            first_kinds = result["documents"][0].meta.get("unit_kinds", [])
+            for expected_kind in expected_kinds:
+                assert expected_kind in first_kinds, (
+                    f"expected kind {expected_kind!r} in {first_kinds!r} for {source!r}"
+                )
+
+    def test_strip_docstrings_keeps_class_header_docstring_when_no_other_body(self):
+        # When a class has a docstring but no body statements before its first method
+        # (i.e. the class_header slice is just the class declaration + the docstring),
+        # stripping the docstring would leave `class Foo:\n`, which is invalid Python.
+        # The docstring is kept in place; it is not moved to meta["docstrings"].
+        import ast
+
+        source = textwrap.dedent(
+            '''
+            class Foo:
+                """Foo docstring."""
+
+                def method(self):
+                    return 1
+            '''
+        ).lstrip()
+        splitter = PythonCodeSplitter(min_effective_lines=1, max_effective_lines=20, strip_docstrings=True)
+        result = splitter.run(documents=[Document(content=source)])
+        header_chunks = [c for c in result["documents"] if "class_header" in c.meta.get("unit_kinds", [])]
+        assert header_chunks
+        header = header_chunks[0]
+        ast.parse(header.content or "")
+        assert '"""' in (header.content or "")
+        assert not header.meta.get("docstrings")
+        # The class docstring is preserved verbatim in the header content.
+        assert "Foo docstring." in (header.content or "")
+
 
 class TestTopLevelStatements:
     @pytest.fixture


### PR DESCRIPTION
### Related Issues

- fixes #12330

### Proposed Changes:

`PythonCodeSplitter` with `strip_docstrings=True` reduced a unit whose body was only the docstring to a header with no body (`def foo():\n`, `class Foo:\n`), which is a `SyntaxError`. The same bug applied to a class whose class-header slice contained only the class-level docstring and no other body statement before the first method: stripping the docstring from the header left `class Foo:\n`, also invalid.

The fix is in `_strip_docstring`: after confirming the first body statement is the docstring, also check that there is at least one other body statement within the slice. If not, return the original slice unchanged and `None` for the docstring, so the chunk stays valid Python and the docstring is not moved to `meta["docstrings"]` (consistent with how units that have nothing to strip are handled today). Functions, methods, and classes whose body has both a docstring and other statements are unaffected: the docstring is still stripped and moved to `meta["docstrings"]` as before.

### How did you test it?

- Added `test_strip_docstrings_keeps_docstring_when_body_is_only_docstring` in `TestDocstringStripping`, covering a function, a class, a nested class, and a method whose body is only the docstring. Each case asserts the emitted content (a) parses as valid Python via `ast.parse`, (b) still contains the docstring inline, and (c) did not move anything to `meta["docstrings"]`.
- Added `test_strip_docstrings_keeps_class_header_docstring_when_no_other_body` covering the class-header-with-only-docstring case (docstring + methods, but no other body statement before the first method).
- The pre-existing `test_strip_docstrings_moves_them_to_meta`, `test_strip_docstrings_preserves_module_docstring`, and `test_strip_class_header_docstring_moves_to_meta` all still pass — the change only affects the empty-body edge case.
- Full module: `71 passed` (was 69). The wider preprocessor surface (`test/components/preprocessors/`) is `358 passed` with no regressions. `hatch run fmt` clean. `hatch run test:types` reports 17 pre-existing errors in 9 unrelated files (azure, openai_counter, etc.) — confirmed pre-existing via `git stash` of this branch.
- Verified the bug end-to-end with a standalone reproducer before the fix (4 cases produce `SyntaxError`; all 4 produce valid Python after the fix).

### Checklist

- [x] I have read the contributors guidelines and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the release note (reno note in `releasenotes/notes/`)
- [x] I have run `hatch run fmt` and `hatch run test:types` locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
