### PR TITLE
docs: update `pip install` instructions to use `weave-haystack` package instead of `weights_biases-haystack`

### DIFF
--- a/docs-website/versioned_docs/version-2.18/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.18/development/tracing.mdx
@@ -137,7 +137,7 @@ Check out the component's [documentation page](../pipeline-components/connectors
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::note
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.18/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.18/pipeline-components/connectors/weaveconnector.mdx
@@ -35,10 +35,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.19/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.19/development/tracing.mdx
@@ -137,7 +137,7 @@ Check out the component's [documentation page](../pipeline-components/connectors
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::note
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.19/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.19/pipeline-components/connectors/weaveconnector.mdx
@@ -39,10 +39,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.20/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.20/development/tracing.mdx
@@ -135,7 +135,7 @@ Check out the component's [documentation page](../pipeline-components/connectors
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::info
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.20/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.20/pipeline-components/connectors/weaveconnector.mdx
@@ -39,10 +39,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.21/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.21/development/tracing.mdx
@@ -135,7 +135,7 @@ Check out the component's [documentation page](../pipeline-components/connectors
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::info
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.21/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.21/pipeline-components/connectors/weaveconnector.mdx
@@ -39,10 +39,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.22/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.22/development/tracing.mdx
@@ -135,7 +135,7 @@ Check out the component's [documentation page](../pipeline-components/connectors
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::info
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.22/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.22/pipeline-components/connectors/weaveconnector.mdx
@@ -39,10 +39,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.23/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.23/development/tracing.mdx
@@ -135,7 +135,7 @@ Check out the component's [documentation page](../pipeline-components/connectors
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::info
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.23/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.23/pipeline-components/connectors/weaveconnector.mdx
@@ -39,10 +39,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.24/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.24/development/tracing.mdx
@@ -135,7 +135,7 @@ Check out the component's [documentation page](../pipeline-components/connectors
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::info
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.24/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.24/pipeline-components/connectors/weaveconnector.mdx
@@ -39,10 +39,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.25/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.25/development/tracing.mdx
@@ -157,7 +157,7 @@ Check out the [MLflow Haystack integration guide](https://haystack.deepset.ai/in
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::info
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.25/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.25/pipeline-components/connectors/weaveconnector.mdx
@@ -39,10 +39,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.26/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.26/development/tracing.mdx
@@ -157,7 +157,7 @@ Check out the [MLflow Haystack integration guide](https://haystack.deepset.ai/in
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::info
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.26/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.26/pipeline-components/connectors/weaveconnector.mdx
@@ -39,10 +39,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.27/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.27/development/tracing.mdx
@@ -157,7 +157,7 @@ Check out the [MLflow Haystack integration guide](https://haystack.deepset.ai/in
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::info
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.27/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.27/pipeline-components/connectors/weaveconnector.mdx
@@ -39,10 +39,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.28/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.28/development/tracing.mdx
@@ -157,7 +157,7 @@ Check out the [MLflow Haystack integration guide](https://haystack.deepset.ai/in
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::info
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.28/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.28/pipeline-components/connectors/weaveconnector.mdx
@@ -39,10 +39,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.29/development/tracing.mdx
+++ b/docs-website/versioned_docs/version-2.29/development/tracing.mdx
@@ -157,7 +157,7 @@ Check out the [MLflow Haystack integration guide](https://haystack.deepset.ai/in
 
 The `WeaveConnector` component allows you to trace and visualize your pipeline execution in [Weights & Biases](https://wandb.ai/site/) framework.
 
-You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weights_biases-haystack`.
+You will first need to create a free account on Weights & Biases website and get your API key, as well as install the integration with `pip install weave-haystack`.
 
 :::info
 Check out the component's [documentation page](../pipeline-components/connectors/weaveconnector.mdx) for more details and example usage.

--- a/docs-website/versioned_docs/version-2.29/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.29/pipeline-components/connectors/weaveconnector.mdx
@@ -40,10 +40,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.30/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.30/pipeline-components/connectors/weaveconnector.mdx
@@ -40,10 +40,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:

--- a/docs-website/versioned_docs/version-2.31/pipeline-components/connectors/weaveconnector.mdx
+++ b/docs-website/versioned_docs/version-2.31/pipeline-components/connectors/weaveconnector.mdx
@@ -40,10 +40,10 @@ You will also need to set the `HAYSTACK_CONTENT_TRACING_ENABLED` environment var
 
 ## Usage
 
-First, install the `weights_biases-haystack` package to use this connector:
+First, install the `weave-haystack` package to use this connector:
 
 ```shell
-pip install weights_biases-haystack
+pip install weave-haystack
 ```
 
 Then, add it to your pipeline without any connections, and it will automatically start sending traces to Weights & Biases:


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/554

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR updates mentions of `weights_biases-haystack` (which doesn't exist) in our documentation to `weave-haystack`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
