### PR TITLE
fix: treat per-document validation failures as partial success in DocumentToImageContent

### DIFF
--- a/haystack/components/converters/image/document_to_image.py
+++ b/haystack/components/converters/image/document_to_image.py
@@ -9,6 +9,7 @@ from haystack.components.converters.image.image_utils import (
     _batch_convert_pdf_pages_to_images,
     _encode_image_to_base64,
     _extract_image_sources_info,
+    _ImageSourceInfo,
     _PDFPageInfo,
     pillow_import,
     pypdfium2_import,
@@ -113,23 +114,31 @@ class DocumentToImageContent:
         :returns:
             Dictionary containing one key:
             - "image_contents": ImageContents created from the processed documents. These contain base64-encoded image
-                data and metadata. The order corresponds to order of input documents.
-        :raises ValueError:
-            If any document is missing the required metadata keys, has an invalid file path, or has an unsupported
-            MIME type. The error message will specify which document and what information is missing or incorrect.
+                data and metadata. The order corresponds to order of input documents. Documents that cannot be
+                converted (for example because they are missing required metadata keys, have an invalid file path,
+                or an unsupported MIME type) yield None at their position in the list and a warning is logged
+                naming them along with the error reasons.
         """
         if not documents:
             return {"image_contents": []}
 
-        images_source_info = _extract_image_sources_info(
-            documents=documents, file_path_meta_field=self.file_path_meta_field, root_path=self.root_path
-        )
-
         image_contents: list[ImageContent | None] = [None] * len(documents)
+        validation_errors: list[str] = []
+
+        valid_images_source_info: list[tuple[int, _ImageSourceInfo]] = []
+        for doc_idx, doc in enumerate(documents):
+            try:
+                images_source_info = _extract_image_sources_info(
+                    documents=[doc], file_path_meta_field=self.file_path_meta_field, root_path=self.root_path
+                )
+                valid_images_source_info.extend((doc_idx, info) for info in images_source_info)
+            except ValueError as e:
+                # the slot stays None at its position so output positions match the input documents
+                validation_errors.append(str(e))
 
         pdf_page_infos: list[_PDFPageInfo] = []
 
-        for doc_idx, image_source_info in enumerate(images_source_info):
+        for doc_idx, image_source_info in valid_images_source_info:
             mime_type = image_source_info["mime_type"]
             path = image_source_info["path"]
             if mime_type == "application/pdf":
@@ -172,8 +181,10 @@ class DocumentToImageContent:
         ]
         if none_image_contents_doc_ids:
             logger.warning(
-                "Conversion failed for some documents. Their output will be None. Document IDs: {document_ids}",
+                "Conversion failed for some documents. Their output will be None. Document IDs: {document_ids}. "
+                "Errors: {errors}",
                 document_ids=none_image_contents_doc_ids,
+                errors=validation_errors,
             )
 
         return {"image_contents": image_contents}

--- a/haystack/components/converters/image/image_utils.py
+++ b/haystack/components/converters/image/image_utils.py
@@ -334,7 +334,8 @@ def _batch_convert_pdf_pages_to_images(
         # Map results back to document indices
         page_number_to_image = dict(converted_pages)
         for page_info in page_infos_for_pdf:
-            converted_images_by_doc_index[page_info["doc_idx"]] = page_number_to_image[page_info["page_number"]]
+            if page_info["page_number"] in page_number_to_image:
+                converted_images_by_doc_index[page_info["doc_idx"]] = page_number_to_image[page_info["page_number"]]
 
     # mypy is not able to infer that we match the declared return type
     return converted_images_by_doc_index  # type: ignore[return-value]

--- a/releasenotes/notes/document-to-image-partial-success-37e0d87e.yaml
+++ b/releasenotes/notes/document-to-image-partial-success-37e0d87e.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    `DocumentToImageContent` now converts documents with partial success instead of failing the whole batch: a
+    document with missing metadata, an invalid file path, an unsupported MIME type, or a missing `page_number`
+    yields `None` at its position in `image_contents`, while valid documents in the same batch are still processed.
+    A single warning naming the failed document IDs and the error reasons is logged. Additionally, requesting an
+    out-of-range PDF page no longer raises a `KeyError`: the affected document yields `None`.

--- a/test/components/converters/image/test_document_to_image_content.py
+++ b/test/components/converters/image/test_document_to_image_content.py
@@ -4,13 +4,12 @@
 
 from unittest.mock import patch
 
-import pytest
 from PIL import Image
 
 from haystack import Document
 from haystack.components.converters.image.document_to_image import DocumentToImageContent
 from haystack.core.serialization import component_from_dict, component_to_dict
-from haystack.dataclasses import ByteStream
+from haystack.dataclasses import ByteStream, ImageContent
 
 
 class TestDocumentToImageContent:
@@ -53,32 +52,42 @@ class TestDocumentToImageContent:
         results = converter.run(documents=[])
         assert results == {"image_contents": []}
 
-    def test_run_with_missing_file_path_metadata(self) -> None:
+    def test_run_with_missing_file_path_metadata(self, caplog) -> None:
         converter = DocumentToImageContent()
         # Document without file_path in metadata
         doc_no_path = Document(content="test", meta={})
         # Document with file_path but file doesn't exist
         doc_no_file = Document(content="test", meta={"file_path": "nonexistent.jpg"})
-        with pytest.raises(ValueError, match="is missing the 'file_path' key"):
-            _ = converter.run(documents=[doc_no_path, doc_no_file])
+        results = converter.run(documents=[doc_no_path, doc_no_file])
+        assert results["image_contents"] == [None, None]
+        assert any(
+            "Conversion failed for some documents." in record.message
+            for record in caplog.records
+            if record.levelname == "WARNING"
+        )
 
-    def test_run_with_non_image_documents(self) -> None:
+    def test_run_with_non_image_documents(self, caplog) -> None:
         converter = DocumentToImageContent()
         docx_doc = Document(content="test", meta={"file_path": "test/test_files/docx/sample_docx.docx"})
-        with pytest.raises(ValueError, match="has an unsupported MIME type"):
-            _ = converter.run(documents=[docx_doc])
+        results = converter.run(documents=[docx_doc])
+        assert results["image_contents"] == [None]
+        assert any(
+            "unsupported MIME type" in record.message for record in caplog.records if record.levelname == "WARNING"
+        )
 
     def test_run_with_invalid_file_path(self, caplog) -> None:
         converter = DocumentToImageContent()
         pdf_doc = Document(content="test", meta={"file_path": "wrong_name.jpg"})
-        with pytest.raises(ValueError, match="has an invalid file path 'wrong_name.jpg'"):
-            _ = converter.run(documents=[pdf_doc])
+        results = converter.run(documents=[pdf_doc])
+        assert results["image_contents"] == [None]
+        assert any("has an invalid file path" in record.message for record in caplog.records)
 
     def test_run_with_pdf_missing_page_number(self, caplog) -> None:
         converter = DocumentToImageContent()
         pdf_doc = Document(content="test", meta={"file_path": "test/test_files/pdf/sample_pdf_1.pdf"})
-        with pytest.raises(ValueError, match="is missing the 'page_number' key"):
-            _ = converter.run(documents=[pdf_doc])
+        results = converter.run(documents=[pdf_doc])
+        assert results["image_contents"] == [None]
+        assert any("missing the 'page_number' key" in record.message for record in caplog.records)
 
     def test_run_with_image_documents(self) -> None:
         converter = DocumentToImageContent(root_path="test/test_files/images")
@@ -97,15 +106,64 @@ class TestDocumentToImageContent:
             "page_number": 1,
         }
 
-    def test_run_with_mixed_document_types(self) -> None:
+    def test_run_with_mixed_document_types(self, caplog) -> None:
         converter = DocumentToImageContent(root_path="test/test_files")
         documents = [
             Document(content="", meta={"file_path": "images/apple.jpg"}),
             Document(content="", meta={"file_path": "pdf/sample_pdf_1.pdf", "page_number": 1}),
             Document(content="text", meta={"file_path": "docx/sample_docx.docx"}),
         ]
-        with pytest.raises(ValueError, match="has an unsupported MIME type"):
-            _ = converter.run(documents=documents)
+        image_contents = converter.run(documents=documents)["image_contents"]
+        assert isinstance(image_contents[0], ImageContent)
+        assert isinstance(image_contents[1], ImageContent)
+        assert image_contents[2] is None
+        assert any("Conversion failed for some documents." in record.message for record in caplog.records)
+
+    def test_run_with_mixed_valid_and_unsupported_mime_documents(self, caplog) -> None:
+        converter = DocumentToImageContent(root_path="test/test_files")
+        documents = [
+            Document(content="", meta={"file_path": "images/apple.jpg"}),
+            Document(content="", meta={"file_path": "pdf/sample_pdf_1.pdf", "page_number": 1}),
+            Document(content="", meta={"file_path": "docx/sample_docx.docx"}),
+        ]
+        image_contents = converter.run(documents=documents)["image_contents"]
+
+        assert len(image_contents) == 3
+        assert isinstance(image_contents[0], ImageContent)
+        assert isinstance(image_contents[1], ImageContent)
+        assert image_contents[2] is None
+
+        warning_records = [record for record in caplog.records if record.levelname == "WARNING"]
+        assert len(warning_records) == 1
+        assert "Conversion failed for some documents." in warning_records[0].message
+        assert "unsupported MIME type" in warning_records[0].message
+
+    def test_run_with_mixed_pdf_documents_missing_page_number(self, caplog) -> None:
+        converter = DocumentToImageContent()
+        documents = [
+            Document(content="", meta={"file_path": "test/test_files/pdf/sample_pdf_1.pdf", "page_number": 1}),
+            Document(content="", meta={"file_path": "test/test_files/pdf/sample_pdf_1.pdf"}),
+        ]
+        image_contents = converter.run(documents=documents)["image_contents"]
+
+        assert len(image_contents) == 2
+        assert isinstance(image_contents[0], ImageContent)
+        assert image_contents[1] is None
+
+        warning_records = [record for record in caplog.records if record.levelname == "WARNING"]
+        assert len(warning_records) == 1
+        assert "missing the 'page_number' key" in warning_records[0].message
+
+    def test_run_with_out_of_range_pdf_page_returns_none(self, caplog) -> None:
+        converter = DocumentToImageContent()
+        doc = Document(content="", meta={"file_path": "test/test_files/pdf/sample_pdf_1.pdf", "page_number": 999})
+        result = converter.run(documents=[doc])
+        assert result == {"image_contents": [None]}
+        assert any(
+            "Conversion failed for some documents." in record.message
+            for record in caplog.records
+            if record.levelname == "WARNING"
+        )
 
     @patch("haystack.components.converters.image.document_to_image._extract_image_sources_info")
     @patch("haystack.components.converters.image.document_to_image._batch_convert_pdf_pages_to_images")
@@ -121,9 +179,10 @@ class TestDocumentToImageContent:
     ):
         converter = DocumentToImageContent()
 
-        mocked_extract_image_sources_info.return_value = [
-            {"path": "doc1.pdf", "mime_type": "application/pdf", "page_number": 999},  # Page 999 doesn't exist
-            {"path": "image1.jpg", "mime_type": "image/jpeg"},
+        # one call per document, each returning that document's source info
+        mocked_extract_image_sources_info.side_effect = [
+            [{"path": "doc1.pdf", "mime_type": "application/pdf", "page_number": 999}],  # Page 999 doesn't exist
+            [{"path": "image1.jpg", "mime_type": "image/jpeg"}],
         ]
         mocked_batch_convert_pdf_pages_to_images.return_value = {}  # Empty dict because page was skipped
         mocked_pil_open.return_value = Image.new("RGB", (100, 100))

--- a/test/components/converters/image/test_image_utils.py
+++ b/test/components/converters/image/test_image_utils.py
@@ -225,3 +225,15 @@ class TestBatchConvertPdfPagesToImages:
 
         assert isinstance(result, dict)
         assert len(result) == 0
+
+    def test_batch_convert_pdf_pages_to_images_skips_out_of_range_page(self, test_files_path):
+        pdf_path = test_files_path / "pdf" / "sample_pdf_1.pdf"
+        pdf_documents: list[_PDFPageInfo] = [
+            {"doc_idx": 0, "path": pdf_path, "page_number": 999},
+            {"doc_idx": 1, "path": pdf_path, "page_number": 1},
+        ]
+
+        result = _batch_convert_pdf_pages_to_images(pdf_page_infos=pdf_documents, return_base64=False)
+
+        assert 0 not in result
+        assert isinstance(result[1], Image.Image)

--- a/test/components/extractors/image/test_llm_document_content_extractor.py
+++ b/test/components/extractors/image/test_llm_document_content_extractor.py
@@ -165,6 +165,26 @@ class TestLLMDocumentContentExtractor:
         # Ensure no attempt was made to call the LLM
         mock_chat_generator.run.assert_not_called()
 
+    def test_run_partial_success_reaches_failed_documents(self):
+        """With a mixed batch, the valid document is extracted and the invalid one lands in failed_documents."""
+        extractor = LLMDocumentContentExtractor(
+            chat_generator=MockChatGenerator('{"document_content": "An apple"}'), root_path="test/test_files"
+        )
+        docs = [
+            Document(content="", meta={"file_path": "images/apple.jpg"}),
+            Document(content="", meta={"file_path": "docx/sample_docx.docx"}),
+        ]
+        result = extractor.run(documents=docs)
+
+        assert len(result["documents"]) == 1
+        assert result["documents"][0].id == docs[0].id
+        assert result["documents"][0].content == "An apple"
+        assert "extraction_error" not in result["documents"][0].meta
+
+        assert len(result["failed_documents"]) == 1
+        assert result["failed_documents"][0].id == docs[1].id
+        assert "extraction_error" in result["failed_documents"][0].meta
+
     @patch.object(DocumentToImageContent, "run")
     def test_run_with_llm_success(self, mock_doc_to_image_run):
         # Mock successful LLM response (JSON with document_content)


### PR DESCRIPTION
### Related Issues

- fixes #12447

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

`DocumentToImageContent.run()` validated the whole batch up front through `_extract_image_sources_info`,
which raises on the first invalid document. One bad document therefore aborted the entire batch, although
`run()` already provides `None` slots plus an aggregated warning for failed conversions, and
`LLMDocumentContentExtractor` routes those `None`s into its documented `failed_documents` return. That
return path was unreachable for any batch containing one invalid document.

Validation failures (missing metadata keys, invalid file path, unsupported MIME type) are now handled per
document: valid documents are converted, invalid ones yield `None` at their position, and the aggregated
warning now lists the error reasons next to the document IDs. An out-of-range PDF page broke the same
contract from the other side — `_batch_convert_pdf_pages_to_images` raised `KeyError` after pypdfium2
skipped the page — so that lookup now leaves the slot `None`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Updated the unit tests that locked in the old `ValueError` behavior (they were authored with the feature
itself in #9628) and added regression tests for mixed batches, out-of-range pages, and extractor-level
`failed_documents` reachability; all 10 fail on `main` and pass here.
`pytest test/components/converters/image test/components/extractors/image -q`: 98 passed, 3 skipped (pre-existing).
Added a release note under `fixes:`.

### Notes for the reviewer

Path-traversal rejections from #11787 now take the same warn+None path as the other validation failures.
That fix is not weakened: the containment check still runs before any file is read, so nothing outside
`root_path` is ever opened — only the whole-batch abort is gone.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.