### PR TITLE
chore: skip testing some python snippets in docstrings

### DIFF
--- a/haystack/hooks/compaction/hooks.py
+++ b/haystack/hooks/compaction/hooks.py
@@ -33,6 +33,7 @@ class CompactionHook:
     reaches `compact_at` of the window, hands it to a `Compactor` to bring back down to `compact_to`. Register it on an
     `Agent` under the `before_llm` hook point:
 
+    <!-- test-ignore -->
     ```python
     from haystack.components.agents import Agent
     from haystack.components.generators.chat import OpenAIResponsesChatGenerator

--- a/haystack/hooks/compaction/sliding_window.py
+++ b/haystack/hooks/compaction/sliding_window.py
@@ -207,6 +207,7 @@ class SlidingWindowCompactor(Compactor):
     only historical turns were removed, and directly after the latest user message when the current task's own steps
     were removed. Only one note is ever present, since a later compaction folds an earlier note into its replacement.
 
+    <!-- test-ignore -->
     ```python
     from haystack.components.agents import Agent
     from haystack.components.generators.chat import OpenAIResponsesChatGenerator

--- a/haystack/hooks/compaction/tool_result_pruning.py
+++ b/haystack/hooks/compaction/tool_result_pruning.py
@@ -23,6 +23,7 @@ class ToolResultPruningCompactor(Compactor):
     This compactor rewrites those results in place rather than removing messages, so every tool call keeps its matching
     result and the model can see what it ran and re-run it if needed.
 
+    <!-- test-ignore -->
     ```python
     from haystack.components.agents import Agent
     from haystack.components.generators.chat import OpenAIResponsesChatGenerator


### PR DESCRIPTION
### Related Issues

- Test Python snippets in docs failing: https://github.com/deepset-ai/haystack/actions/runs/32212398075/job/95947499156

### Proposed Changes:
- skip testing some Python snippets that are incomplete but illustrative

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
