### PR TITLE
feat: more robust check for finish reason in `OpenAIResponsesChatGenerator`

### DIFF
--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -917,11 +917,19 @@ def _convert_streaming_chunks_to_chat_message(chunks: list[StreamingChunk]) -> C
                 _arguments=tool_call_dict["arguments"],
             )
 
-    # We dump the entire final response into meta to be consistent with non-streaming response
-    final_response = chunks[-1].meta.get("response") or {}
+    # We dump the entire final response into meta to be consistent with non-streaming response. The event carrying
+    # the final response (and its usage data) is not guaranteed to be the last event in the stream, so scan for it.
+    responses = [chunk.meta["response"] for chunk in chunks if chunk.meta.get("response")]
+    response_with_usage = next(
+        (response for response in reversed(responses) if response.get("usage") is not None), None
+    )
+    final_response = (response_with_usage or responses[-1]).copy() if responses else {}
     final_response.pop("output", None)
-    if chunks[-1].finish_reason is not None:
-        final_response["finish_reason"] = chunks[-1].finish_reason
+
+    # finish_reason can appear in different places so we look for the last one
+    finish_reasons = [chunk.finish_reason for chunk in chunks if chunk.finish_reason]
+    if finish_reasons:
+        final_response["finish_reason"] = finish_reasons[-1]
     if logprobs:
         final_response["logprobs"] = logprobs
 

--- a/releasenotes/notes/preserve-openai-responses-stream-metadata-6e67c3ba6c6a1f77.yaml
+++ b/releasenotes/notes/preserve-openai-responses-stream-metadata-6e67c3ba6c6a1f77.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Preserve finish reasons and usage metadata when an OpenAI Responses API stream emits events after the completed
+    response event.

--- a/test/components/generators/chat/test_openai_responses_conversion.py
+++ b/test/components/generators/chat/test_openai_responses_conversion.py
@@ -246,6 +246,33 @@ class TestConversionToStreamingChunks:
         message = _convert_streaming_chunks_to_chat_message([chunk])
         assert message.meta["finish_reason"] == finish_reason
 
+    def test_convert_streaming_chunks_scans_for_final_response_and_finish_reason(self) -> None:
+        chunks = [
+            StreamingChunk(content="Hello", meta={"received_at": ANY}),
+            StreamingChunk(
+                content="",
+                finish_reason="stop",
+                meta={
+                    "response": {
+                        "id": "resp_123",
+                        "output": [],
+                        "usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                    },
+                    "received_at": ANY,
+                },
+            ),
+            StreamingChunk(content="", meta={"type": "trailing.event", "received_at": ANY}),
+        ]
+
+        message = _convert_streaming_chunks_to_chat_message(chunks)
+
+        assert message.text == "Hello"
+        assert message.meta == {
+            "id": "resp_123",
+            "usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+            "finish_reason": "stop",
+        }
+
     def test_convert_streaming_chunks_to_chat_message_with_tool_call_empty_reasoning(
         self, openai_responses_streaming_chunks_with_tool_call: MagicMock
     ) -> None:


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Like in OpenAIChatGenerator we scan the streaming chunks backwards to look for the last chunk that has a finish reason and usage attached to it instead of assuming its always the last one. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added new test.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

Not sure how often this happens in practice, but we have observed it before with the chat completions API so we should bring the same logic over here to keep the responses chat generator similarly robust. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
