### PR TITLE
chore: clarify we drop `_meta` from `ChatMessage` in `to_openai_dict_format`

### DIFF
--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -634,6 +634,8 @@ class ChatMessage:
         """
         Convert a ChatMessage to the dictionary format expected by OpenAI's Chat Completions API.
 
+        The `_meta` field of ChatMessage is removed because it is not supported by OpenAI's Chat Completions API.
+
         :param require_tool_call_ids:
             If True (default), enforces that each Tool Call includes a non-null `id` attribute.
             Set to False to allow Tool Calls without `id`, which may be suitable for shallow OpenAI-compatible APIs.


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack-private/issues/532

### Proposed Changes:

- clarify in the docstring that `ChatMessage.to_openai_dict_format` drops `ChatMessage._meta` since OpenAI Chat Completions API does not accept this field

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
