### PR TITLE
feat: Record error type and error message on our spans

### DIFF
--- a/haystack/components/agents/tool_calling.py
+++ b/haystack/components/agents/tool_calling.py
@@ -217,9 +217,10 @@ def _make_context_bound_invoke(
             span.set_content_tag("haystack.agent.step.tool.input", tool_call.arguments)
             try:
                 result = tool.invoke(**args)
-            except ToolInvocationError as e:
-                span.set_content_tag("haystack.agent.step.tool.output", {"error": str(e)})
-                return e
+            except ToolInvocationError as error:
+                span.record_exception(exception=error)
+                span.set_content_tag("haystack.agent.step.tool.output", {"error": str(error)})
+                return error
             span.set_content_tag("haystack.agent.step.tool.output", result)
             return result
 
@@ -254,9 +255,10 @@ def _make_bounded_invoke_async(
                 span.set_content_tag("haystack.agent.step.tool.input", tool_call.arguments)
                 try:
                     result = await tool.invoke_async(**args)
-                except ToolInvocationError as e:
-                    span.set_content_tag("haystack.agent.step.tool.output", {"error": str(e)})
-                    return e
+                except ToolInvocationError as error:
+                    span.record_exception(exception=error)
+                    span.set_content_tag("haystack.agent.step.tool.output", {"error": str(error)})
+                    return error
                 span.set_content_tag("haystack.agent.step.tool.output", result)
                 return result
 

--- a/haystack/tracing/tracer.py
+++ b/haystack/tracing/tracer.py
@@ -69,14 +69,8 @@ class Span(abc.ABC):
         """
         Record an exception that caused the span's operation to fail.
 
-        The default implementation uses OpenTelemetry's `error.type` span attribute. Because Haystack's generic
-        `Span` interface does not expose events, it also stores OpenTelemetry's `exception.message` exception-event
-        field as a content tag. The exception type is always recorded so failures remain queryable without content
-        tracing. The exception message can contain sensitive or high-cardinality data, so it is only recorded when
-        content tracing is enabled.
-
-        Tracer integrations can override this method to use their backend's native exception event and error-status
-        APIs. This default tag-based representation keeps existing third-party `Span` implementations compatible.
+        Records `error.type` as a tag. When content tracing is enabled, also records `exception.message`.
+        Tracer integrations can override this method to use their backend's native exception API.
 
         :param exception: The exception that caused the operation represented by this span to fail.
         """

--- a/haystack/tracing/tracer.py
+++ b/haystack/tracing/tracer.py
@@ -65,6 +65,25 @@ class Span(abc.ABC):
         if tracer.is_content_tracing_enabled:
             self.set_tag(key, value)
 
+    def record_exception(self, exception: BaseException) -> None:
+        """
+        Record an exception that caused the span's operation to fail.
+
+        The default implementation uses OpenTelemetry's `error.type` span attribute. Because Haystack's generic
+        `Span` interface does not expose events, it also stores OpenTelemetry's `exception.message` exception-event
+        field as a content tag. The exception type is always recorded so failures remain queryable without content
+        tracing. The exception message can contain sensitive or high-cardinality data, so it is only recorded when
+        content tracing is enabled.
+
+        Tracer integrations can override this method to use their backend's native exception event and error-status
+        APIs. This default tag-based representation keeps existing third-party `Span` implementations compatible.
+
+        :param exception: The exception that caused the operation represented by this span to fail.
+        """
+        exception_type = type(exception)
+        self.set_tag("error.type", f"{exception_type.__module__}.{exception_type.__qualname__}")
+        self.set_content_tag("exception.message", str(exception))
+
     def get_correlation_data_for_logs(self) -> dict[str, Any]:
         """
         Return a dictionary with correlation data for logs.
@@ -123,7 +142,11 @@ class ProxyTracer(Tracer):
     ) -> Iterator[Span]:
         """Activate and return a new span that inherits from the current active span."""
         with self.actual_tracer.trace(operation_name, tags=tags, parent_span=parent_span) as span:
-            yield span
+            try:
+                yield span
+            except Exception as exception:
+                span.record_exception(exception=exception)
+                raise
 
     def current_span(self) -> Span | None:
         """Return the current active span"""

--- a/releasenotes/notes/record-exceptions-on-tracing-spans-f018bde3b318e8b5.yaml
+++ b/releasenotes/notes/record-exceptions-on-tracing-spans-f018bde3b318e8b5.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Tracing spans now record an ``error.type`` tag when their operation raises an exception. With content tracing
+    enabled, the span also records ``exception.message``. The new ``Span.record_exception`` method lets components
+    annotate failures that they handle internally and lets tracer integrations provide native exception-event and
+    error-status handling.

--- a/test/components/agents/test_tool_calling.py
+++ b/test/components/agents/test_tool_calling.py
@@ -674,7 +674,7 @@ class TestRunToolErrorHandling:
         with pytest.raises(ToolInvocationError):
             _run_tool(messages=[tool_call_message], state=State(schema={}), tools=[faulty_tool])
 
-    def test_tool_invocation_error_does_not_raise_exception(self, faulty_tool):
+    def test_tool_invocation_error_does_not_raise_exception(self, faulty_tool, spying_tracer):
         tool_call = ToolCall(tool_name="faulty_tool", arguments={"location": "Berlin"})
         tool_call_message = ChatMessage.from_assistant(tool_calls=[tool_call])
 
@@ -684,6 +684,26 @@ class TestRunToolErrorHandling:
         tool_message = tool_messages[0]
         assert tool_message.tool_call_results[0].error
         assert "Failed to invoke" in tool_message.tool_call_results[0].result
+
+        tool_span = next(span for span in spying_tracer.spans if span.operation_name == "haystack.agent.step.tool")
+        assert tool_span.tags["error.type"] == "haystack.tools.errors.ToolInvocationError"
+        assert "Failed to invoke" in tool_span.tags["exception.message"]
+
+    @pytest.mark.asyncio
+    async def test_tool_invocation_error_does_not_raise_exception_async(self, faulty_tool, spying_tracer):
+        tool_call = ToolCall(tool_name="faulty_tool", arguments={"location": "Berlin"})
+        tool_call_message = ChatMessage.from_assistant(tool_calls=[tool_call])
+
+        tool_messages, _ = await _run_tool_async(
+            messages=[tool_call_message], state=State(schema={}), tools=[faulty_tool], raise_on_failure=False
+        )
+        tool_message = tool_messages[0]
+        assert tool_message.tool_call_results[0].error
+        assert "Failed to invoke" in tool_message.tool_call_results[0].result
+
+        tool_span = next(span for span in spying_tracer.spans if span.operation_name == "haystack.agent.step.tool")
+        assert tool_span.tags["error.type"] == "haystack.tools.errors.ToolInvocationError"
+        assert "Failed to invoke" in tool_span.tags["exception.message"]
 
     def test_outputs_to_string_with_multiple_outputs(self):
         weather_tool = Tool(

--- a/test/components/generators/chat/test_fallback.py
+++ b/test/components/generators/chat/test_fallback.py
@@ -454,7 +454,10 @@ class TestTracing:
             == {"messages": messages, "generation_kwargs": generation_kwargs, "tools": None, "streaming_callback": None}
             for span in generator_spans
         )
+        assert generator_spans[0].tags["error.type"] == "builtins.RuntimeError"
+        assert generator_spans[0].tags["exception.message"] == "boom"
         assert "haystack.component.output" not in generator_spans[0].tags
+        assert "error.type" not in generator_spans[1].tags
         assert generator_spans[1].tags["haystack.component.output"]["replies"][0].text == "ok"
 
     @pytest.mark.asyncio
@@ -478,7 +481,10 @@ class TestTracing:
             == {"messages": messages, "generation_kwargs": generation_kwargs, "tools": None, "streaming_callback": None}
             for span in generator_spans
         )
+        assert generator_spans[0].tags["error.type"] == "builtins.RuntimeError"
+        assert generator_spans[0].tags["exception.message"] == "boom"
         assert "haystack.component.output" not in generator_spans[0].tags
+        assert "error.type" not in generator_spans[1].tags
         assert generator_spans[1].tags["haystack.component.output"]["replies"][0].text == "ok"
 
 

--- a/test/hooks/human_in_the_loop/test_hooks.py
+++ b/test/hooks/human_in_the_loop/test_hooks.py
@@ -458,6 +458,8 @@ class TestConfirmationHookTracing:
 
         hook_span, tool_span = spying_tracer.spans
         assert tool_span.parent_span is hook_span
+        assert hook_span.tags["error.type"] == "builtins.RuntimeError"
+        assert hook_span.tags["exception.message"] == "execution suspended"
         assert tool_span.tags == {
             "haystack.tool.name": "addition_tool",
             "haystack.tool.call.id": None,
@@ -470,6 +472,8 @@ class TestConfirmationHookTracing:
                 "tool_params": {"a": 1, "b": 2},
                 "tool_call_id": None,
             },
+            "error.type": "builtins.RuntimeError",
+            "exception.message": "execution suspended",
         }
 
 

--- a/test/tracing/test_logging_tracer.py
+++ b/test/tracing/test_logging_tracer.py
@@ -196,5 +196,11 @@ class TestLoggingTracer:
         tags_records = [record for record in records if hasattr(record, "tag_name")]
         assert any(record.tag_name == "haystack.component.name" for record in tags_records)
         assert any(record.tag_value == "failing_component" for record in tags_records)  # type: ignore[attr-defined]
+        error_type_records = [record for record in tags_records if record.tag_name == "error.type"]
+        assert len(error_type_records) == 2
+        assert all(
+            vars(record)["tag_value"] == "haystack.core.errors.PipelineRuntimeError" for record in error_type_records
+        )
+        assert not any(record.tag_name == "exception.message" for record in tags_records)
 
         tracing.disable_tracing()

--- a/test/tracing/test_tracer.py
+++ b/test/tracing/test_tracer.py
@@ -4,6 +4,7 @@
 
 from unittest.mock import Mock
 
+import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
 from haystack.tracing.tracer import (
@@ -17,7 +18,7 @@ from haystack.tracing.tracer import (
     is_tracing_enabled,
     tracer,
 )
-from test.tracing.utils import SpyingSpan, SpyingTracer
+from test.tracing.utils import EagerSpyingSpan, SpyingSpan, SpyingTracer
 
 
 class TestNullTracer:
@@ -49,6 +50,19 @@ class TestProxyTracer:
         assert spying_tracer.spans[0].operation_name == "operation"
         assert spying_tracer.spans[0].parent_span == parent_span
         assert spying_tracer.spans[0].tags == {"key": "value", "key2": "value2"}
+
+    def test_tracing_records_escaping_exception(self) -> None:
+        spying_tracer = SpyingTracer()
+        my_tracer = ProxyTracer(provided_tracer=spying_tracer)
+
+        with pytest.raises(ValueError, match="sensitive details"):
+            with my_tracer.trace("operation"):
+                raise ValueError("sensitive details")
+
+        assert spying_tracer.spans[0].tags == {
+            "error.type": "builtins.ValueError",
+            "exception.message": "sensitive details",
+        }
 
 
 class TestConfigureTracer:
@@ -91,3 +105,15 @@ class TestTracingContent:
         proxy_tracer = ProxyTracer(provided_tracer=SpyingTracer())
 
         assert proxy_tracer.is_content_tracing_enabled is False
+
+    def test_record_exception_message_respects_content_tracing(self, monkeypatch: MonkeyPatch) -> None:
+        span = EagerSpyingSpan(operation_name="test")
+        exception = ValueError("sensitive details")
+
+        monkeypatch.setattr(tracer, "is_content_tracing_enabled", False)
+        span.record_exception(exception=exception)
+        assert span.tags == {"error.type": "builtins.ValueError"}
+
+        monkeypatch.setattr(tracer, "is_content_tracing_enabled", True)
+        span.record_exception(exception=exception)
+        assert span.tags == {"error.type": "builtins.ValueError", "exception.message": "sensitive details"}


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Tracing spans now record an ``error.type`` tag when their operation raises an exception. With content tracing enabled, the span also records ``exception.message``. The new ``Span.record_exception`` method lets components annotate failures that they handle internally and lets tracer integrations provide native exception-event and error-status handling.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
