### PR TITLE
feat: quality of life improvement for pipeline building

### DIFF
--- a/docs-website/docs/concepts/pipelines.mdx
+++ b/docs-website/docs/concepts/pipelines.mdx
@@ -121,7 +121,8 @@ Once all your components are created and ready to be combined in a pipeline, the
 2. Add components to the pipeline with `.add_components({name: component})` or add them individually with
    `.add_component(name, component)`.
    This just adds components to the pipeline without connecting them yet. It's especially useful for loops as it allows the smooth connection of the components in the next step because they all already exist in the pipeline.
-3. Connect components with `.connect("producer_component.output_name", "consumer_component.input_name")`.
+3. Connect several component pairs with `.connect_many([(sender, receiver)])`, or connect one pair with
+   `.connect("producer_component.output_name", "consumer_component.input_name")`.
    At this step, you explicitly connect one of the outputs of a component to one of the inputs of the next component. This is also when the pipeline validates the connection without running the components. It makes the validation fast.
 4. Run the pipeline with `.run({"component_1": {"mandatory_inputs": value}})`.
    Finally, you run the Pipeline by specifying the first component in the pipeline and passing its mandatory inputs. Optionally, you can pass inputs to other components, for example: `.run({"component_1": {"mandatory_inputs": value}, "component_2": {"inputs": value}})`.

--- a/docs-website/docs/concepts/pipelines/creating-pipelines.mdx
+++ b/docs-website/docs/concepts/pipelines/creating-pipelines.mdx
@@ -94,10 +94,26 @@ query_pipeline.add_component(
 
 Adding the exact same component instance again under the same name is a no-op. A name cannot refer to a different
 component, and a component instance cannot appear under multiple names or belong to multiple pipelines at once.
+Both `add_component()` and `add_components()` return the pipeline, so you can chain further pipeline-building calls.
 
 ### 5\. Connect components
 
 Connect the components by indicating which output of a component should be connected to the input of the next component. If a component has only one input or output and the connection is obvious, you can just pass the component name without specifying the input or output.
+
+To create several connections in one call, pass `(sender, receiver)` pairs to `connect_many()`:
+
+```python
+query_pipeline.connect_many(
+    [
+        ("text_embedder.embedding", "retriever"),
+        ("retriever", "prompt_builder.documents"),
+        ("prompt_builder", "llm"),
+    ]
+)
+```
+
+Haystack creates the connections in the order provided. If a pair cannot be connected, subsequent pairs are not
+processed, while earlier successful connections remain in the pipeline. Repeating an existing connection is a no-op.
 
 To understand what inputs are expected to run your pipeline, use an `.inputs()` pipeline function. See a detailed examples in the [Pipeline Inputs](#pipeline-inputs) section below.
 
@@ -123,7 +139,7 @@ pipeline.connect("text_embedder.embedding", "retriever.query_embedding")
 pipeline.connect("text_embedder.embedding", "retriever")
 ```
 
-You need to link all the components together, connecting them gradually in pairs. Here's an explicit example for the pipeline we're assembling:
+You can also connect components individually. Here's an explicit example for the pipeline we're assembling:
 
 ```python
 # Imagine this pipeline has four components: text_embedder, retriever, prompt_builder and llm.
@@ -132,6 +148,29 @@ You need to link all the components together, connecting them gradually in pairs
 query_pipeline.connect("text_embedder.embedding", "retriever")
 query_pipeline.connect("retriever", "prompt_builder.documents")
 query_pipeline.connect("prompt_builder", "llm")
+```
+
+Because the component-addition and connection methods return the pipeline, you can build a pipeline fluently:
+
+```python
+query_pipeline = (
+    Pipeline()
+    .add_components(
+        {
+            "text_embedder": text_embedder,
+            "retriever": retriever,
+            "prompt_builder": prompt_builder,
+            "llm": llm,
+        }
+    )
+    .connect_many(
+        [
+            ("text_embedder.embedding", "retriever"),
+            ("retriever", "prompt_builder.documents"),
+            ("prompt_builder", "llm"),
+        ]
+    )
+)
 ```
 
 ### 6\. Run the pipeline

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -5,7 +5,7 @@
 import itertools
 import json
 from collections import defaultdict
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import AbstractContextManager as ContextManager
 from datetime import datetime
 from enum import IntEnum
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, TextIO, TypeVar, Union, get_args
 
 import networkx
+from typing_extensions import Self
 
 from haystack import logging, tracing
 from haystack.core.component import Component, InputSocket, OutputSocket, component
@@ -393,7 +394,8 @@ class PipelineBase:  # noqa: PLW1641
         """
         return cls.loads(fp.read(), marshaller, callbacks, allowed_modules=allowed_modules, unsafe=unsafe)
 
-    def add_component(self, name: str, instance: Component) -> None:
+    # Self preserves the concrete subclass for fluent calls, so Pipeline().add_component(...).run() type-checks.
+    def add_component(self, name: str, instance: Component) -> Self:
         """
         Add the given component to the pipeline.
 
@@ -405,6 +407,8 @@ class PipelineBase:  # noqa: PLW1641
             The name of the component to add.
         :param instance:
             The component instance to add.
+        :returns:
+            The Pipeline instance.
 
         :raises ValueError:
             If a different component with the same name already exists.
@@ -414,11 +418,12 @@ class PipelineBase:  # noqa: PLW1641
             If the component instance is already in this pipeline under another name or is in another pipeline.
         """
         if not self._validate_component(name, instance):
-            return
+            return self
 
         self._add_component_to_graph(name, instance)
+        return self
 
-    def add_components(self, components: Mapping[str, Component]) -> None:
+    def add_components(self, components: Mapping[str, Component]) -> Self:
         """
         Add multiple components to the pipeline.
 
@@ -430,6 +435,8 @@ class PipelineBase:  # noqa: PLW1641
 
         :param components:
             A mapping of component names to component instances.
+        :returns:
+            The Pipeline instance.
 
         :raises ValueError:
             If a component name is invalid or already belongs to a different component in this pipeline.
@@ -460,6 +467,8 @@ class PipelineBase:  # noqa: PLW1641
 
         for name, instance in components_to_add:
             self._add_component_to_graph(name, instance)
+
+        return self
 
     def _validate_component(self, name: str, instance: Component) -> bool:
         """Validate a component before adding it, returning whether it needs to be added."""
@@ -576,7 +585,7 @@ class PipelineBase:  # noqa: PLW1641
 
         return instance
 
-    def connect(self, sender: str, receiver: str) -> "PipelineBase":  # noqa: PLR0915 PLR0912 C901
+    def connect(self, sender: str, receiver: str) -> Self:  # noqa: PLR0915 PLR0912 C901
         """
         Connects two components together.
 
@@ -780,6 +789,30 @@ class PipelineBase:  # noqa: PLW1641
             mandatory=receiver_socket.is_mandatory,
             conversion_strategy=conversion_strategy,
         )
+        return self
+
+    def connect_many(self, connections: Iterable[tuple[str, str]]) -> Self:
+        """
+        Connect multiple pairs of components.
+
+        Connections are made in the order provided. If connecting a pair raises an exception, no subsequent pairs
+        are connected, while earlier successful connections remain in the pipeline. Repeating an existing connection
+        is a no-op.
+
+        :param connections:
+            An iterable of `(sender, receiver)` pairs. Each value uses the same format accepted by
+            `Pipeline.connect()`.
+        :returns:
+            The Pipeline instance.
+
+        :raises PipelineConnectError:
+            If a pair of components cannot be connected.
+        :raises ValueError:
+            If a sender or receiver component is not present in the pipeline.
+        """
+        for sender, receiver in connections:
+            self.connect(sender, receiver)
+
         return self
 
     def get_component(self, name: str) -> Component:

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -5,7 +5,7 @@
 import itertools
 import json
 from collections import defaultdict
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import AbstractContextManager as ContextManager
 from datetime import datetime
 from enum import IntEnum
@@ -423,7 +423,7 @@ class PipelineBase:  # noqa: PLW1641
         self._add_component_to_graph(name, instance)
         return self
 
-    def add_components(self, components: Mapping[str, Component]) -> Self:
+    def add_components(self, components: dict[str, Component]) -> Self:
         """
         Add multiple components to the pipeline.
 
@@ -434,7 +434,7 @@ class PipelineBase:  # noqa: PLW1641
         Components already present under the same name are ignored when they are the exact same instances.
 
         :param components:
-            A mapping of component names to component instances.
+            A dictionary that maps component names to component instances.
         :returns:
             The Pipeline instance.
 
@@ -449,8 +449,7 @@ class PipelineBase:  # noqa: PLW1641
         components_to_add: list[tuple[str, Component]] = []
         component_names_by_id: dict[int, str] = {}
 
-        # Materialize the items so custom mappings cannot change between validation and insertion.
-        for name, instance in list(components.items()):
+        for name, instance in components.items():
             if not self._validate_component(name, instance):
                 continue
 
@@ -791,7 +790,7 @@ class PipelineBase:  # noqa: PLW1641
         )
         return self
 
-    def connect_many(self, connections: Iterable[tuple[str, str]]) -> Self:
+    def connect_many(self, connections: list[tuple[str, str]]) -> Self:
         """
         Connect multiple pairs of components.
 
@@ -800,7 +799,7 @@ class PipelineBase:  # noqa: PLW1641
         is a no-op.
 
         :param connections:
-            An iterable of `(sender, receiver)` pairs. Each value uses the same format accepted by
+            A list of `(sender, receiver)` pairs. Each value uses the same format accepted by
             `Pipeline.connect()`.
         :returns:
             The Pipeline instance.

--- a/releasenotes/notes/pipeline-connect-many-fluent-0f5322eb79a3477e.yaml
+++ b/releasenotes/notes/pipeline-connect-many-fluent-0f5322eb79a3477e.yaml
@@ -1,0 +1,25 @@
+---
+features:
+  - |
+    Add ``Pipeline.connect_many()`` to connect multiple ``(sender, receiver)`` pairs in one call.
+    ``Pipeline.add_component()`` and ``Pipeline.add_components()`` now return the pipeline, allowing pipeline-building
+    methods to be chained.
+
+    .. code:: python
+
+      pipeline = (
+          Pipeline()
+          .add_components(
+              {
+                  "retriever": retriever,
+                  "prompt_builder": prompt_builder,
+                  "llm": llm,
+              }
+          )
+          .connect_many(
+              [
+                  ("retriever", "prompt_builder.documents"),
+                  ("prompt_builder", "llm"),
+              ]
+          )
+      )

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -2073,7 +2073,7 @@ class TestPipelineConnectMany:
         assert result is pipe
         assert list(pipe.graph.edges) == [("first", "middle", "value/value"), ("middle", "last", "value/value")]
 
-    def test_connect_many_with_empty_iterable(self):
+    def test_connect_many_with_empty_list(self):
         pipe = PipelineBase()
 
         assert pipe.connect_many([]) is pipe

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -147,8 +147,8 @@ class TestPipelineAddComponent:
         pipe = PipelineBase()
         some_component = component_class("Some")()
 
-        pipe.add_component("some", some_component)
-        pipe.add_component("some", some_component)
+        assert pipe.add_component("some", some_component) is pipe
+        assert pipe.add_component("some", some_component) is pipe
 
         assert list(pipe.graph.nodes) == ["some"]
         assert pipe.get_component("some") is some_component
@@ -175,8 +175,9 @@ class TestPipelineAddComponents:
         first_component = component_class("First")()
         second_component = component_class("Second")()
 
-        pipe.add_components({"first": first_component, "second": second_component})
+        result = pipe.add_components({"first": first_component, "second": second_component})
 
+        assert result is pipe
         assert list(pipe.graph.nodes) == ["first", "second"]
         assert pipe.get_component("first") is first_component
         assert pipe.get_component("second") is second_component
@@ -185,8 +186,8 @@ class TestPipelineAddComponents:
         pipe = PipelineBase()
         components = {"first": component_class("First")(), "second": component_class("Second")()}
 
-        pipe.add_components(components)
-        pipe.add_components(components)
+        assert pipe.add_components(components) is pipe
+        assert pipe.add_components(components) is pipe
 
         assert list(pipe.graph.nodes) == ["first", "second"]
 
@@ -2058,6 +2059,49 @@ class TestPipelineBaseFromDict:
             PipelineBase.from_dict(data)
 
         err.match("Missing receiver in connection: {'sender': 'some.sender'}")
+
+
+class TestPipelineConnectMany:
+    def test_connect_many(self):
+        first = component_class("First", output_types={"value": int})()
+        middle = component_class("Middle", input_types={"value": int}, output_types={"value": int})()
+        last = component_class("Last", input_types={"value": int})()
+        pipe = PipelineBase().add_components({"first": first, "middle": middle, "last": last})
+
+        result = pipe.connect_many([("first", "middle"), ("middle", "last")])
+
+        assert result is pipe
+        assert list(pipe.graph.edges) == [("first", "middle", "value/value"), ("middle", "last", "value/value")]
+
+    def test_connect_many_with_empty_iterable(self):
+        pipe = PipelineBase()
+
+        assert pipe.connect_many([]) is pipe
+        assert list(pipe.graph.edges) == []
+
+    def test_connect_many_is_idempotent(self):
+        sender = component_class("Sender", output_types={"value": int})()
+        receiver = component_class("Receiver", input_types={"value": int})()
+        pipe = PipelineBase().add_components({"sender": sender, "receiver": receiver})
+        connections = [("sender.value", "receiver.value")]
+
+        assert pipe.connect_many(connections) is pipe
+        assert pipe.connect_many(connections) is pipe
+
+        assert sender.__haystack_output__.value.receivers == ["receiver"]  # type: ignore[attr-defined]
+        assert receiver.__haystack_input__.value.senders == ["sender"]  # type: ignore[attr-defined]
+        assert list(pipe.graph.edges) == [("sender", "receiver", "value/value")]
+
+    def test_connect_many_stops_after_first_error(self):
+        first = component_class("First", output_types={"value": int})()
+        middle = component_class("Middle", input_types={"value": int}, output_types={"value": int})()
+        last = component_class("Last", input_types={"value": int})()
+        pipe = PipelineBase().add_components({"first": first, "middle": middle, "last": last})
+
+        with pytest.raises(ValueError, match="Component named missing not found"):
+            pipe.connect_many([("first", "middle"), ("missing", "last"), ("middle", "last")])
+
+        assert list(pipe.graph.edges) == [("first", "middle", "value/value")]
 
 
 class TestPipelineConnect:

--- a/test/core/test_serialization_security.py
+++ b/test/core/test_serialization_security.py
@@ -656,6 +656,7 @@ class TestPipelineCallableClassification:
             "close",
             "close_async",
             "connect",
+            "connect_many",
             "draw",
             "dump",
             "dumps",


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add ``Pipeline.connect_many()`` to connect multiple ``(sender, receiver)`` pairs in one call. ``Pipeline.add_component()`` and ``Pipeline.add_components()`` now return the pipeline, allowing pipeline-building methods to be chained.

**Before**

Pipeline construction requires separate calls for every component and connection:

```python
pipeline = Pipeline()

pipeline.add_component("retriever", retriever)
pipeline.add_component("prompt_builder", prompt_builder)
pipeline.add_component("llm", llm)

pipeline.connect("retriever", "prompt_builder.documents")
pipeline.connect("prompt_builder", "llm")
```

**After**

Components and connections can be added in batches and chained fluently:

```python
pipeline = (
    Pipeline()
    .add_components({"retriever": retriever, "prompt_builder": prompt_builder, "llm": llm})
    .connect_many([("retriever", "prompt_builder.documents"), ("prompt_builder", "llm")])
)
```

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

The motivation was to find ways to streamline the code building experience for pipelines in Haystack and help reduce boiler plate by not needing to repeat the same function calls many times. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
