### PR TITLE
test: derive streamed-usage expectations from the SDK object (unbreaks main)

### DIFF
--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -1291,6 +1291,21 @@ class TestOpenAIChatGenerator:
         assert all(isinstance(ts, Toolset) for ts in deserialized.tools)
 
 
+# The streamed usage payload is passed through from the OpenAI SDK object verbatim, so the expected value is
+# derived from that same object rather than restated as a literal. A new openai release that adds a field to
+# CompletionUsage must not fail these tests: the contract under test is "usage is forwarded unchanged", not
+# "the SDK's usage schema has exactly these keys".
+STREAMED_USAGE = CompletionUsage(
+    completion_tokens=42,
+    prompt_tokens=282,
+    total_tokens=324,
+    completion_tokens_details=CompletionTokensDetails(
+        accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0
+    ),
+    prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0, cache_write_tokens=0),
+)
+
+
 @pytest.fixture
 def chat_completion_chunks():
     return [
@@ -1506,15 +1521,7 @@ def chat_completion_chunks():
             object="chat.completion.chunk",
             service_tier="default",
             system_fingerprint="fp_54eb4bd693",
-            usage=CompletionUsage(
-                completion_tokens=42,
-                prompt_tokens=282,
-                total_tokens=324,
-                completion_tokens_details=CompletionTokensDetails(
-                    accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0
-                ),
-                prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0, cache_write_tokens=0),
-            ),
+            usage=STREAMED_USAGE,
         ),
     ]
 
@@ -1706,23 +1713,7 @@ def streaming_chunks():
             finish_reason="tool_calls",
         ),
         StreamingChunk(
-            content="",
-            meta={
-                "model": "gpt-5-mini",
-                "received_at": ANY,
-                "usage": {
-                    "completion_tokens": 42,
-                    "prompt_tokens": 282,
-                    "total_tokens": 324,
-                    "completion_tokens_details": {
-                        "accepted_prediction_tokens": 0,
-                        "audio_tokens": 0,
-                        "reasoning_tokens": 0,
-                        "rejected_prediction_tokens": 0,
-                    },
-                    "prompt_tokens_details": {"audio_tokens": 0, "cached_tokens": 0, "cache_write_tokens": 0},
-                },
-            },
+            content="", meta={"model": "gpt-5-mini", "received_at": ANY, "usage": STREAMED_USAGE.model_dump()}
         ),
     ]
 
@@ -1993,18 +1984,7 @@ class TestChatCompletionChunkConversion:
         assert result.meta["finish_reason"] == "tool_calls"
         assert result.meta["index"] == 0
         assert result.meta["completion_start_time"] is not None
-        assert result.meta["usage"] == {
-            "completion_tokens": 42,
-            "prompt_tokens": 282,
-            "total_tokens": 324,
-            "completion_tokens_details": {
-                "accepted_prediction_tokens": 0,
-                "audio_tokens": 0,
-                "reasoning_tokens": 0,
-                "rejected_prediction_tokens": 0,
-            },
-            "prompt_tokens_details": {"audio_tokens": 0, "cached_tokens": 0, "cache_write_tokens": 0},
-        }
+        assert result.meta["usage"] == STREAMED_USAGE.model_dump()
 
     def test_convert_usage_chunk_to_streaming_chunk(self) -> None:
 


### PR DESCRIPTION
### Related Issues

- No open issue; `main` is currently red and I hit it while running the suite for another PR. Filing the fix directly since CI is blocking everyone.

### Proposed Changes:

**`main` is failing on all three OS jobs.** Run [31934088851](https://github.com/deepset-ai/haystack/actions/runs/31934088851) at `915888bb` — `Unit / ubuntu-latest`, `Unit / macos-latest` and `Unit / windows-latest` all end with:

```
FAILED test/components/generators/chat/test_openai.py::TestChatCompletionChunkConversion::test_convert_chat_completion_chunk_to_streaming_chunk
FAILED test/components/generators/chat/test_openai.py::TestChatCompletionChunkConversion::test_handle_stream_response
= 2 failed, 6113 passed, 8 skipped, 323 deselected =
```

**Cause.** `chore: unpin openai` (#12348) relaxed the constraint to `openai>=2.6.0`, so a fresh environment now resolves **openai 3.1.0**, and `CompletionUsage` gained additive fields:

- `prompt_tokens_details` → `image_tokens`, `text_tokens`
- `completion_tokens_details` → `text_tokens`

Both failing tests restated the expected usage payload as a literal enumerating openai 2.x's exact field set, so `model_dump()` now returns more keys than the literal lists and the comparison fails. The diff is confined to `meta["usage"]`; nothing in `haystack/` is wrong — `_serialize_object` forwards `model_dump()` faithfully, which is precisely what it should do.

**Fix.** The contract these tests exist to protect is *"haystack forwards the SDK's usage unchanged"*, not *"the SDK's usage schema has exactly these keys"*. Restating the schema as a literal encodes the second, which is not this repo's invariant to own — and with the dependency now unpinned it will drift again on the next release that adds a field.

The expected value is therefore derived from the same `CompletionUsage` object the fixture streams. Net **-38/+18** lines: two duplicated literals collapse into one shared object.

```python
STREAMED_USAGE = CompletionUsage(
    completion_tokens=42, prompt_tokens=282, total_tokens=324,
    completion_tokens_details=CompletionTokensDetails(...),
    prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0, cache_write_tokens=0),
)
```

used both as the chunk's `usage=` and, via `.model_dump()`, as the expectation in the `streaming_chunks` fixture and in `test_handle_stream_response`.

### How did you test it?

At this head (`9141ca50`):

- `hatch run test:unit test/components/generators/chat/test_openai.py` → **55 passed** (both previously-failing tests now pass)
- `hatch run test:unit` (full suite) → **6115 passed, 10 skipped, 0 failed** — against `main`'s 6113 passed / **2 failed**
- `hatch run test:types` → **Success: no issues found in 432 source files**
- `hatch run fmt` → **All checks passed!**
- `pre-commit run --files test/components/generators/chat/test_openai.py` → all hooks **Passed**

**Mutation test, because a derived expectation is worth distrusting.** An assertion built from the same object it validates can be tautological, so I checked that this one still fails when the behaviour it guards actually breaks. Patching `_serialize_object` in `haystack/components/generators/utils.py` to drop `prompt_tokens_details` from the dump:

```
FAILED ...::test_convert_chat_completion_chunk_to_streaming_chunk
FAILED ...::test_handle_stream_response
2 failed
```

and with that patch reverted, `2 passed`. So the tests still catch a real pass-through regression; they no longer catch *additive changes to openai's own schema*, which is the part that should not have been asserted.

### Notes for the reviewer

**No release note**, per CONTRIBUTING: this is limited to tests, so it needs the `ignore-for-release-notes` label from a maintainer to bypass that CI check. Say the word if you'd rather I add one instead.

Deliberately scoped to unbreaking CI: I did **not** re-pin `openai`, since #12348 unpinned it on purpose, and I did not touch the other `PromptTokensDetails(...)` fixtures elsewhere in the file — those are inputs rather than expectations, so they are unaffected by additive fields.

Worth noting the general shape, since the unpin makes it recurrent: any assertion that enumerates a third-party model's fields is a scheduled failure. The two sites fixed here were the only ones the suite currently trips on.

**AI assistance disclosure:** this PR was written with an AI assistant. I reviewed the change, and ran the tests and checks reported above.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes. — N/A, no related issue.
- [x] I have added unit tests and updated the docstrings. — existing tests repaired; the shared fixture carries an explanatory comment.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `test:`.
- [x] I have documented my code.
- [ ] I have added a release note file. — intentionally omitted; tests-only, needs `ignore-for-release-notes` (see notes above).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
