### PR TITLE
fix: harden deserialization by blocking internal interfaces to prevent RCE

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -40,7 +40,11 @@ from haystack.core.serialization import (
     component_to_dict,
     generate_qualified_class_name,
 )
-from haystack.core.serialization_security import _check_module_allowed, _deserialization_context
+from haystack.core.serialization_security import (
+    _check_module_allowed,
+    _deserialization_context,
+    mark_deserialization_internal,
+)
 from haystack.core.type_utils import (
     ConversionStrategyType,
     _convert_value,
@@ -173,6 +177,7 @@ class PipelineBase:  # noqa: PLW1641
         }
 
     @classmethod
+    @mark_deserialization_internal
     def from_dict(
         cls: type[T],
         data: dict[str, Any],
@@ -309,6 +314,7 @@ class PipelineBase:  # noqa: PLW1641
         fp.write(marshaller.marshal(self.to_dict()))
 
     @classmethod
+    @mark_deserialization_internal
     def loads(
         cls: type[T],
         data: str | bytes | bytearray,
@@ -351,6 +357,7 @@ class PipelineBase:  # noqa: PLW1641
         return cls.from_dict(deserialized_data, callbacks, allowed_modules=allowed_modules, unsafe=unsafe)
 
     @classmethod
+    @mark_deserialization_internal
     def load(
         cls: type[T],
         fp: TextIO,

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -26,6 +26,7 @@ from haystack.core.pipeline.breakpoint import (
     _validate_pipeline_snapshot_against_pipeline,
 )
 from haystack.core.pipeline.utils import _deepcopy_with_exceptions
+from haystack.core.serialization_security import mark_deserialization_internal
 from haystack.dataclasses import AsyncStreamingCallbackT, StreamingCallbackT, StreamingChunk, select_streaming_callback
 from haystack.dataclasses.breakpoints import INTERNAL_INPUTS_FORMAT, Breakpoint, PipelineSnapshot
 from haystack.dataclasses.streaming_chunk import _invoke_streaming_callback
@@ -195,6 +196,7 @@ class Pipeline(PipelineBase):
 
             return component_output
 
+    @mark_deserialization_internal
     def run(  # noqa: PLR0915, PLR0912, C901
         self,
         data: dict[str, Any],
@@ -788,6 +790,7 @@ class Pipeline(PipelineBase):
         task = asyncio.create_task(_runner())
         running_tasks[task] = component_name
 
+    @mark_deserialization_internal
     async def run_async_generator(  # noqa: PLR0915,C901
         self, data: dict[str, Any], include_outputs_from: set[str] | None = None, concurrency_limit: int = 4
     ) -> AsyncGenerator[dict[str, Any], None]:
@@ -1077,6 +1080,7 @@ class Pipeline(PipelineBase):
                 # This is a no-op on normal completion and on a component error, since no tasks are left running by then
                 await self._cancel_in_flight_tasks(running_tasks, scheduled_components)
 
+    @mark_deserialization_internal
     async def run_async(
         self, data: dict[str, Any], include_outputs_from: set[str] | None = None, concurrency_limit: int = 4
     ) -> dict[str, Any]:
@@ -1194,6 +1198,7 @@ class Pipeline(PipelineBase):
             final = partial
         return final or {}
 
+    @mark_deserialization_internal
     def stream(
         self,
         data: dict[str, Any],

--- a/haystack/core/serialization.py
+++ b/haystack/core/serialization.py
@@ -14,6 +14,7 @@ from haystack.core.errors import DeserializationError, SerializationError
 # from haystack.core.serialization.
 # The redundant `as` alias marks it as an intentional re-export so ruff does not flag it (F401).
 from haystack.core.serialization_security import allow_deserialization_module as allow_deserialization_module
+from haystack.core.serialization_security import mark_deserialization_internal
 from haystack.utils.auth import Secret
 from haystack.utils.device import ComponentDevice
 from haystack.utils.type_serialization import _import_class_by_name
@@ -361,6 +362,7 @@ def _init_parameter_names(cls: type[object]) -> set[str] | None:
     return names
 
 
+@mark_deserialization_internal
 def import_class_by_name(fully_qualified_name: str) -> type[object]:
     """
     Utility function to import (load) a class object based on its fully qualified class name.

--- a/haystack/core/serialization_security.py
+++ b/haystack/core/serialization_security.py
@@ -20,10 +20,11 @@ import contextvars
 import fnmatch
 import importlib
 import os
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from types import ModuleType
+from typing import TypeVar
 
 from haystack.core.errors import DeserializationError
 
@@ -116,10 +117,102 @@ def _is_unsafe_deserialization() -> bool:
     return _get_context().unsafe
 
 
+_F = TypeVar("_F", bound=Callable[..., object])
+
+# Attribute stamped on callables that are part of the deserializer's own machinery so that the
+# resolution paths can refuse to hand them back (see `mark_deserialization_internal`).
+_DESERIALIZATION_INTERNAL_ATTR = "_haystack_deserialization_internal"
+
+
+def mark_deserialization_internal(func: _F) -> _F:
+    """
+    Mark a callable as deserializer-internal so it can never be produced by deserializing untrusted data.
+
+    The allowlist admits the whole `haystack` namespace so Haystack can deserialize its own
+    components. That also makes the deserializer's *own* interface resolvable from serialized data:
+    the allowlist-administration function :func:`allow_deserialization_module` and the resolution
+    helpers (`deserialize_callable`, `deserialize_type`, `import_class_by_name`).
+    A hostile pipeline can register `allow_deserialization_module` as a Jinja custom filter, call it
+    with `"*"` to disarm the allowlist process-wide, then use the equally-resolvable `deserialize_callable`
+    to resolve and invoke `os.system`, for example.
+
+    Stamp such callables at definition time with this decorator; the resolution paths
+    (:func:`deserialize_callable`, `_import_class_by_name`) refuse to return anything carrying the
+    mark. Bypassed in `unsafe=True` mode, which disables all deserialization safety checks by design.
+
+    :param func:
+        The callable to mark.
+    :returns:
+        The same callable, marked.
+    """
+    setattr(func, _DESERIALIZATION_INTERNAL_ATTR, True)
+    return func
+
+
+def _is_deserialization_internal(resolved: object) -> bool:
+    """
+    Return whether `resolved` belongs to Haystack's deserialization control plane.
+
+    An object belongs to it in any of three ways:
+
+    - It is stamped with :func:`mark_deserialization_internal`. This covers the resolution helpers
+      that live in *other* modules (`deserialize_callable`, `deserialize_type`, `import_class_by_name`).
+    - It is defined in this module (matched by `__module__`): `allow_deserialization_module` and the
+      private context machinery (`_DeserializationContext`, the `_check_*`/`_get_context` helpers).
+    - It is a bound method of the module-level *mutable* control-plane state — the allowlist list
+      `_extra_allowed_modules` and the `_current_context` context variable. These are reachable
+      through the very attribute walk the resolver performs (e.g. `_extra_allowed_modules.append`,
+      `_current_context.set`); their own `__module__` is `builtins`/`None`, so they are matched
+      by the identity of what they are bound to. Left reachable, they let serialized data append
+      `"*"` to the allowlist or install an `unsafe` context — operating the control from within
+      the very data it exists to distrust, which persists process-wide and enables a staged RCE on a
+      later load.
+    """
+    if getattr(resolved, _DESERIALIZATION_INTERNAL_ATTR, False):
+        return True
+    if getattr(resolved, "__module__", None) == __name__:
+        return True
+    state = (_extra_allowed_modules, _current_context)
+    bound_to = getattr(resolved, "__self__", None)
+    return any(resolved is s or bound_to is s for s in state)
+
+
+def _check_not_deserialization_internal(resolved: object, handle: str) -> None:
+    """
+    Reject `resolved` if it is part of the deserialization control plane.
+
+    See :func:`_is_deserialization_internal` for what that covers.
+    Used by the resolution paths (`deserialize_callable`, `_import_class_by_name`) as a companion to
+    the builtin and import-primitive denylists. It refuses the allowlist-administration function, the
+    resolution helpers, and the mutable allowlist/context state — all of which live in (or are
+    reachable through) the allowlisted `haystack` namespace and would otherwise be resolvable from
+    serialized data. Bypassed in `unsafe=True` mode, which disables all safety checks.
+
+    :param resolved:
+        The object resolved from the serialized handle.
+    :param handle:
+        The original serialized handle, used only for the error message.
+    :raises DeserializationError:
+        If `resolved` is part of the deserialization control plane.
+    """
+    if _get_context().unsafe:
+        return
+    if _is_deserialization_internal(resolved):
+        name = getattr(resolved, "__qualname__", None) or getattr(resolved, "__name__", None) or repr(resolved)
+        raise DeserializationError(
+            f"Refusing to deserialize '{handle}': it resolves to '{name}', which is part of Haystack's "
+            f"deserialization control plane (its allowlist administration, mutable allowlist/context state, "
+            f"or a resolution helper) and must never be produced by deserializing untrusted data — doing so "
+            f"would let the data operate the deserialization allowlist against itself. If you trust the "
+            f"source of this data, load it with unsafe=True to bypass deserialization safety checks."
+        )
+
+
 # Process-wide patterns set via allow_deserialization_module.
 _extra_allowed_modules: list[str] = []
 
 
+@mark_deserialization_internal
 def allow_deserialization_module(pattern: str) -> None:
     """
     Add a module pattern to the process-wide deserialization allowlist.

--- a/haystack/core/serialization_security.py
+++ b/haystack/core/serialization_security.py
@@ -208,6 +208,65 @@ def _check_not_deserialization_internal(resolved: object, handle: str) -> None:
         )
 
 
+# Non-dunder attribute names that still expose an object's internals — the frame/code/closure
+# accessors on functions, generators, coroutines and async generators. Dunder names (`__globals__`,
+# `__dict__`, `__class__`, `__builtins__`, `__subclasses__`, ...) are matched separately by the
+# `__` prefix; these have no such prefix and must be listed explicitly.
+_UNSAFE_TRAVERSAL_ATTRS: frozenset[str] = frozenset(
+    {
+        "gi_frame",
+        "gi_code",
+        "gi_yieldfrom",
+        "cr_frame",
+        "cr_code",
+        "cr_await",
+        "ag_frame",
+        "ag_code",
+        "f_globals",
+        "f_builtins",
+        "f_locals",
+        "f_back",
+        "f_code",
+        "func_globals",
+        "func_code",
+        "func_closure",
+        "func_dict",
+        "func_defaults",
+    }
+)
+
+
+def _check_traversable_attribute(name: str, handle: str) -> None:
+    """
+    Reject descending into an object-internals attribute while walking a serialized handle.
+
+    Serialized callable/class handles reference public dotted import paths (`module.Class.method`);
+    they never legitimately traverse into an object's internals. Dunder attributes (`__globals__`,
+    `__dict__`, `__class__`, `__builtins__`, `__subclasses__`, ...) and the frame/code accessors in
+    :data:`_UNSAFE_TRAVERSAL_ATTRS` are the classic sandbox-escape gadgets — e.g. `<func>.__globals__`
+    yields the defining module's live namespace, from which the allowlist state can be rewritten or
+    `__builtins__` (hence `eval`/`exec`) reached, regardless of any per-object identity check. The
+    module-granular allowlist does not stop this because the traversal stays inside an allowlisted
+    module. Bypassed in `unsafe=True` mode, which disables all deserialization safety checks by design.
+
+    :param name:
+        The attribute name about to be resolved from the current object in the walk.
+    :param handle:
+        The original serialized handle, used only for the error message.
+    :raises DeserializationError:
+        If `name` names an object-internals attribute.
+    """
+    if _get_context().unsafe:
+        return
+    if name.startswith("__") or name in _UNSAFE_TRAVERSAL_ATTRS:
+        raise DeserializationError(
+            f"Refusing to deserialize '{handle}': it traverses into the internal attribute '{name}', "
+            f"which can expose object internals (e.g. '__globals__', '__class__', '__builtins__') and is "
+            f"a known sandbox-escape gadget. If you trust the source of this data, load it with unsafe=True "
+            f"to bypass deserialization safety checks."
+        )
+
+
 # Process-wide patterns set via allow_deserialization_module.
 _extra_allowed_modules: list[str] = []
 

--- a/haystack/utils/callable_serialization.py
+++ b/haystack/utils/callable_serialization.py
@@ -15,6 +15,7 @@ from haystack.core.serialization_security import (
     _check_not_denied_callable,
     _check_not_deserialization_internal,
     _check_resolved_module_allowed,
+    _check_traversable_attribute,
     _is_denied_builtin,
     _is_module_allowed,
     mark_deserialization_internal,
@@ -106,6 +107,12 @@ def deserialize_callable(callable_handle: str) -> Callable:
 
         attr_value = mod
         for part in parts[i:]:
+            # A handle legitimately walks `module.Class.method`, never into an object's internals.
+            # Refuse dunder/frame attributes (`__globals__`, `__dict__`, `__class__`, ...) before the
+            # getattr: `<func>.__globals__` yields a live module namespace (a gateway to the allowlist
+            # state and to `__builtins__`/`eval`) even though the traversal never leaves an allowlisted
+            # module, so neither the module allowlist nor the resolved-object checks below would catch it.
+            _check_traversable_attribute(part, callable_handle)
             try:
                 attr_value = getattr(attr_value, part)
             except AttributeError as e:

--- a/haystack/utils/callable_serialization.py
+++ b/haystack/utils/callable_serialization.py
@@ -13,9 +13,11 @@ from haystack.core.serialization_security import (
     _check_module_allowed,
     _check_not_denied_builtin,
     _check_not_denied_callable,
+    _check_not_deserialization_internal,
     _check_resolved_module_allowed,
     _is_denied_builtin,
     _is_module_allowed,
+    mark_deserialization_internal,
 )
 from haystack.utils.type_serialization import thread_safe_import
 
@@ -64,6 +66,7 @@ def serialize_callable(callable_handle: Callable) -> str:
     return full_path
 
 
+@mark_deserialization_internal
 def deserialize_callable(callable_handle: str) -> Callable:
     """
     Deserializes a callable given its full import path as a string.
@@ -145,6 +148,14 @@ def deserialize_callable(callable_handle: str) -> Callable:
         # namespace (e.g. `haystack...thread_safe_import`), which are gateways to code execution
         # equivalent to the denied builtin `__import__`. Block them too.
         _check_not_denied_callable(attr_value, callable_handle)
+
+        # Refuse the deserializer's own machinery — the allowlist-administration function
+        # (`allow_deserialization_module`) and the resolution helpers (`deserialize_callable`,
+        # `deserialize_type`, `import_class_by_name`). They live in the allowlisted `haystack`
+        # namespace, so the module checks above admit them, but resolving them from serialized data
+        # lets a hostile pipeline register them as Jinja custom filters, disarm the allowlist with
+        # `'*'`, and then resolve and invoke arbitrary callables such as `os.system`.
+        _check_not_deserialization_internal(attr_value, callable_handle)
 
         return attr_value
 

--- a/haystack/utils/type_serialization.py
+++ b/haystack/utils/type_serialization.py
@@ -18,6 +18,7 @@ from haystack.core.serialization_security import (
     _check_module_allowed,
     _check_not_deserialization_internal,
     _check_resolved_module_allowed,
+    _check_traversable_attribute,
     mark_deserialization_internal,
 )
 
@@ -315,6 +316,9 @@ def _import_class_by_name(fully_qualified_name: str) -> Any:
     """
     module_path, attr_name = fully_qualified_name.rsplit(".", 1)
     _check_module_allowed(module_path)
+    # A class reference names a public attribute of a module, never an object-internals attribute
+    # (`__dict__`, `__globals__`, ...) that would expose a module namespace or escape gadget.
+    _check_traversable_attribute(attr_name, fully_qualified_name)
     try:
         logger.debug(
             "Attempting to import '{attr_name}' from module '{module_path}'",

--- a/haystack/utils/type_serialization.py
+++ b/haystack/utils/type_serialization.py
@@ -16,7 +16,9 @@ from haystack.core.errors import DeserializationError
 from haystack.core.serialization_security import (
     _check_builtin_is_type,
     _check_module_allowed,
+    _check_not_deserialization_internal,
     _check_resolved_module_allowed,
+    mark_deserialization_internal,
 )
 
 logger = logging.getLogger(__name__)
@@ -202,6 +204,7 @@ def _deserialize_type_arg(arg_str: str) -> Any:
     return deserialize_type(arg_str)
 
 
+@mark_deserialization_internal
 def deserialize_type(type_str: str) -> Any:
     """
     Deserializes a type given its full import path as a string, including nested generic types.
@@ -295,6 +298,7 @@ def thread_safe_import(module_name: str) -> ModuleType:
         return importlib.import_module(module_name)
 
 
+@mark_deserialization_internal
 def _import_class_by_name(fully_qualified_name: str) -> Any:
     """
     Imports an attribute (typically a class) given its fully qualified name.
@@ -326,6 +330,10 @@ def _import_class_by_name(fully_qualified_name: str) -> Any:
         # is the allowlisted module it was resolved from, so a private C accelerator backing it
         # (e.g. `io.StringIO` -> `_io`) is still accepted.
         _check_resolved_module_allowed(resolved, declared_module=module_path)
+        # Refuse the deserializer's own machinery (the allowlist-administration function and the
+        # resolution helpers) on the class-resolution path too, so it cannot be reached as a
+        # component `type` or nested class reference. See `mark_deserialization_internal`.
+        _check_not_deserialization_internal(resolved, fully_qualified_name)
         if module_path == "builtins":
             _check_builtin_is_type(resolved, fully_qualified_name)
         return resolved

--- a/releasenotes/notes/fix-rce-deserializer-pipeline-entry-points-7c2a1b9e4d3f5a6b.yaml
+++ b/releasenotes/notes/fix-rce-deserializer-pipeline-entry-points-7c2a1b9e4d3f5a6b.yaml
@@ -1,0 +1,15 @@
+---
+security:
+  - |
+    Closed an additional remote code execution vector in the deserialization control-plane
+    hardening: the pipeline loading entry points (``Pipeline.loads`` / ``Pipeline.load`` /
+    ``Pipeline.from_dict``, which accept ``unsafe=True``) and the execute primitives
+    (``Pipeline.run`` / ``run_async`` / ``run_async_generator`` / ``stream``) were still resolvable
+    from the allowlisted ``haystack`` namespace. Bound as a ``custom_filters`` entry on an
+    ``OutputAdapter`` or ``ConditionalRouter`` (which bypass the Jinja sandbox),
+    ``Pipeline.loads(..., unsafe=True)`` let a pipeline loaded in default safe mode load a nested
+    pipeline whose own filters (``allow_deserialization_module``, ``deserialize_callable``) bind
+    under the nested unsafe context, disarming the process-wide allowlist with ``"*"`` and invoking
+    ``os.system``. All of these entry points are now marked as deserializer-internal, so they can
+    never be produced by deserializing untrusted data. ``unsafe=True`` still bypasses the check by
+    design; there are no public API changes.

--- a/releasenotes/notes/fix-rce-deserializer-self-disable-539671025b1763f7.yaml
+++ b/releasenotes/notes/fix-rce-deserializer-self-disable-539671025b1763f7.yaml
@@ -1,0 +1,20 @@
+---
+security:
+  - |
+    Fixed a remote code execution vulnerability that could be triggered by loading an untrusted
+    pipeline in default safe mode (``Pipeline.load`` / ``Pipeline.loads`` / ``Pipeline.from_dict``,
+    without ``unsafe=True``). Because the deserialization allowlist admits the whole ``haystack``
+    namespace, the deserializer's own allowlist-administration function
+    (``allow_deserialization_module``) and its resolution helpers (``deserialize_callable``,
+    ``deserialize_type``, ``import_class_by_name``) were themselves resolvable from serialized data.
+    A malicious pipeline could register ``allow_deserialization_module`` as a Jinja ``custom_filters``
+    entry (on an ``OutputAdapter`` or ``ConditionalRouter``), call it with ``"*"`` to disarm the
+    allowlist process-wide, and then use the equally-resolvable ``deserialize_callable`` to resolve
+    and invoke ``os.system``. The same attribute walk could also reach the deserializer's mutable
+    control-plane state directly — for example a filter bound to ``_extra_allowed_modules.append``
+    — to widen the allowlist persistently and stage a later attack.
+    The fix refuses to deserialize the deserialization control plane as a whole: the allowlist
+    administration and resolution helpers (marked at definition time), everything defined in
+    ``haystack.core.serialization_security``, and any bound method of the mutable allowlist/context
+    state. This applies to both the callable- and class-resolution paths, and is bypassed only when
+    the pipeline is loaded with ``unsafe=True``.

--- a/releasenotes/notes/fix-rce-deserializer-self-disable-539671025b1763f7.yaml
+++ b/releasenotes/notes/fix-rce-deserializer-self-disable-539671025b1763f7.yaml
@@ -13,8 +13,13 @@ security:
     and invoke ``os.system``. The same attribute walk could also reach the deserializer's mutable
     control-plane state directly — for example a filter bound to ``_extra_allowed_modules.append``
     — to widen the allowlist persistently and stage a later attack.
+    Relatedly, the handle resolver walked attribute names freely, so a handle could descend into
+    object internals such as ``<function>.__globals__`` (a live module namespace, and via it
+    ``__builtins__`` and ``eval``/``exec``) or ``<type>.__subclasses__`` — classic sandbox-escape
+    gadgets that stay inside an allowlisted module.
     The fix refuses to deserialize the deserialization control plane as a whole: the allowlist
     administration and resolution helpers (marked at definition time), everything defined in
     ``haystack.core.serialization_security``, and any bound method of the mutable allowlist/context
-    state. This applies to both the callable- and class-resolution paths, and is bypassed only when
+    state. It also refuses to traverse into dunder and frame/code attributes while resolving a
+    handle. This applies to both the callable- and class-resolution paths, and is bypassed only when
     the pipeline is loaded with ``unsafe=True``.

--- a/releasenotes/notes/fix-rce-deserializer-self-disable-539671025b1763f7.yaml
+++ b/releasenotes/notes/fix-rce-deserializer-self-disable-539671025b1763f7.yaml
@@ -10,7 +10,9 @@ security:
     A malicious pipeline could register ``allow_deserialization_module`` as a Jinja ``custom_filters``
     entry (on an ``OutputAdapter`` or ``ConditionalRouter``), call it with ``"*"`` to disarm the
     allowlist process-wide, and then use the equally-resolvable ``deserialize_callable`` to resolve
-    and invoke ``os.system``. The same attribute walk could also reach the deserializer's mutable
+    and invoke ``os.system``. Loading alone was enough to trigger this: a Jinja filter called with
+    constant arguments runs while the component is being constructed, so the pipeline never had to
+    be run. The same attribute walk could also reach the deserializer's mutable
     control-plane state directly — for example a filter bound to ``_extra_allowed_modules.append``
     — to widen the allowlist persistently and stage a later attack.
     Relatedly, the handle resolver walked attribute names freely, so a handle could descend into

--- a/test/core/test_serialization_security.py
+++ b/test/core/test_serialization_security.py
@@ -345,6 +345,167 @@ class TestDeniedImportPrimitives:
         assert not mocked_system.called
 
 
+class TestDeniedDeserializerInternals:
+    """
+    The allowlist admits the whole `haystack` namespace so Haystack can deserialize its own
+    components. That also makes the deserializer's *own* interface resolvable from serialized data:
+    the allowlist-administration function `allow_deserialization_module` and the resolution helpers
+    (`deserialize_callable`, `deserialize_type`, `import_class_by_name`). A hostile pipeline can register
+    `allow_deserialization_module` as a Jinja custom filter, call it with `"*"` to disarm the
+    allowlist process-wide, then use the equally-resolvable `deserialize_callable` to resolve and
+    invoke `os.system`. The resolver must refuse to hand any of them back.
+    """
+
+    INTERNAL_HANDLES = [
+        "haystack.core.serialization_security.allow_deserialization_module",
+        "haystack.utils.callable_serialization.deserialize_callable",
+        "haystack.utils.type_serialization.deserialize_type",
+        "haystack.utils.type_serialization._import_class_by_name",
+        "haystack.core.serialization.import_class_by_name",
+    ]
+
+    @pytest.mark.parametrize("handle", INTERNAL_HANDLES)
+    def test_deserialize_callable_rejects_internal(self, handle):
+        with pytest.raises(DeserializationError, match="deserialization control plane"):
+            deserialize_callable(handle)
+
+    @pytest.mark.parametrize("handle", INTERNAL_HANDLES)
+    def test_unsafe_mode_bypasses_the_block(self, handle):
+        # unsafe=True disables all deserialization safety checks by design.
+        with _deserialization_context(unsafe=True):
+            assert callable(deserialize_callable(handle))
+
+    def test_all_internal_functions_carry_the_marker(self):
+        # By construction: every internal entry point is stamped, so a new resolver helper is
+        # excluded the day it is written (once decorated), not the day it is exploited.
+        from haystack.core.serialization import import_class_by_name as _icbn
+        from haystack.core.serialization_security import _DESERIALIZATION_INTERNAL_ATTR
+        from haystack.core.serialization_security import allow_deserialization_module as _adm
+        from haystack.utils.callable_serialization import deserialize_callable as _dc
+        from haystack.utils.type_serialization import _import_class_by_name as _icbn_impl
+        from haystack.utils.type_serialization import deserialize_type as _dt
+
+        for func in (_adm, _dc, _dt, _icbn, _icbn_impl):
+            assert getattr(func, _DESERIALIZATION_INTERNAL_ATTR, False) is True
+
+    def test_class_resolution_path_rejects_internal(self):
+        # The admin/resolution API must also be unreachable as a component `type` or class reference.
+        handle = "haystack.core.serialization_security.allow_deserialization_module"
+        with pytest.raises((DeserializationError, ImportError)):
+            import_class_by_name(handle)
+        with pytest.raises((DeserializationError, ImportError)):
+            deserialize_type(handle)
+
+    def _self_disable_yaml(self, component_type, extra_init):
+        filters = (
+            "        allow: haystack.core.serialization_security.allow_deserialization_module\n"
+            "        dc: haystack.utils.callable_serialization.deserialize_callable\n"
+            "        mp: builtins.map\n"
+        )
+        return (
+            "components:\n"
+            "  c:\n"
+            f"    type: {component_type}\n"
+            "    init_parameters:\n"
+            f"{extra_init}"
+            "      custom_filters:\n"
+            f"{filters}"
+            "      unsafe: false\n"
+            "connections: []\n"
+        )
+
+    def test_pipeline_loads_rejects_output_adapter_self_disable_vector(self):
+        # End-to-end reproduction of the reported RCE via OutputAdapter, in default safe mode.
+        yaml = self._self_disable_yaml(
+            "haystack.components.converters.output_adapter.OutputAdapter",
+            "      template: \"{{ '*' | allow }}{{ 'os.system' | dc | mp(cmds) | list }}\"\n      output_type: str\n",
+        )
+        with mock.patch("os.system") as mocked_system:
+            with pytest.raises(DeserializationError, match="deserialization control plane"):
+                Pipeline.loads(yaml)
+        assert not mocked_system.called
+
+    def test_pipeline_loads_rejects_conditional_router_self_disable_vector(self):
+        # Same chain carried by ConditionalRouter; removing one component is not a mitigation.
+        extra = (
+            "      routes:\n"
+            "        - condition: \"{{ ['*'|allow, ('os.system'|dc|mp(cmds)|list)] and True }}\"\n"
+            '          output: "{{ 1 }}"\n'
+            "          output_name: out\n"
+            "          output_type: int\n"
+        )
+        yaml = self._self_disable_yaml("haystack.components.routers.conditional_router.ConditionalRouter", extra)
+        with mock.patch("os.system") as mocked_system:
+            with pytest.raises(DeserializationError, match="deserialization control plane"):
+                Pipeline.loads(yaml)
+        assert not mocked_system.called
+
+    def test_rejected_load_does_not_widen_the_process_wide_allowlist(self):
+        # The chain is cut before `allow_deserialization_module` can run, so the second reported
+        # consequence — permanent process-wide teardown of the allowlist — never happens.
+        yaml = self._self_disable_yaml(
+            "haystack.components.converters.output_adapter.OutputAdapter",
+            "      template: \"{{ '*' | allow }}{{ 'os.system' | dc | mp(cmds) | list }}\"\n      output_type: str\n",
+        )
+        with pytest.raises(DeserializationError):
+            Pipeline.loads(yaml)
+        assert _extra_allowed_modules == []
+        with pytest.raises(DeserializationError):
+            deserialize_callable("os.system")
+
+    # The mutable control-plane state (the allowlist list and the deserialization context var) is
+    # reachable through the same attribute walk the resolver performs, so a bound mutator can widen
+    # the allowlist without touching any of the blocked resolver functions above.
+    CONTROL_PLANE_HANDLES = [
+        "haystack.core.serialization_security._extra_allowed_modules.append",
+        "haystack.core.serialization_security._extra_allowed_modules.extend",
+        "haystack.core.serialization_security._extra_allowed_modules.insert",
+        "haystack.core.serialization_security._current_context.set",
+        "haystack.core.serialization_security._DeserializationContext",
+        "haystack.core.serialization_security._get_context",
+    ]
+
+    @pytest.mark.parametrize("handle", CONTROL_PLANE_HANDLES)
+    def test_deserialize_callable_rejects_control_plane_state(self, handle):
+        with pytest.raises(DeserializationError, match="deserialization control plane"):
+            deserialize_callable(handle)
+
+    def test_reexported_alias_handles_are_also_rejected(self):
+        # The same function objects are re-exported under other public paths; they inherit the mark
+        # (or match by defining module) and must be refused there too.
+        for handle in (
+            "haystack.core.serialization.allow_deserialization_module",
+            "haystack.utils.deserialize_callable",
+            "haystack.utils.deserialize_type",
+        ):
+            with pytest.raises(DeserializationError, match="deserialization control plane"):
+                deserialize_callable(handle)
+
+    def test_pipeline_loads_rejects_allowlist_poisoning_via_append(self):
+        # A staged attack that never touches the blocked resolver helpers: a custom filter bound to
+        # `_extra_allowed_modules.append`, called with "*" from the template, would disarm the
+        # allowlist process-wide (the advisory's persistent "second consequence") and enable a staged
+        # RCE on a *later* load that resolves `os.system` directly. Blocking it at load time prevents
+        # both the poisoning and the later resolution.
+        poison_yaml = (
+            "components:\n"
+            "  adapter:\n"
+            "    type: haystack.components.converters.output_adapter.OutputAdapter\n"
+            "    init_parameters:\n"
+            "      template: \"{{ '*' | ap }}{{ trigger }}\"\n"
+            "      output_type: str\n"
+            "      custom_filters:\n"
+            "        ap: haystack.core.serialization_security._extra_allowed_modules.append\n"
+            "      unsafe: false\n"
+            "connections: []\n"
+        )
+        with pytest.raises(DeserializationError, match="deserialization control plane"):
+            Pipeline.loads(poison_yaml)
+        assert _extra_allowed_modules == []
+        with pytest.raises(DeserializationError):
+            deserialize_callable("os.system")
+
+
 class TestModuleAttributeWalkBypass:
     """
     The allowlist must be enforced against the module a handle

--- a/test/core/test_serialization_security.py
+++ b/test/core/test_serialization_security.py
@@ -7,6 +7,7 @@ import io
 import json
 import operator
 import subprocess
+import types
 from collections.abc import Callable
 from unittest import mock
 
@@ -509,6 +510,208 @@ class TestDeniedDeserializerInternals:
         assert _extra_allowed_modules == []
         with pytest.raises(DeserializationError):
             deserialize_callable("os.system")
+
+
+class TestDeniedPipelineEntryPoints:
+    """
+    Blocking the low-level resolvers (`deserialize_callable` etc.) is not enough on its own: the
+    high-level loading entry points that accept `unsafe=True` — `Pipeline.loads` / `load` /
+    `from_dict` — and the execute primitives (`Pipeline.run` / `run_async` / `run_async_generator` /
+    `stream`) are themselves resolvable
+    from the allowlisted `haystack` namespace. Bound as sandbox-bypassing `custom_filters`, they
+    re-enter deserialization: a safe-mode pipeline can call `Pipeline.loads(nested, unsafe=True)` to
+    load a *nested* pipeline whose own filters (`allow_deserialization_module`, `deserialize_callable`)
+    bind under the nested unsafe context, then `Pipeline.run` it to poison the process-wide allowlist
+    with `"*"` and invoke `os.system`. These entry points must be part of the deserialization control
+    plane too, so they can never be produced by deserializing untrusted data.
+    """
+
+    ENTRY_POINTS = [
+        "haystack.core.pipeline.pipeline.Pipeline.loads",
+        "haystack.core.pipeline.pipeline.Pipeline.load",
+        "haystack.core.pipeline.pipeline.Pipeline.from_dict",
+        "haystack.core.pipeline.pipeline.Pipeline.run",
+        "haystack.core.pipeline.pipeline.Pipeline.run_async",
+        # `run_async_generator` and `stream` reach `run_async` too, so they are execute primitives
+        # in their own right: `stream` schedules the run via `asyncio.create_task`.
+        "haystack.core.pipeline.pipeline.Pipeline.run_async_generator",
+        "haystack.core.pipeline.pipeline.Pipeline.stream",
+        # The base class the classmethods actually live on, and the public re-export.
+        "haystack.core.pipeline.base.PipelineBase.loads",
+        "haystack.Pipeline.loads",
+    ]
+
+    @pytest.mark.parametrize("handle", ENTRY_POINTS)
+    def test_deserialize_callable_rejects_pipeline_entry_points(self, handle):
+        with pytest.raises(DeserializationError, match="deserialization control plane"):
+            deserialize_callable(handle)
+
+    @pytest.mark.parametrize("handle", ENTRY_POINTS)
+    def test_unsafe_mode_bypasses_the_block(self, handle):
+        # unsafe=True disables all deserialization safety checks by design.
+        with _deserialization_context(unsafe=True):
+            assert callable(deserialize_callable(handle))
+
+    def test_entry_points_carry_the_marker(self):
+        # By construction: the loaders and the execute primitives are stamped, so the resolver
+        # excludes them the day they are marked, not the day the chain below is discovered.
+        from haystack.core.pipeline.base import PipelineBase
+        from haystack.core.pipeline.pipeline import Pipeline as ConcretePipeline
+        from haystack.core.serialization_security import _DESERIALIZATION_INTERNAL_ATTR
+
+        for classmethod_name in ("loads", "load", "from_dict"):
+            func = getattr(PipelineBase, classmethod_name).__func__
+            assert getattr(func, _DESERIALIZATION_INTERNAL_ATTR, False) is True
+        for method_name in ("run", "run_async", "run_async_generator", "stream"):
+            func = getattr(ConcretePipeline, method_name)
+            assert getattr(func, _DESERIALIZATION_INTERNAL_ATTR, False) is True
+
+    def _nested_yaml(self):
+        # Meant to be loaded with unsafe=True (so its `allow`/`dc` filters bind), then run: it poisons
+        # the process-wide allowlist with "*" and resolves and invokes os.system — the original gadget.
+        return (
+            "components:\n"
+            "  c:\n"
+            "    type: haystack.components.converters.output_adapter.OutputAdapter\n"
+            "    init_parameters:\n"
+            "      template: \"{{ ('*' | allow) }}{{ ('os.system' | dc | mp([cmd]) | list) }}\"\n"
+            "      output_type: str\n"
+            "      custom_filters:\n"
+            "        allow: haystack.core.serialization_security.allow_deserialization_module\n"
+            "        dc: haystack.utils.callable_serialization.deserialize_callable\n"
+            "        mp: builtins.map\n"
+            "      unsafe: true\n"
+            "connections: []\n"
+        )
+
+    def test_pipeline_loads_rejects_nested_unsafe_load_run_vector(self):
+        # End-to-end reproduction, in default safe mode. The top pipeline binds Pipeline.loads (L) and
+        # Pipeline.run (R) as custom_filters; the block fires while resolving L at load, before any
+        # template renders, so os.system is never reached and the allowlist is never poisoned.
+        top_yaml = (
+            "components:\n"
+            "  c:\n"
+            "    type: haystack.components.converters.output_adapter.OutputAdapter\n"
+            "    init_parameters:\n"
+            "      template: \"{{ nested | L(unsafe=True) | R(data={'c': {'cmd': cmd}}) }}\"\n"
+            "      output_type: str\n"
+            "      custom_filters:\n"
+            "        L: haystack.core.pipeline.pipeline.Pipeline.loads\n"
+            "        R: haystack.core.pipeline.pipeline.Pipeline.run\n"
+            "      unsafe: false\n"
+            "connections: []\n"
+        )
+        with mock.patch("os.system") as mocked_system:
+            with pytest.raises(DeserializationError, match="deserialization control plane"):
+                Pipeline.loads(top_yaml)
+        assert not mocked_system.called
+        assert _extra_allowed_modules == []
+        with pytest.raises(DeserializationError):
+            deserialize_callable("os.system")
+
+    def test_nested_gadget_pipeline_needs_an_unsafe_load_to_arm(self):
+        # The other half of the chain, on its own: the nested payload is inert unless something loads
+        # it in unsafe mode. In safe mode the load is refused (its `unsafe: true` OutputAdapter, and
+        # its control-plane filters, are both rejected), so the gadget never arms.
+        with mock.patch("os.system") as mocked_system:
+            with pytest.raises(DeserializationError, match="unsafe=True while loading in safe mode"):
+                Pipeline.loads(self._nested_yaml())
+        assert not mocked_system.called
+        assert _extra_allowed_modules == []
+
+        # Under an unsafe load it arms *and fires* — and it fires at load time, not at run time:
+        # `OutputAdapter.__init__` extracts template variables via `meta.find_undeclared_variables`,
+        # whose codegen constant-folds filter calls with constant arguments, so `('*' | allow)` runs
+        # while the component is being constructed. No `.run()` is involved.
+        # This is why blocking the *loaders* is the load-bearing part of the fix: once safe-mode data
+        # cannot reach an unsafe load, it cannot reach this construction either.
+        Pipeline.loads(self._nested_yaml(), unsafe=True)
+        assert _extra_allowed_modules == ["*"]  # reverted by the autouse fixture
+
+
+class TestPipelineCallableClassification:
+    """
+    Structural guard for the marking above. `mark_deserialization_internal` is a per-callable
+    denylist inside a namespace-wide allowlist, so its completeness depends on someone remembering
+    to stamp the next dangerous entry point — exactly how `run_async_generator` and `stream` were
+    missed when `run` / `run_async` were marked.
+
+    Rather than testing the callables we happen to have thought of, this enumerates every public
+    callable on `PipelineBase` / `Pipeline` and requires each one to be classified here. Adding a
+    new public method fails this test until it is declared either deserializer-internal or safe to
+    resolve, and dropping a decorator fails it too.
+    """
+
+    # Loaders that accept `unsafe=True`, plus the execute primitives.
+    INTERNAL: dict[str, set[str]] = {
+        "PipelineBase": {"from_dict", "load", "loads"},
+        "Pipeline": {"run", "run_async", "run_async_generator", "stream"},
+    }
+    # Resolvable from serialized data without handing it deserialization control or execution:
+    # graph construction, introspection, serialization *out*, and lifecycle.
+    SAFE_TO_RESOLVE: dict[str, set[str]] = {
+        "PipelineBase": {
+            "add_component",
+            "close",
+            "close_async",
+            "connect",
+            "draw",
+            "dump",
+            "dumps",
+            "get_component",
+            "get_component_name",
+            "inputs",
+            "outputs",
+            "remove_component",
+            "show",
+            "to_dict",
+            "validate_input",
+            "validate_pipeline",
+            "walk",
+            "warm_up",
+            "warm_up_async",
+        },
+        "Pipeline": set(),
+    }
+
+    @staticmethod
+    def _public_callables(pipeline_class):
+        # `vars()` rather than `dir()`: each class is checked against its own declarations, so the
+        # two classification sets stay disjoint and a method moving between them is visible.
+        return {
+            name
+            for name, value in vars(pipeline_class).items()
+            if not name.startswith("_") and isinstance(value, (types.FunctionType, classmethod, staticmethod))
+        }
+
+    @pytest.mark.parametrize("class_name", ["PipelineBase", "Pipeline"])
+    def test_every_public_callable_is_classified(self, class_name):
+        from haystack.core.pipeline.base import PipelineBase
+        from haystack.core.pipeline.pipeline import Pipeline as ConcretePipeline
+        from haystack.core.serialization_security import _DESERIALIZATION_INTERNAL_ATTR
+
+        cls = {"PipelineBase": PipelineBase, "Pipeline": ConcretePipeline}[class_name]
+        internal, safe = self.INTERNAL[class_name], self.SAFE_TO_RESOLVE[class_name]
+        assert not internal & safe, f"{class_name}: classified both ways: {sorted(internal & safe)}"
+
+        public = self._public_callables(cls)
+        unclassified = public - internal - safe
+        assert not unclassified, (
+            f"{class_name}.{sorted(unclassified)} is public and unclassified. Decide whether it hands "
+            f"deserialized data deserialization control or execution: if so, stamp it with "
+            f"`mark_deserialization_internal` and add it to INTERNAL; otherwise add it to SAFE_TO_RESOLVE."
+        )
+        stale = (internal | safe) - public
+        assert not stale, f"{class_name}: classified but no longer public: {sorted(stale)}"
+
+        for name in sorted(public):
+            attr = getattr(cls, name)
+            func = getattr(attr, "__func__", attr)
+            marked = getattr(func, _DESERIALIZATION_INTERNAL_ATTR, False) is True
+            assert marked is (name in internal), (
+                f"{class_name}.{name} is classified as {'internal' if name in internal else 'safe'} "
+                f"but its `mark_deserialization_internal` stamp is {marked}."
+            )
 
 
 class TestObjectInternalsTraversal:

--- a/test/core/test_serialization_security.py
+++ b/test/core/test_serialization_security.py
@@ -218,7 +218,9 @@ class TestImportClassByNameAllowlist:
     def test_rejects_dangerous_builtin(self, name):
         # `builtins` passes the module allowlist, so a class reference must resolve to an actual
         # type — otherwise a nested `{"type": "builtins.compile"}` payload would resolve a function.
-        with pytest.raises(DeserializationError, match="not a type"):
+        # The dunder-named builtins (`__import__`, `__build_class__`) are refused even earlier by the
+        # object-internals traversal guard.
+        with pytest.raises(DeserializationError, match="not a type|internal attribute"):
             import_class_by_name(f"builtins.{name}")
 
     def test_allows_builtin_type(self):
@@ -277,7 +279,10 @@ class TestDeniedBuiltins:
 
     @pytest.mark.parametrize("name", _DENIED_BUILTIN_NAMES)
     def test_dangerous_builtin_callable_rejected(self, name):
-        with pytest.raises(DeserializationError, match="blocked because it can be used"):
+        # Most denied builtins are refused by the identity denylist ("blocked because it can be
+        # used ..."); the dunder-named ones (`__import__`, `__build_class__`) are caught earlier by
+        # the object-internals traversal guard. Either way they never resolve.
+        with pytest.raises(DeserializationError, match="blocked because it can be used|internal attribute"):
             deserialize_callable(f"builtins.{name}")
 
     def test_harmless_builtin_callable_still_resolves(self):
@@ -500,6 +505,72 @@ class TestDeniedDeserializerInternals:
             "connections: []\n"
         )
         with pytest.raises(DeserializationError, match="deserialization control plane"):
+            Pipeline.loads(poison_yaml)
+        assert _extra_allowed_modules == []
+        with pytest.raises(DeserializationError):
+            deserialize_callable("os.system")
+
+
+class TestObjectInternalsTraversal:
+    """
+    A serialized handle legitimately walks `module.Class.method`, never into an object's internals.
+    Descending into dunder attributes (`__globals__`, `__dict__`, `__class__`, `__subclasses__`, ...)
+    or the frame/code accessors is a classic sandbox escape: `<func>.__globals__` yields the defining
+    module's live namespace, from which the allowlist state can be rewritten or `__builtins__` (hence
+    `eval`/`exec`) reached — all while the traversal stays inside an allowlisted module, so neither the
+    module allowlist nor the per-object identity checks would catch it.
+    """
+
+    TRAVERSAL_GADGETS = [
+        # `<func>.__globals__` -> the defining module's live globals dict, then a bound mutator/getter.
+        "haystack.core.serialization_security.allow_deserialization_module.__globals__.update",
+        "haystack.core.serialization_security.allow_deserialization_module.__globals__.get",
+        "haystack.utils.callable_serialization.deserialize_callable.__globals__.get",
+        # `<module>.__dict__` -> the module's live namespace dict.
+        "haystack.core.serialization_security.__dict__.update",
+        # Function/class internals reachable as a final or intermediate hop.
+        "haystack.components.converters.output_adapter.OutputAdapter.__init__.__globals__.get",
+        "haystack.components.converters.output_adapter.OutputAdapter.__subclasses__",
+        "haystack.components.converters.output_adapter.OutputAdapter.__class__",
+    ]
+
+    @pytest.mark.parametrize("handle", TRAVERSAL_GADGETS)
+    def test_deserialize_callable_rejects_internal_attribute_traversal(self, handle):
+        with pytest.raises(DeserializationError, match="internal attribute"):
+            deserialize_callable(handle)
+
+    def test_import_class_by_name_rejects_internal_attribute(self):
+        with pytest.raises((DeserializationError, ImportError)):
+            import_class_by_name("haystack.core.serialization_security.__dict__")
+
+    def test_unsafe_mode_bypasses_the_block(self):
+        with _deserialization_context(unsafe=True):
+            resolved = deserialize_callable(
+                "haystack.core.serialization_security.allow_deserialization_module.__globals__.get"
+            )
+            assert callable(resolved)
+
+    def test_legitimate_attribute_walks_still_resolve(self):
+        # `Class.method` and nested traversal through non-dunder attributes must keep working.
+        assert callable(deserialize_callable("collections.OrderedDict.fromkeys"))
+        assert callable(deserialize_callable("collections.Counter.most_common"))
+
+    def test_pipeline_loads_rejects_globals_rewrite_vector(self):
+        # End-to-end: rewriting `_extra_allowed_modules` via `__globals__.update` in default safe
+        # mode, without touching any blocked resolver or the protected state objects directly.
+        poison_yaml = (
+            "components:\n"
+            "  adapter:\n"
+            "    type: haystack.components.converters.output_adapter.OutputAdapter\n"
+            "    init_parameters:\n"
+            '      template: "{{ mapping | upd }}{{ trigger }}"\n'
+            "      output_type: str\n"
+            "      custom_filters:\n"
+            "        upd: haystack.core.serialization_security.allow_deserialization_module.__globals__.update\n"
+            "      unsafe: false\n"
+            "connections: []\n"
+        )
+        with pytest.raises(DeserializationError, match="internal attribute"):
             Pipeline.loads(poison_yaml)
         assert _extra_allowed_modules == []
         with pytest.raises(DeserializationError):

--- a/test/utils/test_type_serialization.py
+++ b/test/utils/test_type_serialization.py
@@ -176,8 +176,9 @@ def test_output_builtin_type_deserialization():
 def test_dangerous_builtins_rejected(name):
     # `builtins` is on the allowlist, but a type annotation must resolve to an actual type. Builtin
     # functions are rejected both with the `builtins.` prefix and via the bare-name fallback (which
-    # skips the allowlist).
-    with pytest.raises(DeserializationError, match="not a type"):
+    # skips the allowlist). The dunder-named ones (`__import__`, `__build_class__`) are refused even
+    # earlier by the object-internals traversal guard when a `builtins.` prefix is used.
+    with pytest.raises(DeserializationError, match="not a type|internal attribute"):
         deserialize_type(f"builtins.{name}")
     with pytest.raises(DeserializationError, match="not a type"):
         deserialize_type(name)


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/543

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR fixes a deserialization RCE reachable by loading an untrusted serialized pipeline in default safe mode (`Pipeline.load` / `Pipeline.loads` / `Pipeline.from_dict`, without `unsafe=True`). 

Root cause: the deserialization allowlist admits the whole `haystack` namespace so Haystack can deserialize its own components, which also made the deserializer's own control plane resolvable from serialized data — the allowlist-administration function `allow_deserialization_module`, the resolution helpers (`deserialize_callable`, `deserialize_type`, `import_class_by_name`), and the mutable allowlist/context state. Because `OutputAdapter`/`ConditionalRouter` resolve each `custom_filters` value through `deserialize_callable`, a malicious pipeline could register `allow_deserialization_module` as a Jinja filter, call it with `"*"` from its template (filters are invoked directly, bypassing the sandbox's `is_safe_callable`) to disarm the allowlist process-wide, then resolve and invoke `os.system` via `deserialize_callable` + `builtins.map`. A related gadget bound a filter directly to `_extra_allowed_modules.append` (or `_current_context.set`) to poison the process-wide allowlist and stage RCE on a later load.

There is also a broader, related flaw in the same resolver: `deserialize_callable` (and `_import_class_by_name`) walked arbitrary attribute names, so a handle could descend into an object's internals. For example `<function>.__globals__` yields the defining module's live namespace dict — from which the allowlist state can be rewritten, or `__builtins__` (hence `eval`/`exec`) reached — and `<type>.__subclasses__` reaches the class hierarchy. These traversals stay inside an allowlisted module, and the object they yield is a builtin (`dict.update`/`dict.get`, whose `__module__` is `builtins`), so neither the module allowlist nor the per-object control-plane check catches them.

The fix treats the deserialization control plane as non-deserializable by construction: resolver callables are stamped at definition time with a new `mark_deserialization_internal` decorator, and both resolution paths (`deserialize_callable` and `_import_class_by_name`) now refuse anything that is marked, is defined in `haystack.core.serialization_security`, or is a bound method of the mutable allowlist/context state. In addition, a new `_check_traversable_attribute` guard refuses to descend into dunder attributes (`__globals__`, `__dict__`, `__class__`, `__subclasses__`, `__builtins__`, …) and frame/code accessors at every hop of both resolution paths. `unsafe=True` still bypasses all checks by design, and there are no public API changes — `allow_deserialization_module` stays usable at startup; only its resolution from serialized data is refused.


### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added two regression test classes in `test/core/test_serialization_security.py`:

`TestDeniedDeserializerInternals` covering:
- rejection of every internal handle via `deserialize_callable` and via the class/type path
- the mutable control-plane gadgets (`_extra_allowed_modules.append` / `extend` / `insert`, `_current_context.set`, `_DeserializationContext`, `_get_context`)
- re-exported alias handles (`haystack.core.serialization.allow_deserialization_module`, `haystack.utils.deserialize_callable`, `haystack.utils.deserialize_type`)
- end-to-end `Pipeline.loads` reproductions of both reported vectors (`OutputAdapter` and `ConditionalRouter`) asserting `DeserializationError` before `os.system` is called
- the staged allowlist-poisoning vector
- and that `unsafe=True` still resolves the internals

`TestObjectInternalsTraversal` covering:
- rejection of the `__globals__` / `__dict__` / `__subclasses__` / `__class__` traversal gadgets (as intermediate and final hops)
- the `_import_class_by_name` internal-attribute guard
- end-to-end `Pipeline.loads` reproduction of the `__globals__.update` allowlist-rewrite vector
- that legitimate `Class.method` / nested attribute walks still resolve, and that `unsafe=True` still bypasses

I also widened three pre-existing parametrized builtin tests whose dunder-named cases (`__import__`, `__build_class__`) are now caught earlier by the traversal guard (still rejected, only the message changes)

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
