### PR TITLE
test: enable mypy typing checks for test/components/evaluators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ all = 'pytest {args:test}'
 e2e = 'pytest {args:e2e}'
 
 # TODO We want to eventually type the whole test folder
-types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/fuzz/ test/skill_stores/ test/token_counters/ test/components/agents/test_state_class.py test/components/caching/ test/components/converters/test_utils.py test/components/embedders/ test/components/generators/ test/components/joiners/ test/components/query/ test/components/rankers/ test/components/routers/ test/components/validators/ test/components/writers/}"
+types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/fuzz/ test/skill_stores/ test/token_counters/ test/components/agents/test_state_class.py test/components/caching/ test/components/converters/test_utils.py test/components/embedders/ test/components/evaluators/ test/components/generators/ test/components/joiners/ test/components/query/ test/components/rankers/ test/components/routers/ test/components/validators/ test/components/writers/}"
 
 [project.urls]
 "CI: GitHub" = "https://github.com/deepset-ai/haystack/actions"

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -55,7 +55,7 @@ class TestContextRelevanceEvaluator:
         assert component._chat_generator.api_key.resolve_value() == "test-api-key"
         assert component._chat_generator.generation_kwargs == {"response_format": {"type": "json_object"}, "seed": 42}
 
-        assert set(component.__haystack_output__._sockets_dict) == {"score", "individual_scores", "results", "meta"}
+        assert set(component.__haystack_output__._sockets_dict) == {"score", "individual_scores", "results", "meta"}  # type: ignore[attr-defined]
 
     def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/test/components/evaluators/test_document_ndcg.py
+++ b/test/components/evaluators/test_document_ndcg.py
@@ -170,7 +170,7 @@ def test_calculate_dcg_without_scores():
 def test_calculate_dcg_empty():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [Document(content="doc1")]
-    ret_docs = []
+    ret_docs: list[Document] = []
     dcg = evaluator.calculate_dcg(gt_docs, ret_docs)
     assert dcg == 0
 
@@ -198,7 +198,7 @@ def test_calculate_idcg_without_scores():
 
 def test_calculate_idcg_empty():
     evaluator = DocumentNDCGEvaluator()
-    gt_docs = []
+    gt_docs: list[Document] = []
     idcg = evaluator.calculate_idcg(gt_docs)
     assert idcg == 0
 

--- a/test/components/evaluators/test_document_recall.py
+++ b/test/components/evaluators/test_document_recall.py
@@ -153,14 +153,14 @@ class TestDocumentRecallEvaluatorSingleHit:
         assert new_evaluator.mode == RecallMode.SINGLE_HIT
 
     def test_empty_ground_truth_documents(self, evaluator):
-        ground_truth_documents = [[]]
+        ground_truth_documents: list[list[Document]] = [[]]
         retrieved_documents = [[Document(content="test")]]
         score = evaluator.run(ground_truth_documents, retrieved_documents)
         assert score == {"individual_scores": [0.0], "score": 0.0}
 
     def test_empty_retrieved_documents(self, evaluator):
         ground_truth_documents = [[Document(content="test")]]
-        retrieved_documents = [[]]
+        retrieved_documents: list[list[Document]] = [[]]
         score = evaluator.run(ground_truth_documents, retrieved_documents)
         assert score == {"individual_scores": [0.0], "score": 0.0}
 
@@ -283,14 +283,14 @@ class TestDocumentRecallEvaluatorMultiHit:
         assert new_evaluator.mode == RecallMode.MULTI_HIT
 
     def test_empty_ground_truth_documents(self, evaluator):
-        ground_truth_documents = [[]]
+        ground_truth_documents: list[list[Document]] = [[]]
         retrieved_documents = [[Document(content="test")]]
         score = evaluator.run(ground_truth_documents, retrieved_documents)
         assert score == {"individual_scores": [0.0], "score": 0.0}
 
     def test_empty_retrieved_documents(self, evaluator):
         ground_truth_documents = [[Document(content="test")]]
-        retrieved_documents = [[]]
+        retrieved_documents: list[list[Document]] = [[]]
         score = evaluator.run(ground_truth_documents, retrieved_documents)
         assert score == {"individual_scores": [0.0], "score": 0.0}
 

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -70,7 +70,7 @@ class TestFaithfulnessEvaluator:
         assert component._chat_generator.api_key.resolve_value() == "test-api-key"
         assert component._chat_generator.generation_kwargs == {"response_format": {"type": "json_object"}, "seed": 42}
 
-        assert set(component.__haystack_output__._sockets_dict) == {"score", "individual_scores", "results", "meta"}
+        assert set(component.__haystack_output__._sockets_dict) == {"score", "individual_scores", "results", "meta"}  # type: ignore[attr-defined]
 
     def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -34,7 +34,7 @@ class TestLLMEvaluator:
         assert isinstance(component._chat_generator, OpenAIChatGenerator)
         assert component._chat_generator.generation_kwargs == {"response_format": {"type": "json_object"}, "seed": 42}
 
-        assert set(component.__haystack_output__._sockets_dict) == {"results", "meta"}
+        assert set(component.__haystack_output__._sockets_dict) == {"results", "meta"}  # type: ignore[attr-defined]
 
     def test_key_resolved_at_warm_up_not_init(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -71,7 +71,7 @@ class TestLLMEvaluator:
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs={("predicted_answers", list[str])},
+                inputs={("predicted_answers", list[str])},  # type: ignore[arg-type]
                 outputs=["score"],
                 examples=[
                     {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
@@ -80,7 +80,7 @@ class TestLLMEvaluator:
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs=[(list[str], "predicted_answers")],
+                inputs=[(list[str], "predicted_answers")],  # type: ignore[list-item]
                 outputs=["score"],
                 examples=[
                     {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
@@ -89,7 +89,7 @@ class TestLLMEvaluator:
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs=[list[str]],
+                inputs=[list[str]],  # type: ignore[list-item]
                 outputs=["score"],
                 examples=[
                     {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
@@ -98,7 +98,7 @@ class TestLLMEvaluator:
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs={("predicted_answers", str)},
+                inputs={("predicted_answers", str)},  # type: ignore[arg-type]
                 outputs=["score"],
                 examples=[
                     {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
@@ -110,7 +110,7 @@ class TestLLMEvaluator:
             LLMEvaluator(
                 instructions="test-instruction",
                 inputs=[("predicted_answers", list[str])],
-                outputs="score",
+                outputs="score",  # type: ignore[arg-type]
                 examples=[
                     {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
                 ],
@@ -119,7 +119,7 @@ class TestLLMEvaluator:
             LLMEvaluator(
                 instructions="test-instruction",
                 inputs=[("predicted_answers", list[str])],
-                outputs=[["score"]],
+                outputs=[["score"]],  # type: ignore[list-item]
                 examples=[
                     {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
                 ],
@@ -131,7 +131,7 @@ class TestLLMEvaluator:
                 instructions="test-instruction",
                 inputs=[("predicted_answers", list[str])],
                 outputs=["score"],
-                examples={
+                examples={  # type: ignore[arg-type]
                     "inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"},
                     "outputs": {"custom_score": 1},
                 },
@@ -142,7 +142,7 @@ class TestLLMEvaluator:
                 inputs=[("predicted_answers", list[str])],
                 outputs=["score"],
                 examples=[
-                    [
+                    [  # type: ignore[list-item]
                         {
                             "inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"},
                             "outputs": {"custom_score": 1},

--- a/test/components/evaluators/test_sas_evaluator.py
+++ b/test/components/evaluators/test_sas_evaluator.py
@@ -50,6 +50,7 @@ class TestSASEvaluator:
 
         assert evaluator._model == "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
         assert evaluator._batch_size == 32
+        assert evaluator._device is not None
         assert evaluator._device.to_torch_str() == "cuda:0"
         assert evaluator._token.resolve_value() == "fake-token"
 
@@ -87,7 +88,7 @@ class TestSASEvaluator:
             "The Meiji Restoration in 1868 transformed Japan into a modernized world power.",
         ]
         with pytest.raises(ValueError):
-            evaluator.run(ground_truth_answers=ground_truths, predicted_answers=predictions)
+            evaluator.run(ground_truth_answers=ground_truths, predicted_answers=predictions)  # type: ignore[arg-type]
 
     @pytest.mark.integration
     @pytest.mark.slow


### PR DESCRIPTION
### Related Issues

- part of #10396

### Proposed Changes:

`test/components/evaluators/` is not in the repository mypy target, so its ten test modules are not checked by `hatch run test:types`. This is the next disjoint increment for #10396, claimed in [this comment](https://github.com/deepset-ai/haystack/issues/10396#issuecomment-5386122201). It does not overlap the increments in flight: #12435 has `fetchers/`, #12343 has `extractors/`, #12433 has `samplers/`.

The baseline was 19 errors across 5 modules. Nothing here changes what a test asserts:

- **6 `var-annotated`** — empty list literals in `test_document_recall.py` and `test_document_ndcg.py` that mypy cannot infer an element type for. Annotated as `list[list[Document]]` / `list[Document]`.
- **8 `arg-type` / `list-item`** in `test_llm_evaluator.py` — all inside `pytest.raises(ValueError)` blocks under an existing `# Invalid inputs` comment, so the wrong types are the point of the test. Narrow `# type: ignore[...]` comments, same approach as the already-merged #12394.
- **1 `arg-type`** in `test_sas_evaluator.py` — `predictions` deliberately contains `None` to assert `run()` rejects it. Same treatment.
- **1 `union-attr`** in `test_sas_evaluator.py` — `_device` is `ComponentDevice | None` and the test reads `to_torch_str()`. `from_dict` always sets it on that path, so this is narrowed with an `assert` rather than silenced.
- **3 `attr-defined`** on `__haystack_output__`, which the `@component` decorator attaches at runtime. Ignored the same way the production code reads it in `core/pipeline/base.py`.

Per AGENTS.md I kept `type: ignore` to the cases where it is necessary; each one sits on a call whose whole purpose is to pass a value the annotation rejects.

### How did you test it?

Red/green against the repository configuration:

- Before: `mypy test/components/evaluators/` reported 19 errors in 5 files.
- After: `Success: no issues found in 10 source files`.
- Full target: `hatch run test:types` -> `Success: no issues found in 457 source files` (up from 447, the 10 newly covered modules).
- `hatch run test:unit test/components/evaluators/` -> 158 passed, 6 deselected.
- `hatch run fmt-check test/components/evaluators/` -> clean.

### Notes for the reviewer

The only line that changes behaviour at runtime is the added `assert evaluator._device is not None` in `test_sas_evaluator.py`, which is a type narrowing that also documents the invariant that test already relies on. Every other change is an annotation or a trailing comment; the assertions themselves are untouched.

No release note: this is test-only, which AGENTS.md excludes from the release-note requirement.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- [x] I have documented my code.
- [ ] I have added a release note file - not needed here: AGENTS.md scopes the requirement to user-facing changes, and this is test-only.
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

