### PR TITLE
ci: fix docs search sync for 3.x

### DIFF
--- a/.github/utils/docs_search_sync.py
+++ b/.github/utils/docs_search_sync.py
@@ -12,6 +12,7 @@ It is used in the docs_search_sync.yml workflow.
 """
 
 import os
+import re
 import sys
 import time
 from pathlib import Path
@@ -34,13 +35,15 @@ def collect_docs_files(version: int) -> list[DeepsetCloudFile]:
     """
     repo_root = Path(__file__).parent.parent.parent
     build_dir = repo_root / "docs-website" / "build"
-    # we want to exclude previous and temporarily unstable versions (2.x) and next version (next)
-    exclude = ("2.", "next")
+    # The stable version is served at the root of the section: docs/agents/index.html.
+    # The other versions have their own directory: docs/2.31/agents/index.html, docs/3.1-unstable/agents/index.html,
+    # docs/next/agents/index.html. We want to exclude those directories.
+    exclude_dir = re.compile(r"\d+\.\d+(-unstable)?|next")
 
     files = []
     for section in ("docs", "reference"):
         for subfolder in (build_dir / section).iterdir():
-            if subfolder.is_dir() and not any(x in subfolder.name for x in exclude):
+            if subfolder.is_dir() and not exclude_dir.fullmatch(subfolder.name):
                 for html_file in subfolder.rglob("*.html"):
                     files.append(
                         DeepsetCloudFile(


### PR DESCRIPTION
### Related Issues

The docs search sync workflow only uploads the stable docs to DC, so it filters out the directories of the other versions.

Yesterday, after we created the temporary docs for 3.1 release (3.1-unstable), our workflow failed: https://github.com/deepset-ai/haystack/actions/runs/32205149511/job/95992100899

This is a timeout, but I noticed that we tried to process twice the usual number of files.

This happened because we were only filtering out directories containing "2.x": we never updated this for 3.x

### Proposed Changes:
- adopt a more robust filtering mechanism

### How did you test it?
Local runs

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
