### PR TITLE
feat: add tracing to fallback chat generator

### DIFF
--- a/haystack/components/generators/chat/fallback.py
+++ b/haystack/components/generators/chat/fallback.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.chat.types import ChatGenerator
-from haystack.components.generators.utils import _normalize_messages
+from haystack.components.generators.utils import _normalize_messages, _trace_chat_generator_run
 from haystack.core.serialization import component_to_dict
 from haystack.dataclasses import ChatMessage, StreamingCallbackT
 from haystack.tools import ToolsType
@@ -122,9 +122,16 @@ class FallbackChatGenerator:
         tools: ToolsType | None,
         streaming_callback: StreamingCallbackT | None,
     ) -> dict[str, Any]:
-        return gen.run(
-            messages=messages, generation_kwargs=generation_kwargs, tools=tools, streaming_callback=streaming_callback
-        )
+        generator_inputs = {
+            "messages": messages,
+            "generation_kwargs": generation_kwargs,
+            "tools": tools,
+            "streaming_callback": streaming_callback,
+        }
+        with _trace_chat_generator_run(chat_generator=gen, generator_inputs=generator_inputs) as span:
+            result = gen.run(**generator_inputs)
+            span.set_content_tag(key="haystack.component.output", value=result)
+            return result
 
     async def _run_single_async(
         self,
@@ -134,13 +141,16 @@ class FallbackChatGenerator:
         tools: ToolsType | None,
         streaming_callback: StreamingCallbackT | None,
     ) -> dict[str, Any]:
-        return await _execute_component_async(
-            gen,
-            messages=messages,
-            generation_kwargs=generation_kwargs,
-            tools=tools,
-            streaming_callback=streaming_callback,
-        )
+        generator_inputs = {
+            "messages": messages,
+            "generation_kwargs": generation_kwargs,
+            "tools": tools,
+            "streaming_callback": streaming_callback,
+        }
+        with _trace_chat_generator_run(chat_generator=gen, generator_inputs=generator_inputs) as span:
+            result = await _execute_component_async(component_instance=gen, **generator_inputs)
+            span.set_content_tag(key="haystack.component.output", value=result)
+            return result
 
     @component.output_types(replies=list[ChatMessage], meta=dict[str, Any])
     def run(
@@ -165,7 +175,7 @@ class FallbackChatGenerator:
         """
         self.warm_up()
 
-        messages = _normalize_messages(messages)
+        messages = _normalize_messages(messages=messages)
 
         failed: list[str] = []
         last_error: BaseException | None = None
@@ -222,7 +232,7 @@ class FallbackChatGenerator:
         """
         await self.warm_up_async()
 
-        messages = _normalize_messages(messages)
+        messages = _normalize_messages(messages=messages)
 
         failed: list[str] = []
         last_error: BaseException | None = None

--- a/releasenotes/notes/trace-fallback-chat-generator-calls-2d70a779e2deb9ef.yaml
+++ b/releasenotes/notes/trace-fallback-chat-generator-calls-2d70a779e2deb9ef.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    ``FallbackChatGenerator`` now wraps every internal ``ChatGenerator`` attempt in a
+    ``haystack.chat_generator.run`` tracing span for both synchronous and asynchronous execution. With content
+    tracing enabled, each span records the forwarded inputs and the successful generator output, making fallback
+    attempts and their token usage visible in traces.

--- a/test/components/generators/chat/test_fallback.py
+++ b/test/components/generators/chat/test_fallback.py
@@ -433,6 +433,55 @@ async def test_failover_trigger_401_authentication_async():
     assert meta["failed_chat_generators"] == ["_DummyHTTPErrorGen"]
 
 
+class TestTracing:
+    def test_run_traces_each_chat_generator_attempt(self, spying_tracer):
+        messages = [ChatMessage.from_user("hi")]
+        generation_kwargs = {"temperature": 0.1}
+        fallback = FallbackChatGenerator(chat_generators=[_DummyFailGen(), _DummySuccessGen()])
+
+        with spying_tracer.trace("parent") as parent_span:
+            fallback.run(messages=messages, generation_kwargs=generation_kwargs)
+
+        generator_spans = [s for s in spying_tracer.spans if s.operation_name == "haystack.chat_generator.run"]
+        assert len(generator_spans) == 2
+        assert all(span.parent_span is parent_span for span in generator_spans)
+        assert [span.tags["haystack.component.type"] for span in generator_spans] == [
+            "_DummyFailGen",
+            "_DummySuccessGen",
+        ]
+        assert all(
+            span.tags["haystack.component.input"]
+            == {"messages": messages, "generation_kwargs": generation_kwargs, "tools": None, "streaming_callback": None}
+            for span in generator_spans
+        )
+        assert "haystack.component.output" not in generator_spans[0].tags
+        assert generator_spans[1].tags["haystack.component.output"]["replies"][0].text == "ok"
+
+    @pytest.mark.asyncio
+    async def test_run_async_traces_each_chat_generator_attempt(self, spying_tracer):
+        messages = [ChatMessage.from_user("hi")]
+        generation_kwargs = {"temperature": 0.1}
+        fallback = FallbackChatGenerator(chat_generators=[_DummyFailGen(), _DummySuccessGen()])
+
+        with spying_tracer.trace("parent") as parent_span:
+            await fallback.run_async(messages=messages, generation_kwargs=generation_kwargs)
+
+        generator_spans = [s for s in spying_tracer.spans if s.operation_name == "haystack.chat_generator.run"]
+        assert len(generator_spans) == 2
+        assert all(span.parent_span is parent_span for span in generator_spans)
+        assert [span.tags["haystack.component.type"] for span in generator_spans] == [
+            "_DummyFailGen",
+            "_DummySuccessGen",
+        ]
+        assert all(
+            span.tags["haystack.component.input"]
+            == {"messages": messages, "generation_kwargs": generation_kwargs, "tools": None, "streaming_callback": None}
+            for span in generator_spans
+        )
+        assert "haystack.component.output" not in generator_spans[0].tags
+        assert generator_spans[1].tags["haystack.component.output"]["replies"][0].text == "ok"
+
+
 class TestComponentLifecycle:
     def test_warm_up_delegates_to_every_generator(self) -> None:
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

Request from @ju-gu to better debug issues with the fallback chat generator on the platform and to track usage. 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->


``FallbackChatGenerator`` now wraps every internal ``ChatGenerator`` attempt in a ``haystack.chat_generator.run`` tracing span for both synchronous and asynchronous execution. With content tracing enabled, each span records the forwarded inputs and the successful generator output, making fallback attempts and their token usage visible in traces.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
