### PR TITLE
feat: set `tools` in `State` so its available to `before_run` hooks

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -743,6 +743,7 @@ class Agent:
         state.set("tool_call_counts", {tool.name: 0 for tool in flat_tools})
         state.set("exit_reason", None)
         state.set("continue_run", False)
+        state.set("tools", flat_tools)
         state.set("hook_context", hook_context or {})
 
         streaming_callback = select_streaming_callback(  # type: ignore[call-overload]

--- a/releasenotes/notes/agent-before-run-tools-f5ee03eb231cfea2.yaml
+++ b/releasenotes/notes/agent-before-run-tools-f5ee03eb231cfea2.yaml
@@ -1,5 +1,7 @@
 ---
 enhancements:
   - |
-    Make the Agent's run-scoped tools available in ``State`` to ``before_run`` hooks. Dynamic toolsets such as
-    ``SearchableToolset`` continue to refresh the State tool snapshot before each LLM step.
+    ``before_run`` hooks can now read ``state.data["tools"]``. The key was previously written only once the first step
+    had started, so a ``before_run`` hook hit a ``KeyError``. It holds a snapshot of the tools available at that point,
+    refreshed before every LLM call, so with a dynamic toolset such as ``SearchableToolset`` a ``before_run`` hook sees
+    only the tools discovered so far.

--- a/releasenotes/notes/agent-before-run-tools-f5ee03eb231cfea2.yaml
+++ b/releasenotes/notes/agent-before-run-tools-f5ee03eb231cfea2.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Make the Agent's run-scoped tools available in ``State`` to ``before_run`` hooks. Dynamic toolsets such as
+    ``SearchableToolset`` continue to refresh the State tool snapshot before each LLM step.

--- a/test/components/agents/test_agent_hooks.py
+++ b/test/components/agents/test_agent_hooks.py
@@ -203,7 +203,6 @@ class TestBeforeRunHook:
             available_tool_names.extend(tool.name for tool in state.data["tools"])
 
         agent = _agent(MockChatGenerator(), tools=[save], hooks={"before_run": [hook(record_tools)]})
-        agent.chat_generator.run = MagicMock(return_value={"replies": [ChatMessage.from_assistant("done")]})
         agent.run(messages=[ChatMessage.from_user("hi")])
         assert available_tool_names == ["save"]
 

--- a/test/components/agents/test_agent_hooks.py
+++ b/test/components/agents/test_agent_hooks.py
@@ -196,6 +196,17 @@ class TestAgentHooksValidation:
 
 
 class TestBeforeRunHook:
+    def test_tools_are_available_before_the_first_step(self):
+        available_tool_names: list[str] = []
+
+        def record_tools(state: State) -> None:
+            available_tool_names.extend(tool.name for tool in state.data["tools"])
+
+        agent = _agent(MockChatGenerator(), tools=[save], hooks={"before_run": [hook(record_tools)]})
+        agent.chat_generator.run = MagicMock(return_value={"replies": [ChatMessage.from_assistant("done")]})
+        agent.run(messages=[ChatMessage.from_user("hi")])
+        assert available_tool_names == ["save"]
+
     def test_runs_once_across_multi_step_run(self):
         agent = _agent(
             MockChatGenerator(),


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Request from @tstadel 

Make the Agent's run-scoped tools available in ``State`` to ``before_run`` hooks. Dynamic toolsets such as ``SearchableToolset`` continue to refresh the State tool snapshot before each LLM step.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
