### PR TITLE
fix: convert images off the event loop in LLMDocumentContentExtractor.run_async

### DIFF
--- a/haystack/components/extractors/image/llm_document_content_extractor.py
+++ b/haystack/components/extractors/image/llm_document_content_extractor.py
@@ -422,7 +422,10 @@ class LLMDocumentContentExtractor:
 
         await self.warm_up_async()
 
-        image_contents = self._document_to_image_content.run(documents=documents)["image_contents"]
+        # Reading the files and rendering PDF pages is blocking work and `DocumentToImageContent` has no
+        # `run_async`, so it runs in a thread instead of on the event loop.
+        conversion_result = await _execute_component_async(self._document_to_image_content, documents=documents)
+        image_contents = conversion_result["image_contents"]
 
         # Capture the current span here so concurrent tasks nest their generator spans under the component span.
         parent_span = tracing.tracer.current_span()

--- a/releasenotes/notes/fix-llm-content-extractor-async-image-conversion-69772090bd3a32c4.yaml
+++ b/releasenotes/notes/fix-llm-content-extractor-async-image-conversion-69772090bd3a32c4.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed ``LLMDocumentContentExtractor.run_async`` converting documents to images on the event loop.
+    ``DocumentToImageContent`` reads every file and renders the requested PDF pages, and it has no
+    ``run_async``, so calling it directly blocked the loop for the whole batch before any LLM call
+    started. It now runs through ``_execute_component_async``, which hands the synchronous work to a
+    thread.

--- a/test/components/extractors/image/test_llm_document_content_extractor.py
+++ b/test/components/extractors/image/test_llm_document_content_extractor.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import os
+import threading
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -579,6 +580,33 @@ class TestLLMDocumentContentExtractorAsync:
         assert len(result["documents"]) == 1
         assert len(result["failed_documents"]) == 0
         assert result["documents"][0].content == "Extracted via sync run"
+
+    @pytest.mark.asyncio
+    @patch.object(DocumentToImageContent, "run")
+    async def test_run_async_converts_images_off_the_event_loop(self, mock_doc_to_image_run):
+        """
+        Turning documents into images reads the files and renders PDF pages, and `DocumentToImageContent`
+        only has a synchronous `run`, so `run_async` has to hand that work to a thread.
+        """
+        conversion_thread = None
+
+        def record_thread(documents):
+            nonlocal conversion_thread
+            conversion_thread = threading.current_thread()
+            return {"image_contents": [ImageContent.from_file_path("./test/test_files/images/apple.jpg")]}
+
+        mock_doc_to_image_run.side_effect = record_thread
+
+        mock_chat_generator = Mock(spec=OpenAIChatGenerator)
+        mock_chat_generator.run_async = AsyncMock(
+            return_value={"replies": [ChatMessage.from_assistant(text='{"document_content": "Extracted"}')]}
+        )
+        extractor = LLMDocumentContentExtractor(chat_generator=mock_chat_generator)
+
+        await extractor.run_async(documents=[Document(content="", meta={"file_path": "/path/to/image.pdf"})])
+
+        assert conversion_thread is not None
+        assert conversion_thread is not threading.current_thread()
 
     @pytest.mark.asyncio
     @patch.object(DocumentToImageContent, "run")


### PR DESCRIPTION
### Related Issues

- No issue; found while reading the component.

### Proposed Changes:

`LLMDocumentContentExtractor.run_async` converts the documents to images with a direct call:

```python
image_contents = self._document_to_image_content.run(documents=documents)["image_contents"]
```

`DocumentToImageContent` reads every file from disk, renders the requested page of each PDF and base64-encodes the result, and it implements no `run_async`. So the whole batch is converted on the event loop before the first LLM call is even scheduled, and anything else sharing that loop waits for it.

The module already imports `_execute_component_async` and uses it for the chat generator, which is exactly the helper for this: it prefers `run_async` when a component has one and otherwise runs `run` in a thread. This change routes the conversion through it. If `DocumentToImageContent` grows a `run_async` later, this call site picks it up for free.

`run` is untouched.

### How did you test it?

- New unit test `test_run_async_converts_images_off_the_event_loop`: patches `DocumentToImageContent.run` to record the thread it executes on and asserts it is not the thread running the event loop. It fails on `main`, where the conversion runs on the main thread.
- `hatch run test:unit` — 6116 passed, 10 skipped.
- `hatch run test:types` and `hatch run fmt` clean.

### Notes for the reviewer

I looked for the same pattern across the components with a `run_async` and this was the one remaining call that does blocking I/O; the other direct `run` calls in async methods are prompt builders, which are pure CPU and cheap.

I used an AI assistant while writing this change. I have reviewed it, reproduced the behaviour, and run the tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- I have documented my code.
- I have added a release note file.
- I have run pre-commit hooks and fixed any issue.
