### PR TITLE
fix: avoid AssertionError in PipelineBase.__eq__ when comparing against non-Pipeline types

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -123,9 +123,8 @@ class PipelineBase:  # noqa: PLW1641
         Pipelines of the same type share every metadata, node and edge, but they're not required to use
         the same node instances: this allows pipeline saved and then loaded back to be equal to themselves.
         """
-        if not isinstance(self, type(other)):
+        if not isinstance(other, type(self)):
             return False
-        assert isinstance(other, PipelineBase)
         return self.to_dict() == other.to_dict()
 
     def __repr__(self) -> str:

--- a/releasenotes/notes/fix-pipeline-base-equality-non-pipeline-objects-8b2c4e1.yaml
+++ b/releasenotes/notes/fix-pipeline-base-equality-non-pipeline-objects-8b2c4e1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed ``PipelineBase.__eq__`` raising ``AssertionError`` when comparing a ``Pipeline`` instance against non-Pipeline objects or testing membership in collections.

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -1759,6 +1759,15 @@ class TestPipelineBaseFromDict:
     def test_from_dict_with_empty_dict(self):
         assert PipelineBase() == PipelineBase.from_dict({})
 
+    def test_equality_with_non_pipeline_objects(self):
+        pipe = PipelineBase()
+        assert pipe != object()
+        assert (pipe == object()) is False
+        assert (pipe == "string") is False
+        assert (pipe == 123) is False
+        assert (pipe == None) is False
+        assert (pipe in [object(), "other", 42]) is False
+
     def test_from_dict_with_components_instances(self):
         add_two = AddFixedValue(add=2)
         add_default = AddFixedValue()


### PR DESCRIPTION
### Summary of Changes

Fixes #12386

`PipelineBase.__eq__` previously evaluated `if not isinstance(self, type(other)): return False` followed by an `assert isinstance(other, PipelineBase)`.

When comparing a `Pipeline` instance against `object()` (or testing membership in collections containing `object` instances), `isinstance(self, object)` evaluated to `True`, bypassing the check and causing the `assert isinstance(other, PipelineBase)` statement to raise an unhandled `AssertionError` at runtime.

### Fix
- Updated `__eq__` to check `if not isinstance(other, type(self)): return False`
- Removed redundant `assert isinstance(other, PipelineBase)`
- Added unit tests for equality comparison with `object()`, strings, numbers, None, and heterogeneous list containment.
- Added release note in `releasenotes/notes/`.
