### PR TITLE
fix: honor LinkContentFetcher retry attempts

### DIFF
--- a/haystack/components/fetchers/link_content.py
+++ b/haystack/components/fetchers/link_content.py
@@ -183,7 +183,7 @@ class LinkContentFetcher:
 
         @retry(
             reraise=True,
-            stop=stop_after_attempt(self.retry_attempts),
+            stop=stop_after_attempt(self.retry_attempts + 1),
             wait=wait_exponential(multiplier=1, min=2, max=10),
             retry=(retry_if_exception_type((httpx.HTTPStatusError, httpx.RequestError))),
             # This callback is invoked only after failed requests (exception raised)

--- a/releasenotes/notes/honor-link-content-fetcher-retry-attempts-208ecd3b2dda2053.yaml
+++ b/releasenotes/notes/honor-link-content-fetcher-retry-attempts-208ecd3b2dda2053.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    ``LinkContentFetcher`` now performs the configured number of retries in synchronous runs.
+    Previously, ``retry_attempts`` counted the initial request as an attempt, so synchronous runs
+    performed one fewer retry than configured and behaved differently from asynchronous runs.

--- a/test/components/fetchers/test_link_content_fetcher.py
+++ b/test/components/fetchers/test_link_content_fetcher.py
@@ -159,6 +159,25 @@ class TestLinkContentFetcher:
             with pytest.raises(httpx.HTTPStatusError):
                 fetcher.run(["https://non_existent_website_dot.com/"])
 
+    def test_run_retries_once_when_retry_attempts_is_one(self):
+        url = "https://www.example.com"
+        successful_response = Mock(status_code=200, text="Success", headers={"Content-Type": "text/plain"})
+
+        with patch("haystack.components.fetchers.link_content.httpx.Client") as client_mock:
+            client = client_mock.return_value
+            client.headers = {}
+            client.get.side_effect = [
+                httpx.RequestError("transient failure", request=httpx.Request("GET", url)),
+                successful_response,
+            ]
+
+            fetcher = LinkContentFetcher(retry_attempts=1)
+            with patch("haystack.components.fetchers.link_content.wait_exponential", return_value=wait_none()):
+                streams = fetcher.run(urls=[url])["streams"]
+
+        assert streams[0].data == successful_response.text.encode()
+        assert client.get.call_count == 2
+
     def test_request_headers_merging_and_ua_override(self):
         # Patch the Client class to control the instance created by LinkContentFetcher
         with patch("haystack.components.fetchers.link_content.httpx.Client") as ClientMock:


### PR DESCRIPTION
### Related Issues

- None. I did not find a matching issue or pull request after searching the full repository history.

### Proposed Changes

`LinkContentFetcher.retry_attempts` is documented as the number of retries, but the synchronous path passed it directly to Tenacity's total-attempt limit. As a result, `retry_attempts=1` made only the initial request and never retried, while the asynchronous path correctly made the initial request plus one retry.

This change counts the initial request separately in the synchronous path, aligning it with the documented option and the asynchronous implementation. It also adds a regression test that fails the first request and succeeds on the configured retry.

### How did you test it?

- Regression test before the fix: failed with the first `httpx.RequestError`, confirming that no retry occurred.
- `hatch run test:unit test/components/fetchers/test_link_content_fetcher.py -q` — 26 passed, 7 deselected.
- `hatch run fmt` — all checks passed.
- `hatch run test:types` — no issues found in 441 source files.
- `hatch run reno lint .` — passed.

### Notes for the reviewer

The production change is intentionally limited to the Tenacity stop condition. A release note is included.

This PR was fully generated with OpenAI Codex assistance. The complete diff was checked against the documented contract and the synchronous and asynchronous implementations, and the relevant tests and repository checks listed above were run locally.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] No related issue exists to update.
- [x] I have added a focused unit test; the existing public docstring already describes the intended behavior.
- [x] The PR title uses a conventional commit type.
- [x] The behavior change is documented in the release note.
- [x] I have added the required release note file.
- [x] I have run the repository formatting and lint checks and fixed all findings.
