### PR TITLE
fix: AzureOpenAIChatGenerator.to_dict() crashes when response_format is a plain dict

### DIFF
--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -324,7 +324,7 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         # If it's already a json schema, it's left as is
         generation_kwargs = self.generation_kwargs.copy()
         response_format = generation_kwargs.get("response_format")
-        if response_format and issubclass(response_format, BaseModel):
+        if response_format and isinstance(response_format, type) and issubclass(response_format, BaseModel):
             json_schema = {
                 "type": "json_schema",
                 "json_schema": {

--- a/releasenotes/notes/fix-azure-chat-generator-to-dict-response-format-1b844d5eaadcbd81.yaml
+++ b/releasenotes/notes/fix-azure-chat-generator-to-dict-response-format-1b844d5eaadcbd81.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix crash in `AzureOpenAIChatGenerator.to_dict()` when `response_format` is passed as a dictionary.

--- a/releasenotes/notes/fix-azure-chat-generator-to-dict-response-format-1b844d5eaadcbd81.yaml
+++ b/releasenotes/notes/fix-azure-chat-generator-to-dict-response-format-1b844d5eaadcbd81.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix crash in `AzureOpenAIChatGenerator.to_dict()` when `response_format` is passed as a dictionary.
+    Fix crash in ``AzureOpenAIChatGenerator.to_dict()`` when ``response_format`` is passed as a dictionary.

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -343,8 +343,6 @@ class TestAzureOpenAIChatGenerator:
         ],
     )
     def test_to_dict_with_dict_response_format(self, monkeypatch: pytest.MonkeyPatch, rf: dict[str, Any]) -> None:
-        # Regression: to_dict() crashed with TypeError when response_format was a plain dict
-        # because issubclass() was called without the isinstance(..., type) guard.
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
         component = AzureOpenAIChatGenerator(
             azure_endpoint="some-non-existing-endpoint", generation_kwargs={"response_format": rf}

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -335,8 +335,24 @@ class TestAzureOpenAIChatGenerator:
             },
         }
 
-    def test_from_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.parametrize(
+        "rf",
+        [
+            {"type": "json_object"},
+            {"type": "json_schema", "json_schema": {"name": "MySchema", "strict": True, "schema": {}}},
+        ],
+    )
+    def test_to_dict_with_dict_response_format(self, monkeypatch: pytest.MonkeyPatch, rf: dict[str, Any]) -> None:
+        # Regression: to_dict() crashed with TypeError when response_format was a plain dict
+        # because issubclass() was called without the isinstance(..., type) guard.
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        component = AzureOpenAIChatGenerator(
+            azure_endpoint="some-non-existing-endpoint", generation_kwargs={"response_format": rf}
+        )
+        data = component.to_dict()
+        assert data["init_parameters"]["generation_kwargs"]["response_format"] == rf
 
+    def test_from_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
         monkeypatch.setenv("AZURE_OPENAI_AD_TOKEN", "test-ad-token")
         data = {


### PR DESCRIPTION
**Related Issues**

Closes #12406

**Proposed Changes**

- Added the missing `isinstance(response_format, type)` guard before calling `issubclass(response_format, BaseModel)` in `AzureOpenAIChatGenerator.to_dict()`.
- Added a parametrized regression test (`test_to_dict_with_dict_response_format`) in `test/components/generators/chat/test_azure.py` covering both dictionary-based structured output formats: `{"type": "json_object"}` and `{"type": "json_schema", ...}`.
- Added release note in `releasenotes/notes/fix-azure-chat-generator-to-dict-response-format-1b844d5eaadcbd81.yaml`.

**How did you test it?**

```bash
hatch -e test run pytest test/components/generators/chat/test_azure.py
```

30 passed, 5 skipped in 0.57s.

```bash
hatch -e test run pytest test/components/generators/chat/test_azure.py -k test_to_dict_with_dict_response_format
```

2 passed, 34 deselected in 0.19s.

**Notes for the reviewer**

- **Root cause:** `issubclass()` expects a class (`type`) as its first argument. When `response_format` is provided in `generation_kwargs` as a plain dictionary (standard for OpenAI JSON mode and Structured Outputs), evaluating `issubclass(dict_instance, BaseModel)` raises an unhandled `TypeError: issubclass() arg 1 must be a class` during `to_dict()` serialization.
- This change aligns `AzureOpenAIChatGenerator.to_dict()` with the existing pattern in `OpenAIChatGenerator.to_dict()` (`haystack/components/generators/chat/openai.py`) and `AzureOpenAIResponsesGenerator.to_dict()` (`haystack/components/generators/chat/azure_responses.py`).

- **Reproducer:**
```python
    from haystack.components.generators.chat import AzureOpenAIChatGenerator

    generator = AzureOpenAIChatGenerator(
        azure_endpoint="https://example-resource.azure.openai.com/",
        generation_kwargs={"response_format": {"type": "json_object"}},
    )

    # Before fix -> TypeError: issubclass() arg 1 must be a class
    # After fix  -> serializes successfully with response_format preserved
    generator.to_dict()
```

**Checklist**

- [x] Read contributors guidelines and code of conduct
- [x] Updated related issue
- [x] Added unit tests and updated docstrings
- [x] Used conventional commit type in PR title (`fix: AzureOpenAIChatGenerator.to_dict() crashes when response_format is a plain dict`)
- [x] Documented code
- [x] Added release note (`releasenotes/notes/fix-azure-chat-generator-to-dict-response-format-1b844d5eaadcbd81.yaml`)
- [x] Run pre-commit hooks and fixed any issues