### PR TITLE
fix: block pipeline entry points from deserialization control plane

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -40,7 +40,11 @@ from haystack.core.serialization import (
     component_to_dict,
     generate_qualified_class_name,
 )
-from haystack.core.serialization_security import _check_module_allowed, _deserialization_context
+from haystack.core.serialization_security import (
+    _check_module_allowed,
+    _deserialization_context,
+    mark_deserialization_internal,
+)
 from haystack.core.type_utils import (
     ConversionStrategyType,
     _convert_value,
@@ -173,6 +177,7 @@ class PipelineBase:  # noqa: PLW1641
         }
 
     @classmethod
+    @mark_deserialization_internal
     def from_dict(
         cls: type[T],
         data: dict[str, Any],
@@ -309,6 +314,7 @@ class PipelineBase:  # noqa: PLW1641
         fp.write(marshaller.marshal(self.to_dict()))
 
     @classmethod
+    @mark_deserialization_internal
     def loads(
         cls: type[T],
         data: str | bytes | bytearray,
@@ -351,6 +357,7 @@ class PipelineBase:  # noqa: PLW1641
         return cls.from_dict(deserialized_data, callbacks, allowed_modules=allowed_modules, unsafe=unsafe)
 
     @classmethod
+    @mark_deserialization_internal
     def load(
         cls: type[T],
         fp: TextIO,

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -790,6 +790,7 @@ class Pipeline(PipelineBase):
         task = asyncio.create_task(_runner())
         running_tasks[task] = component_name
 
+    @mark_deserialization_internal
     async def run_async_generator(  # noqa: PLR0915,C901
         self, data: dict[str, Any], include_outputs_from: set[str] | None = None, concurrency_limit: int = 4
     ) -> AsyncGenerator[dict[str, Any], None]:
@@ -1197,6 +1198,7 @@ class Pipeline(PipelineBase):
             final = partial
         return final or {}
 
+    @mark_deserialization_internal
     def stream(
         self,
         data: dict[str, Any],

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -26,6 +26,7 @@ from haystack.core.pipeline.breakpoint import (
     _validate_pipeline_snapshot_against_pipeline,
 )
 from haystack.core.pipeline.utils import _deepcopy_with_exceptions
+from haystack.core.serialization_security import mark_deserialization_internal
 from haystack.dataclasses import AsyncStreamingCallbackT, StreamingCallbackT, StreamingChunk, select_streaming_callback
 from haystack.dataclasses.breakpoints import INTERNAL_INPUTS_FORMAT, Breakpoint, PipelineSnapshot
 from haystack.dataclasses.streaming_chunk import _invoke_streaming_callback
@@ -195,6 +196,7 @@ class Pipeline(PipelineBase):
 
             return component_output
 
+    @mark_deserialization_internal
     def run(  # noqa: PLR0915, PLR0912, C901
         self,
         data: dict[str, Any],
@@ -1077,6 +1079,7 @@ class Pipeline(PipelineBase):
                 # This is a no-op on normal completion and on a component error, since no tasks are left running by then
                 await self._cancel_in_flight_tasks(running_tasks, scheduled_components)
 
+    @mark_deserialization_internal
     async def run_async(
         self, data: dict[str, Any], include_outputs_from: set[str] | None = None, concurrency_limit: int = 4
     ) -> dict[str, Any]:

--- a/releasenotes/notes/fix-rce-deserializer-pipeline-entry-points-7c2a1b9e4d3f5a6b.yaml
+++ b/releasenotes/notes/fix-rce-deserializer-pipeline-entry-points-7c2a1b9e4d3f5a6b.yaml
@@ -4,7 +4,8 @@ security:
     Closed an additional remote code execution vector related to the deserialization control-plane
     hardening: the pipeline loading entry points (``Pipeline.loads`` / ``Pipeline.load`` /
     ``Pipeline.from_dict``, which accept ``unsafe=True``) and the execute primitives
-    (``Pipeline.run`` / ``Pipeline.run_async``) were still resolvable from the allowlisted
+    (``Pipeline.run`` / ``Pipeline.run_async`` / ``Pipeline.run_async_generator`` /
+    ``Pipeline.stream``) were still resolvable from the allowlisted
     ``haystack`` namespace. Bound as ``custom_filters`` on an ``OutputAdapter`` or
     ``ConditionalRouter`` (which bypass the Jinja sandbox), a pipeline loaded in default safe mode
     could call ``Pipeline.loads(..., unsafe=True)`` to load a nested pipeline whose own filters

--- a/releasenotes/notes/fix-rce-deserializer-pipeline-entry-points-7c2a1b9e4d3f5a6b.yaml
+++ b/releasenotes/notes/fix-rce-deserializer-pipeline-entry-points-7c2a1b9e4d3f5a6b.yaml
@@ -1,0 +1,15 @@
+---
+security:
+  - |
+    Closed an additional remote code execution vector related to the deserialization control-plane
+    hardening: the pipeline loading entry points (``Pipeline.loads`` / ``Pipeline.load`` /
+    ``Pipeline.from_dict``, which accept ``unsafe=True``) and the execute primitives
+    (``Pipeline.run`` / ``Pipeline.run_async``) were still resolvable from the allowlisted
+    ``haystack`` namespace. Bound as ``custom_filters`` on an ``OutputAdapter`` or
+    ``ConditionalRouter`` (which bypass the Jinja sandbox), a pipeline loaded in default safe mode
+    could call ``Pipeline.loads(..., unsafe=True)`` to load a nested pipeline whose own filters
+    (``allow_deserialization_module``, ``deserialize_callable``) bind under the nested unsafe
+    context, then ``Pipeline.run`` it to disarm the process-wide allowlist with ``"*"`` and invoke
+    ``os.system``. These entry points are now marked as deserializer-internal, so they can never be
+    produced by deserializing untrusted data. As before, ``unsafe=True`` bypasses the check by design
+    and there are no public API changes.

--- a/releasenotes/notes/fix-rce-deserializer-pipeline-entry-points-7c2a1b9e4d3f5a6b.yaml
+++ b/releasenotes/notes/fix-rce-deserializer-pipeline-entry-points-7c2a1b9e4d3f5a6b.yaml
@@ -1,16 +1,15 @@
 ---
 security:
   - |
-    Closed an additional remote code execution vector related to the deserialization control-plane
+    Closed an additional remote code execution vector in the deserialization control-plane
     hardening: the pipeline loading entry points (``Pipeline.loads`` / ``Pipeline.load`` /
     ``Pipeline.from_dict``, which accept ``unsafe=True``) and the execute primitives
-    (``Pipeline.run`` / ``Pipeline.run_async`` / ``Pipeline.run_async_generator`` /
-    ``Pipeline.stream``) were still resolvable from the allowlisted
-    ``haystack`` namespace. Bound as ``custom_filters`` on an ``OutputAdapter`` or
-    ``ConditionalRouter`` (which bypass the Jinja sandbox), a pipeline loaded in default safe mode
-    could call ``Pipeline.loads(..., unsafe=True)`` to load a nested pipeline whose own filters
-    (``allow_deserialization_module``, ``deserialize_callable``) bind under the nested unsafe
-    context, then ``Pipeline.run`` it to disarm the process-wide allowlist with ``"*"`` and invoke
-    ``os.system``. These entry points are now marked as deserializer-internal, so they can never be
-    produced by deserializing untrusted data. As before, ``unsafe=True`` bypasses the check by design
-    and there are no public API changes.
+    (``Pipeline.run`` / ``run_async`` / ``run_async_generator`` / ``stream``) were still resolvable
+    from the allowlisted ``haystack`` namespace. Bound as a ``custom_filters`` entry on an
+    ``OutputAdapter`` or ``ConditionalRouter`` (which bypass the Jinja sandbox),
+    ``Pipeline.loads(..., unsafe=True)`` let a pipeline loaded in default safe mode load a nested
+    pipeline whose own filters (``allow_deserialization_module``, ``deserialize_callable``) bind
+    under the nested unsafe context, disarming the process-wide allowlist with ``"*"`` and invoking
+    ``os.system``. All of these entry points are now marked as deserializer-internal, so they can
+    never be produced by deserializing untrusted data. ``unsafe=True`` still bypasses the check by
+    design; there are no public API changes.

--- a/releasenotes/notes/fix-rce-deserializer-self-disable-539671025b1763f7.yaml
+++ b/releasenotes/notes/fix-rce-deserializer-self-disable-539671025b1763f7.yaml
@@ -10,7 +10,9 @@ security:
     A malicious pipeline could register ``allow_deserialization_module`` as a Jinja ``custom_filters``
     entry (on an ``OutputAdapter`` or ``ConditionalRouter``), call it with ``"*"`` to disarm the
     allowlist process-wide, and then use the equally-resolvable ``deserialize_callable`` to resolve
-    and invoke ``os.system``. The same attribute walk could also reach the deserializer's mutable
+    and invoke ``os.system``. Loading alone was enough to trigger this: a Jinja filter called with
+    constant arguments runs while the component is being constructed, so the pipeline never had to
+    be run. The same attribute walk could also reach the deserializer's mutable
     control-plane state directly — for example a filter bound to ``_extra_allowed_modules.append``
     — to widen the allowlist persistently and stage a later attack.
     Relatedly, the handle resolver walked attribute names freely, so a handle could descend into

--- a/test/core/test_serialization_security.py
+++ b/test/core/test_serialization_security.py
@@ -7,6 +7,7 @@ import io
 import json
 import operator
 import subprocess
+import types
 from collections.abc import Callable
 from unittest import mock
 
@@ -607,6 +608,110 @@ class TestDeniedPipelineEntryPoints:
         assert _extra_allowed_modules == []
         with pytest.raises(DeserializationError):
             deserialize_callable("os.system")
+
+    def test_nested_gadget_pipeline_needs_an_unsafe_load_to_arm(self):
+        # The other half of the chain, on its own: the nested payload is inert unless something loads
+        # it in unsafe mode. In safe mode the load is refused (its `unsafe: true` OutputAdapter, and
+        # its control-plane filters, are both rejected), so the gadget never arms.
+        with mock.patch("os.system") as mocked_system:
+            with pytest.raises(DeserializationError, match="unsafe=True while loading in safe mode"):
+                Pipeline.loads(self._nested_yaml())
+        assert not mocked_system.called
+        assert _extra_allowed_modules == []
+
+        # Under an unsafe load it arms *and fires* — and it fires at load time, not at run time:
+        # `OutputAdapter.__init__` extracts template variables via `meta.find_undeclared_variables`,
+        # whose codegen constant-folds filter calls with constant arguments, so `('*' | allow)` runs
+        # while the component is being constructed. No `.run()` is involved.
+        # This is why blocking the *loaders* is the load-bearing part of the fix: once safe-mode data
+        # cannot reach an unsafe load, it cannot reach this construction either.
+        Pipeline.loads(self._nested_yaml(), unsafe=True)
+        assert _extra_allowed_modules == ["*"]  # reverted by the autouse fixture
+
+
+class TestPipelineCallableClassification:
+    """
+    Structural guard for the marking above. `mark_deserialization_internal` is a per-callable
+    denylist inside a namespace-wide allowlist, so its completeness depends on someone remembering
+    to stamp the next dangerous entry point — exactly how `run_async_generator` and `stream` were
+    missed when `run` / `run_async` were marked.
+
+    Rather than testing the callables we happen to have thought of, this enumerates every public
+    callable on `PipelineBase` / `Pipeline` and requires each one to be classified here. Adding a
+    new public method fails this test until it is declared either deserializer-internal or safe to
+    resolve, and dropping a decorator fails it too.
+    """
+
+    # Loaders that accept `unsafe=True`, plus the execute primitives.
+    INTERNAL: dict[str, set[str]] = {
+        "PipelineBase": {"from_dict", "load", "loads"},
+        "Pipeline": {"run", "run_async", "run_async_generator", "stream"},
+    }
+    # Resolvable from serialized data without handing it deserialization control or execution:
+    # graph construction, introspection, serialization *out*, and lifecycle.
+    SAFE_TO_RESOLVE: dict[str, set[str]] = {
+        "PipelineBase": {
+            "add_component",
+            "close",
+            "close_async",
+            "connect",
+            "draw",
+            "dump",
+            "dumps",
+            "get_component",
+            "get_component_name",
+            "inputs",
+            "outputs",
+            "remove_component",
+            "show",
+            "to_dict",
+            "validate_input",
+            "validate_pipeline",
+            "walk",
+            "warm_up",
+            "warm_up_async",
+        },
+        "Pipeline": set(),
+    }
+
+    @staticmethod
+    def _public_callables(pipeline_class):
+        # `vars()` rather than `dir()`: each class is checked against its own declarations, so the
+        # two classification sets stay disjoint and a method moving between them is visible.
+        return {
+            name
+            for name, value in vars(pipeline_class).items()
+            if not name.startswith("_") and isinstance(value, (types.FunctionType, classmethod, staticmethod))
+        }
+
+    @pytest.mark.parametrize("class_name", ["PipelineBase", "Pipeline"])
+    def test_every_public_callable_is_classified(self, class_name):
+        from haystack.core.pipeline.base import PipelineBase
+        from haystack.core.pipeline.pipeline import Pipeline as ConcretePipeline
+        from haystack.core.serialization_security import _DESERIALIZATION_INTERNAL_ATTR
+
+        cls = {"PipelineBase": PipelineBase, "Pipeline": ConcretePipeline}[class_name]
+        internal, safe = self.INTERNAL[class_name], self.SAFE_TO_RESOLVE[class_name]
+        assert not internal & safe, f"{class_name}: classified both ways: {sorted(internal & safe)}"
+
+        public = self._public_callables(cls)
+        unclassified = public - internal - safe
+        assert not unclassified, (
+            f"{class_name}.{sorted(unclassified)} is public and unclassified. Decide whether it hands "
+            f"deserialized data deserialization control or execution: if so, stamp it with "
+            f"`mark_deserialization_internal` and add it to INTERNAL; otherwise add it to SAFE_TO_RESOLVE."
+        )
+        stale = (internal | safe) - public
+        assert not stale, f"{class_name}: classified but no longer public: {sorted(stale)}"
+
+        for name in sorted(public):
+            attr = getattr(cls, name)
+            func = getattr(attr, "__func__", attr)
+            marked = getattr(func, _DESERIALIZATION_INTERNAL_ATTR, False) is True
+            assert marked is (name in internal), (
+                f"{class_name}.{name} is classified as {'internal' if name in internal else 'safe'} "
+                f"but its `mark_deserialization_internal` stamp is {marked}."
+            )
 
 
 class TestObjectInternalsTraversal:

--- a/test/core/test_serialization_security.py
+++ b/test/core/test_serialization_security.py
@@ -511,6 +511,99 @@ class TestDeniedDeserializerInternals:
             deserialize_callable("os.system")
 
 
+class TestDeniedPipelineEntryPoints:
+    """
+    Blocking the low-level resolvers (`deserialize_callable` etc.) is not enough on its own: the
+    high-level loading entry points that accept `unsafe=True` — `Pipeline.loads` / `load` /
+    `from_dict` — and the execute primitive `Pipeline.run` / `run_async` are themselves resolvable
+    from the allowlisted `haystack` namespace. Bound as sandbox-bypassing `custom_filters`, they
+    re-enter deserialization: a safe-mode pipeline can call `Pipeline.loads(nested, unsafe=True)` to
+    load a *nested* pipeline whose own filters (`allow_deserialization_module`, `deserialize_callable`)
+    bind under the nested unsafe context, then `Pipeline.run` it to poison the process-wide allowlist
+    with `"*"` and invoke `os.system`. These entry points must be part of the deserialization control
+    plane too, so they can never be produced by deserializing untrusted data.
+    """
+
+    ENTRY_POINTS = [
+        "haystack.core.pipeline.pipeline.Pipeline.loads",
+        "haystack.core.pipeline.pipeline.Pipeline.load",
+        "haystack.core.pipeline.pipeline.Pipeline.from_dict",
+        "haystack.core.pipeline.pipeline.Pipeline.run",
+        "haystack.core.pipeline.pipeline.Pipeline.run_async",
+        # The base class the classmethods actually live on, and the public re-export.
+        "haystack.core.pipeline.base.PipelineBase.loads",
+        "haystack.Pipeline.loads",
+    ]
+
+    @pytest.mark.parametrize("handle", ENTRY_POINTS)
+    def test_deserialize_callable_rejects_pipeline_entry_points(self, handle):
+        with pytest.raises(DeserializationError, match="deserialization control plane"):
+            deserialize_callable(handle)
+
+    @pytest.mark.parametrize("handle", ENTRY_POINTS)
+    def test_unsafe_mode_bypasses_the_block(self, handle):
+        # unsafe=True disables all deserialization safety checks by design.
+        with _deserialization_context(unsafe=True):
+            assert callable(deserialize_callable(handle))
+
+    def test_entry_points_carry_the_marker(self):
+        # By construction: the loaders and the run primitive are stamped, so the resolver excludes
+        # them the day they are marked, not the day the chain below is discovered.
+        from haystack.core.pipeline.base import PipelineBase
+        from haystack.core.pipeline.pipeline import Pipeline as ConcretePipeline
+        from haystack.core.serialization_security import _DESERIALIZATION_INTERNAL_ATTR
+
+        for classmethod_name in ("loads", "load", "from_dict"):
+            func = getattr(PipelineBase, classmethod_name).__func__
+            assert getattr(func, _DESERIALIZATION_INTERNAL_ATTR, False) is True
+        for method_name in ("run", "run_async"):
+            func = getattr(ConcretePipeline, method_name)
+            assert getattr(func, _DESERIALIZATION_INTERNAL_ATTR, False) is True
+
+    def _nested_yaml(self):
+        # Meant to be loaded with unsafe=True (so its `allow`/`dc` filters bind), then run: it poisons
+        # the process-wide allowlist with "*" and resolves and invokes os.system — the original gadget.
+        return (
+            "components:\n"
+            "  c:\n"
+            "    type: haystack.components.converters.output_adapter.OutputAdapter\n"
+            "    init_parameters:\n"
+            "      template: \"{{ ('*' | allow) }}{{ ('os.system' | dc | mp([cmd]) | list) }}\"\n"
+            "      output_type: str\n"
+            "      custom_filters:\n"
+            "        allow: haystack.core.serialization_security.allow_deserialization_module\n"
+            "        dc: haystack.utils.callable_serialization.deserialize_callable\n"
+            "        mp: builtins.map\n"
+            "      unsafe: true\n"
+            "connections: []\n"
+        )
+
+    def test_pipeline_loads_rejects_nested_unsafe_load_run_vector(self):
+        # End-to-end reproduction, in default safe mode. The top pipeline binds Pipeline.loads (L) and
+        # Pipeline.run (R) as custom_filters; the block fires while resolving L at load, before any
+        # template renders, so os.system is never reached and the allowlist is never poisoned.
+        top_yaml = (
+            "components:\n"
+            "  c:\n"
+            "    type: haystack.components.converters.output_adapter.OutputAdapter\n"
+            "    init_parameters:\n"
+            "      template: \"{{ nested | L(unsafe=True) | R(data={'c': {'cmd': cmd}}) }}\"\n"
+            "      output_type: str\n"
+            "      custom_filters:\n"
+            "        L: haystack.core.pipeline.pipeline.Pipeline.loads\n"
+            "        R: haystack.core.pipeline.pipeline.Pipeline.run\n"
+            "      unsafe: false\n"
+            "connections: []\n"
+        )
+        with mock.patch("os.system") as mocked_system:
+            with pytest.raises(DeserializationError, match="deserialization control plane"):
+                Pipeline.loads(top_yaml)
+        assert not mocked_system.called
+        assert _extra_allowed_modules == []
+        with pytest.raises(DeserializationError):
+            deserialize_callable("os.system")
+
+
 class TestObjectInternalsTraversal:
     """
     A serialized handle legitimately walks `module.Class.method`, never into an object's internals.

--- a/test/core/test_serialization_security.py
+++ b/test/core/test_serialization_security.py
@@ -515,7 +515,8 @@ class TestDeniedPipelineEntryPoints:
     """
     Blocking the low-level resolvers (`deserialize_callable` etc.) is not enough on its own: the
     high-level loading entry points that accept `unsafe=True` — `Pipeline.loads` / `load` /
-    `from_dict` — and the execute primitive `Pipeline.run` / `run_async` are themselves resolvable
+    `from_dict` — and the execute primitives (`Pipeline.run` / `run_async` / `run_async_generator` /
+    `stream`) are themselves resolvable
     from the allowlisted `haystack` namespace. Bound as sandbox-bypassing `custom_filters`, they
     re-enter deserialization: a safe-mode pipeline can call `Pipeline.loads(nested, unsafe=True)` to
     load a *nested* pipeline whose own filters (`allow_deserialization_module`, `deserialize_callable`)
@@ -530,6 +531,10 @@ class TestDeniedPipelineEntryPoints:
         "haystack.core.pipeline.pipeline.Pipeline.from_dict",
         "haystack.core.pipeline.pipeline.Pipeline.run",
         "haystack.core.pipeline.pipeline.Pipeline.run_async",
+        # `run_async_generator` and `stream` reach `run_async` too, so they are execute primitives
+        # in their own right: `stream` schedules the run via `asyncio.create_task`.
+        "haystack.core.pipeline.pipeline.Pipeline.run_async_generator",
+        "haystack.core.pipeline.pipeline.Pipeline.stream",
         # The base class the classmethods actually live on, and the public re-export.
         "haystack.core.pipeline.base.PipelineBase.loads",
         "haystack.Pipeline.loads",
@@ -547,8 +552,8 @@ class TestDeniedPipelineEntryPoints:
             assert callable(deserialize_callable(handle))
 
     def test_entry_points_carry_the_marker(self):
-        # By construction: the loaders and the run primitive are stamped, so the resolver excludes
-        # them the day they are marked, not the day the chain below is discovered.
+        # By construction: the loaders and the execute primitives are stamped, so the resolver
+        # excludes them the day they are marked, not the day the chain below is discovered.
         from haystack.core.pipeline.base import PipelineBase
         from haystack.core.pipeline.pipeline import Pipeline as ConcretePipeline
         from haystack.core.serialization_security import _DESERIALIZATION_INTERNAL_ATTR
@@ -556,7 +561,7 @@ class TestDeniedPipelineEntryPoints:
         for classmethod_name in ("loads", "load", "from_dict"):
             func = getattr(PipelineBase, classmethod_name).__func__
             assert getattr(func, _DESERIALIZATION_INTERNAL_ATTR, False) is True
-        for method_name in ("run", "run_async"):
+        for method_name in ("run", "run_async", "run_async_generator", "stream"):
             func = getattr(ConcretePipeline, method_name)
             assert getattr(func, _DESERIALIZATION_INTERNAL_ATTR, False) is True
 


### PR DESCRIPTION
### Related Issues

- Follow-up to #12378

#12378 marks the low-level resolvers as deserializer-internal but leaves the **high-level pipeline entry points** resolvable from the allowlisted `haystack` namespace. Bound as `custom_filters` (which bypass the Jinja sandbox), they reconstruct the RCE in default safe mode: `Pipeline.loads(nested, unsafe=True)` re-enters deserialization, so the nested pipeline can bind `allow_deserialization_module` and `deserialize_callable` as filters — poisoning `_extra_allowed_modules` to `['*']` process-wide and invoking `os.system`. Confirmed on the #12378 branch.

Note on timing: the nested payload fires at **load** time, not at `.run()` time. `OutputAdapter.__init__` extracts template variables via `meta.find_undeclared_variables`, whose codegen constant-folds filter calls with constant arguments, so `('*' | allow)` executes during construction. Blocking the **loaders** is therefore the load-bearing part of this fix; marking the execute primitives is defense in depth.

### Proposed Changes:

- Mark `PipelineBase.from_dict` / `loads` / `load` as `mark_deserialization_internal` (`base.py`).
- Mark the execute primitives `Pipeline.run` / `run_async` / `run_async_generator` / `stream` (`pipeline.py`).
- `TestDeniedPipelineEntryPoints`: direct-resolution rejection, marker invariant, `unsafe=True` bypass, end-to-end reproduction of the chain.
- `TestPipelineCallableClassification`: enumerates every public callable on `PipelineBase` / `Pipeline` and requires each to be declared internal or safe-to-resolve, so the next unmarked entry point fails CI instead of shipping.
- Security release note.

### How did you test it?

- `hatch run test:unit test/core/` (1818 passed), `hatch run fmt`, `hatch run test:types` clean.
- Verified the fix breaks the chain (allowlist stays `[]`, no file created) and that normal `run` / `dumps`-`loads` round-trips are unaffected.
- Verified the classification guard fails on a new public method, a dropped decorator, and a stale entry.

### Notes for the reviewer

Targeting `fix-rce-deserializer-self-disable` so it merges into #12378.

No public API changes; `unsafe=True` still bypasses the check by design. These entry points are never legitimately produced by deserializing data.

Out of scope, found while testing: constant folding calls filters in safe mode too (the sandbox's `call` hook is not on the `as_const` path). Not exploitable today — no dangerous callable resolves in safe mode — but `builtins.input` does, and folded at load time it blocks `Pipeline.loads` on stdin. Fixing it properly means extracting template variables without the codegen path, which touches `OutputAdapter`, `ConditionalRouter`, `PromptBuilder` and `ChatPromptBuilder`. Happy to file separately.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
