### PR TITLE
feat: Add quality of life `Pipeline.add_components` function

### DIFF
--- a/docs-website/docs/concepts/pipelines.mdx
+++ b/docs-website/docs/concepts/pipelines.mdx
@@ -118,7 +118,8 @@ Once all your components are created and ready to be combined in a pipeline, the
 
 1. Create the pipeline with `Pipeline()`.
    This creates the Pipeline object.
-2. Add components to the pipeline, one by one, with `.add_component(name, component)`.
+2. Add components to the pipeline with `.add_components({name: component})` or add them individually with
+   `.add_component(name, component)`.
    This just adds components to the pipeline without connecting them yet. It's especially useful for loops as it allows the smooth connection of the components in the next step because they all already exist in the pipeline.
 3. Connect components with `.connect("producer_component.output_name", "consumer_component.input_name")`.
    At this step, you explicitly connect one of the outputs of a component to one of the inputs of the next component. This is also when the pipeline validates the connection without running the components. It makes the validation fast.

--- a/docs-website/docs/concepts/pipelines/creating-pipelines.mdx
+++ b/docs-website/docs/concepts/pipelines/creating-pipelines.mdx
@@ -71,8 +71,9 @@ query_pipeline.add_components(
 )
 ```
 
-Haystack validates every dictionary entry before adding any components. If validation fails, the pipeline remains
-unchanged.
+Before adding anything, Haystack checks that every name is valid, every value is a Haystack component instance, no
+name belongs to a different component, and no instance is already assigned to another name or pipeline. If any check
+fails, the pipeline remains unchanged.
 
 You can instead add components individually with `add_component()`:
 

--- a/docs-website/docs/concepts/pipelines/creating-pipelines.mdx
+++ b/docs-website/docs/concepts/pipelines/creating-pipelines.mdx
@@ -59,7 +59,22 @@ query_pipeline = Pipeline()
 
 ### 4\. Add components
 
-Add components to the pipeline one by one. The order in which you do this doesn't matter:
+Add components to the pipeline. The order in which you do this doesn't matter. You can add several components at
+once by passing a dictionary to `add_components()`:
+
+```python
+query_pipeline.add_components(
+    {
+        "text_embedder": text_embedder,
+        "retriever": retriever,
+    }
+)
+```
+
+The operation is atomic: Haystack validates every dictionary entry before changing the pipeline. If any component
+cannot be added, none of the new components are added.
+
+You can instead add components individually with `add_component()`:
 
 ```python
 query_pipeline.add_component("component_name", component_type)
@@ -75,6 +90,9 @@ query_pipeline.add_component(
     InMemoryEmbeddingRetriever(document_store=document_store),
 )
 ```
+
+Adding the exact same component instance again under the same name is a no-op. A name cannot refer to a different
+component, and a component instance cannot appear under multiple names or belong to multiple pipelines at once.
 
 ### 5\. Connect components
 

--- a/docs-website/docs/concepts/pipelines/creating-pipelines.mdx
+++ b/docs-website/docs/concepts/pipelines/creating-pipelines.mdx
@@ -71,8 +71,8 @@ query_pipeline.add_components(
 )
 ```
 
-The operation is atomic: Haystack validates every dictionary entry before changing the pipeline. If any component
-cannot be added, none of the new components are added.
+Haystack validates every dictionary entry before adding any components. If validation fails, the pipeline remains
+unchanged.
 
 You can instead add components individually with `add_component()`:
 

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -398,7 +398,8 @@ class PipelineBase:  # noqa: PLW1641
         Add the given component to the pipeline.
 
         Components are not connected to anything by default: use `Pipeline.connect()` to connect components together.
-        Component names must be unique, but component instances can be reused if needed.
+        Component names must be unique, and a component instance can only be added to one pipeline at a time.
+        Adding the same component instance with the same name more than once is a no-op.
 
         :param name:
             The name of the component to add.
@@ -406,12 +407,64 @@ class PipelineBase:  # noqa: PLW1641
             The component instance to add.
 
         :raises ValueError:
-            If a component with the same name already exists.
+            If a different component with the same name already exists.
         :raises PipelineValidationError:
             If the given instance is not a component.
+        :raises PipelineError:
+            If the component instance is already in this pipeline under another name or is in another pipeline.
         """
+        if not self._validate_component(name, instance):
+            return
+
+        self._add_component_to_graph(name, instance)
+
+    def add_components(self, components: Mapping[str, Component]) -> None:
+        """
+        Add multiple components to the pipeline.
+
+        Components are not connected to anything by default: use `Pipeline.connect()` to connect components together.
+        All components are validated before any of them is added. If validation fails, the pipeline remains unchanged.
+        Components already present under the same name are ignored when they are the exact same instances.
+
+        :param components:
+            A mapping of component names to component instances.
+
+        :raises ValueError:
+            If a component name is invalid or already belongs to a different component in this pipeline.
+        :raises PipelineValidationError:
+            If one of the given instances is not a component.
+        :raises PipelineError:
+            If a component instance is already in this pipeline under another name, is in another pipeline,
+            or occurs more than once in the mapping.
+        """
+        components_to_add: list[tuple[str, Component]] = []
+        component_names_by_id: dict[int, str] = {}
+
+        # Materialize the items so custom mappings cannot change between validation and insertion.
+        for name, instance in list(components.items()):
+            if not self._validate_component(name, instance):
+                continue
+
+            instance_id = id(instance)
+            previous_name = component_names_by_id.get(instance_id)
+            if previous_name is not None:
+                raise PipelineError(
+                    f"Component instance cannot be added to the pipeline more than once. "
+                    f"It is mapped to both '{previous_name}' and '{name}'."
+                )
+
+            component_names_by_id[instance_id] = name
+            components_to_add.append((name, instance))
+
+        for name, instance in components_to_add:
+            self._add_component_to_graph(name, instance)
+
+    def _validate_component(self, name: str, instance: Component) -> bool:
+        """Validate a component before adding it, returning whether it needs to be added."""
         # Component names are unique
         if name in self.graph.nodes:
+            if self.graph.nodes[name]["instance"] is instance:
+                return False
             raise ValueError(f"A component named '{name}' already exists in this pipeline: choose another name.")
 
         # Components can't be named `_debug`
@@ -428,13 +481,24 @@ class PipelineBase:  # noqa: PLW1641
                 f"'{type(instance)}' doesn't seem to be a component. Is this class decorated with @component?"
             )
 
-        if getattr(instance, "__haystack_added_to_pipeline__", None):
-            msg = (
-                "Component has already been added in another Pipeline. Components can't be shared between Pipelines. "
-                "Create a new instance instead."
-            )
+        if owning_pipeline := getattr(instance, "__haystack_added_to_pipeline__", None):
+            if owning_pipeline is self:
+                existing_name = self.get_component_name(instance)
+                msg = (
+                    f"Component has already been added to this Pipeline under the name '{existing_name}'. "
+                    "A component instance can only be added once."
+                )
+            else:
+                msg = (
+                    "Component has already been added in another Pipeline. "
+                    "Components can't be shared between Pipelines. Create a new instance instead."
+                )
             raise PipelineError(msg)
 
+        return True
+
+    def _add_component_to_graph(self, name: str, instance: Component) -> None:
+        """Add an already validated component to the graph."""
         setattr(instance, "__haystack_added_to_pipeline__", self)  # noqa: B010
         setattr(instance, "__component_name__", name)  # noqa: B010
 

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -423,7 +423,9 @@ class PipelineBase:  # noqa: PLW1641
         Add multiple components to the pipeline.
 
         Components are not connected to anything by default: use `Pipeline.connect()` to connect components together.
-        All components are validated before any of them is added. If validation fails, the pipeline remains unchanged.
+        Before adding anything, Haystack checks that every name is valid, every value is a Component instance,
+        no name belongs to a different component, and no instance is assigned to another name or pipeline.
+        If any check fails, the pipeline remains unchanged.
         Components already present under the same name are ignored when they are the exact same instances.
 
         :param components:

--- a/releasenotes/notes/add-pipeline-components-e7f7ed72c9c0147d.yaml
+++ b/releasenotes/notes/add-pipeline-components-e7f7ed72c9c0147d.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Add ``Pipeline.add_components()`` to atomically add a mapping of component names to component instances.
+    Add ``Pipeline.add_components()`` to add a mapping of component names to component instances in one call.
     Re-adding the same component instance under the same name with ``Pipeline.add_component()`` or
     ``Pipeline.add_components()`` is now a no-op.
 

--- a/releasenotes/notes/add-pipeline-components-e7f7ed72c9c0147d.yaml
+++ b/releasenotes/notes/add-pipeline-components-e7f7ed72c9c0147d.yaml
@@ -1,0 +1,16 @@
+---
+features:
+  - |
+    Add ``Pipeline.add_components()`` to atomically add a mapping of component names to component instances.
+    Re-adding the same component instance under the same name with ``Pipeline.add_component()`` or
+    ``Pipeline.add_components()`` is now a no-op.
+
+    .. code:: python
+
+      pipeline.add_components(
+          {
+              "retriever": retriever,
+              "prompt_builder": prompt_builder,
+              "llm": llm,
+          }
+      )

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -123,6 +123,109 @@ def lazy_variadic_input_socket():
     return InputSocket("variadic_input", Variadic[int], senders=["sender1", "sender2"])
 
 
+class TestPipelineAddComponent:
+    def test_add_invalid_component_name(self):
+        pipe = PipelineBase()
+        with pytest.raises(ValueError):
+            pipe.add_component("this.is.not.a.valida.name", FakeComponent)
+        with pytest.raises(ValueError):
+            pipe.add_component("_debug", FakeComponent)
+
+    def test_add_component_to_different_pipelines(self):
+        first_pipe = PipelineBase()
+        second_pipe = PipelineBase()
+        some_component = component_class("Some")()
+
+        assert some_component.__haystack_added_to_pipeline__ is None  # type: ignore[attr-defined]
+        first_pipe.add_component("some", some_component)
+        assert some_component.__haystack_added_to_pipeline__ is first_pipe  # type: ignore[attr-defined]
+
+        with pytest.raises(PipelineError):
+            second_pipe.add_component("some", some_component)
+
+    def test_add_same_component_with_same_name_is_no_op(self):
+        pipe = PipelineBase()
+        some_component = component_class("Some")()
+
+        pipe.add_component("some", some_component)
+        pipe.add_component("some", some_component)
+
+        assert list(pipe.graph.nodes) == ["some"]
+        assert pipe.get_component("some") is some_component
+
+    def test_add_different_component_with_same_name_raises(self):
+        pipe = PipelineBase()
+        pipe.add_component("some", component_class("Some")())
+
+        with pytest.raises(ValueError, match="A component named 'some' already exists"):
+            pipe.add_component("some", component_class("Other")())
+
+    def test_add_same_component_with_different_name_raises(self):
+        pipe = PipelineBase()
+        some_component = component_class("Some")()
+        pipe.add_component("some", some_component)
+
+        with pytest.raises(PipelineError, match="already been added"):
+            pipe.add_component("other", some_component)
+
+
+class TestPipelineAddComponents:
+    def test_add_components(self):
+        pipe = PipelineBase()
+        first_component = component_class("First")()
+        second_component = component_class("Second")()
+
+        pipe.add_components({"first": first_component, "second": second_component})
+
+        assert list(pipe.graph.nodes) == ["first", "second"]
+        assert pipe.get_component("first") is first_component
+        assert pipe.get_component("second") is second_component
+
+    def test_add_components_is_idempotent(self):
+        pipe = PipelineBase()
+        components = {"first": component_class("First")(), "second": component_class("Second")()}
+
+        pipe.add_components(components)
+        pipe.add_components(components)
+
+        assert list(pipe.graph.nodes) == ["first", "second"]
+
+    def test_add_components_validates_all_components_before_adding_any(self):
+        pipe = PipelineBase()
+        first_component = component_class("First")()
+        second_component = component_class("Second")()
+
+        with pytest.raises(ValueError, match="invalid component name"):
+            pipe.add_components({"first": first_component, "invalid.name": second_component})
+
+        assert list(pipe.graph.nodes) == []
+        assert first_component.__haystack_added_to_pipeline__ is None  # type: ignore[attr-defined]
+        assert second_component.__haystack_added_to_pipeline__ is None  # type: ignore[attr-defined]
+
+    def test_add_components_with_existing_name_does_not_add_new_components(self):
+        pipe = PipelineBase()
+        existing_component = component_class("Existing")()
+        new_component = component_class("New")()
+        pipe.add_component("existing", existing_component)
+
+        with pytest.raises(ValueError, match="A component named 'existing' already exists"):
+            pipe.add_components({"new": new_component, "existing": component_class("Replacement")()})
+
+        assert list(pipe.graph.nodes) == ["existing"]
+        assert pipe.get_component("existing") is existing_component
+        assert new_component.__haystack_added_to_pipeline__ is None  # type: ignore[attr-defined]
+
+    def test_add_components_rejects_same_instance_under_different_names(self):
+        pipe = PipelineBase()
+        some_component = component_class("Some")()
+
+        with pytest.raises(PipelineError, match="mapped to both 'first' and 'second'"):
+            pipe.add_components({"first": some_component, "second": some_component})
+
+        assert list(pipe.graph.nodes) == []
+        assert some_component.__haystack_added_to_pipeline__ is None  # type: ignore[attr-defined]
+
+
 class TestPipelineBase:
     """
     This class contains only unit tests for the PipelineBase class.
@@ -251,25 +354,6 @@ class TestPipelineBase:
         image_path = tmp_path / "test.png"
         pipe.draw(path=image_path)
         assert image_path.read_bytes() == mock_to_mermaid_image.return_value
-
-    def test_add_invalid_component_name(self):
-        pipe = PipelineBase()
-        with pytest.raises(ValueError):
-            pipe.add_component("this.is.not.a.valida.name", FakeComponent)
-        with pytest.raises(ValueError):
-            pipe.add_component("_debug", FakeComponent)
-
-    def test_add_component_to_different_pipelines(self):
-        first_pipe = PipelineBase()
-        second_pipe = PipelineBase()
-        some_component = component_class("Some")()
-
-        assert some_component.__haystack_added_to_pipeline__ is None  # type: ignore[attr-defined]
-        first_pipe.add_component("some", some_component)
-        assert some_component.__haystack_added_to_pipeline__ is first_pipe  # type: ignore[attr-defined]
-
-        with pytest.raises(PipelineError):
-            second_pipe.add_component("some", some_component)
 
     def test_remove_component_raises_if_invalid_component_name(self):
         pipe = PipelineBase()

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -190,7 +190,7 @@ class TestPipelineAddComponents:
 
         assert list(pipe.graph.nodes) == ["first", "second"]
 
-    def test_add_components_validates_all_components_before_adding_any(self):
+    def test_add_components_checks_all_components_before_adding_any(self):
         pipe = PipelineBase()
         first_component = component_class("First")()
         second_component = component_class("Second")()

--- a/test/core/test_serialization_security.py
+++ b/test/core/test_serialization_security.py
@@ -652,6 +652,7 @@ class TestPipelineCallableClassification:
     SAFE_TO_RESOLVE: dict[str, set[str]] = {
         "PipelineBase": {
             "add_component",
+            "add_components",
             "close",
             "close_async",
             "connect",


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add ``Pipeline.add_components()`` to atomically add a mapping of component names to component instances. Re-adding the same component instance under the same name with ``Pipeline.add_component()`` or ``Pipeline.add_components()`` is now a no-op instead of raising an error. 

The motivation for this was to help reduce repetition and boiler plate when creating pipelines.

**Before**

Each component must be registered separately:

```python
pipeline = Pipeline()

pipeline.add_component("retriever", retriever)
pipeline.add_component("prompt_builder", prompt_builder)
pipeline.add_component("llm", llm)
pipeline.add_component("answer_builder", answer_builder)
```

**After**

Components can be registered declaratively in one operation:

```python
pipeline = Pipeline()

pipeline.add_components(
    {"retriever": retriever, "prompt_builder": prompt_builder, "llm": llm, "answer_builder": answer_builder}
)
```

`add_components()` validates the entire mapping before changing the pipeline.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
