### PR TITLE
fix: keep EmbeddingBasedDocumentSplitter.run_async on the async path

### DIFF
--- a/haystack/components/preprocessors/embedding_based_document_splitter.py
+++ b/haystack/components/preprocessors/embedding_based_document_splitter.py
@@ -456,6 +456,8 @@ class EmbeddingBasedDocumentSplitter:
         further splitting is possible.
 
         This works because the threshold for splits is calculated dynamically based on the provided of embeddings.
+
+        Keep in sync with `_split_large_splits_async`.
         """
         final_splits = []
 
@@ -488,6 +490,9 @@ class EmbeddingBasedDocumentSplitter:
 
         Mirrors `_split_large_splits`, but embeds through the async path so that the recursion does not block the
         event loop with synchronous embedder calls.
+
+        Keep in sync with `_split_large_splits`, which also documents why re-running the splitter on an oversized
+        chunk can split it further.
         """
         final_splits = []
 
@@ -495,6 +500,9 @@ class EmbeddingBasedDocumentSplitter:
             if len(split) <= self.max_length:
                 final_splits.append(split)
             else:
+                # Recursively split large splits
+                # We can reuse the same _split_text_async method to split the text into smaller chunks because the
+                # threshold for splits is calculated dynamically based on embeddings from `split`.
                 sub_splits = await self._split_text_async(text=split)
 
                 # Stop splitting if no further split is possible or continue with recursion

--- a/haystack/components/preprocessors/embedding_based_document_splitter.py
+++ b/haystack/components/preprocessors/embedding_based_document_splitter.py
@@ -276,7 +276,7 @@ class EmbeddingBasedDocumentSplitter:
         merged_splits = self._merge_small_splits(splits=splits)
 
         # Recursively split splits larger than max_length
-        final_splits = self._split_large_splits(splits=merged_splits)
+        final_splits = await self._split_large_splits_async(splits=merged_splits)
 
         # Create Document objects from the final splits
         return EmbeddingBasedDocumentSplitter._create_documents_from_splits(splits=final_splits, original_doc=doc)
@@ -479,6 +479,35 @@ class EmbeddingBasedDocumentSplitter:
                     final_splits.append(split)
                 else:
                     final_splits.extend(self._split_large_splits(splits=sub_splits))
+
+        return final_splits
+
+    async def _split_large_splits_async(self, splits: list[str]) -> list[str]:
+        """
+        Asynchronously and recursively split splits that are above max_length.
+
+        Mirrors `_split_large_splits`, but embeds through the async path so that the recursion does not block the
+        event loop with synchronous embedder calls.
+        """
+        final_splits = []
+
+        for split in splits:
+            if len(split) <= self.max_length:
+                final_splits.append(split)
+            else:
+                sub_splits = await self._split_text_async(text=split)
+
+                # Stop splitting if no further split is possible or continue with recursion
+                if len(sub_splits) == 1:
+                    logger.warning(
+                        "Could not split a chunk further below max_length={max_length}. "
+                        "Returning chunk of length {length}.",
+                        max_length=self.max_length,
+                        length=len(split),
+                    )
+                    final_splits.append(split)
+                else:
+                    final_splits.extend(await self._split_large_splits_async(splits=sub_splits))
 
         return final_splits
 

--- a/releasenotes/notes/fix-embedding-splitter-async-recursion-7a1fa697999ddcfd.yaml
+++ b/releasenotes/notes/fix-embedding-splitter-async-recursion-7a1fa697999ddcfd.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixed `EmbeddingBasedDocumentSplitter.run_async` embedding through the synchronous path while
-    recursively splitting chunks longer than `max_length`. Only the first pass was async: the recursion
-    called the sync splitting helper, so the embedder's blocking `run` ran on the event loop for every
-    over-long chunk. The recursion now embeds through `run_async` as well.
+    Fixed ``EmbeddingBasedDocumentSplitter.run_async`` embedding through the synchronous path while
+    recursively splitting chunks longer than ``max_length``. Only the first pass was async: the recursion
+    called the sync splitting helper, so the embedder's blocking ``run`` ran on the event loop for every
+    over-long chunk. The recursion now embeds through ``run_async`` as well.

--- a/releasenotes/notes/fix-embedding-splitter-async-recursion-7a1fa697999ddcfd.yaml
+++ b/releasenotes/notes/fix-embedding-splitter-async-recursion-7a1fa697999ddcfd.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed `EmbeddingBasedDocumentSplitter.run_async` embedding through the synchronous path while
+    recursively splitting chunks longer than `max_length`. Only the first pass was async: the recursion
+    called the sync splitting helper, so the embedder's blocking `run` ran on the event loop for every
+    over-long chunk. The recursion now embeds through `run_async` as well.

--- a/test/components/preprocessors/test_embedding_based_document_splitter.py
+++ b/test/components/preprocessors/test_embedding_based_document_splitter.py
@@ -801,6 +801,38 @@ Artificial intelligence is transforming education by enabling personalized learn
             if i in [9, 10]:
                 assert split_doc.meta["page_number"] == 4
 
+    @pytest.mark.asyncio
+    async def test_recursive_split_of_large_chunks_stays_async(self) -> None:
+        """
+        `run_async` must embed through the embedder's async path, including while recursively splitting
+        chunks that came out longer than max_length. Reaching for the synchronous `run` there blocks the
+        event loop on the embedder's network calls.
+        """
+        calls = {"sync": 0, "async": 0}
+
+        def embed(documents: list[Document]) -> dict[str, list[Document]]:
+            # Alternating embeddings so consecutive groups look unrelated and the text keeps splitting.
+            return {"documents": [replace(doc, embedding=[float(i % 3), 1.0, 0.0]) for i, doc in enumerate(documents)]}
+
+        class RecordingEmbedder:
+            def run(self, documents: list[Document]) -> dict[str, list[Document]]:
+                calls["sync"] += 1
+                return embed(documents)
+
+            async def run_async(self, documents: list[Document]) -> dict[str, list[Document]]:
+                calls["async"] += 1
+                return embed(documents)
+
+        text = " ".join(f"Sentence number {i} about topic {i % 4}." for i in range(40))
+        splitter = EmbeddingBasedDocumentSplitter(document_embedder=RecordingEmbedder(), min_length=10, max_length=120)
+        splitter.warm_up()
+
+        await splitter.run_async(documents=[Document(content=text)])
+
+        # The first pass is async, and the recursion into the over-long chunk has to be too.
+        assert calls["async"] > 1
+        assert calls["sync"] == 0
+
 
 class TestComponentLifecycle:
     def test_warm_up_builds_splitter_and_delegates_to_embedder(self):


### PR DESCRIPTION
### Related Issues

- No issue; found while reading the component.

### Proposed Changes:

`EmbeddingBasedDocumentSplitter._split_document_async` is only async for the first pass:

```python
splits = await self._split_text_async(text=doc.content)
merged_splits = self._merge_small_splits(splits=splits)
final_splits = self._split_large_splits(splits=merged_splits)   # synchronous
```

`_split_large_splits` re-splits every chunk that came out longer than `max_length` by calling `_split_text`, which calls `_calculate_embeddings`, which calls `self.document_embedder.run(...)`. So in `run_async` the recursion embeds through the blocking path, on the event loop, once per over-long chunk and again at every level of the recursion.

This is not an edge case — `max_length` is the setting whose whole purpose is to trigger that recursion, and the sync path is identical up to that point, so the async version silently behaves like the sync one for the most expensive part of the work.

Added `_split_large_splits_async`, mirroring the sync version but awaiting `_split_text_async`, and called it from `_split_document_async`. The sync path is untouched.

### How did you test it?

- New unit test `test_recursive_split_of_large_chunks_stays_async`: a recording embedder that implements both `run` and `run_async`, and a document long enough that the first pass produces a chunk over `max_length`. The test asserts the async path is used more than once (so the recursion did happen) and that `run` is never called. On `main` it fails with `sync == 1`.
- `hatch run test:unit` — 6116 passed, 10 skipped.
- `hatch run test:types` and `hatch run fmt` clean.

### Notes for the reviewer

The two `_split_large_splits` methods are near-duplicates, which I kept deliberately: the alternative is to thread an "am I async" flag through the recursion, and the sync/async pairs elsewhere in this file (`_split_document`, `_split_text`, `_calculate_embeddings`) are written the same way.

I used an AI assistant while writing this change. I have reviewed it, reproduced the behaviour, and run the tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- I have documented my code.
- I have added a release note file.
- I have run pre-commit hooks and fixed any issue.
