### PR TITLE
fix: fix agent tool spans not getting nested under each other

### DIFF
--- a/haystack/components/agents/tool_calling.py
+++ b/haystack/components/agents/tool_calling.py
@@ -178,9 +178,9 @@ def _create_tool_result_streaming_chunk(tool_message: ChatMessage, tool_call: To
     )
 
 
-def _create_tool_span(tool: Tool, tool_call: ToolCall) -> Any:
+def _create_tool_span(tool: Tool, tool_call: ToolCall, parent_span: tracing.Span | None) -> Any:
     """
-    Create one tracing span for a single tool call, nested under the currently active span.
+    Create one tracing span for a single tool call, nested under `parent_span`.
 
     The established standard for tracing agents is one span per tool call, so each call gets its own span rather than
     grouping all of a step's calls together. The OpenTelemetry GenAI semantic conventions codify this with a dedicated
@@ -188,26 +188,32 @@ def _create_tool_span(tool: Tool, tool_call: ToolCall) -> Any:
     (https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md#execute-tool-span),
     and tracing backends such as Langfuse follow the same model. The span is tagged with the tool's identity; the caller
     adds the call arguments and result as content tags.
+
+    The parent is passed in rather than read from the tracer here: the calls of a step run concurrently, so a tracer
+    that tracks the active span globally would report a sibling tool span as current and the spans would end up chained
+    instead of side by side.
     """
     return tracing.tracer.trace(
         "haystack.agent.step.tool",
         tags={"haystack.tool.name": tool_call.tool_name, "haystack.tool.description": tool.description},
-        parent_span=tracing.tracer.current_span(),
+        parent_span=parent_span,
     )
 
 
-def _make_context_bound_invoke(tool: Tool, args: dict[str, Any], tool_call: ToolCall) -> Callable[[], Any]:
+def _make_context_bound_invoke(
+    tool: Tool, args: dict[str, Any], tool_call: ToolCall, parent_span: tracing.Span | None
+) -> Callable[[], Any]:
     """
     Return a zero-arg callable that runs `tool.invoke(**args)` under the current contextvars snapshot.
 
-    This preserves tracing spans and other context-local state across thread-pool boundaries, so the per-call span
-    created inside the worker nests correctly under the step span. The callable returns a ToolInvocationError instead
-    of raising so that parallel executions can collect failures without aborting the whole batch.
+    This preserves tracing spans and other context-local state across thread-pool boundaries, so spans opened by the
+    tool itself stay attached to the calling trace. The callable returns a ToolInvocationError instead of raising so
+    that parallel executions can collect failures without aborting the whole batch.
     """
     ctx = contextvars.copy_context()
 
     def _invoke() -> Any:
-        with _create_tool_span(tool, tool_call) as span:
+        with _create_tool_span(tool, tool_call, parent_span) as span:
             span.set_content_tag("haystack.agent.step.tool.input", tool_call.arguments)
             try:
                 result = tool.invoke(**args)
@@ -224,15 +230,19 @@ def _make_context_bound_invoke(tool: Tool, args: dict[str, Any], tool_call: Tool
 
 
 def _make_bounded_invoke_async(
-    tool: Tool, args: dict[str, Any], semaphore: asyncio.Semaphore, tool_call: ToolCall
+    tool: Tool,
+    args: dict[str, Any],
+    semaphore: asyncio.Semaphore,
+    tool_call: ToolCall,
+    parent_span: tracing.Span | None,
 ) -> Callable[[], Any]:
     """
     Return a zero-arg async callable that awaits `tool.invoke_async(**args)` while holding `semaphore`.
 
     Concurrency is bounded uniformly across native-async tools and sync-fallback tools (which dispatch
     to a worker thread inside `Tool.invoke_async`). ContextVars naturally inherit into child tasks for
-    the native-async branch, and `asyncio.to_thread` propagates them for the fallback branch, so the per-call
-    span nests correctly under the step span.
+    the native-async branch, and `asyncio.to_thread` propagates them for the fallback branch, so spans opened by
+    the tool itself stay attached to the calling trace.
 
     Returns a `ToolInvocationError` instead of raising so that gathered executions can collect failures
     without aborting the whole batch.
@@ -240,7 +250,7 @@ def _make_bounded_invoke_async(
 
     async def _runner() -> Any:
         async with semaphore:
-            with _create_tool_span(tool, tool_call) as span:
+            with _create_tool_span(tool, tool_call, parent_span) as span:
                 span.set_content_tag("haystack.agent.step.tool.input", tool_call.arguments)
                 try:
                     result = await tool.invoke_async(**args)
@@ -543,6 +553,9 @@ def _run_tool(
     results: list[ChatMessage | None] = [None] * len(tool_calls)
     stream_index = 0
 
+    # Resolved once, before any tool runs, so all per-call spans of this step become siblings under the same parent.
+    parent_span = tracing.tracer.current_span()
+
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for batch in batches:
             # Prepare args at the start of each batch so tools that read from State observe writes merged by earlier
@@ -556,7 +569,11 @@ def _run_tool(
                     streaming_callback=streaming_callback,
                     enable_streaming_passthrough=enable_streaming_callback_passthrough,
                 )
-                futures[idx] = executor.submit(_make_context_bound_invoke(resolved_tools[idx], args, tool_calls[idx]))
+                futures[idx] = executor.submit(
+                    _make_context_bound_invoke(
+                        tool=resolved_tools[idx], args=args, tool_call=tool_calls[idx], parent_span=parent_span
+                    )
+                )
 
             # Merge results in call order within the batch so write-write merges stay deterministic.
             for idx in batch:
@@ -629,6 +646,9 @@ async def _run_tool_async(
     # and sync tools are dispatched to a worker thread inside `Tool.invoke_async`.
     semaphore = asyncio.Semaphore(max_workers)
 
+    # Resolved once, before any tool runs, so all per-call spans of this step become siblings under the same parent.
+    parent_span = tracing.tracer.current_span()
+
     for batch in batches:
         # Prepare args at the start of each batch so readers observe writes merged by earlier batches.
         tasks = {}
@@ -640,7 +660,13 @@ async def _run_tool_async(
                 streaming_callback=streaming_callback,
                 enable_streaming_passthrough=enable_streaming_callback_passthrough,
             )
-            tasks[idx] = _make_bounded_invoke_async(resolved_tools[idx], args, semaphore, tool_calls[idx])()
+            tasks[idx] = _make_bounded_invoke_async(
+                tool=resolved_tools[idx],
+                args=args,
+                semaphore=semaphore,
+                tool_call=tool_calls[idx],
+                parent_span=parent_span,
+            )()
         batch_results = await asyncio.gather(*tasks.values())
 
         # Merge results in call order within the batch so write-write merges stay deterministic.

--- a/releasenotes/notes/fix-parallel-tool-span-parent-3f1a6c2d9b4e70a8.yaml
+++ b/releasenotes/notes/fix-parallel-tool-span-parent-3f1a6c2d9b4e70a8.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed the parent of the ``haystack.agent.step.tool`` spans when an Agent step invokes several tools. The parent span
+    is now resolved once before the tools run, so all tool calls of a step appear as siblings. Previously each span
+    asked the tracer for the currently active span from inside its own concurrent invocation, which made the tool calls
+    after the first one appear nested under a sibling tool call.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import re
+import threading
 from collections.abc import Iterator
 from datetime import datetime
 from typing import Any
@@ -1313,8 +1314,22 @@ class TestAgentTracing:
 
         assert spying_tracer.spans[0].tags["haystack.agent.steps_taken"] == 2
 
-    def test_tracing_span_run_with_parallel_tool_calls(self, spying_tracer, weather_tool):
+    def test_tracing_span_run_with_parallel_tool_calls(self, spying_tracer):
         """Each tool call in a step gets its own `haystack.agent.step.tool` span instead of one grouped span."""
+        # The barrier holds each call inside its own tool span until the other call has opened its span too, so both
+        # spans are provably open at the same time — the situation in which a span could pick a sibling as its parent.
+        barrier = threading.Barrier(2, timeout=10)
+
+        def blocking_weather_function(location: str):
+            barrier.wait()
+            return weather_function(location)
+
+        weather_tool = Tool(
+            name="weather_tool",
+            description="Provides weather information for a given location.",
+            parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
+            function=blocking_weather_function,
+        )
         agent = Agent(chat_generator=_parallel_tool_calling_generator(), tools=[weather_tool])
 
         agent.run([ChatMessage.from_user("What's the weather in Berlin and Paris?")])
@@ -1325,6 +1340,10 @@ class TestAgentTracing:
         for span in tool_spans:
             assert span.tags["haystack.tool.name"] == "weather_tool"
         assert {span.tags["haystack.agent.step.tool.input"]["location"] for span in tool_spans} == {"Berlin", "Paris"}
+        # The tool spans are siblings under the step that requested the calls, not chained under each other.
+        step_span = spying_tracer.spans[1]
+        assert step_span.operation_name == "haystack.agent.step"
+        assert all(span.parent_span is step_span for span in tool_spans)
 
     @pytest.mark.asyncio
     async def test_tracing_span_run_async_with_parallel_tool_calls(self, spying_tracer, weather_tool):
@@ -1336,6 +1355,10 @@ class TestAgentTracing:
         tool_spans = [s for s in spying_tracer.spans if s.operation_name == "haystack.agent.step.tool"]
         assert len(tool_spans) == 2
         assert {span.tags["haystack.agent.step.tool.input"]["location"] for span in tool_spans} == {"Berlin", "Paris"}
+        # The tool spans are siblings under the step that requested the calls, not chained under each other.
+        step_span = spying_tracer.spans[1]
+        assert step_span.operation_name == "haystack.agent.step"
+        assert all(span.parent_span is step_span for span in tool_spans)
 
     def test_tracing_in_pipeline(self, spying_tracer, weather_tool):
         agent = Agent(chat_generator=MockChatGeneratorWithoutRunAsync(), tools=[weather_tool])

--- a/test/tracing/utils.py
+++ b/test/tracing/utils.py
@@ -36,11 +36,20 @@ class SpyingSpan(Span):
 
 
 class SpyingTracer(Tracer):
+    """
+    A tracer that records every span it creates, in creation order, in `spans`.
+
+    Open spans are also kept on a stack, so `current_span` returns the innermost span whose `trace` block has not
+    exited yet. The stack lives on the tracer instance rather than in a ContextVar, mirroring tracing backends such
+    as Langfuse: code that opens a span while sibling spans are open concurrently sees a sibling as the current span.
+    """
+
     def current_span(self) -> Span | None:
-        return self.spans[-1] if self.spans else None
+        return self._open_spans[-1] if self._open_spans else None
 
     def __init__(self) -> None:
         self.spans: list[SpyingSpan] = []
+        self._open_spans: list[SpyingSpan] = []
 
     @contextlib.contextmanager
     def trace(
@@ -52,7 +61,11 @@ class SpyingTracer(Tracer):
 
         self.spans.append(new_span)
 
-        yield new_span
+        self._open_spans.append(new_span)
+        try:
+            yield new_span
+        finally:
+            self._open_spans.remove(new_span)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
### Related Issues

- fixes issue found by @tstadel 

Tools run in parallel can get nested under each other 

<img width="1684" height="892" alt="image (4)" src="https://github.com/user-attachments/assets/10760d2c-6f7c-4525-b2d1-def333285a65" />


### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Update the tool span code to resolve the parent span before all tool calls and pass down the parent span when constructing each individual tool span. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

This was missed originally since the SpyingTracer did not work like a typical tracing backend. So it was updated along with two existing tests to ensure that the tool spans have the same parent and don't nest under each other. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
