### PR TITLE
ci: run type checking on Python 3.12 and unpin numpy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,9 @@ env:
   AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
   AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
   PYTHON_VERSION: "3.10"
+  # numpy's stubs require a 3.12+ interpreter, so type checking runs above the floor.
+  # See [tool.mypy] in pyproject.toml.
+  MYPY_PYTHON_VERSION: "3.12"
   HATCH_VERSION: "1.16.5"
 
 permissions:
@@ -197,7 +200,7 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: steps.files.outputs.any_changed == 'true'
         with:
-          python-version: "${{ env.PYTHON_VERSION }}"
+          python-version: "${{ env.MYPY_PYTHON_VERSION }}"
 
       - name: Install Hatch
         id: hatch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@ hatch run test:integration
 ### Type checking with mypy
 hatch run test:types
 
+Type checking targets Python 3.12, above the 3.10 floor in `requires-python`, because numpy's stubs use PEP 695 `type` statements that mypy rejects below 3.12. So mypy will not catch code that breaks on 3.10; the unit test matrix runs on 3.10 and covers that.
+
 To fix type issues, avoid `type: ignore`, casts, or assertions when possible. If they are necessary, explain why.
 
 ### Format and lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,6 +288,11 @@ To check for static type errors, run:
 hatch run test:types
 ```
 
+Note that type checking targets Python 3.12, even though Haystack supports 3.10 and above. numpy's
+type stubs use [PEP 695](https://peps.python.org/pep-0695/) `type` statements, which mypy rejects as
+a syntax error below 3.12. Support for the older versions is covered by the unit test matrix, which
+runs on Python 3.10.
+
 To format your code and perform linting using Ruff (with automatic fixes), run:
 ```sh
 hatch run fmt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,7 @@ docs = "haystack-pydoc pydoc tmp_api_reference"
 # we override dependencies from the default environment
 dependencies = [
   # Haystack is compatible both with numpy 1.x and 2.x, but we test with 2.x.
-  # numpy 2.5 stubs use PEP 695 `type` statements, which mypy rejects under python_version = "3.10".
-  "numpy>=2,<2.5",
+  "numpy>=2",
   "numba>=0.54.0", # This pin helps uv resolve the dependency tree. See https://github.com/astral-sh/uv/issues/7881
 
   "pandas",                                           # AzureOCRDocumentConverter, CSVDocumentCleaner, CSVDocumentSplitter,
@@ -194,7 +193,10 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "class"
 
 [tool.mypy]
-python_version = "3.10"
+# Deliberately above the 3.10 floor in `requires-python`: numpy's stubs use PEP 695 `type`
+# statements, which mypy rejects as a syntax error below 3.12. The floor stays covered by the
+# unit test matrix, which runs on 3.10.
+python_version = "3.12"
 check_untyped_defs = true
 disallow_incomplete_defs = true
 ignore_missing_imports = true


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/539, the follow-up to the `numpy<2.5` pin added in #12332
 
numpy's type stubs require a 3.12+ target , which unpinning requires moving the mypy target to 3.12.

**Details:** numpy 2.5.2 ships [PEP 695](https://peps.python.org/pep-0695/) `type` statements and numpy 2.5 has `requires-python >=3.12`. mypy rejects the `type statements` below target 3.12 with `error: Type statement is only supported in Python 3.12 and greater`.

In our CI however, the mypy job runs on 3.10, where numpy 2.5 is uninstallable, so uv resolved 2.2.6. The [job cited in #12332](https://github.com/deepset-ai/haystack/actions/runs/31675493850/job/94370083742) shows only errors from the openai 3 SDK but none from numpy. The pin only affected developers whose local env is Python >=3.12.

### Proposed Changes:

- `pyproject.toml`: `numpy>=2,<2.5` → `numpy>=2`
- `pyproject.toml`: `[tool.mypy] python_version` 3.10 → 3.12 with an explanatory comment
- `.github/workflows/tests.yml`: new `MYPY_PYTHON_VERSION: "3.12"`, used **only** by the `mypy` job's `setup-python`. `PYTHON_VERSION` stays `3.10`, so the unit, integration, e2e and slow jobs are untouched
- `CONTRIBUTING.md` / `AGENTS.md`: document the 3.12 target and the gap it leaves

### How did you test it?

Locally with Python 3.12.8, numpy 2.5.2 and openai 3.1.0

### Notes for the reviewer

I think the additions to AGENTS.md and CONTRIBUTING.md are helpful but happy to shorten them or drop them entirely if you think they are not needed.

**The trade-off:** at target 3.12 mypy no longer catches code that breaks on Python 3.10. Verified: `enum.StrEnum`, `typing.override`, `itertools.batched` and `datetime.UTC` are all flagged at target 3.10 and all pass at 3.12. In addition, no CI job runs *tests* on Python >=3.12, which means we don't test with numpy 2.5. I am okay accepting this. Don't want to run always two mypy jobs with 3.10 (numpy<=2.5) and 3.12 (numpy>=2) and don't want to bump Python version of our tests.

Python 3.10 reaches EOL in October but even with 3.11 we would have the same issue.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes. — pending, the investigation write-up will be posted on the issue
- I have added unit tests and updated the docstrings. — n/a, no source code changed
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes). — n/a, not user-facing: test dependency, type-checker config and CI only
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
