### PR TITLE
fix: prevent unhandled AssertionError in PipelineBase.__eq__ when comparing to non-Pipeline types

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -119,9 +119,8 @@ class PipelineBase:  # noqa: PLW1641
         Pipelines of the same type share every metadata, node and edge, but they're not required to use
         the same node instances: this allows pipeline saved and then loaded back to be equal to themselves.
         """
-        if not isinstance(self, type(other)):
+        if not isinstance(other, type(self)):
             return False
-        assert isinstance(other, PipelineBase)
         return self.to_dict() == other.to_dict()
 
     def __repr__(self) -> str:

--- a/releasenotes/notes/fix-pipeline-base-eq-a665ea11824f86fb.yaml
+++ b/releasenotes/notes/fix-pipeline-base-eq-a665ea11824f86fb.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix unhandled ``AssertionError`` crash when comparing a ``Pipeline`` to any non-Pipeline object (such as ``pipeline == object()`` or ``pipeline in [object(), ...]``) caused by an inverted ``isinstance`` check in ``PipelineBase.__eq__``.

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -130,6 +130,35 @@ class TestPipelineBase:
     It doesn't test Pipeline.run(), that is done separately in a different way.
     """
 
+    def test_pipeline_equality(self):
+        pipeline_1 = PipelineBase(metadata={"test": "data"})
+        pipeline_1.add_component("comp1", FakeComponent())
+        pipeline_2 = PipelineBase(metadata={"test": "data"})
+        pipeline_2.add_component("comp1", FakeComponent())
+
+        assert pipeline_1 == pipeline_2
+
+    def test_pipeline_eq_no_crash_on_non_pipeline_types(self):
+        pipeline = PipelineBase()
+
+        assert pipeline != object()
+        assert object() != pipeline
+        assert pipeline != "not a pipeline"
+        assert pipeline != 123
+        assert pipeline is not None
+        assert pipeline != None  # noqa: E711
+        assert pipeline not in [object(), "not a pipeline", 123]
+
+    def test_pipeline_equality_subclasses(self):
+        class CustomPipeline(PipelineBase):
+            pass
+
+        pipeline = PipelineBase()
+        custom_pipeline = CustomPipeline()
+
+        assert pipeline != custom_pipeline
+        assert custom_pipeline != pipeline
+
     def test_pipeline_dumps(self, test_files_path):
         pipeline = PipelineBase(max_runs_per_component=99)
         pipeline.add_component("Comp1", FakeComponent("Foo"))


### PR DESCRIPTION
**Related Issues**

Closes #12386

**Proposed Changes**

- Corrected the inverted check `if not isinstance(self, type(other))` to `if not isinstance(other, type(self))` in `PipelineBase.__eq__`.
- Removed the redundant `assert isinstance(other, PipelineBase)` check.
- Added regression tests covering equality of identical pipelines, comparison against non-Pipeline objects (e.g. `object()`, strings, ints, `None`, and list membership), and subclass comparisons.
- Added release note in `releasenotes/notes/fix-pipeline-base-eq-a665ea11824f86fb.yaml`.

**How did you test it?**

```bash
hatch run test:unit test/core/pipeline/test_pipeline_base.py
```

154 passed, 2 deselected in 4.56s.

**Notes for the reviewer**

- **Root cause:** `PipelineBase.__eq__` previously checked `isinstance(self, type(other))` instead of `isinstance(other, type(self))`. When a `Pipeline` instance was compared against any object whose type is a superclass of `Pipeline` (such as `object()`), `isinstance(self, object)` evaluated to `True`. This bypassed the early return and hit `assert isinstance(other, PipelineBase)`, raising an unhandled `AssertionError`.
- In Python, `__eq__` must return `False` (or `NotImplemented`) when comparing incompatible types and never raise an `AssertionError`.

- **Reproducer:**
    ```python
    from haystack import Pipeline

    pipeline = Pipeline()

    # Before fix -> raises AssertionError
    # After fix  -> False
    pipeline == object()
    pipeline in [object(), "other_type"]
    ```

- The fix ensures `PipelineBase.__eq__` adheres to Python's data model contract for equality comparisons.

**Checklist**

- [x] Read contributors guidelines and code of conduct
- [x] Updated related issue
- [x] Added unit tests and updated docstrings
- [x] Used conventional commit type in PR title
- [x] Documented code
- [x] Added release note (`releasenotes/notes/fix-pipeline-base-eq-a665ea11824f86fb.yaml`)
- [x] Run pre-commit hooks and fixed any issues