### PR TITLE
fix: Agent clone and serialization with a tools-less chat generator

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -435,9 +435,12 @@ class Agent:
         """
         # --- Validation ---
         self._chat_generator_supports_tools: bool = "tools" in inspect.signature(chat_generator.run).parameters
-        # We use an explicit None check for tools b/c testing for truthiness calls __len__, which for SearchableToolset
-        # would iterate and prematurely warm it up at init.
-        if tools is not None and not self._chat_generator_supports_tools:
+        # An empty list carries no tools, so it must not trip this check: `tools` is normalized to `[]` below, and
+        # both `clone()` and `to_dict()` feed that normalized value straight back into `__init__`. This mirrors the
+        # equivalent check in `run()`. Only a list is measured; a Toolset is never tested for truthiness here b/c
+        # that calls __len__, which for SearchableToolset would iterate and prematurely warm it up at init.
+        tools_provided = tools is not None and (not isinstance(tools, list) or len(tools) > 0)
+        if tools_provided and not self._chat_generator_supports_tools:
             raise TypeError(
                 f"{type(chat_generator).__name__} does not accept tools parameter in its run method. "
                 "The Agent component requires a chat generator that supports tools when tools are provided."

--- a/releasenotes/notes/agent-empty-tools-list-serialization-699c89ec10b89698.yaml
+++ b/releasenotes/notes/agent-empty-tools-list-serialization-699c89ec10b89698.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fix ``Agent.clone()`` and ``Agent.to_dict()``/``from_dict()`` raising ``TypeError`` for an
+    ``Agent`` built on a chat generator that does not accept a ``tools`` parameter. ``tools`` is
+    normalized to an empty list at init, and both round-trip paths passed that empty list back to
+    the constructor, where it was treated as "tools were provided". An empty list now carries no
+    tools, matching the equivalent check already applied in ``Agent.run()``. Passing ``tools=[]``
+    explicitly to such an ``Agent`` is accepted for the same reason. A non-empty ``tools`` value
+    still raises, and a ``Toolset`` is still never tested for truthiness at init.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -144,7 +144,7 @@ class MockChatGeneratorWithoutTools:
     """A mock chat generator that implements ChatGenerator protocol but doesn't support tools."""
 
     def to_dict(self) -> dict[str, Any]:
-        return {"type": "MockChatGeneratorWithoutTools", "data": {}}
+        return {"type": "test.components.agents.test_agent.MockChatGeneratorWithoutTools", "init_parameters": {}}
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "MockChatGeneratorWithoutTools":
@@ -284,6 +284,13 @@ class TestAgentInit:
 
         with pytest.raises(TypeError, match="MockChatGeneratorWithoutTools does not accept tools"):
             Agent(chat_generator=chat_generator, tools=[weather_tool])
+
+    def test_empty_tools_list_with_chat_generator_without_tools_support(self):
+        # An empty list carries no tools, so it must be accepted just like `tools=None`. `run()` already
+        # treats it that way, and `clone()`/`to_dict()` both feed the normalized `[]` back into `__init__`.
+        agent = Agent(chat_generator=MockChatGeneratorWithoutTools(), tools=[])
+
+        assert agent.tools == []
 
 
 class TestAgentSerialization:
@@ -512,8 +519,32 @@ class TestAgentSerialization:
         assert all(isinstance(ts, Toolset) for ts in restored.tools)
         assert restored.tools[0][0].function is weather_function
 
+    def test_to_dict_from_dict_without_tools(self):
+        # `to_dict` serializes the normalized `self.tools`, which is `[]` when no tools were given.
+        # `from_dict` hands that `[]` straight back to `__init__`, so the round trip must survive it.
+        agent = Agent(chat_generator=MockChatGeneratorWithoutTools(), max_agent_steps=3)
+
+        data = agent.to_dict()
+        assert data["init_parameters"]["tools"] == []
+
+        restored = Agent.from_dict(data)
+
+        assert restored.tools == []
+        assert restored.max_agent_steps == 3
+        assert type(restored.chat_generator).__name__ == "MockChatGeneratorWithoutTools"
+
 
 class TestAgentClone:
+    def test_clone_without_tools(self):
+        # `clone()` reads back the normalized `self.tools` (`[]`) and passes it to `__init__`.
+        agent = Agent(chat_generator=MockChatGeneratorWithoutTools(), system_prompt="You are helpful")
+
+        clone = agent.clone()
+
+        assert clone is not agent
+        assert clone.tools == []
+        assert clone.to_dict() == agent.to_dict()
+
     def test_clone(self, weather_tool):
         agent = Agent(
             chat_generator=MockChatGenerator("Hello"),


### PR DESCRIPTION
### Related Issues

- No existing issue; found while reading `Agent`'s init/serialization paths. Happy to open one if you'd prefer the bug tracked separately.

### Proposed Changes:

An `Agent` built on a chat generator whose `run()` has no `tools` parameter is a **supported** configuration — the suite already covers constructing and running one in `TestAgentRun::test_no_tools_with_chat_generator_without_tools_support`. But such an `Agent` cannot be cloned or serialized: both raise `TypeError`.

The cause is a value that changes shape between the two passes:

1. `__init__` guards with `tools is not None` (`agent.py:441`). `tools=None` passes.
2. `__init__` then normalizes it away: `self.tools = tools if tools is not None else []` (`agent.py:469`).
3. `clone()` rebuilds from `getattr(self, name)` for each init param, so it passes `tools=[]`. `to_dict()` emits `serialize_tools_or_toolset(self.tools)` → `[]`, which `from_dict` hands back to `__init__`.
4. On that second pass `[] is not None` is `True`, so the guard fires and raises — for an Agent that has no tools.

The same rule is already implemented a second time for the run path, at `agent.py:734`:

```python
if flat_tools and not self._chat_generator_supports_tools:
```

That one uses truthiness, so it correctly treats an empty list as "no tools". The two guards disagree, and the `run()` one is right — an empty list carries no tools. This change makes `__init__` agree with it.

The `is not None` form was deliberate, per the comment it replaces: truthiness on a `Toolset` calls `__len__`, which for `SearchableToolset` would iterate and prematurely warm it up at init. That property is preserved — only a `list` is ever measured:

```python
tools_provided = tools is not None and (not isinstance(tools, list) or len(tools) > 0)
```

`isinstance(tools, list)` short-circuits before any `__len__` call, so a `Toolset` is still never measured here. A non-empty `tools` value still raises exactly as before, and passing `tools=[]` explicitly is now accepted for the same reason `tools=None` is.

### How did you test it?

Three unit tests, one per affected entry point, added to the classes that already own those behaviours. Each **fails on `main` and passes with the change** — verified by reverting only `agent.py` and re-running:

```
# with agent.py reverted, tests present:
FAILED TestAgentInit::test_empty_tools_list_with_chat_generator_without_tools_support
FAILED TestAgentSerialization::test_to_dict_from_dict_without_tools
FAILED TestAgentClone::test_clone_without_tools
3 failed, 1 passed        # the 1 passing is the existing test_no_tools_... run-path case

# with the change:
4 passed
```

Full runs at this head (`36706ae`):

- `hatch run test:unit test/components/agents/test_agent.py` → **104 passed**
- `hatch run test:unit test/components/agents/ test/tools/ test/core/` → **2359 passed**, 173 deselected
- `hatch run test:types` → **Success: no issues found in 432 source files**
- `hatch run fmt` → **All checks passed!**
- `pre-commit run --files <the three changed files>` → all hooks **Passed**

`test_chat_generator_must_support_tools` (non-empty tools + tools-less generator still raises) is unchanged and still passes.

### Notes for the reviewer

**One pre-existing failure, unrelated to this PR, that I did not tick as green.** A full `hatch run test:unit` at this head reports **2 failed, 6116 passed**. Both failures are in `test/components/generators/chat/test_openai.py`:

```
TestChatCompletionChunkConversion::test_convert_chat_completion_chunk_to_streaming_chunk
TestChatCompletionChunkConversion::test_handle_stream_response
```

They reproduce identically on a clean checkout of `main` (`915888bb`) with none of my changes applied, so they are not caused by this PR. For what it's worth, they look like fallout from `chore: unpin openai` (#12348): with `openai>=2.6.0` now resolving to **openai 3.1.0**, the usage payload gained fields the fixtures don't expect — the diff is confined to `meta`, e.g. `prompt_tokens_details` now carrying `cache_write_tokens` / `image_tokens` / `text_tokens`. Flagging it because a fresh install currently hits it; happy to open a separate issue or PR if that's useful.

**One test-scaffolding change.** `MockChatGeneratorWithoutTools.to_dict()` returned `{"type": "MockChatGeneratorWithoutTools", "data": {}}` — a bare class name and a `data` key, neither of which round-trips through `component_from_dict`. It is now a resolvable dotted path with `init_parameters`, which is what the serialization test needs. Nothing referenced the old shape.

I did not touch the `:raises TypeError:` docstring, since it remains accurate — a generator that doesn't support tools still raises when tools are actually provided.

Alternatives I considered and rejected: leaving `self.tools` un-normalized (wide blast radius — plenty of code assumes a list), or emitting `None` from `clone()`/`to_dict()` when empty (fixes the round trip but leaves an explicit `tools=[]` still raising, and leaves the two guards disagreeing).

**AI assistance disclosure:** this PR was written with an AI assistant. I reviewed the change, and ran the tests and quality checks reported above.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes. — N/A, no related issue exists.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
