### PR TITLE
added e2e pipelines test utilizing gpu

### DIFF
--- a/e2e/pipelines/test_fully_local_rag_pipeline.py
+++ b/e2e/pipelines/test_fully_local_rag_pipeline.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+End-to-end test for a fully local RAG pipeline on GPU (CUDA or Intel XPU).
+
+Indexing and querying both run on-device, using ``HuggingFaceLocalChatGenerator`` for
+generation, so the test needs no API key and exercises the GPU path from embedding through
+generation. The available device is auto-detected, and the test skips when no GPU is
+present, so it is safe to run in CPU-only CI.
+"""
+
+import pytest
+
+from haystack import Document, Pipeline
+from haystack.components.builders import ChatPromptBuilder
+from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
+from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
+from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
+from haystack.components.writers import DocumentWriter
+from haystack.dataclasses import ChatMessage
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack.utils import ComponentDevice
+
+EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+GENERATOR_MODEL = "Qwen/Qwen3-0.6B"
+
+
+def _available_gpu_devices() -> list[str]:
+    """
+    Return the torch device strings for the GPUs available on this machine.
+
+    Returns an empty list on CPU-only machines, which causes the GPU test to be skipped.
+    """
+    try:
+        import torch
+    except ImportError:
+        return []
+
+    devices = []
+    if torch.cuda.is_available():
+        devices.append("cuda:0")
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        devices.append("xpu:0")
+    return devices
+
+
+AVAILABLE_GPU_DEVICES = _available_gpu_devices()
+
+# Parametrize over every GPU backend present so the same assertions run on CUDA and XPU.
+gpu_device = pytest.mark.parametrize("device_str", AVAILABLE_GPU_DEVICES)
+requires_gpu = pytest.mark.skipif(
+    not AVAILABLE_GPU_DEVICES,
+    reason="No GPU (CUDA or XPU) available. This test requires an accelerator.",
+)
+
+
+@requires_gpu
+@gpu_device
+def test_fully_local_rag_pipeline(device_str, tmp_path, del_hf_env_vars):
+    """
+    Fully local RAG pipeline on GPU — no external API key required.
+
+    indexing:  embed (GPU) → write
+    querying:  embed (GPU) → retrieve → prompt → local LLM (GPU) → answer
+    """
+    device = ComponentDevice.from_str(device_str)
+    expected_device_type = device_str.split(":")[0]
+
+    documents = [
+        Document(content="My name is Jean and I live in Paris."),
+        Document(content="My name is Mark and I live in Berlin."),
+        Document(content="My name is Giorgio and I live in Rome."),
+        Document(content="My name is Mario and I live in the capital of Italy."),
+    ]
+
+    # --- Indexing pipeline ---
+    document_store = InMemoryDocumentStore()
+    indexing = Pipeline()
+    indexing.add_component(
+        instance=SentenceTransformersDocumentEmbedder(model=EMBEDDING_MODEL, device=device),
+        name="doc_embedder",
+    )
+    indexing.add_component(instance=DocumentWriter(document_store=document_store), name="writer")
+    indexing.connect("doc_embedder", "writer")
+    indexing.run({"doc_embedder": {"documents": documents}})
+
+    # Confirm embedder ran on GPU
+    assert indexing.get_component("doc_embedder").embedding_backend.model.device.type == expected_device_type
+
+    # --- RAG query pipeline ---
+    prompt_template = [
+        ChatMessage.from_system("You are a helpful assistant. Answer using only the documents provided."),
+        ChatMessage.from_user(
+            "Documents:\n{% for doc in documents %}{{ doc.content }}\n{% endfor %}\nQuestion: {{ question }}"
+        ),
+    ]
+
+    rag = Pipeline()
+    rag.add_component(
+        instance=SentenceTransformersTextEmbedder(model=EMBEDDING_MODEL, device=device),
+        name="text_embedder",
+    )
+    rag.add_component(
+        instance=InMemoryEmbeddingRetriever(document_store=document_store, top_k=2),
+        name="retriever",
+    )
+    rag.add_component(instance=ChatPromptBuilder(template=prompt_template), name="prompt_builder")
+    rag.add_component(
+        instance=HuggingFaceLocalChatGenerator(
+            model=GENERATOR_MODEL,
+            device=device,
+            generation_kwargs={"max_new_tokens": 50},
+        ),
+        name="llm",
+    )
+    rag.connect("text_embedder.embedding", "retriever.query_embedding")
+    rag.connect("retriever.documents", "prompt_builder.documents")
+    rag.connect("prompt_builder.prompt", "llm.messages")
+
+    # Serialize/deserialize — GPU device must survive a YAML round-trip
+    with open(tmp_path / "local_rag_gpu.yaml", "w") as f:
+        rag.dump(f)
+    with open(tmp_path / "local_rag_gpu.yaml", "r") as f:
+        rag = Pipeline.load(f)
+
+    result = rag.run(
+        {
+            "text_embedder": {"text": "Who lives in Rome?"},
+            "prompt_builder": {"question": "Who lives in Rome?"},
+        }
+    )
+
+    # --- Correctness ---
+    replies = result["llm"]["replies"]
+    assert len(replies) > 0
+    answer_text = replies[0].text
+    assert isinstance(answer_text, str) and len(answer_text) > 0
+    # The answer should mention Giorgio (the person living in Rome)
+    assert "Giorgio" in answer_text or "Rome" in answer_text
+
+    # --- GPU placement: text embedder and LLM both on the requested device ---
+    assert rag.get_component("text_embedder").embedding_backend.model.device.type == expected_device_type
+    assert rag.get_component("llm").pipeline.device.type == expected_device_type

--- a/e2e/pipelines/test_gpu_device_placement.py
+++ b/e2e/pipelines/test_gpu_device_placement.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+End-to-end tests for model device placement on GPU hardware (CUDA or Intel XPU).
+
+Covers device resolution (auto-selection and the ``HAYSTACK_XPU_ENABLED`` gate) and
+explicit placement of a SentenceTransformers embedder, asserting against a real
+accelerator. The available device is auto-detected, and the tests skip when no GPU is
+present, so they are safe to run in CPU-only CI.
+"""
+
+import pytest
+
+from haystack import Document
+from haystack.components.embedders import SentenceTransformersDocumentEmbedder
+from haystack.utils import ComponentDevice
+
+EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def _available_gpu_devices() -> list[str]:
+    """
+    Return the torch device strings for the GPUs available on this machine.
+
+    Returns an empty list on CPU-only machines, which causes the GPU tests to be skipped.
+    """
+    try:
+        import torch
+    except ImportError:
+        return []
+
+    devices = []
+    if torch.cuda.is_available():
+        devices.append("cuda:0")
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        devices.append("xpu:0")
+    return devices
+
+
+AVAILABLE_GPU_DEVICES = _available_gpu_devices()
+
+# Parametrize over every GPU backend present so the same assertions run on CUDA and XPU.
+gpu_device = pytest.mark.parametrize("device_str", AVAILABLE_GPU_DEVICES)
+requires_gpu = pytest.mark.skipif(
+    not AVAILABLE_GPU_DEVICES,
+    reason="No GPU (CUDA or XPU) available. These tests require an accelerator.",
+)
+
+
+DOCUMENTS = [
+    Document(content="My name is Jean and I live in Paris."),
+    Document(content="My name is Mark and I live in Berlin."),
+    Document(content="My name is Mario and I live in the capital of Italy."),
+    Document(content="My name is Giorgio and I live in Rome."),
+    Document(content="The Eiffel Tower is a wrought-iron lattice tower in Paris, France."),
+    Document(content="Rome is the capital city of Italy and was the center of the Roman Empire."),
+]
+
+
+@requires_gpu
+def test_auto_select_resolves_to_gpu(del_hf_env_vars, monkeypatch):
+    """
+    Device resolution against a real accelerator.
+
+    1. With no ``device=`` argument, a component resolves to the GPU via
+       ``_get_default_device()`` (priority CUDA > XPU > MPS > CPU).
+
+    2. ``HAYSTACK_XPU_ENABLED`` gates only the XPU branch, so ``"false"`` forces a CPU
+       fallback on an XPU-only host while CUDA hosts stay on CUDA.
+    """
+    import torch
+
+    # Start from the default (unset) env state so auto-selection is unbiased.
+    monkeypatch.delenv("HAYSTACK_XPU_ENABLED", raising=False)
+
+    cuda = torch.cuda.is_available()
+    expected_type = "cuda" if cuda else "xpu"
+
+    # --- 1. Real model, no device= -> lands on the auto-selected GPU ---
+    embedder = SentenceTransformersDocumentEmbedder(model=EMBEDDING_MODEL)
+    embedder.warm_up()
+    assert embedder.device.to_torch_str().split(":")[0] == expected_type
+    assert embedder.embedding_backend.model.device.type == expected_type
+
+    # --- 2. HAYSTACK_XPU_ENABLED gates ONLY the XPU branch ---
+    monkeypatch.setenv("HAYSTACK_XPU_ENABLED", "false")
+    resolved = ComponentDevice.resolve_device(None).to_torch_str().split(":")[0]
+    if cuda:
+        # CUDA is not gated by this var — still selected.
+        assert resolved == "cuda"
+    else:
+        # XPU disabled and no CUDA/MPS on an Intel GPU host -> CPU fallback.
+        assert resolved == "cpu"
+
+
+@requires_gpu
+@gpu_device
+def test_embedder_places_model_on_gpu(device_str, del_hf_env_vars):
+    """The SentenceTransformers embedders must load their model onto the requested GPU."""
+    device = ComponentDevice.from_str(device_str)
+
+    doc_embedder = SentenceTransformersDocumentEmbedder(model=EMBEDDING_MODEL, device=device)
+    doc_embedder.warm_up()
+
+    assert doc_embedder.device.to_torch_str() == device_str
+    model_device = doc_embedder.embedding_backend.model.device
+    assert model_device.type == device_str.split(":")[0]
+
+    result = doc_embedder.run(documents=DOCUMENTS)
+    embedded = result["documents"]
+    assert len(embedded) == len(DOCUMENTS)
+    assert all(doc.embedding is not None for doc in embedded)
+    assert len(embedded[0].embedding) == 384  # all-MiniLM-L6-v2 embedding dim


### PR DESCRIPTION
---

### Related Issues

<!-- Replace with the real issue number, or delete this section if there is no related issue. -->

- N/A — no existing issue; happy to open one if maintainers prefer to track it.

### Proposed Changes:

Adds two end-to-end test files covering model device placement on GPU hardware (NVIDIA CUDA and Intel XPU).

**`e2e/pipelines/test_gpu_device_placement.py`** (2 tests)

- `test_auto_select_resolves_to_gpu` — covers Haystack's device resolution against a real accelerator:
  - With no `device=` argument, a component resolves to the GPU via `_get_default_device()` (priority CUDA > XPU > MPS > CPU).
  - `HAYSTACK_XPU_ENABLED=false` gates only the XPU branch, so it forces a CPU fallback on an XPU-only host while CUDA hosts stay on CUDA.
- `test_embedder_places_model_on_gpu` — asserts `SentenceTransformersDocumentEmbedder` loads its model onto the requested GPU (`model.device.type`), then embeds documents and checks the output dimension.

**`e2e/pipelines/test_fully_local_rag_pipeline.py`** (1 test)

- `test_fully_local_rag_pipeline` — a RAG pipeline where indexing and querying both run on-device: embed → write, then embed → retrieve → `ChatPromptBuilder` → `HuggingFaceLocalChatGenerator` → answer. Uses a local generator, so it needs no API key. Round-trips the pipeline through YAML to confirm the device survives serialization, then asserts both the embedder and the LLM are on the requested device.

**Why these paths:**

Device resolution is currently exercised by unit tests that patch `torch.cuda.is_available` / `torch.xpu.is_available` (`test/utils/test_device.py`), so the resolution logic itself is well covered, but never against real hardware. Since the existing e2e tests don't pass `device=`, they rely on auto-selection implicitly — these tests make that behavior explicit and assert it. The local-RAG test complements the existing RAG e2e tests, which use `OpenAIGenerator` and are gated on `OPENAI_API_KEY`, by covering on-device generation.

**Hardware handling:**

Both files auto-detect the available accelerator and skip via `pytest.mark.skipif` when no GPU is present, so they are no-ops on CPU-only runners. GPU tests are parametrized over every backend found, so the same assertions run on CUDA and on XPU without duplicated test code.

### How did you test it?

- Ran the new tests on Intel XPU hardware (`torch 2.13.0+xpu`, native `torch.xpu` — no IPEX required): all pass, with models confirmed on `xpu:0`.
- Verified the skip path on a CPU-only environment: both files collect cleanly and all tests report as skipped, so the e2e CI job (`ubuntu-latest`) is unaffected.
- Ran `hatch run fmt` and `hatch run test:types`.


### Notes for the reviewer

- **Release note:** these changes are limited to tests, so I have not added a release note. Please apply the `ignore-for-release-notes` label if you agree, or let me know and I'll add one.
- **CI behavior:** the e2e workflow runs on `ubuntu-latest`, which has no GPU, so all three tests will skip there. They are meant to be run on demand on accelerator hardware. If you'd prefer a dedicated GPU runner or a marker to select them, I'm happy to adjust.
- **XPU support itself is already in `main`** — `ComponentDevice` has handled `DeviceType.XPU` and the `HAYSTACK_XPU_ENABLED` gate for a while. This PR adds no XPU functionality; it only adds test coverage for hardware that existing code already supports.
- The two device tests are grouped in one file since they share a subject and harness, following the grouping in `test_named_entity_extractor.py` and `test_rag_pipelines_e2e.py`. The RAG pipeline gets its own file named after the pipeline, matching `test_hybrid_doc_search_pipeline.py` and friends.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes). — *N/A: tests-only change, requesting `ignore-for-release-notes`.*
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
