### PR TITLE
fix: recursive_splitter validation message and docstring accuracy

### DIFF
--- a/haystack/components/joiners/answer_joiner.py
+++ b/haystack/components/joiners/answer_joiner.py
@@ -96,8 +96,8 @@ class AnswerJoiner:
         :param top_k:
             The maximum number of Answers to return. Must be `None` or greater than 0.
         :param sort_by_score:
-            If `True`, sorts the documents by score in descending order.
-            If a document has no score, it is handled as if its score is -infinity.
+            If `True`, sorts the answers by score in descending order.
+            If an answer has no score, it is handled as if its score is -infinity.
 
         :raises ValueError:
             If `top_k` is not `None` and is less than or equal to 0.
@@ -154,7 +154,7 @@ class AnswerJoiner:
 
     def _concatenate(self, answer_lists: list[list[AnswerType]]) -> list[AnswerType]:
         """
-        Concatenate multiple lists of Answers, flattening them into a single list and sorting by score.
+        Concatenate multiple lists of Answers, flattening them into a single list.
 
         :param answer_lists: List of lists of Answers to be flattened.
         """

--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -70,7 +70,8 @@ class RecursiveDocumentSplitter:
 
         :param split_length: The maximum length of each chunk by default in words, but can be in characters or tokens.
             See the `split_units` parameter.
-        :param split_overlap: The number of overlapping units (words, characters, or tokens, per `split_unit`) between consecutive chunks.
+        :param split_overlap: The number of overlapping units (words, characters, or tokens, per
+            `split_unit`) between consecutive chunks.
         :param split_unit: The unit of the split_length parameter. It can be either "word", "char", or "token".
             If "token" is selected, the text will be split into tokens using the tiktoken tokenizer (o200k_base).
         :param separators: An optional list of separator strings to use for splitting the text. The string

--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -70,7 +70,7 @@ class RecursiveDocumentSplitter:
 
         :param split_length: The maximum length of each chunk by default in words, but can be in characters or tokens.
             See the `split_units` parameter.
-        :param split_overlap: The number of characters to overlap between consecutive chunks.
+        :param split_overlap: The number of overlapping units (words, characters, or tokens, per `split_unit`) between consecutive chunks.
         :param split_unit: The unit of the split_length parameter. It can be either "word", "char", or "token".
             If "token" is selected, the text will be split into tokens using the tiktoken tokenizer (o200k_base).
         :param separators: An optional list of separator strings to use for splitting the text. The string
@@ -113,7 +113,7 @@ class RecursiveDocumentSplitter:
         if self.split_length < 1:
             raise ValueError("Split length must be at least 1 character.")
         if self.split_overlap < 0:
-            raise ValueError("Overlap must be greater than zero.")
+            raise ValueError("split_overlap must be greater than or equal to 0.")
         if self.split_overlap >= self.split_length:
             raise ValueError("Overlap cannot be greater than or equal to the chunk size.")
         if not all(isinstance(separator, str) for separator in self.separators):

--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -195,7 +195,7 @@ class MetaFieldRanker:
         :param ranking_mode:
             (optional) The mode used to combine the Retriever's and Ranker's scores.
             Possible values are 'reciprocal_rank_fusion' (default) and 'linear_score'.
-            Use the 'score' mode only with Retrievers or Rankers that return a score in range [0,1].
+            Use the 'linear_score' mode only with Retrievers or Rankers that return a score in range [0,1].
             If not provided, the ranking_mode provided at initialization time is used.
         :param sort_order:
             Whether to sort the meta field by ascending or descending order.

--- a/releasenotes/notes/fix-splitter-message-docstrings-490155c7796d449f.yaml
+++ b/releasenotes/notes/fix-splitter-message-docstrings-490155c7796d449f.yaml
@@ -1,7 +1,7 @@
 fixes:
   - |
-    Correct the `split_overlap` validation message in `RecursiveDocumentSplitter` (0 is the
+    Correct the ``split_overlap`` validation message in ``RecursiveDocumentSplitter`` (0 is the
     default and only negative values are rejected) and clarify that overlap is measured in
-    `split_units`. Also fix stale docstrings in `AnswerJoiner` (documented parameters the
+    ``split_units``. Also fix stale docstrings in ``AnswerJoiner`` (documented parameters the
     methods do not take, and claimed sorting that only happens for answers) and the
-    `meta_field` ranker (referenced a nonexistent `score` mode).
+    ``meta_field`` ranker (referenced a nonexistent ``score`` mode).

--- a/releasenotes/notes/fix-splitter-message-docstrings-490155c7796d449f.yaml
+++ b/releasenotes/notes/fix-splitter-message-docstrings-490155c7796d449f.yaml
@@ -1,0 +1,7 @@
+fixes:
+  - |
+    Correct the `split_overlap` validation message in `RecursiveDocumentSplitter` (0 is the
+    default and only negative values are rejected) and clarify that overlap is measured in
+    `split_units`. Also fix stale docstrings in `AnswerJoiner` (documented parameters the
+    methods do not take, and claimed sorting that only happens for answers) and the
+    `meta_field` ranker (referenced a nonexistent `score` mode).


### PR DESCRIPTION
## Summary
All verified at HEAD:

- **`recursive_splitter`**: the validation only rejects *negative* `split_overlap` (0 is the default), but the error message said "Overlap must be greater than zero-️ — `document_splitter` and `hierarchical_document_splitter` already word this identical check as "must be greater than or equal to 0". Also, `split_overlap` is measured in `split_units` (word/char/token), not always characters — `_get_overlap()` slices by unit and `_run_one()` even carries the comment 'split_overlap is in split_units, not chars'.
- **`answer_joiner`**: `sort_by_score` docstring said 'documents' (verbatim copy-paste from `DocumentJoiner`); it sorts answers. `_concatenate` docstring claimed it "sorts by score-️ but it only flattens (sorting happens in `run()` and only when `sort_by_score=True`).
- **`meta_field` ranker**: `run()` docstring referenced a nonexistent `'score'` mode; valid values are `reciprocal_rank_fusion` and `linear_score` (the `__init__` docstring for the same parameter already says `linear_score`).