### PR TITLE
fix: deep-copy document metadata in PythonCodeSplitter

### DIFF
--- a/haystack/components/preprocessors/python_code_splitter.py
+++ b/haystack/components/preprocessors/python_code_splitter.py
@@ -4,6 +4,7 @@
 
 import ast
 import math
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -472,7 +473,7 @@ class PythonCodeSplitter:
         """Construct the output meta dict for a chunk of merged units."""
         meta: dict[str, Any] = {}
         if parent_doc.meta:
-            meta.update({k: v for k, v in parent_doc.meta.items() if k not in {"split_id"}})
+            meta.update(deepcopy({k: v for k, v in parent_doc.meta.items() if k not in {"split_id"}}))
         meta["source_id"] = parent_doc.id
 
         # Units are emitted in source order, so chunk[0]/chunk[-1] give the extremes.
@@ -549,10 +550,9 @@ class PythonCodeSplitter:
         splitter = DocumentSplitter(split_by="line", split_length=split_length, split_overlap=overlap)
         intermediate = splitter.run(documents=[Document(content=unit.source)])["documents"]
 
-        base_meta = self._build_chunk_meta([unit], parent_doc)
         results: list[Document] = []
         for idx, piece in enumerate(intermediate):
-            meta = dict(base_meta)
+            meta = self._build_chunk_meta([unit], parent_doc)
             meta["secondary_split"] = True
             meta["secondary_split_index"] = idx
             meta["secondary_split_total"] = len(intermediate)

--- a/releasenotes/notes/python-code-splitter-deepcopy-meta-680b3566c200b63b.yaml
+++ b/releasenotes/notes/python-code-splitter-deepcopy-meta-680b3566c200b63b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    ``PythonCodeSplitter`` now deep-copies the metadata of the document it splits, matching ``DocumentSplitter``
+    and the other splitters. Previously it copied it shallowly, so nested values such as a dict under
+    ``meta["sheet"]`` were shared between every chunk and with the input document, and editing one chunk's
+    metadata changed all the others. The pieces produced by the oversized-function secondary split shared their
+    metadata the same way.

--- a/test/components/preprocessors/test_python_code_splitter.py
+++ b/test/components/preprocessors/test_python_code_splitter.py
@@ -296,6 +296,25 @@ class TestFileNamePropagation:
         for chunk in result["documents"]:
             assert chunk.meta["project"] == "haystack"
 
+    def test_nested_metadata_is_not_shared_between_chunks(self, simple_module_source):
+        splitter = PythonCodeSplitter(min_effective_lines=1, max_effective_lines=1)
+        doc = Document(content=simple_module_source, meta={"sheet": {"name": "Q3"}})
+
+        chunks = splitter.run(documents=[doc])["documents"]
+        chunks[0].meta["sheet"]["name"] = "Q4"
+
+        assert chunks[1].meta["sheet"] == {"name": "Q3"}
+        assert doc.meta["sheet"] == {"name": "Q3"}
+
+    def test_metadata_keys_sharing_one_value_still_share_it_within_a_chunk(self, simple_module_source):
+        shared = {"labels": []}
+        splitter = PythonCodeSplitter(min_effective_lines=1, max_effective_lines=1)
+        doc = Document(content=simple_module_source, meta={"primary": shared, "alias": shared})
+
+        chunk = splitter.run(documents=[doc])["documents"][0]
+
+        assert chunk.meta["primary"] is chunk.meta["alias"]
+
 
 class TestDecorators:
     def test_decorators_metadata_present(self):
@@ -841,6 +860,16 @@ class TestOversizedFallback:
         result = splitter.run(documents=[Document(content=oversized_function_source)])
         for piece in result["documents"]:
             assert piece.meta.get("qualified_name") == "giant"
+
+    def test_nested_metadata_is_not_shared_between_secondary_pieces(self, oversized_function_source):
+        splitter = PythonCodeSplitter(min_effective_lines=2, max_effective_lines=5, oversized_factor=3)
+        doc = Document(content=oversized_function_source, meta={"sheet": {"name": "Q3"}})
+
+        pieces = splitter.run(documents=[doc])["documents"]
+        pieces[0].meta["sheet"]["name"] = "Q4"
+
+        assert pieces[1].meta["sheet"] == {"name": "Q3"}
+        assert doc.meta["sheet"] == {"name": "Q3"}
 
 
 class TestEdgeCases:


### PR DESCRIPTION
### Related Issues

None.

### Proposed Changes:

`PythonCodeSplitter` shallow-copied parent metadata: appending to `chunks[0].meta["tags"]` on `main` at 75ee514 changed every chunk's `tags` and the input `Document` too. `DocumentSplitter` doesn't.

`_build_chunk_meta` now deep-copies filtered parent metadata, matching `DocumentSplitter`. The oversized-function secondary split also gave every piece a shallow `dict()` of one shared `base_meta`; each piece now builds its own.

The copy preserves `meta["a"] is meta["b"]` within a chunk, as `DocumentSplitter` does.

### How did you test it?

Three unit tests in `test_python_code_splitter.py`, named after equivalents in the CSV, Markdown and hierarchical splitter test files. The two `test_nested_metadata_is_not_shared_*` tests fail without the fix and pass with it. `test_metadata_keys_sharing_one_value_still_share_it_within_a_chunk` preserves the aliasing contract.

`hatch` isn't available in my environment, so I ran pytest, ruff, mypy, and the pre-commit hooks directly. All passed. The only failures across `test/components/preprocessors/` are the 31 NLTK-download tests that already fail on a clean checkout here.

### Notes for the reviewer

Deep-copying per chunk isn't free: 200 chunks against a 5,000-entry meta takes about 4.3s, but `DocumentSplitter` already pays exactly that. Metadata holding something `deepcopy` can't handle raises `TypeError`, as every other splitter already does.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the tests and checks above.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes. (no related issue; the repro is in this description)
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.