### PR TITLE
docs: keep the number of docs versions constant

### DIFF
--- a/.github/utils/create_unstable_docs_docusaurus.py
+++ b/.github/utils/create_unstable_docs_docusaurus.py
@@ -100,3 +100,33 @@ if __name__ == "__main__":
     config = config.replace(f"label: '{target_unstable}'", f"label: '{next_unstable}'")
     with open("docs-website/docusaurus.config.js", "w") as f:
         f.write(config)
+
+    # Stable versions outside the build budget are not reachable on the website: redirect them to the current version
+    max_versions_match = re.search(r"const MAX_TOTAL_VERSIONS = (\d+);", config)
+    if max_versions_match is None:
+        sys.exit("Can't find MAX_TOTAL_VERSIONS in docs-website/docusaurus.config.js")
+
+    unstable_versions = [v for v in versions_list if v.endswith("-unstable")]
+    stable_versions = [v for v in versions_list if not v.endswith("-unstable")]
+    # the current version (docs/) always takes one slot, each unstable version takes one more
+    active_stable_count = max(0, int(max_versions_match.group(1)) - 1 - len(unstable_versions))
+    inactive_versions = stable_versions[active_stable_count:]
+
+    with open("docs-website/vercel.json") as f:
+        vercel_config = json.load(f)
+    existing_redirects = vercel_config.get("redirects", [])
+    existing_sources = {r.get("source") for r in existing_redirects}
+
+    added = 0
+    for v in inactive_versions:
+        for base in ("docs", "reference"):
+            source = f"/{base}/{v}/:slug*"
+            if source not in existing_sources:
+                existing_redirects.append({"source": source, "destination": f"/{base}/:slug*", "permanent": True})
+                added += 1
+
+    vercel_config["redirects"] = existing_redirects
+    with open("docs-website/vercel.json", "w") as f:
+        json.dump(vercel_config, f, indent=2)
+        f.write("\n")
+    print(f"Updated vercel.json with {added} redirect(s) for inactive versions: {inactive_versions}")

--- a/.github/utils/promote_unstable_docs_docusaurus.py
+++ b/.github/utils/promote_unstable_docs_docusaurus.py
@@ -12,7 +12,6 @@ import shutil
 import sys
 
 VERSION_VALIDATOR = re.compile(r"^[0-9]+\.[0-9]+$")
-MAX_STABLE_VERSIONS = 5
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -93,29 +92,3 @@ if __name__ == "__main__":
     config = config.replace(f"lastVersion: '{previous_stable}'", f"lastVersion: '{target_version}'")  # "2.19" -> "2.20"
     with open("docs-website/docusaurus.config.js", "w") as f:
         f.write(config)
-
-    # regenerate vercel.json redirects for inactive versions (those beyond the top MAX_STABLE_VERSIONS)
-    with open("docs-website/versions.json") as f:
-        updated_versions = json.load(f)
-    stable_versions = [v for v in updated_versions if not v.endswith("-unstable")]
-    inactive_versions = stable_versions[MAX_STABLE_VERSIONS:]
-    redirects = []
-    for v in inactive_versions:
-        redirects.append({"source": f"/docs/{v}/:slug*", "destination": "/docs/:slug*", "permanent": True})
-        redirects.append({"source": f"/reference/{v}/:slug*", "destination": "/reference/:slug*", "permanent": True})
-
-    with open("docs-website/vercel.json") as f:
-        vercel_config = json.load(f)
-
-    existing_redirects = vercel_config.get("redirects", [])
-    existing_sources = {r.get("source") for r in existing_redirects}
-
-    for r in redirects:
-        if r["source"] not in existing_sources:
-            existing_redirects.append(r)
-
-    vercel_config["redirects"] = existing_redirects
-    with open("docs-website/vercel.json", "w") as f:
-        json.dump(vercel_config, f, indent=2)
-        f.write("\n")
-    print(f"Updated vercel.json with {len(redirects)} redirect(s) for inactive versions: {inactive_versions}")

--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -7,13 +7,17 @@
 import {themes as prismThemes} from 'prism-react-renderer';
 import versions from './versions.json' with { type: 'json' };
 
-// Only build the current version (docs/) plus the 5 most recent stable versions (e.g. 2.x) and the unstable
-// versioned docs (e.g. 2.x-unstable; only present during the release process).
-const MAX_STABLE_VERSIONS = 5;
+// Keep the total number of built versions constant to keep memory/build time reasonable
+// Build the current version (docs/), the unstable version (e.g. 3.x-unstable, only present during the release process)
+// and fill the remaining slots with the most recent stable versions (e.g. 3.x)
+const MAX_TOTAL_VERSIONS = 5;
+const unstableVersions = versions.filter(v => v.endsWith('-unstable'));
 const activeVersions = [
   'current',
-  ...versions.filter(v => v.endsWith('-unstable')),
-  ...versions.filter(v => !v.endsWith('-unstable')).slice(0, MAX_STABLE_VERSIONS),
+  ...unstableVersions,
+  ...versions
+    .filter(v => !v.endsWith('-unstable'))
+    .slice(0, MAX_TOTAL_VERSIONS - unstableVersions.length),
 ];
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)

--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -10,15 +10,13 @@ import versions from './versions.json' with { type: 'json' };
 // Keep the total number of built versions constant to keep memory/build time reasonable
 // Build the current version (docs/), the unstable version (e.g. 3.x-unstable, only present during the release process)
 // and fill the remaining slots with the most recent stable versions (e.g. 3.x)
-const MAX_TOTAL_VERSIONS = 5;
+const MAX_TOTAL_VERSIONS = 6;
 const unstableVersions = versions.filter(v => v.endsWith('-unstable'));
 const activeVersions = [
   'current',
   ...unstableVersions,
-  ...versions
-    .filter(v => !v.endsWith('-unstable'))
-    .slice(0, MAX_TOTAL_VERSIONS - unstableVersions.length),
-];
+  ...versions.filter(v => !v.endsWith('-unstable')),
+].slice(0, MAX_TOTAL_VERSIONS);
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 

--- a/docs-website/reference_versioned_docs/version-3.1-unstable/integrations-api/amazon_sagemaker.md
+++ b/docs-website/reference_versioned_docs/version-3.1-unstable/integrations-api/amazon_sagemaker.md
@@ -5,11 +5,8 @@ description: "Amazon Sagemaker integration for Haystack"
 slug: "/integrations-amazon-sagemaker"
 ---
 
-<a id="haystack_integrations.components.generators.amazon_sagemaker.sagemaker"></a>
 
-## Module haystack\_integrations.components.generators.amazon\_sagemaker.sagemaker
-
-<a id="haystack_integrations.components.generators.amazon_sagemaker.sagemaker.SagemakerGenerator"></a>
+## haystack_integrations.components.generators.amazon_sagemaker.sagemaker
 
 ### SagemakerGenerator
 
@@ -20,6 +17,7 @@ For guidance on how to deploy a model to SageMaker, refer to the
 [SageMaker JumpStart foundation models documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/jumpstart-foundation-models-use.html).
 
 Usage example:
+
 ```python
 # Make sure your AWS credentials are set up correctly. You can use environment variables or a shared credentials
 # file. Then you can use the generator as follows:
@@ -33,118 +31,112 @@ print(response)
 >>> and respond to natural human language in a way that is both meaningful and useful.'], 'meta': [{}]}
 ```
 
-<a id="haystack_integrations.components.generators.amazon_sagemaker.sagemaker.SagemakerGenerator.__init__"></a>
-
-#### SagemakerGenerator.\_\_init\_\_
+#### __init__
 
 ```python
-def __init__(
-        model: str,
-        aws_access_key_id: Secret | None = Secret.from_env_var(
-            ["AWS_ACCESS_KEY_ID"], strict=False),
-        aws_secret_access_key: Secret
-    | None = Secret.from_env_var(  # noqa: B008
-        ["AWS_SECRET_ACCESS_KEY"], strict=False),
-        aws_session_token: Secret | None = Secret.from_env_var(
-            ["AWS_SESSION_TOKEN"], strict=False),
-        aws_region_name: Secret | None = Secret.from_env_var(
-            ["AWS_DEFAULT_REGION"], strict=False),
-        aws_profile_name: Secret | None = Secret.from_env_var(["AWS_PROFILE"],
-                                                              strict=False),
-        aws_custom_attributes: dict[str, Any] | None = None,
-        generation_kwargs: dict[str, Any] | None = None)
+__init__(
+    model: str,
+    aws_access_key_id: Secret | None = Secret.from_env_var(
+        ["AWS_ACCESS_KEY_ID"], strict=False
+    ),
+    aws_secret_access_key: Secret | None = Secret.from_env_var(
+        ["AWS_SECRET_ACCESS_KEY"], strict=False
+    ),
+    aws_session_token: Secret | None = Secret.from_env_var(
+        ["AWS_SESSION_TOKEN"], strict=False
+    ),
+    aws_region_name: Secret | None = Secret.from_env_var(
+        ["AWS_DEFAULT_REGION"], strict=False
+    ),
+    aws_profile_name: Secret | None = Secret.from_env_var(
+        ["AWS_PROFILE"], strict=False
+    ),
+    aws_custom_attributes: dict[str, Any] | None = None,
+    generation_kwargs: dict[str, Any] | None = None,
+) -> None
 ```
 
 Instantiates the session with SageMaker.
 
-**Arguments**:
+**Parameters:**
 
-- `aws_access_key_id`: The `Secret` for AWS access key ID.
-- `aws_secret_access_key`: The `Secret` for AWS secret access key.
-- `aws_session_token`: The `Secret` for AWS session token.
-- `aws_region_name`: The `Secret` for AWS region name. If not provided, the default region will be used.
-- `aws_profile_name`: The `Secret` for AWS profile name. If not provided, the default profile will be used.
-- `model`: The name for SageMaker Model Endpoint.
-- `aws_custom_attributes`: Custom attributes to be passed to SageMaker, for example `{"accept_eula": True}`
-in case of Llama-2 models.
-- `generation_kwargs`: Additional keyword arguments for text generation. For a list of supported parameters
-see your model's documentation page, for example here for HuggingFace models:
-https://huggingface.co/blog/sagemaker-huggingface-llm#4-run-inference-and-chat-with-our-model
+- **aws_access_key_id** (<code>Secret | None</code>) – The `Secret` for AWS access key ID.
+- **aws_secret_access_key** (<code>Secret | None</code>) – The `Secret` for AWS secret access key.
+- **aws_session_token** (<code>Secret | None</code>) – The `Secret` for AWS session token.
+- **aws_region_name** (<code>Secret | None</code>) – The `Secret` for AWS region name. If not provided, the default region will be used.
+- **aws_profile_name** (<code>Secret | None</code>) – The `Secret` for AWS profile name. If not provided, the default profile will be used.
+- **model** (<code>str</code>) – The name for SageMaker Model Endpoint.
+- **aws_custom_attributes** (<code>dict\[str, Any\] | None</code>) – Custom attributes to be passed to SageMaker, for example `{"accept_eula": True}`
+  in case of Llama-2 models.
+- **generation_kwargs** (<code>dict\[str, Any\] | None</code>) – Additional keyword arguments for text generation. For a list of supported parameters
+  see your model's documentation page, for example here for HuggingFace models:
+  https://huggingface.co/blog/sagemaker-huggingface-llm#4-run-inference-and-chat-with-our-model
 
 Specifically, Llama-2 models support the following inference payload parameters:
 
 - `max_new_tokens`: Model generates text until the output length (excluding the input context length)
-    reaches `max_new_tokens`. If specified, it must be a positive integer.
+  reaches `max_new_tokens`. If specified, it must be a positive integer.
 - `temperature`: Controls the randomness in the output. Higher temperature results in output sequence with
-    low-probability words and lower temperature results in output sequence with high-probability words.
-    If `temperature=0`, it results in greedy decoding. If specified, it must be a positive float.
+  low-probability words and lower temperature results in output sequence with high-probability words.
+  If `temperature=0`, it results in greedy decoding. If specified, it must be a positive float.
 - `top_p`: In each step of text generation, sample from the smallest possible set of words with cumulative
-    probability `top_p`. If specified, it must be a float between 0 and 1.
+  probability `top_p`. If specified, it must be a float between 0 and 1.
 - `return_full_text`: If `True`, input text will be part of the output generated text. If specified, it must
-    be boolean. The default value for it is `False`.
+  be boolean. The default value for it is `False`.
 
-<a id="haystack_integrations.components.generators.amazon_sagemaker.sagemaker.SagemakerGenerator.to_dict"></a>
-
-#### SagemakerGenerator.to\_dict
+#### to_dict
 
 ```python
-def to_dict() -> dict[str, Any]
+to_dict() -> dict[str, Any]
 ```
 
 Serializes the component to a dictionary.
 
-**Returns**:
+**Returns:**
 
-Dictionary with serialized data.
+- <code>dict\[str, Any\]</code> – Dictionary with serialized data.
 
-<a id="haystack_integrations.components.generators.amazon_sagemaker.sagemaker.SagemakerGenerator.from_dict"></a>
-
-#### SagemakerGenerator.from\_dict
+#### from_dict
 
 ```python
-@classmethod
-def from_dict(cls, data: dict[str, Any]) -> "SagemakerGenerator"
+from_dict(data: dict[str, Any]) -> SagemakerGenerator
 ```
 
 Deserializes the component from a dictionary.
 
-**Arguments**:
+**Parameters:**
 
-- `data`: Dictionary to deserialize from.
+- **data** (<code>dict\[str, Any\]</code>) – Dictionary to deserialize from.
 
-**Returns**:
+**Returns:**
 
-Deserialized component.
+- <code>SagemakerGenerator</code> – Deserialized component.
 
-<a id="haystack_integrations.components.generators.amazon_sagemaker.sagemaker.SagemakerGenerator.run"></a>
-
-#### SagemakerGenerator.run
+#### run
 
 ```python
-@component.output_types(replies=list[str], meta=list[dict[str, Any]])
-def run(
-    prompt: str,
-    generation_kwargs: dict[str, Any] | None = None
+run(
+    prompt: str, generation_kwargs: dict[str, Any] | None = None
 ) -> dict[str, list[str] | list[dict[str, Any]]]
 ```
 
 Invoke the text generation inference based on the provided prompt and generation parameters.
 
-**Arguments**:
+**Parameters:**
 
-- `prompt`: The string prompt to use for text generation.
-- `generation_kwargs`: Additional keyword arguments for text generation. These parameters will
-potentially override the parameters passed in the `__init__` method.
+- **prompt** (<code>str</code>) – The string prompt to use for text generation.
+- **generation_kwargs** (<code>dict\[str, Any\] | None</code>) – Additional keyword arguments for text generation.
+  These are merged per key with the `generation_kwargs` passed at initialization: keys provided here
+  take precedence, keys set only at initialization are kept.
 
-**Raises**:
+**Returns:**
 
-- `ValueError`: If the model response type is not a list of dictionaries or a single dictionary.
-- `SagemakerNotReadyError`: If the SageMaker model is not ready to accept requests.
-- `SagemakerInferenceError`: If the SageMaker Inference returns an error.
-
-**Returns**:
-
-A dictionary with the following keys:
+- <code>dict\[str, list\[str\] | list\[dict\[str, Any\]\]\]</code> – A dictionary with the following keys:
 - `replies`: A list of strings containing the generated responses
 - `meta`: A list of dictionaries containing the metadata for each response.
 
+**Raises:**
+
+- <code>ValueError</code> – If the model response type is not a list of dictionaries or a single dictionary.
+- <code>SagemakerNotReadyError</code> – If the SageMaker model is not ready to accept requests.
+- <code>SagemakerInferenceError</code> – If the SageMaker Inference returns an error.

--- a/docs-website/reference_versioned_docs/version-3.1-unstable/integrations-api/google_genai.md
+++ b/docs-website/reference_versioned_docs/version-3.1-unstable/integrations-api/google_genai.md
@@ -285,7 +285,10 @@ Creates an GoogleGenAIMultimodalDocumentEmbedder component.
   Required when using Vertex AI with Application Default Credentials.
 - **file_path_meta_field** (<code>str</code>) – The metadata field in the Document that contains the file path to the file to embed.
 - **root_path** (<code>str | None</code>) – The root directory path where document files are located. If provided, file paths in
-  document metadata will be resolved relative to this path. If None, file paths are treated as absolute paths.
+  document metadata will be resolved relative to this path and are guaranteed to stay within it.
+  If None, file paths are treated as absolute paths with no containment check.
+  If document metadata, in particular `file_path_meta_field`, may be influenced by untrusted input,
+  set `root_path` to a dedicated data directory so that path-traversal beyond it is rejected.
 - **image_size** (<code>tuple\[int, int\] | None</code>) – Only used for images and PDF pages. If provided, resizes the image to fit within the specified dimensions
   (width, height) while maintaining aspect ratio. This reduces file size, memory usage, and processing time,
   which is beneficial when working with models that have resolution constraints or when transmitting images
@@ -348,6 +351,13 @@ Embeds a list of documents.
 - `documents`: A list of documents with embeddings.
 - `meta`: Information about the usage of the model.
 
+**Raises:**
+
+- <code>TypeError</code> – If the input is not a list of `Documents`.
+- <code>ValueError</code> – If a document is missing the file path metadata field, its file path escapes `root_path`, or its
+  MIME type is not supported.
+- <code>RuntimeError</code> – If the conversion of some documents fails.
+
 #### run_async
 
 ```python
@@ -367,6 +377,13 @@ Embeds a list of documents asynchronously.
 - <code>dict\[str, list\[Document\]\] | dict\[str, Any\]</code> – A dictionary with the following keys:
 - `documents`: A list of documents with embeddings.
 - `meta`: Information about the usage of the model.
+
+**Raises:**
+
+- <code>TypeError</code> – If the input is not a list of `Documents`.
+- <code>ValueError</code> – If a document is missing the file path metadata field, its file path escapes `root_path`, or its
+  MIME type is not supported.
+- <code>RuntimeError</code> – If the conversion of some documents fails.
 
 ## haystack_integrations.components.embedders.google_genai.text_embedder
 

--- a/docs-website/vercel.json
+++ b/docs-website/vercel.json
@@ -155,6 +155,16 @@
       "source": "/reference/2.27/:slug*",
       "destination": "/reference/:slug*",
       "permanent": true
+    },
+    {
+      "source": "/docs/2.28/:slug*",
+      "destination": "/docs/:slug*",
+      "permanent": true
+    },
+    {
+      "source": "/reference/2.28/:slug*",
+      "destination": "/reference/:slug*",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
### Related Issues
During the 3.1.0 release process, the Vercel build for https://github.com/deepset-ai/haystack/pull/12390 did not complete within 45 minutes.

We decided to merge the PR into main and the Vercel build in main timed out after 45 minutes.

https://vercel.com/deepset-ai/haystack-docs/deployments

We use the standard build machine with 4vCPUs and 8GB RAM. (Other more costly options are available; see https://vercel.com/docs/builds/managing-builds#larger-build-machines) 

After some local investigation, I am convinced that the problem here is excessive RAM usage (due to an additional docs version), which makes the build process hang forever.

This only happens during the release process because the current mechanism sets `MAX_STABLE_VERSIONS` while unstable versions are not capped.

In normal times, we build for example: 2.28, 2.29, 2.30, 2.31, 3.0, unstable (5 stable + unstable from main = 6)
During the release window for 3.1: 2.28, 2.29, 2.30, 2.31, 3.0, 3.1-unstable, unstable (5 stable + unstable from release process + unstable from main = **7**)
After the 3.1 release: 2.29, 2.30, 2.31, 3.0, 3.1, unstable (5 stable + unstable from main = 6)

In short, during the release window we build docs for 7 versions, including one (2.28) that will be dropped after the release. Each version increases the RAM usage.

### Proposed Changes:
- make the number of docs versions we build constant (6), in normal times and during the release window; anticipate dropping the oldest stable version
- move the redirects for the oldest stable version (e.g. 2.28) from promote_unstable_docs_docusaurus.py (as the last step of the release) to create_unstable_docs_docusaurus.py (first step of the release)
- (add missing redirects)

### How did you test it?
Vercel build. It now works again in ~3 minutes.

### Notes for the reviewer
Since our docs website keeps growing due to new components and integrations, it might be that at some point we will have to decide whether to:
- build less than 6 docs versions
- switch to more powerful/expensive build machines

@julian-risch FYI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
