### PR TITLE
test: reconcile env-var security test with callable traversal hardening

### DIFF
--- a/test/core/test_serialization_security.py
+++ b/test/core/test_serialization_security.py
@@ -268,27 +268,40 @@ class TestUnsafeDeserializationEnvVar:
         monkeypatch.delenv(UNSAFE_DESERIALIZATION_ENV_VAR)
         assert _is_module_allowed("subprocess")
 
-    def test_env_write_reachable_from_serialized_data_cannot_disable_safety(self, monkeypatch):
+    def test_env_write_gadget_is_not_resolvable_from_serialized_data(self, monkeypatch):
         """
-        Regression test for the reason the snapshot is frozen.
+        First line of defense: the gadget cannot be resolved at all.
 
         `os.environ.update` is `collections.abc.MutableMapping.update`, and `collections` is on the
-        default allowlist — so if any allowlisted module binds `os.environ` at module scope, a
-        serialized handle can resolve that mutator in *safe* mode and call it (e.g. as an
-        `OutputAdapter` Jinja `custom_filters` entry, which runs while the component is being
-        constructed). Were the env var read fresh on every check, that would switch the ongoing load
-        into unsafe mode and hand the pipeline arbitrary code execution.
+        default allowlist — so a handle that walks an allowlisted module's scope-level `os.environ`
+        binding ends at a callable whose own module *is* allowed. The per-hop check on the real
+        module of every traversed object rejects the `environ` hop itself, because that object
+        belongs to the un-allowlisted `os`.
         """
         monkeypatch.setattr(type_serialization, "environ", os.environ, raising=False)
-        # Resolving the gadget is itself a deserialization check, so the snapshot is already frozen
-        # by the time the attacker gets to call it — as it would be in a real load.
-        update = deserialize_callable("haystack.utils.type_serialization.environ.update")
+        with pytest.raises(DeserializationError, match="module 'os'"):
+            deserialize_callable("haystack.utils.type_serialization.environ.update")
+
+    def test_env_write_reachable_from_serialized_data_cannot_disable_safety(self, monkeypatch):
+        """
+        Second line of defense, and the reason the snapshot is frozen.
+
+        Even granting the attacker the env write that the gadget above would have performed — say
+        via a mutator the traversal check cannot see, or as an `OutputAdapter` Jinja
+        `custom_filters` entry that runs while the component is being constructed — the ongoing
+        load must not flip into unsafe mode. Were the env var read fresh on every check, it would,
+        handing the pipeline arbitrary code execution.
+        """
+        # Any deserialization check snapshots the env var, so by the time the attacker's payload
+        # runs the mode is already frozen — as it would be mid-load in a real process. Assert the
+        # safe-mode baseline here to take that snapshot without relying on the gadget above.
+        assert not _is_module_allowed("subprocess")
 
         # Register the variable before the write: the write below goes straight to the real
         # environment, so monkeypatch has to know the pre-attack state to undo it at teardown.
         # (Registering afterwards would record the polluted value and leak it into other tests.)
         monkeypatch.setenv(UNSAFE_DESERIALIZATION_ENV_VAR, "")
-        update({UNSAFE_DESERIALIZATION_ENV_VAR: "1"})
+        os.environ.update({UNSAFE_DESERIALIZATION_ENV_VAR: "1"})
         assert os.environ[UNSAFE_DESERIALIZATION_ENV_VAR] == "1"  # the write lands ...
 
         assert not _is_unsafe_deserialization()  # ... and changes nothing


### PR DESCRIPTION
### Related Issues

- Fixes the `main` unit-test failure introduced by the interaction of #12397 and #12416
- Failing run: https://github.com/deepset-ai/haystack/actions/runs/32487053308

`main` is red on all three OS runners with one failing test:

```
FAILED test/core/test_serialization_security.py::TestUnsafeDeserializationEnvVar::
       test_env_write_reachable_from_serialized_data_cannot_disable_safety
  DeserializationError: Refusing to deserialize a class from module 'os'
= 1 failed, 6276 passed, 8 skipped, 323 deselected =
```

### Proposed Changes:

Split the unit test for deserialization security so each defense layer is covered on its own

### How did you test it?

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes. — n/a, no issue; the failing CI run is linked above
- I have added unit tests and updated the docstrings. — test-only PR; both tests carry docstrings explaining which layer they guard
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `test:`, no breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes). — n/a, test-only change, labelled `ignore-for-release-notes`
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.