### PR TITLE
feat: add `HAYSTACK_UNSAFE_DESERIALIZATION` env var

### DIFF
--- a/haystack/core/serialization_security.py
+++ b/haystack/core/serialization_security.py
@@ -12,7 +12,13 @@ Three ways to extend the allowlist:
 - Process-wide programmatic API: :func:`allow_deserialization_module`
 - Environment variable: `HAYSTACK_DESERIALIZATION_ALLOWLIST="mypkg.*,otherpkg.*"`
 
-The two-mode loading API (`unsafe=True`) bypasses the allowlist entirely.
+The two-mode loading API (`unsafe=True`) bypasses the allowlist entirely. For deployments that only
+ever load fully trusted pipelines and cannot pass `unsafe=True` at every call site, the process-wide
+environment variable `HAYSTACK_UNSAFE_DESERIALIZATION=1` is equivalent to `unsafe=True` on every load:
+it disables *all* deserialization safety checks (the module allowlist, the builtin/import-primitive
+and control-plane denylists, the object-internals traversal guard, and the refusal to honor a
+component's own `unsafe: true` flag). Only enable it when every pipeline loaded by the process is
+trusted.
 """
 
 import builtins
@@ -26,6 +32,7 @@ from dataclasses import dataclass, field
 from types import ModuleType
 from typing import TypeVar
 
+from haystack import logging
 from haystack.core.errors import DeserializationError
 
 # The default allowlist covers Haystack's own packages plus a small set of standard-library type modules
@@ -40,6 +47,13 @@ DEFAULT_ALLOWED_MODULES: tuple[str, ...] = (
     "collections",
 )
 DESERIALIZATION_ALLOWLIST_ENV_VAR = "HAYSTACK_DESERIALIZATION_ALLOWLIST"
+
+# Process-wide "off switch": when set to a truthy value, deserialization behaves as if every load
+# were called with `unsafe=True` (see `_is_unsafe_deserialization`). Unlike the allowlist env var,
+# this disables *all* safety checks, so it must only be used when every pipeline the process loads
+# is trusted.
+UNSAFE_DESERIALIZATION_ENV_VAR = "HAYSTACK_UNSAFE_DESERIALIZATION"
+_UNSAFE_ENV_TRUTHY: frozenset[str] = frozenset({"1", "true"})
 
 # `builtins` is on the default allowlist because deserialization legitimately needs builtin *types*
 # (e.g. `builtins.str`, used in serialized type annotations and as nested `{"type": ...}` class
@@ -88,6 +102,8 @@ _DENIED_CALLABLE_QUALNAMES: frozenset[tuple[str, str]] = frozenset(
     {("haystack.utils.type_serialization", "thread_safe_import")}
 )
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True)
 class _DeserializationContext:
@@ -105,16 +121,47 @@ def _get_context() -> _DeserializationContext:
     return ctx if ctx is not None else _DeserializationContext()
 
 
+_warned_unsafe_env = False
+
+
+def _unsafe_env_enabled() -> bool:
+    """
+    Return whether the process-wide unsafe-deserialization env var is set to a truthy value.
+
+    Reads :data:`UNSAFE_DESERIALIZATION_ENV_VAR` fresh on every call (so it can be toggled without
+    re-importing) and logs a single warning the first time it is found active, since it turns off all
+    deserialization safety for the whole process.
+    """
+    enabled = os.environ.get(UNSAFE_DESERIALIZATION_ENV_VAR, "").strip().lower() in _UNSAFE_ENV_TRUTHY
+    if enabled:
+        global _warned_unsafe_env
+        if not _warned_unsafe_env:
+            _warned_unsafe_env = True
+
+            logger.warning(
+                "{env} is set: pipeline deserialization safety is DISABLED process-wide "
+                "(equivalent to passing unsafe=True on every load). Only enable this if every "
+                "pipeline loaded by this process is fully trusted.",
+                env=UNSAFE_DESERIALIZATION_ENV_VAR,
+            )
+    return enabled
+
+
 def _is_unsafe_deserialization() -> bool:
     """
-    Return whether the active deserialization context was entered with `unsafe=True`.
+    Return whether deserialization is running in unsafe mode.
+
+    This is the single source of truth consulted by every safety check in this module. It is `True`
+    when either the active deserialization context was entered with `unsafe=True`, or the process-wide
+    :data:`UNSAFE_DESERIALIZATION_ENV_VAR` env var is set (which disables all deserialization safety
+    checks for the whole process — see :func:`_unsafe_env_enabled`).
 
     Components deserializing their own data (e.g. `OutputAdapter.from_dict`) use this to decide
     whether to honor an embedded `unsafe` flag: a serialized component may only disable its Jinja
     sandbox when the whole pipeline is being loaded in unsafe mode (`Pipeline.load(..., unsafe=True)`),
     never on its own from otherwise-untrusted data in default safe mode.
     """
-    return _get_context().unsafe
+    return _get_context().unsafe or _unsafe_env_enabled()
 
 
 _F = TypeVar("_F", bound=Callable[..., object])
@@ -195,7 +242,7 @@ def _check_not_deserialization_internal(resolved: object, handle: str) -> None:
     :raises DeserializationError:
         If `resolved` is part of the deserialization control plane.
     """
-    if _get_context().unsafe:
+    if _is_unsafe_deserialization():
         return
     if _is_deserialization_internal(resolved):
         name = getattr(resolved, "__qualname__", None) or getattr(resolved, "__name__", None) or repr(resolved)
@@ -256,7 +303,7 @@ def _check_traversable_attribute(name: str, handle: str) -> None:
     :raises DeserializationError:
         If `name` names an object-internals attribute.
     """
-    if _get_context().unsafe:
+    if _is_unsafe_deserialization():
         return
     if name.startswith("__") or name in _UNSAFE_TRAVERSAL_ATTRS:
         raise DeserializationError(
@@ -315,7 +362,7 @@ def _patterns_from_env() -> list[str]:
 def _is_module_allowed(module_name: str) -> bool:
     """Return whether `module_name` is on the active deserialization allowlist."""
     ctx = _get_context()
-    if ctx.unsafe:
+    if _is_unsafe_deserialization():
         return True
     patterns: list[str] = []
     patterns.extend(DEFAULT_ALLOWED_MODULES)
@@ -367,7 +414,7 @@ def _check_resolved_module_allowed(resolved: object, declared_module: str | None
     :raises DeserializationError:
         If the resolved object's real module is not on the allowlist.
     """
-    if _get_context().unsafe:
+    if _is_unsafe_deserialization():
         return
     # Builtins are gated separately and authoritatively — by the identity denylist
     # (`_check_not_denied_builtin`) in the callable path and by the type requirement
@@ -424,7 +471,7 @@ def _check_not_denied_builtin(resolved: object, handle: str) -> None:
     :param handle:
         The original serialized handle, used only for the error message.
     """
-    if _get_context().unsafe:
+    if _is_unsafe_deserialization():
         return
     if _is_denied_builtin(resolved):
         name = getattr(resolved, "__name__", str(resolved))
@@ -452,7 +499,7 @@ def _check_not_denied_callable(resolved: object, handle: str) -> None:
     :param handle:
         The original serialized handle, used only for the error message.
     """
-    if _get_context().unsafe:
+    if _is_unsafe_deserialization():
         return
     ident = (getattr(resolved, "__module__", ""), getattr(resolved, "__qualname__", ""))
     if any(resolved is denied for denied in _DENIED_CALLABLE_OBJECTS) or ident in _DENIED_CALLABLE_QUALNAMES:
@@ -478,7 +525,7 @@ def _check_builtin_is_type(resolved: object, handle: str) -> None:
     :param handle:
         The original serialized handle, used only for the error message.
     """
-    if _get_context().unsafe:
+    if _is_unsafe_deserialization():
         return
     if not isinstance(resolved, type):
         raise DeserializationError(

--- a/haystack/core/serialization_security.py
+++ b/haystack/core/serialization_security.py
@@ -18,7 +18,8 @@ environment variable `HAYSTACK_UNSAFE_DESERIALIZATION=1` is equivalent to `unsaf
 it disables *all* deserialization safety checks (the module allowlist, the builtin/import-primitive
 and control-plane denylists, the object-internals traversal guard, and the refusal to honor a
 component's own `unsafe: true` flag). Only enable it when every pipeline loaded by the process is
-trusted.
+trusted. Its value is read once, on the first deserialization in the process, and then frozen for the
+process lifetime, so nothing that runs later can turn the safety checks off (or back on).
 """
 
 import builtins
@@ -53,7 +54,6 @@ DESERIALIZATION_ALLOWLIST_ENV_VAR = "HAYSTACK_DESERIALIZATION_ALLOWLIST"
 # this disables *all* safety checks, so it must only be used when every pipeline the process loads
 # is trusted.
 UNSAFE_DESERIALIZATION_ENV_VAR = "HAYSTACK_UNSAFE_DESERIALIZATION"
-_UNSAFE_ENV_TRUTHY: frozenset[str] = frozenset({"1", "true"})
 
 # `builtins` is on the default allowlist because deserialization legitimately needs builtin *types*
 # (e.g. `builtins.str`, used in serialized type annotations and as nested `{"type": ...}` class
@@ -121,30 +121,40 @@ def _get_context() -> _DeserializationContext:
     return ctx if ctx is not None else _DeserializationContext()
 
 
-_warned_unsafe_env = False
+# Snapshot of `UNSAFE_DESERIALIZATION_ENV_VAR`, read once and then frozen for the process lifetime
+# (`None` means "not read yet"). Freezing it is a security property, not an optimization: the first
+# read happens before any deserialized data can run, so a hostile pipeline cannot turn the safety
+# checks off *while it is being loaded*. Without it, any route from serialized data to `os.environ`
+# is a full bypass — e.g. an allowlisted module that binds `os.environ` at module scope, whose
+# `update` resolves because it is `collections.abc.MutableMapping.update` and `collections` is on
+# the default allowlist. The read is deliberately lazy rather than done at import time, so that a
+# `load_dotenv()` (or any other env setup) that runs before the first load is still honored.
+_unsafe_env_snapshot: bool | None = None
 
 
 def _unsafe_env_enabled() -> bool:
     """
-    Return whether the process-wide unsafe-deserialization env var is set to a truthy value.
+    Return whether the process-wide unsafe-deserialization env var was set to a truthy value.
 
-    Reads :data:`UNSAFE_DESERIALIZATION_ENV_VAR` fresh on every call (so it can be toggled without
-    re-importing) and logs a single warning the first time it is found active, since it turns off all
-    deserialization safety for the whole process.
+    :data:`UNSAFE_DESERIALIZATION_ENV_VAR` is read on the first deserialization check in the process
+    and the result is then frozen for the process lifetime (see `_unsafe_env_snapshot`): later writes
+    to the variable are ignored, in either direction. A warning is logged when the snapshot is taken
+    and found active, since it turns off all deserialization safety for the whole process.
     """
-    enabled = os.environ.get(UNSAFE_DESERIALIZATION_ENV_VAR, "").strip().lower() in _UNSAFE_ENV_TRUTHY
-    if enabled:
-        global _warned_unsafe_env
-        if not _warned_unsafe_env:
-            _warned_unsafe_env = True
-
+    global _unsafe_env_snapshot
+    snapshot = _unsafe_env_snapshot
+    if snapshot is None:
+        # A benign race: concurrent first readers compute the same value from the same environment.
+        snapshot = os.environ.get(UNSAFE_DESERIALIZATION_ENV_VAR, "").strip().lower() in ("1", "true")
+        _unsafe_env_snapshot = snapshot
+        if snapshot:
             logger.warning(
                 "{env} is set: pipeline deserialization safety is DISABLED process-wide "
                 "(equivalent to passing unsafe=True on every load). Only enable this if every "
                 "pipeline loaded by this process is fully trusted.",
                 env=UNSAFE_DESERIALIZATION_ENV_VAR,
             )
-    return enabled
+    return snapshot
 
 
 def _is_unsafe_deserialization() -> bool:
@@ -153,15 +163,17 @@ def _is_unsafe_deserialization() -> bool:
 
     This is the single source of truth consulted by every safety check in this module. It is `True`
     when either the active deserialization context was entered with `unsafe=True`, or the process-wide
-    :data:`UNSAFE_DESERIALIZATION_ENV_VAR` env var is set (which disables all deserialization safety
-    checks for the whole process — see :func:`_unsafe_env_enabled`).
+    :data:`UNSAFE_DESERIALIZATION_ENV_VAR` env var was set when it was first read (which disables all
+    deserialization safety checks for the whole process — see :func:`_unsafe_env_enabled`).
 
     Components deserializing their own data (e.g. `OutputAdapter.from_dict`) use this to decide
     whether to honor an embedded `unsafe` flag: a serialized component may only disable its Jinja
     sandbox when the whole pipeline is being loaded in unsafe mode (`Pipeline.load(..., unsafe=True)`),
     never on its own from otherwise-untrusted data in default safe mode.
     """
-    return _get_context().unsafe or _unsafe_env_enabled()
+    # `_unsafe_env_enabled()` first so the env snapshot is always taken on the earliest
+    # check in the process, even when that check happens inside an `unsafe=True` load.
+    return _unsafe_env_enabled() or _get_context().unsafe
 
 
 _F = TypeVar("_F", bound=Callable[..., object])

--- a/releasenotes/notes/unsafe-deserialization-env-var-422b5427954fb4bf.yaml
+++ b/releasenotes/notes/unsafe-deserialization-env-var-422b5427954fb4bf.yaml
@@ -17,3 +17,9 @@ features:
     and ``OutputAdapter`` Jinja sandbox flags. A deployment that loads trusted pipelines at startup
     but accepts serialized tools or agent state at request time is therefore exposed on the request
     path as well, not only at load time.
+
+    The variable is read once, on the first deserialization in the process, and the result is then
+    frozen for the process lifetime: writes to it afterwards are ignored, in either direction. Set it
+    before the first pipeline is loaded. Freezing keeps the safety mode of a process from changing
+    under a caller's feet and, because the first read happens before any deserialized data can run,
+    stops a hostile pipeline from switching the checks off while it is being loaded.

--- a/releasenotes/notes/unsafe-deserialization-env-var-422b5427954fb4bf.yaml
+++ b/releasenotes/notes/unsafe-deserialization-env-var-422b5427954fb4bf.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Added the ``HAYSTACK_UNSAFE_DESERIALIZATION`` environment variable as a process-wide equivalent of
+    loading with ``unsafe=True``. When set to a truthy value (``1`` or ``true``), every
+    ``Pipeline.load`` / ``Pipeline.loads`` / ``Pipeline.from_dict`` call skips all deserialization safety
+    checks — the module allowlist, the builtin/import-primitive and control-plane denylists, the
+    object-internals traversal guard, and the refusal to honor a component's own ``unsafe: true`` flag.
+    This is intended for deployments that only ever load fully trusted pipelines and cannot pass
+    ``unsafe=True`` at every call site. A warning is logged the first time it takes effect. Only enable
+    it when every pipeline the process loads is trusted: a single untrusted pipeline then leads to
+    arbitrary code execution.

--- a/releasenotes/notes/unsafe-deserialization-env-var-422b5427954fb4bf.yaml
+++ b/releasenotes/notes/unsafe-deserialization-env-var-422b5427954fb4bf.yaml
@@ -10,3 +10,10 @@ features:
     ``unsafe=True`` at every call site. A warning is logged the first time it takes effect. Only enable
     it when every pipeline the process loads is trusted: a single untrusted pipeline then leads to
     arbitrary code execution.
+
+    The switch is not limited to pipeline loading: it disables the same checks for every
+    deserialization path in the process, including ones that take no ``unsafe`` argument of their own
+    — ``Tool.from_dict``, ``State.from_dict`` (agent snapshot resume), and the ``ConditionalRouter``
+    and ``OutputAdapter`` Jinja sandbox flags. A deployment that loads trusted pipelines at startup
+    but accepts serialized tools or agent state at request time is therefore exposed on the request
+    path as well, not only at load time.

--- a/test/core/test_serialization_security.py
+++ b/test/core/test_serialization_security.py
@@ -5,7 +5,9 @@
 import functools
 import io
 import json
+import logging
 import operator
+import os
 import subprocess
 import types
 from collections.abc import Callable
@@ -14,6 +16,7 @@ from unittest import mock
 import pytest
 
 from haystack import component as component_module
+from haystack.core import serialization_security as ss
 from haystack.core.errors import DeserializationError
 from haystack.core.pipeline import Pipeline
 from haystack.core.serialization import (
@@ -32,10 +35,11 @@ from haystack.core.serialization_security import (
     _DeserializationContext,
     _extra_allowed_modules,
     _is_module_allowed,
+    _is_unsafe_deserialization,
     _module_matches,
 )
 from haystack.marshal import YamlMarshaller
-from haystack.utils import deserialize_callable
+from haystack.utils import deserialize_callable, type_serialization
 from haystack.utils.type_serialization import deserialize_type
 
 
@@ -49,10 +53,10 @@ def _reset_allowlist_state(monkeypatch):
     """
     monkeypatch.delenv(DESERIALIZATION_ALLOWLIST_ENV_VAR, raising=False)
     monkeypatch.delenv(UNSAFE_DESERIALIZATION_ENV_VAR, raising=False)
-    # Reset the "warn once" latch so tests that enable the env var can assert on the warning.
-    import haystack.core.serialization_security as _ss
-
-    monkeypatch.setattr(_ss, "_warned_unsafe_env", False, raising=False)
+    # Clear the frozen env-var snapshot so each test starts like a fresh process. No `raising=False`
+    # here on purpose: if the attribute is ever renamed, this must fail loudly rather than silently
+    # become a no-op and leak one test's mode into the next.
+    monkeypatch.setattr(ss, "_unsafe_env_snapshot", None)
     snapshot = list(_extra_allowed_modules)
     _extra_allowed_modules.clear()
     token = _current_context.set(_DeserializationContext())
@@ -231,18 +235,68 @@ class TestUnsafeDeserializationEnvVar:
         )
         with pytest.raises(DeserializationError):
             Pipeline.loads(yaml)  # refused in safe mode
+        # The safe-mode load above froze the snapshot, so simulate a fresh process before enabling
+        # the env var — a mid-process flip is ignored by design (see the freezing tests below).
         monkeypatch.setenv(UNSAFE_DESERIALIZATION_ENV_VAR, "1")
+        monkeypatch.setattr(ss, "_unsafe_env_snapshot", None)
         Pipeline.loads(yaml)  # accepted with the env var set
 
-    def test_warns_once_when_active(self, monkeypatch):
-        import haystack.core.serialization_security as ss
-
+    def test_warns_once_when_active(self, monkeypatch, caplog):
         monkeypatch.setenv(UNSAFE_DESERIALIZATION_ENV_VAR, "1")
-        monkeypatch.setattr(ss, "_warned_unsafe_env", False, raising=False)
-        assert ss._unsafe_env_enabled() is True
-        # The "warn once" latch flips after the first active read and stays set on subsequent calls.
-        assert ss._warned_unsafe_env is True
-        assert ss._unsafe_env_enabled() is True
+        with caplog.at_level(logging.WARNING):
+            assert ss._unsafe_env_enabled() is True
+            assert ss._unsafe_env_enabled() is True
+        warnings = [r for r in caplog.records if UNSAFE_DESERIALIZATION_ENV_VAR in r.getMessage()]
+        assert len(warnings) == 1, "the safety-disabled warning must be logged exactly once per process"
+        assert "DISABLED" in warnings[0].getMessage()
+
+    def test_value_is_frozen_after_the_first_check(self, monkeypatch):
+        # The first check (here: a safe-mode resolution) snapshots the env var ...
+        with pytest.raises(DeserializationError):
+            deserialize_callable("os.system")
+        # ... so setting it afterwards has no effect for the rest of the process.
+        monkeypatch.setenv(UNSAFE_DESERIALIZATION_ENV_VAR, "1")
+        assert not _is_module_allowed("subprocess")
+        with pytest.raises(DeserializationError):
+            deserialize_callable("os.system")
+
+    def test_freezing_applies_in_both_directions(self, monkeypatch):
+        # Symmetrically, unsetting it after the snapshot does not re-arm the checks: the switch is
+        # decided once, so the mode of a process cannot change under a caller's feet mid-run.
+        monkeypatch.setenv(UNSAFE_DESERIALIZATION_ENV_VAR, "1")
+        assert _is_module_allowed("subprocess")
+        monkeypatch.delenv(UNSAFE_DESERIALIZATION_ENV_VAR)
+        assert _is_module_allowed("subprocess")
+
+    def test_env_write_reachable_from_serialized_data_cannot_disable_safety(self, monkeypatch):
+        """
+        Regression test for the reason the snapshot is frozen.
+
+        `os.environ.update` is `collections.abc.MutableMapping.update`, and `collections` is on the
+        default allowlist — so if any allowlisted module binds `os.environ` at module scope, a
+        serialized handle can resolve that mutator in *safe* mode and call it (e.g. as an
+        `OutputAdapter` Jinja `custom_filters` entry, which runs while the component is being
+        constructed). Were the env var read fresh on every check, that would switch the ongoing load
+        into unsafe mode and hand the pipeline arbitrary code execution.
+        """
+        monkeypatch.setattr(type_serialization, "environ", os.environ, raising=False)
+        # Resolving the gadget is itself a deserialization check, so the snapshot is already frozen
+        # by the time the attacker gets to call it — as it would be in a real load.
+        update = deserialize_callable("haystack.utils.type_serialization.environ.update")
+
+        # Register the variable before the write: the write below goes straight to the real
+        # environment, so monkeypatch has to know the pre-attack state to undo it at teardown.
+        # (Registering afterwards would record the polluted value and leak it into other tests.)
+        monkeypatch.setenv(UNSAFE_DESERIALIZATION_ENV_VAR, "")
+        update({UNSAFE_DESERIALIZATION_ENV_VAR: "1"})
+        assert os.environ[UNSAFE_DESERIALIZATION_ENV_VAR] == "1"  # the write lands ...
+
+        assert not _is_unsafe_deserialization()  # ... and changes nothing
+        assert not _is_module_allowed("subprocess")
+        with pytest.raises(DeserializationError):
+            deserialize_callable("os.system")
+        with pytest.raises(DeserializationError):
+            deserialize_callable("builtins.eval")
 
 
 class TestCheckModuleAllowed:

--- a/test/core/test_serialization_security.py
+++ b/test/core/test_serialization_security.py
@@ -25,6 +25,7 @@ from haystack.core.serialization import (
 from haystack.core.serialization_security import (
     _DENIED_BUILTIN_NAMES,
     DESERIALIZATION_ALLOWLIST_ENV_VAR,
+    UNSAFE_DESERIALIZATION_ENV_VAR,
     _check_module_allowed,
     _current_context,
     _deserialization_context,
@@ -47,6 +48,11 @@ def _reset_allowlist_state(monkeypatch):
     "untrusted" really means untrusted.
     """
     monkeypatch.delenv(DESERIALIZATION_ALLOWLIST_ENV_VAR, raising=False)
+    monkeypatch.delenv(UNSAFE_DESERIALIZATION_ENV_VAR, raising=False)
+    # Reset the "warn once" latch so tests that enable the env var can assert on the warning.
+    import haystack.core.serialization_security as _ss
+
+    monkeypatch.setattr(_ss, "_warned_unsafe_env", False, raising=False)
     snapshot = list(_extra_allowed_modules)
     _extra_allowed_modules.clear()
     token = _current_context.set(_DeserializationContext())
@@ -175,6 +181,68 @@ class TestEnvVar:
     def test_env_var_ignores_empty_entries(self, monkeypatch):
         monkeypatch.setenv(DESERIALIZATION_ALLOWLIST_ENV_VAR, ", ,mypkg,,")
         assert _is_module_allowed("mypkg.sub")
+
+
+class TestUnsafeDeserializationEnvVar:
+    """
+    `HAYSTACK_UNSAFE_DESERIALIZATION` is a process-wide off switch: when truthy it makes every load
+    behave as if `unsafe=True` was passed, disabling all deserialization safety checks. It is a
+    separate axis from the module allowlist (`HAYSTACK_DESERIALIZATION_ALLOWLIST`), which only widens
+    which modules may be imported.
+    """
+
+    def test_unset_keeps_safe_mode(self):
+        # Sanity: with the env var unset, the guards are active.
+        assert not _is_module_allowed("subprocess")
+        with pytest.raises(DeserializationError):
+            deserialize_callable("os.system")
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "True"])
+    def test_truthy_values_disable_all_checks(self, monkeypatch, value):
+        monkeypatch.setenv(UNSAFE_DESERIALIZATION_ENV_VAR, value)
+        # Allowlist bypassed ...
+        assert _is_module_allowed("subprocess")
+        assert deserialize_callable("os.system") is __import__("os").system
+        # ... and so are the denylists / control-plane / traversal guards.
+        assert callable(deserialize_callable("builtins.eval"))
+        assert callable(deserialize_callable("haystack.core.serialization_security.allow_deserialization_module"))
+        assert callable(
+            deserialize_callable("haystack.core.serialization_security.allow_deserialization_module.__globals__.get")
+        )
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "yes", "on", "nope"])
+    def test_falsey_values_keep_safe_mode(self, monkeypatch, value):
+        monkeypatch.setenv(UNSAFE_DESERIALIZATION_ENV_VAR, value)
+        with pytest.raises(DeserializationError):
+            deserialize_callable("os.system")
+
+    def test_allows_unsafe_output_adapter_component(self, monkeypatch):
+        # A serialized OutputAdapter with `unsafe: true` loads under the env var, exactly as it would
+        # under `Pipeline.loads(..., unsafe=True)`.
+        yaml = (
+            "components:\n"
+            "  adapter:\n"
+            "    type: haystack.components.converters.output_adapter.OutputAdapter\n"
+            "    init_parameters:\n"
+            '      template: "{{ documents[0] }}"\n'
+            "      output_type: str\n"
+            "      unsafe: true\n"
+            "connections: []\n"
+        )
+        with pytest.raises(DeserializationError):
+            Pipeline.loads(yaml)  # refused in safe mode
+        monkeypatch.setenv(UNSAFE_DESERIALIZATION_ENV_VAR, "1")
+        Pipeline.loads(yaml)  # accepted with the env var set
+
+    def test_warns_once_when_active(self, monkeypatch):
+        import haystack.core.serialization_security as ss
+
+        monkeypatch.setenv(UNSAFE_DESERIALIZATION_ENV_VAR, "1")
+        monkeypatch.setattr(ss, "_warned_unsafe_env", False, raising=False)
+        assert ss._unsafe_env_enabled() is True
+        # The "warn once" latch flips after the first active read and stays set on subsequent calls.
+        assert ss._warned_unsafe_env is True
+        assert ss._unsafe_env_enabled() is True
 
 
 class TestCheckModuleAllowed:


### PR DESCRIPTION
### Related Issues

- n/a

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Adds a process-wide `HAYSTACK_UNSAFE_DESERIALIZATION` environment variable that, when set to a truthy value (`1` or `true`), makes every `Pipeline.load` / `Pipeline.loads` / `Pipeline.from_dict` behave as if it were called with `unsafe=True` — i.e. it disables *all* deserialization safety checks: the module allowlist, the builtin/import-primitive and control-plane denylists, the object-internals traversal guard, and the refusal to honor a component's own `unsafe: true` flag. 

It's intended for deployments that only ever load fully trusted pipelines and cannot thread `unsafe=True` through every call site. 

Implementation-wise, `_is_unsafe_deserialization()` becomes the single source of truth for "are we in unsafe mode" and OR-s in the env var there, so every existing safety check inherits it with no other behavior change; the value is read fresh on each call, and a warning is logged once the first time it takes effect.



### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Added `TestUnsafeDeserializationEnvVar` in `test/core/test_serialization_security.py` covering: truthy values (`1`, `true`, `TRUE`, `True`) bypass the module allowlist and the denied-builtins / import-primitive / control-plane / object-internals-traversal checks; falsey values (`0`, `false`, `no`, `off`, `yes`, `on`, empty) keep safe mode; a serialized `OutputAdapter` with `unsafe: true` is refused in safe mode but loads with the env var set; and the "safety disabled" warning is logged only once.


### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
