### PR TITLE
fix: merge a short trailing split in EmbeddingBasedDocumentSplitter

### DIFF
--- a/haystack/components/preprocessors/embedding_based_document_splitter.py
+++ b/haystack/components/preprocessors/embedding_based_document_splitter.py
@@ -445,6 +445,17 @@ class EmbeddingBasedDocumentSplitter:
         # Don't forget the last split
         merged.append(current_split)
 
+        # The loop above only merges forward, so the final split never had a chance to absorb anything and can
+        # still be below min_length. Merge it into its predecessor instead, subject to the same max_length limit
+        # that governs forward merges.
+        if (
+            len(merged) > 1
+            and len(merged[-1]) < self.min_length
+            and len(merged[-2]) + len(merged[-1]) < self.max_length
+        ):
+            trailing_split = merged.pop()
+            merged[-1] += trailing_split
+
         return merged
 
     def _split_large_splits(self, splits: list[str]) -> list[str]:

--- a/haystack/components/preprocessors/embedding_based_document_splitter.py
+++ b/haystack/components/preprocessors/embedding_based_document_splitter.py
@@ -445,9 +445,8 @@ class EmbeddingBasedDocumentSplitter:
         # Don't forget the last split
         merged.append(current_split)
 
-        # The loop above only merges forward, so the final split never had a chance to absorb anything and can
-        # still be below min_length. Merge it into its predecessor instead, subject to the same max_length limit
-        # that governs forward merges.
+        # The loop only merges forward, so the final split can still be below min_length. Merge it backwards,
+        # subject to the same max_length limit as forward merges.
         if (
             len(merged) > 1
             and len(merged[-1]) < self.min_length

--- a/releasenotes/notes/merge-short-trailing-split-8f5b640fdbc3ccbe.yaml
+++ b/releasenotes/notes/merge-short-trailing-split-8f5b640fdbc3ccbe.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixed `EmbeddingBasedDocumentSplitter` emitting a final split shorter than `min_length`. Small splits were
-    only merged forward, so the last one had nothing left to absorb and was returned as its own document. It is
-    now merged into the preceding split, unless doing so would reach `max_length` — the same limit that already
-    governs forward merges.
+    Fixed ``EmbeddingBasedDocumentSplitter`` emitting a final split shorter than ``min_length``. Small splits
+    were only merged forward, so the last one had nothing left to absorb and was returned as its own document.
+    It is now merged into the preceding split, unless doing so would reach ``max_length``, the same limit that
+    already governs forward merges.

--- a/releasenotes/notes/merge-short-trailing-split-8f5b640fdbc3ccbe.yaml
+++ b/releasenotes/notes/merge-short-trailing-split-8f5b640fdbc3ccbe.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed `EmbeddingBasedDocumentSplitter` emitting a final split shorter than `min_length`. Small splits were
+    only merged forward, so the last one had nothing left to absorb and was returned as its own document. It is
+    now merged into the preceding split, unless doing so would reach `max_length` — the same limit that already
+    governs forward merges.

--- a/test/components/preprocessors/test_embedding_based_document_splitter.py
+++ b/test/components/preprocessors/test_embedding_based_document_splitter.py
@@ -215,6 +215,36 @@ class TestEmbeddingBasedDocumentSplitter:
         # Second split is merged with third split to get above min_length and still beneath max_length
         assert merged[1] == "1234567891234"
 
+    def test_merge_small_splits_merges_short_trailing_split(self):
+        mock_embedder = Mock()
+        splitter = EmbeddingBasedDocumentSplitter(document_embedder=mock_embedder, min_length=10)
+
+        # The loop only merges forward, so the final accumulator has nothing left to absorb.
+        splits = ["Long enough text ", "Ok."]
+        merged = splitter._merge_small_splits(splits=splits)
+
+        assert merged == ["Long enough text Ok."]
+
+    def test_merge_small_splits_keeps_short_trailing_split_when_max_length_blocks(self):
+        mock_embedder = Mock()
+        splitter = EmbeddingBasedDocumentSplitter(document_embedder=mock_embedder, min_length=10, max_length=15)
+
+        # Merging backwards would reach max_length, so the short tail stays on its own,
+        # matching how a blocked forward merge already behaves.
+        splits = ["123456789012", "1234"]
+        merged = splitter._merge_small_splits(splits=splits)
+
+        assert merged == ["123456789012", "1234"]
+
+    def test_merge_small_splits_keeps_a_lone_short_split(self):
+        mock_embedder = Mock()
+        splitter = EmbeddingBasedDocumentSplitter(document_embedder=mock_embedder, min_length=10)
+
+        # Nothing to merge into.
+        merged = splitter._merge_small_splits(splits=["Ok."])
+
+        assert merged == ["Ok."]
+
     def test_create_documents_from_splits(self):
         mock_embedder = Mock()
         splitter = EmbeddingBasedDocumentSplitter(document_embedder=mock_embedder)


### PR DESCRIPTION
### Related Issues

- fixes #12436

### Proposed Changes:

`_merge_small_splits` only merges *forward*: it keeps a running accumulator and folds the next split into it while the accumulator is below `min_length`. Whatever is left in that accumulator when the loop ends is appended unconditionally, so a final split shorter than `min_length` is emitted as its own document — silently breaking the documented promise that *"splits below this length will be merged"*. This is common in practice: a closing line, a signature, a table footer.

The trailing split is now merged into its predecessor instead. The merge is guarded by the same `max_length` limit that already governs forward merges, so the existing tradeoff is preserved: when a merge would reach `max_length` the short split is left alone, exactly as `test_merge_small_splits_respect_max_length` already documents for a blocked forward merge. Because the guard is strictly `< max_length`, the merged result can never become something `_split_large_splits` has to re-split.

Both `_split_document` and `_split_document_async` go through this helper, so both paths are covered.

### How did you test it?

Three unit tests in `test_embedding_based_document_splitter.py`:

- `test_merge_small_splits_merges_short_trailing_split` — the regression. Fails on `main` (returns `["Long enough text ", "Ok."]`), passes with this change.
- `test_merge_small_splits_keeps_short_trailing_split_when_max_length_blocks` — the backward merge must not override `max_length`.
- `test_merge_small_splits_keeps_a_lone_short_split` — a single split has nothing to merge into and must be returned as is.

Locally: `hatch run test:unit test/components/preprocessors/` → 361 passed; `hatch run test:types` → no issues in 447 source files; `hatch run fmt-check` on both changed files → clean.

### Notes for the reviewer

The behaviour when a merge is blocked by `max_length` is deliberately unchanged — `min_length` stays best-effort in that case, matching the existing forward-merge behaviour rather than introducing a second rule.

One overlap to flag: #12434 also touches this file, but in `_find_split_points` (~line 376) and its tests, roughly 50 lines away from `_merge_small_splits`. I don't expect a conflict; happy to rebase if that one lands first.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
