### PR TITLE
fix: validate max_runs_per_component on pipeline deserialization

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -74,7 +74,26 @@ _COMPONENT_INPUT = "haystack.component.input"
 _COMPONENT_OUTPUT = "haystack.component.output"
 _COMPONENT_VISITS = "haystack.component.visits"
 
+# Hard upper bound for `max_runs_per_component`: this protects the loop-detection mechanism from serialized
+# pipelines that set an arbitrarily large value to effectively disable it.
+MAX_RUNS_PER_COMPONENT_LIMIT = 1_000_000
+
 InputsType = dict[str, dict[str, list[dict[str, Any]]]]
+
+
+def _validate_max_runs_per_component(value: Any) -> None:
+    """
+    Validates a `max_runs_per_component` value.
+
+    :param value: The value to validate.
+    :raises ValueError: If the value is not an integer, is not positive, or exceeds
+        `MAX_RUNS_PER_COMPONENT_LIMIT`.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or not 0 < value <= MAX_RUNS_PER_COMPONENT_LIMIT:
+        raise ValueError(
+            f"'max_runs_per_component' must be an integer in the range (0, {MAX_RUNS_PER_COMPONENT_LIMIT}], "
+            f"got {value!r}"
+        )
 
 
 class ComponentPriority(IntEnum):
@@ -107,9 +126,12 @@ class PipelineBase:  # noqa: PLW1641
             How many times the `Pipeline` can run the same Component.
             If this limit is reached a `PipelineMaxComponentRuns` exception is raised.
             If not set defaults to 100 runs per Component.
+            Must be a positive integer no greater than `MAX_RUNS_PER_COMPONENT_LIMIT`.
         :param connection_type_validation: Whether the pipeline will validate the types of the connections.
             Defaults to True.
+        :raises ValueError: If `max_runs_per_component` is not a positive integer within the allowed range.
         """
+        _validate_max_runs_per_component(max_runs_per_component)
         self._telemetry_runs = 0
         self._last_telemetry_sent: datetime | None = None
         self.metadata = metadata or {}
@@ -219,6 +241,10 @@ class PipelineBase:  # noqa: PLW1641
         data_copy = _deepcopy_with_exceptions(data)  # to prevent modification of original data
         metadata = data_copy.get("metadata", {})
         max_runs_per_component = data_copy.get("max_runs_per_component", 100)
+        try:
+            _validate_max_runs_per_component(max_runs_per_component)
+        except ValueError as e:
+            raise DeserializationError(f"Invalid 'max_runs_per_component' value in the serialized pipeline: {e}") from e
         connection_type_validation = data_copy.get("connection_type_validation", True)
         pipe = cls(
             metadata=metadata,

--- a/releasenotes/notes/validate-max-runs-per-component-on-deserialization-33c72dbe6c5c3d6f.yaml
+++ b/releasenotes/notes/validate-max-runs-per-component-on-deserialization-33c72dbe6c5c3d6f.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    ``Pipeline`` deserialization now validates ``max_runs_per_component``: it must be a positive integer no
+    greater than 1000000. A maliciously crafted serialized pipeline can no longer effectively disable the
+    pipeline's loop protection by setting an arbitrarily large value. The ``Pipeline`` constructor applies the
+    same validation and raises a ``ValueError`` for out-of-range values.

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -21,7 +21,7 @@ from haystack.core.errors import (
     PipelineRuntimeError,
 )
 from haystack.core.pipeline import Pipeline
-from haystack.core.pipeline.base import ComponentPriority, PipelineBase
+from haystack.core.pipeline.base import MAX_RUNS_PER_COMPONENT_LIMIT, ComponentPriority, PipelineBase
 from haystack.core.pipeline.component_checks import _NoOutputProduced
 from haystack.core.pipeline.utils import FIFOPriorityQueue
 from haystack.core.serialization import DeserializationCallbacks
@@ -637,6 +637,20 @@ class TestPipelineBase:
             ],
         }
         assert res == expected
+
+    def test_init_valid_max_runs_per_component(self):
+        # the default, ordinary values and the hard limit are all accepted
+        assert PipelineBase()._max_runs_per_component == 100
+        assert PipelineBase(max_runs_per_component=1)._max_runs_per_component == 1
+        assert PipelineBase(max_runs_per_component=42)._max_runs_per_component == 42
+        assert PipelineBase(max_runs_per_component=MAX_RUNS_PER_COMPONENT_LIMIT)._max_runs_per_component == (
+            MAX_RUNS_PER_COMPONENT_LIMIT
+        )
+
+    @pytest.mark.parametrize("invalid_value", [0, -1, 10**9, 1.5, "100", None, True])
+    def test_init_rejects_invalid_max_runs_per_component(self, invalid_value):
+        with pytest.raises(ValueError, match="'max_runs_per_component' must be an integer"):
+            PipelineBase(max_runs_per_component=invalid_value)
 
     def test_describe_input_only_no_inputs_components(self):
         A = component_class("A", input_types={}, output={"x": 0})
@@ -1780,6 +1794,24 @@ class TestPipelineBaseFromDict:
                 "mandatory": True,
             },
         )
+
+    def test_from_dict_accepts_valid_max_runs_per_component(self):
+        # regular values and the hard limit are accepted; the value is not modified
+        for valid_value in [1, 100, 10_000, MAX_RUNS_PER_COMPONENT_LIMIT]:
+            data = {"metadata": {}, "max_runs_per_component": valid_value, "components": {}, "connections": []}
+            pipe = PipelineBase.from_dict(data)
+            assert pipe._max_runs_per_component == valid_value
+
+        # the default applies when the value is absent
+        pipe = PipelineBase.from_dict({"metadata": {}, "components": {}, "connections": []})
+        assert pipe._max_runs_per_component == 100
+
+    @pytest.mark.parametrize("malicious_value", [0, -1, 999_999_999, 10**12, 1.5, "100", None, True])
+    def test_from_dict_rejects_invalid_max_runs_per_component(self, malicious_value):
+        """A serialized pipeline cannot disable the loop protection with an out-of-range value."""
+        data = {"metadata": {}, "max_runs_per_component": malicious_value, "components": {}, "connections": []}
+        with pytest.raises(DeserializationError, match="'max_runs_per_component' must be an integer"):
+            PipelineBase.from_dict(data)
 
     # TODO: Remove this, this should be a component test.
     # The pipeline can't handle this in any case nor way.


### PR DESCRIPTION
Untrusted serialized pipelines could set an arbitrarily large
max_runs_per_component (for example 999999999) to effectively disable the
pipeline loop protection. Validate the value both in the PipelineBase
constructor (ValueError) and during from_dict (DeserializationError,
consistent with other deserialization failures): it must be a positive
integer no greater than a hard limit of 1000000.