### PR TITLE
chore: clarify how `generation_kwargs` passed in `run` are handled

### DIFF
--- a/docs-website/docs/pipeline-components/agents-1/agent.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/agent.mdx
@@ -91,8 +91,8 @@ def fallback_on_max_steps(state: State) -> None:
 - `tools`: A list of tool or toolset instances the agent can call. Supported types: [`Tool`](../../tools/tool.mdx), [`ComponentTool`](../../tools/componenttool.mdx), [`PipelineTool`](../../tools/pipelinetool.mdx), [`AgentTool`](../../tools/agenttool.mdx), [`MCPTool`](../../tools/mcptool.mdx), [`Toolset`](../../tools/toolset.mdx), [`MCPToolset`](../../tools/mcptoolset.mdx), [`SearchableToolset`](../../tools/searchabletoolset.mdx). Tool names must be unique; duplicate names are detected at the start of each agent step, before the chat generator is called.
 - `system_prompt`: A plain string or Jinja2 template used as the system message for every run. If the template contains Jinja2 variables, those variables become additional inputs to `run()`.
 - `user_prompt`: A Jinja2 template appended to the user-provided messages on each run. Template variables become additional inputs to `run()`. Use `required_variables` to enforce which variables must be provided.
-- `exit_conditions`: List of conditions that cause the agent to stop. Use `”text”` to stop when the LLM replies without a tool call, or a tool name to stop once that tool has been executed. Defaults to `[“text”]`. Exit conditions are evaluated at runtime rather than validated at initialization, so a condition can name a tool that is only loaded later — for example, a tool passed at runtime via `run(tools=...)` or one discovered by a [`SearchableToolset`](../../tools/searchabletoolset.mdx).
-- `state_schema`: Defines the agent's runtime state — a dict mapping key names to type configs (e.g. `{“docs”: {“type”: list[Document]}}`). Tools can read from and write to state keys via `inputs_from_state` and `outputs_to_state`. See [State](./state.mdx) for full details.
+- `exit_conditions`: List of conditions that cause the agent to stop. Use `"text"` to stop when the LLM replies without a tool call, or a tool name to stop once that tool has been executed. Defaults to `["text"]`. Exit conditions are evaluated at runtime rather than validated at initialization, so a condition can name a tool that is only loaded later — for example, a tool passed at runtime via `run(tools=...)` or one discovered by a [`SearchableToolset`](../../tools/searchabletoolset.mdx).
+- `state_schema`: Defines the agent's runtime state — a dict mapping key names to type configs (e.g. `{"docs": {"type": list[Document]}}`). Tools can read from and write to state keys via `inputs_from_state` and `outputs_to_state`. See [State](./state.mdx) for full details.
 - `streaming_callback`: A callback invoked for each streamed token. Use the built-in `print_streaming_chunk` for console output.
 - `max_agent_steps`: Maximum number of LLM + tool call iterations before the agent stops. Defaults to `100`.
 - `raise_on_tool_invocation_failure`: If `True`, raises an exception when a tool call fails. If `False` (default), the error is passed back to the LLM as a message so it can recover.
@@ -105,7 +105,7 @@ def fallback_on_max_steps(state: State) -> None:
 `run()` also accepts parameters that override the init-time configuration for a single call:
 
 - `tools`: Pass a list of `Tool`/`Toolset` objects, or a list of tool name strings to select a subset of the agent's configured tools for this run.
-- `generation_kwargs`: Additional keyword arguments forwarded to the LLM, overriding any set at init time (e.g. `{“temperature”: 0.2}`).
+- `generation_kwargs`: Additional keyword arguments forwarded to the chat generator (e.g. `{"temperature": 0.2}`). They are merged per key with the `generation_kwargs` set at the chat generator's initialization: keys passed here take precedence, keys set only at initialization are kept.
 - `hook_context`: A dict of request-scoped resources made available to [hooks](./hooks.mdx) via `state.data["hook_context"]` — for example, a user ID or a WebSocket connection.
 
 :::info

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -694,8 +694,9 @@ class Agent:
         :param messages: List of ChatMessage objects to start the agent with.
         :param streaming_callback: Optional callback for streaming responses.
         :param requires_async: Whether the agent run requires asynchronous execution.
-        :param generation_kwargs: Additional keyword arguments for chat generator. These parameters will
-            override the parameters passed during component initialization.
+        :param generation_kwargs: Additional keyword arguments for the chat generator. These are merged per key
+            with the `generation_kwargs` passed at the chat generator's initialization: keys provided here take
+            precedence, keys set only at initialization are kept.
         :param tools: Optional list of Tool objects, a Toolset, or list of tool names to use for this run.
             When passing tool names, tools are selected from the Agent's originally configured tools.
         :param hook_context: Optional dictionary of request-scoped resources made available to hooks via
@@ -815,8 +816,9 @@ class Agent:
         :param messages: List of Haystack ChatMessage objects to process.
         :param streaming_callback: A callback that will be invoked when a response is streamed from the LLM.
             The same callback can be configured to emit tool results when a tool is called.
-        :param generation_kwargs: Additional keyword arguments for LLM. These parameters will
-            override the parameters passed during component initialization.
+        :param generation_kwargs: Additional keyword arguments for the chat generator. These are merged per key
+            with the `generation_kwargs` passed at the chat generator's initialization: keys provided here take
+            precedence, keys set only at initialization are kept.
         :param tools: Optional list of Tool objects, a Toolset, or list of tool names to use for this run.
             When passing tool names, tools are selected from the Agent's originally configured tools.
         :param hook_context: Optional dictionary of request-scoped resources made available to hooks via
@@ -899,8 +901,9 @@ class Agent:
         :param messages: List of Haystack ChatMessage objects to process.
         :param streaming_callback: An asynchronous callback that will be invoked when a response is streamed from the
             LLM. The same callback can be configured to emit tool results when a tool is called.
-        :param generation_kwargs: Additional keyword arguments for LLM. These parameters will
-            override the parameters passed during component initialization.
+        :param generation_kwargs: Additional keyword arguments for the chat generator. These are merged per key
+            with the `generation_kwargs` passed at the chat generator's initialization: keys provided here take
+            precedence, keys set only at initialization are kept.
         :param tools: Optional list of Tool objects, a Toolset, or list of tool names to use for this run.
         :param hook_context: Optional dictionary of request-scoped resources made available to hooks via
             `state.data.get("hook_context")`. Useful in web/server environments to provide per-request objects

--- a/haystack/components/generators/chat/llm.py
+++ b/haystack/components/generators/chat/llm.py
@@ -139,8 +139,9 @@ class LLM(Agent):
             required or optional depends on the `user_prompt` configuration: if `user_prompt` has no template
             variables, `messages` must be provided. Passed via `**kwargs`.
         :param streaming_callback: A callback that will be invoked when a response is streamed from the LLM.
-        :param generation_kwargs: Additional keyword arguments for the underlying chat generator. These parameters
-            will override the parameters passed during component initialization.
+        :param generation_kwargs: Additional keyword arguments for the chat generator. These are merged per key
+            with the `generation_kwargs` passed at the chat generator's initialization: keys provided here take
+            precedence, keys set only at initialization are kept.
         :param kwargs: Additional keyword arguments. These are used to fill template variables in `user_prompt` or
             `system_prompt` (the keys must match template variable names).
         :returns:
@@ -179,8 +180,9 @@ class LLM(Agent):
             variables, `messages` must be provided. Passed via `**kwargs`.
         :param streaming_callback: An asynchronous callback that will be invoked when a response is streamed
             from the LLM.
-        :param generation_kwargs: Additional keyword arguments for the underlying chat generator. These parameters
-            will override the parameters passed during component initialization.
+        :param generation_kwargs: Additional keyword arguments for the chat generator. These are merged per key
+            with the `generation_kwargs` passed at the chat generator's initialization: keys provided here take
+            precedence, keys set only at initialization are kept.
         :param kwargs: Additional keyword arguments. These are used to fill template variables in `user_prompt` or
             `system_prompt` (the keys must match template variable names).
         :returns:

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -358,8 +358,9 @@ class OpenAIChatGenerator:
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
         :param generation_kwargs:
-            Additional keyword arguments for text generation. These parameters will
-            override the parameters passed during component initialization.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set
+            only at initialization are kept.
             For details on OpenAI API parameters, see [OpenAI documentation](https://platform.openai.com/docs/api-reference/chat/create).
         :param tools:
             A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
@@ -440,8 +441,9 @@ class OpenAIChatGenerator:
             A callback function that is called when a new token is received from the stream. Async callbacks are
             preferred; a sync callback is accepted but will run synchronously on the event loop and may block it.
         :param generation_kwargs:
-            Additional keyword arguments for text generation. These parameters will
-            override the parameters passed during component initialization.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set
+            only at initialization are kept.
             For details on OpenAI API parameters, see [OpenAI documentation](https://platform.openai.com/docs/api-reference/chat/create).
         :param tools: A list of Tool and/or Toolset objects, or a single Toolset for which the model can prepare calls.
             If set, it will override the `tools` parameter provided during initialization.

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -380,8 +380,9 @@ class OpenAIResponsesChatGenerator:
         :param streaming_callback:
             A callback function that is called when a new token is received from the stream.
         :param generation_kwargs:
-            Additional keyword arguments for text generation. These parameters will
-            override the parameters passed during component initialization.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set
+            only at initialization are kept.
             For details on OpenAI API parameters, see [OpenAI documentation](https://platform.openai.com/docs/api-reference/responses/create).
         :param tools:
             The tools that the model can use to prepare calls. If set, it will override the
@@ -456,8 +457,9 @@ class OpenAIResponsesChatGenerator:
             A callback function that is called when a new token is received from the stream. Async callbacks are
             preferred; a sync callback is accepted but will run synchronously on the event loop and may block it.
         :param generation_kwargs:
-            Additional keyword arguments for text generation. These parameters will
-            override the parameters passed during component initialization.
+            Additional keyword arguments for text generation. These are merged per key with the
+            `generation_kwargs` passed at initialization: keys provided here take precedence, keys set
+            only at initialization are kept.
             For details on OpenAI API parameters, see [OpenAI documentation](https://platform.openai.com/docs/api-reference/responses/create).
         :param tools:
             A list of tools or a Toolset for which the model can prepare calls. If set, it will override the

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -507,6 +507,20 @@ class TestOpenAIChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
+    def test_run_merges_generation_kwargs_with_the_ones_set_at_init(
+        self, chat_messages: list[ChatMessage], openai_mock_chat_completion: MagicMock
+    ) -> None:
+
+        component = OpenAIChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            generation_kwargs={"max_completion_tokens": 10, "temperature": 0.5},
+        )
+        component.run(chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = openai_mock_chat_completion.call_args
+        assert kwargs["temperature"] == 0.9
+        assert kwargs["max_completion_tokens"] == 10
+
     def test_run_with_params_streaming(
         self, chat_messages: list[ChatMessage], openai_mock_chat_completion_chunk: MagicMock
     ) -> None:

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -507,7 +507,7 @@ class TestOpenAIChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    def test_run_merges_generation_kwargs_with_the_ones_set_at_init(
+    def test_run_with_generation_kwargs(
         self, chat_messages: list[ChatMessage], openai_mock_chat_completion: MagicMock
     ) -> None:
 

--- a/test/components/generators/chat/test_openai_async.py
+++ b/test/components/generators/chat/test_openai_async.py
@@ -197,7 +197,7 @@ class TestOpenAIChatGeneratorAsync:
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
     @pytest.mark.asyncio
-    async def test_run_async_merges_generation_kwargs_with_the_ones_set_at_init(
+    async def test_run_with_generation_kwargs_async(
         self, chat_messages: list[ChatMessage], openai_mock_async_chat_completion: MagicMock
     ) -> None:
 

--- a/test/components/generators/chat/test_openai_async.py
+++ b/test/components/generators/chat/test_openai_async.py
@@ -197,6 +197,21 @@ class TestOpenAIChatGeneratorAsync:
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
     @pytest.mark.asyncio
+    async def test_run_async_merges_generation_kwargs_with_the_ones_set_at_init(
+        self, chat_messages: list[ChatMessage], openai_mock_async_chat_completion: MagicMock
+    ) -> None:
+
+        component = OpenAIChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            generation_kwargs={"max_completion_tokens": 10, "temperature": 0.5},
+        )
+        await component.run_async(chat_messages, generation_kwargs={"temperature": 0.9})
+
+        _, kwargs = openai_mock_async_chat_completion.call_args
+        assert kwargs["temperature"] == 0.9
+        assert kwargs["max_completion_tokens"] == 10
+
+    @pytest.mark.asyncio
     async def test_run_with_params_streaming_async(
         self, chat_messages: list[ChatMessage], openai_mock_async_chat_completion_chunk: MagicMock
     ) -> None:

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -601,6 +601,17 @@ class TestRun:
         assert len(response["replies"]) == 1
         assert isinstance(response["replies"][0], ChatMessage)
 
+    def test_run_merges_generation_kwargs_with_the_ones_set_at_init(self, openai_mock_responses: MagicMock) -> None:
+
+        component = OpenAIResponsesChatGenerator(
+            api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_output_tokens": 10, "temperature": 0.5}
+        )
+        component.run([ChatMessage.from_user("What's the capital of France")], generation_kwargs={"temperature": 0.9})
+
+        kwargs = openai_mock_responses.call_args.kwargs
+        assert kwargs["temperature"] == 0.9
+        assert kwargs["max_output_tokens"] == 10
+
     def test_run_with_flattened_generation_kwargs(
         self, openai_mock_responses: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1220,6 +1231,21 @@ class TestOpenAIResponsesChatGeneratorAsync:
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) == 1
         assert isinstance(response["replies"][0], ChatMessage)
+
+    async def test_run_async_merges_generation_kwargs_with_the_ones_set_at_init(
+        self, openai_mock_async_responses: MagicMock
+    ) -> None:
+
+        component = OpenAIResponsesChatGenerator(
+            api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_output_tokens": 10, "temperature": 0.5}
+        )
+        await component.run_async(
+            [ChatMessage.from_user("What's the capital of France")], generation_kwargs={"temperature": 0.9}
+        )
+
+        kwargs = openai_mock_async_responses.call_args.kwargs
+        assert kwargs["temperature"] == 0.9
+        assert kwargs["max_output_tokens"] == 10
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -601,7 +601,7 @@ class TestRun:
         assert len(response["replies"]) == 1
         assert isinstance(response["replies"][0], ChatMessage)
 
-    def test_run_merges_generation_kwargs_with_the_ones_set_at_init(self, openai_mock_responses: MagicMock) -> None:
+    def test_run_with_generation_kwargs(self, openai_mock_responses: MagicMock) -> None:
 
         component = OpenAIResponsesChatGenerator(
             api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_output_tokens": 10, "temperature": 0.5}
@@ -1232,9 +1232,7 @@ class TestOpenAIResponsesChatGeneratorAsync:
         assert len(response["replies"]) == 1
         assert isinstance(response["replies"][0], ChatMessage)
 
-    async def test_run_async_merges_generation_kwargs_with_the_ones_set_at_init(
-        self, openai_mock_async_responses: MagicMock
-    ) -> None:
+    async def test_run_async_with_generation_kwargs(self, openai_mock_async_responses: MagicMock) -> None:
 
         component = OpenAIResponsesChatGenerator(
             api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_output_tokens": 10, "temperature": 0.5}


### PR DESCRIPTION
### Related Issues

While working on https://github.com/deepset-ai/haystack-private/issues/541, I realized that we describe `generation_kwargs` handling in `run` method in a not so clear way: we say they override those passed at `__init__`.
What happens instead:
- at init: `generation_kwargs= {"max_completion_tokens": 10, "temperature": 0.5}`
- at run: `generation_kwargs={"temperature":0.9}`
- result: `generation_kwargs= {"max_completion_tokens": 10, "temperature": 0.9}`

I think this is a legitimate choice, also used in every integration (except for Google GenAI), but we need to document/test it

### Proposed Changes:
- better explain the merging logic in the docstrings
- test this behavior

### How did you test it?
CI, new tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
