### PR TITLE
fix: prevent double counting token usage in traces when using fallback chat generator

### DIFF
--- a/haystack/components/generators/chat/fallback.py
+++ b/haystack/components/generators/chat/fallback.py
@@ -128,10 +128,8 @@ class FallbackChatGenerator:
             "tools": tools,
             "streaming_callback": streaming_callback,
         }
-        with _trace_chat_generator_run(chat_generator=gen, generator_inputs=generator_inputs) as span:
-            result = gen.run(**generator_inputs)
-            span.set_content_tag(key="haystack.component.output", value=result)
-            return result
+        with _trace_chat_generator_run(chat_generator=gen, generator_inputs=generator_inputs):
+            return gen.run(**generator_inputs)
 
     async def _run_single_async(
         self,
@@ -147,10 +145,8 @@ class FallbackChatGenerator:
             "tools": tools,
             "streaming_callback": streaming_callback,
         }
-        with _trace_chat_generator_run(chat_generator=gen, generator_inputs=generator_inputs) as span:
-            result = await _execute_component_async(component_instance=gen, **generator_inputs)
-            span.set_content_tag(key="haystack.component.output", value=result)
-            return result
+        with _trace_chat_generator_run(chat_generator=gen, generator_inputs=generator_inputs):
+            return await _execute_component_async(component_instance=gen, **generator_inputs)
 
     @component.output_types(replies=list[ChatMessage], meta=dict[str, Any])
     def run(

--- a/releasenotes/notes/trace-fallback-chat-generator-calls-2d70a779e2deb9ef.yaml
+++ b/releasenotes/notes/trace-fallback-chat-generator-calls-2d70a779e2deb9ef.yaml
@@ -3,5 +3,5 @@ enhancements:
   - |
     ``FallbackChatGenerator`` now wraps every internal ``ChatGenerator`` attempt in a
     ``haystack.chat_generator.run`` tracing span for both synchronous and asynchronous execution. With content
-    tracing enabled, each span records the forwarded inputs and the successful generator output, making fallback
-    attempts and their token usage visible in traces.
+    tracing enabled, each internal span records the forwarded inputs. The successful output remains on the enclosing
+    ``FallbackChatGenerator`` component span so tracing backends do not count its token usage twice.

--- a/test/components/generators/chat/test_fallback.py
+++ b/test/components/generators/chat/test_fallback.py
@@ -10,7 +10,7 @@ from urllib.error import HTTPError as URLLibHTTPError
 
 import pytest
 
-from haystack import component, default_from_dict, default_to_dict
+from haystack import Pipeline, component, default_from_dict, default_to_dict
 from haystack.components.generators.chat.fallback import FallbackChatGenerator
 from haystack.core.errors import SerializationError
 from haystack.dataclasses import ChatMessage, StreamingCallbackT
@@ -434,6 +434,27 @@ async def test_failover_trigger_401_authentication_async():
 
 
 class TestTracing:
+    def test_pipeline_traces_output_only_on_fallback_component_span(self, spying_tracer):
+        messages = [ChatMessage.from_user("hi")]
+        fallback = FallbackChatGenerator(chat_generators=[_DummySuccessGen()])
+        pipeline = Pipeline()
+        pipeline.add_component(name="fallback", instance=fallback)
+
+        pipeline.run(data={"fallback": {"messages": messages}})
+
+        fallback_spans = [
+            span
+            for span in spying_tracer.spans
+            if span.operation_name == "haystack.component.run"
+            and span.tags["haystack.component.type"] == "FallbackChatGenerator"
+        ]
+        generator_spans = [span for span in spying_tracer.spans if span.operation_name == "haystack.chat_generator.run"]
+
+        assert len(fallback_spans) == 1
+        assert fallback_spans[0].tags["haystack.component.output"]["replies"][0].text == "ok"
+        assert len(generator_spans) == 1
+        assert "haystack.component.output" not in generator_spans[0].tags
+
     def test_run_traces_each_chat_generator_attempt(self, spying_tracer):
         messages = [ChatMessage.from_user("hi")]
         generation_kwargs = {"temperature": 0.1}
@@ -454,8 +475,7 @@ class TestTracing:
             == {"messages": messages, "generation_kwargs": generation_kwargs, "tools": None, "streaming_callback": None}
             for span in generator_spans
         )
-        assert "haystack.component.output" not in generator_spans[0].tags
-        assert generator_spans[1].tags["haystack.component.output"]["replies"][0].text == "ok"
+        assert all("haystack.component.output" not in span.tags for span in generator_spans)
 
     @pytest.mark.asyncio
     async def test_run_async_traces_each_chat_generator_attempt(self, spying_tracer):
@@ -478,8 +498,7 @@ class TestTracing:
             == {"messages": messages, "generation_kwargs": generation_kwargs, "tools": None, "streaming_callback": None}
             for span in generator_spans
         )
-        assert "haystack.component.output" not in generator_spans[0].tags
-        assert generator_spans[1].tags["haystack.component.output"]["replies"][0].text == "ok"
+        assert all("haystack.component.output" not in span.tags for span in generator_spans)
 
 
 class TestComponentLifecycle:


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

@julian-risch pointed out that with the implementation in https://github.com/deepset-ai/haystack/pull/12470 that when using fallback chat generator in a pipeline or in other components that we would emit two identical spans with token usage, which would cause token usage double counting. 

This PR fixes that by removing the output content span from inside the fallback chat generator. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New test and updated existing ones.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
