### PR TITLE
test: cover empty tool results

### DIFF
--- a/test/components/agents/test_tool_calling.py
+++ b/test/components/agents/test_tool_calling.py
@@ -411,6 +411,50 @@ class TestRunTool:
         assert tool_call_result.result == '{"weather": "mostly sunny", "temperature": 7, "unit": "celsius"}'
         assert tool_call_result.origin == tool_call
 
+    @pytest.mark.parametrize(("empty_result", "serialized_result"), [("", ""), ([], "[]"), ({}, "{}")])
+    def test_run_with_empty_tool_result(self, empty_result, serialized_result):
+        empty_tool = Tool(
+            name="empty_tool",
+            description="Returns an empty result.",
+            parameters={"type": "object", "properties": {}},
+            function=lambda: empty_result,
+        )
+        tool_call = ToolCall(id="empty-call", tool_name="empty_tool", arguments={})
+
+        tool_messages, _ = _run_tool(
+            messages=[ChatMessage.from_assistant(tool_calls=[tool_call])], state=State(schema={}), tools=[empty_tool]
+        )
+
+        tool_call_result = tool_messages[0].tool_call_result
+        assert tool_call_result is not None
+        assert tool_call_result.result == serialized_result
+        assert not tool_call_result.error
+        assert tool_call_result.origin == tool_call
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("empty_result", "serialized_result"), [("", ""), ([], "[]"), ({}, "{}")])
+    async def test_run_async_with_empty_tool_result(self, empty_result, serialized_result):
+        async def return_empty_result():
+            return empty_result
+
+        empty_tool = Tool(
+            name="empty_tool",
+            description="Returns an empty result.",
+            parameters={"type": "object", "properties": {}},
+            async_function=return_empty_result,
+        )
+        tool_call = ToolCall(id="empty-call", tool_name="empty_tool", arguments={})
+
+        tool_messages, _ = await _run_tool_async(
+            messages=[ChatMessage.from_assistant(tool_calls=[tool_call])], state=State(schema={}), tools=[empty_tool]
+        )
+
+        tool_call_result = tool_messages[0].tool_call_result
+        assert tool_call_result is not None
+        assert tool_call_result.result == serialized_result
+        assert not tool_call_result.error
+        assert tool_call_result.origin == tool_call
+
     def test_parallel_tool_calling_with_state_updates(self):
         """Test that parallel tool execution with state updates works correctly with the state lock."""
         execution_log = []


### PR DESCRIPTION
### Related Issues

- Fixes deepset-ai/haystack#12455

### Proposed Changes:

Add parameterized regression coverage for tools that successfully return an empty string, list, or dictionary. The tests exercise both synchronous and asynchronous invocation and verify serialization, success status, and tool-call correlation.

### How did you test it?

- `hatch run test:unit test/components/agents/test_tool_calling.py -q` — 71 passed
- `hatch run pre-commit run --files test/components/agents/test_tool_calling.py` — all hooks passed
- `hatch run fmt test/components/agents/test_tool_calling.py` — passed, unchanged

### Notes for the reviewer

This is test-only regression coverage; runtime behavior is unchanged.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes through this linked PR.
- I have added unit tests; docstring updates are N/A because no production API changed.
- I've used the `test:` [conventional commit type](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- Documentation is N/A because this PR changes regression tests only.
- A release note is N/A because this test-only PR has no user-facing change.
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and all applicable hooks passed.
