### PR TITLE
fix: avoid duplicating overlap when DocumentSplitter merges a below-threshold segment

### DIFF
--- a/haystack/components/preprocessors/document_splitter.py
+++ b/haystack/components/preprocessors/document_splitter.py
@@ -292,8 +292,11 @@ class DocumentSplitter:
 
             # check if length of current units is below split_threshold
             if len(current_units) < split_threshold and len(text_splits) > 0:
-                # concatenate the last split with the current one
-                text_splits[-1] += txt
+                # concatenate the last split with the current one. The first `split_overlap` units
+                # of this segment are already part of the previous split (that is what the overlap
+                # is), so only append the units beyond the overlap; otherwise the overlapping text
+                # would be duplicated and the merged chunk would not be present in the source.
+                text_splits[-1] += "".join(current_units[split_overlap:])
 
             # NOTE: If skip_empty_documents is True, this line skips documents that have content=""
             elif not self.skip_empty_documents or len(txt) > 0:

--- a/releasenotes/notes/fix-document-splitter-threshold-overlap-duplication-a1b2c3d4e5f60718.yaml
+++ b/releasenotes/notes/fix-document-splitter-threshold-overlap-duplication-a1b2c3d4e5f60718.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed `DocumentSplitter` producing chunks that were not present in the source document when
+    `split_threshold` was set together with `split_overlap`. Merging a below-threshold trailing
+    segment into the previous split re-appended the overlapping units, duplicating text. The
+    overlap is now added only once.

--- a/releasenotes/notes/fix-document-splitter-threshold-overlap-duplication-a1b2c3d4e5f60718.yaml
+++ b/releasenotes/notes/fix-document-splitter-threshold-overlap-duplication-a1b2c3d4e5f60718.yaml
@@ -1,7 +1,0 @@
----
-fixes:
-  - |
-    Fixed `DocumentSplitter` producing chunks that were not present in the source document when
-    `split_threshold` was set together with `split_overlap`. Merging a below-threshold trailing
-    segment into the previous split re-appended the overlapping units, duplicating text. The
-    overlap is now added only once.

--- a/releasenotes/notes/fix-document-splitter-threshold-overlap-duplication-eadffcd349cd50c6.yaml
+++ b/releasenotes/notes/fix-document-splitter-threshold-overlap-duplication-eadffcd349cd50c6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed ``DocumentSplitter`` producing chunks that were not present in the source document when
+    ``split_threshold`` was set together with ``split_overlap``. Merging a below-threshold trailing
+    segment into the previous split re-appended the overlapping units, duplicating text. The
+    overlap is now added only once.

--- a/test/components/preprocessors/test_document_splitter.py
+++ b/test/components/preprocessors/test_document_splitter.py
@@ -108,6 +108,18 @@ class TestSplittingByFunctionOrCharacterRegex:
             == "This is a text with some words. There is a second sentence. And there is a third sentence."
         )
 
+    def test_split_by_word_with_threshold_and_overlap_does_not_duplicate_overlap(self):
+        # When ``split_threshold`` merges a small trailing segment into the previous split and
+        # ``split_overlap`` is set, the overlapping units must not be duplicated: every chunk must
+        # remain a substring of the source. Regression test.
+        text = "a b c d e f"
+        splitter = DocumentSplitter(split_by="word", split_length=3, split_overlap=1, split_threshold=3)
+        result = splitter.run(documents=[Document(content=text)])
+        contents = [doc.content for doc in result["documents"]]
+        for content in contents:
+            assert content in text, f"chunk {content!r} is not present in the source text"
+        assert contents == ["a b c ", "c d e f"]
+
     def test_split_by_word_multiple_input_docs(self):
         splitter = DocumentSplitter(split_by="word", split_length=10)
         text1 = "This is a text with some words. There is a second sentence. And there is a third sentence."


### PR DESCRIPTION
### Related Issues
Fixes a correctness bug in `DocumentSplitter` (found while looking at the recently reported overlap issues in `RecursiveDocumentSplitter`, #12281 — this one is in the base `DocumentSplitter`, a different code path).

### Proposed Changes

`DocumentSplitter._concatenate_units` merges a below-`split_threshold` trailing segment into the previous split to avoid tiny chunks. When `split_overlap > 0`, consecutive windows share their boundary units, so the merged segment's leading `split_overlap` units are **already** part of the previous split. It appended the full segment anyway, duplicating that overlap and producing chunks that don't exist in the source document.

**Reproducer (on `main`):**
```python
from haystack import Document
from haystack.components.preprocessors import DocumentSplitter

splitter = DocumentSplitter(split_by="word", split_length=3, split_overlap=1, split_threshold=3)
docs = splitter.run(documents=[Document(content="a b c d e f")])["documents"]
print([d.content for d in docs])
# ['a b c ', 'c d e e f']   <-  'c d e e f' is not in the source ("e" duplicated)
```

Fix: when merging, append only the units **beyond** the overlap (`current_units[split_overlap:]`), so the overlapping text is added once. Output becomes `['a b c ', 'c d e f']`.

### How did you test it?
Added `test_split_by_word_with_threshold_and_overlap_does_not_duplicate_overlap` (fails on `main`, passes with the fix). The full `test_document_splitter.py` suite passes (55 tests); `ruff check`/`ruff format` clean. Added a release note.

### Notes for the reviewer
The diff is a one-line change in the merge branch plus a regression test and release note.

---
_This PR was written with the assistance of an AI coding agent and reviewed/tested by me before submission._
