### PR TITLE
fix: deep-copy document metadata in PythonCodeSplitter

### DIFF
--- a/haystack/components/preprocessors/python_code_splitter.py
+++ b/haystack/components/preprocessors/python_code_splitter.py
@@ -4,6 +4,7 @@
 
 import ast
 import math
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -472,7 +473,7 @@ class PythonCodeSplitter:
         """Construct the output meta dict for a chunk of merged units."""
         meta: dict[str, Any] = {}
         if parent_doc.meta:
-            meta.update({k: v for k, v in parent_doc.meta.items() if k not in {"split_id"}})
+            meta.update(deepcopy({k: v for k, v in parent_doc.meta.items() if k not in {"split_id"}}))
         meta["source_id"] = parent_doc.id
 
         # Units are emitted in source order, so chunk[0]/chunk[-1] give the extremes.
@@ -552,7 +553,7 @@ class PythonCodeSplitter:
         base_meta = self._build_chunk_meta([unit], parent_doc)
         results: list[Document] = []
         for idx, piece in enumerate(intermediate):
-            meta = dict(base_meta)
+            meta = deepcopy(base_meta)
             meta["secondary_split"] = True
             meta["secondary_split_index"] = idx
             meta["secondary_split_total"] = len(intermediate)

--- a/releasenotes/notes/python-code-splitter-deepcopy-nested-meta-720311a239fca28b.yaml
+++ b/releasenotes/notes/python-code-splitter-deepcopy-nested-meta-720311a239fca28b.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    ``PythonCodeSplitter`` now deep-copies the metadata of the document it splits, matching the other
+    splitters. Previously it copied it shallowly, so nested values such as a list under ``meta["tags"]``
+    were shared between every chunk and with the input document, and editing one chunk's metadata
+    changed all the others. The secondary line-based split of oversized units had the same problem.

--- a/test/components/preprocessors/test_python_code_splitter.py
+++ b/test/components/preprocessors/test_python_code_splitter.py
@@ -296,6 +296,26 @@ class TestFileNamePropagation:
         for chunk in result["documents"]:
             assert chunk.meta["project"] == "haystack"
 
+    def test_nested_metadata_is_not_shared_between_chunks(self, class_source):
+        """Each chunk gets its own copy of nested metadata, so editing one does not reach its siblings."""
+        doc = Document(content=class_source, meta={"tags": ["code"]})
+
+        chunks = PythonCodeSplitter(min_effective_lines=2, max_effective_lines=5).run(documents=[doc])["documents"]
+        chunks[0].meta["tags"].append("shape")
+
+        assert chunks[1].meta["tags"] == ["code"]
+        assert doc.meta["tags"] == ["code"]
+
+    def test_nested_metadata_is_not_shared_between_secondary_split_pieces(self, oversized_function_source):
+        """The secondary line-based split copies nested metadata too."""
+        doc = Document(content=oversized_function_source, meta={"tags": ["code"]})
+
+        chunks = PythonCodeSplitter(min_effective_lines=2, max_effective_lines=5).run(documents=[doc])["documents"]
+        chunks[0].meta["tags"].append("giant")
+
+        assert chunks[1].meta["tags"] == ["code"]
+        assert doc.meta["tags"] == ["code"]
+
 
 class TestDecorators:
     def test_decorators_metadata_present(self):


### PR DESCRIPTION
## Problem

`PythonCodeSplitter` copies the input document's metadata shallowly, so nested values are shared between every chunk and with the caller's document:

```python
doc = Document(content=class_source, meta={"tags": ["code"]})
chunks = PythonCodeSplitter(min_effective_lines=2, max_effective_lines=5).run(documents=[doc])["documents"]

chunks[0].meta["tags"] is chunks[1].meta["tags"]   # True
chunks[0].meta["tags"] is doc.meta["tags"]         # True

chunks[0].meta["tags"].append("shape")
chunks[1].meta["tags"]   # ['code', 'shape']
doc.meta["tags"]         # ['code', 'shape']   <- the caller's document is mutated
```

## Root cause

Two shallow copies:

- `_build_chunk_meta` does `meta.update({k: v for k, v in parent_doc.meta.items() ...})`, so every chunk holds references into the input document's metadata.
- `_secondary_split` does `meta = dict(base_meta)`, so the pieces of an oversized unit share the same nested objects with each other.

## Fix

Deep-copy at both sites, matching the other splitters.

This is the same defect as #12248, fixed for the Markdown, CSV and hierarchical splitters by #12249. `PythonCodeSplitter` was not covered there. I checked the remaining splitters — `DocumentSplitter`, `RecursiveDocumentSplitter`, `CSVDocumentCleaner` and `DocumentCleaner` are already safe, so this should close out the family.

## Tests

Two regression tests in `TestFileNamePropagation`, one per fixed site, written in the same shape as the one #12249 added to `test_markdown_header_splitter.py`.

Reverting the fix fails both, on the leaked mutation itself:

```
assert ['code', 'shape'] == ['code']
assert ['code', 'giant'] == ['code']
```

`test/components/preprocessors/` is green: 369 passed, 10 skipped (69 -> 71 in this file). `ruff check` and `ruff format --check` clean.

## Risk

Behavioural change is limited to chunks no longer aliasing the caller's metadata. Deep-copying runs once per chunk on metadata that was already being copied, so the added cost is proportional to metadata size, not document size.

---

AI assistance was used to write this change.
