### PR TITLE
fix: support unhashable metadata comparison values in recall and NDCG evaluators

### DIFF
--- a/haystack/components/evaluators/_utils.py
+++ b/haystack/components/evaluators/_utils.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+
+def _make_hashable(value: Any) -> Any:
+    """
+    Convert nested lists, tuples, and dictionaries into hashable comparison values.
+
+    Lists and tuples keep their order, while dictionaries ignore key insertion order, matching Python's equality
+    semantics for these container types. Primitive values are returned unchanged.
+
+    :param value: The value to convert.
+    :returns: A hashable representation for values composed of supported containers and primitive values.
+    """
+    if isinstance(value, list):
+        return ("list", tuple(_make_hashable(item) for item in value))
+    if isinstance(value, tuple):
+        return ("tuple", tuple(_make_hashable(item) for item in value))
+    if isinstance(value, dict):
+        return ("dict", frozenset((key, _make_hashable(item)) for key, item in value.items()))
+    return value

--- a/haystack/components/evaluators/document_ndcg.py
+++ b/haystack/components/evaluators/document_ndcg.py
@@ -6,6 +6,7 @@ from math import log2
 from typing import Any
 
 from haystack import Document, component, default_to_dict
+from haystack.components.evaluators._utils import _make_hashable
 
 
 @component
@@ -45,6 +46,8 @@ class DocumentNDCGEvaluator:
             - A `meta.` prefix followed by a key name: uses `doc.meta["<key>"]`
               (e.g. `"meta.file_id"`, `"meta.page_number"`)
               Nested keys are supported (e.g. `"meta.source.url"`).
+              List and dictionary values are compared as complete values, with list order preserved and dictionary key
+              order ignored.
         """
         self.document_comparison_field = document_comparison_field
 
@@ -84,6 +87,7 @@ class DocumentNDCGEvaluator:
             value = self._get_comparison_value(doc)
             if value is None:
                 continue
+            value = _make_hashable(value)
             relevance = doc.score if doc.score is not None else 1.0
             relevant_value_to_score[value] = max(relevant_value_to_score.get(value, relevance), relevance)
         return relevant_value_to_score
@@ -177,6 +181,8 @@ class DocumentNDCGEvaluator:
         # retrieval of the same document then finds nothing, so it cannot inflate DCG past IDCG.
         for i, doc in enumerate(ret_docs):
             value = self._get_comparison_value(doc)
+            if value is not None:
+                value = _make_hashable(value)
             if value is not None and value in relevant_value_to_score:
                 dcg += relevant_value_to_score.pop(value) / log2(i + 2)  # i + 2 because i is 0-indexed
         return dcg

--- a/haystack/components/evaluators/document_recall.py
+++ b/haystack/components/evaluators/document_recall.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Any
 
 from haystack import component, default_to_dict, logging
+from haystack.components.evaluators._utils import _make_hashable
 from haystack.dataclasses import Document
 
 logger = logging.getLogger(__name__)
@@ -83,6 +84,8 @@ class DocumentRecallEvaluator:
             - A `meta.` prefix followed by a key name: uses `doc.meta["<key>"]`
               (e.g. `"meta.file_id"`, `"meta.page_number"`)
               Nested keys are supported (e.g. `"meta.source.url"`).
+              List and dictionary values are compared as complete values, with list order preserved and dictionary key
+              order ignored.
         """
         if isinstance(mode, str):
             mode = RecallMode.from_str(mode)
@@ -116,7 +119,9 @@ class DocumentRecallEvaluator:
         """
         Collect the unique comparison values of the documents, ignoring missing or empty ones.
         """
-        return {value for doc in documents if (value := self._get_comparison_value(doc)) not in ("", None)}
+        return {
+            _make_hashable(value) for doc in documents if (value := self._get_comparison_value(doc)) not in ("", None)
+        }
 
     def _comparison_sets(
         self, ground_truth_documents: list[Document], retrieved_documents: list[Document]

--- a/releasenotes/notes/support-unhashable-evaluator-comparison-values-4a8bca5dfcf7c1ab.yaml
+++ b/releasenotes/notes/support-unhashable-evaluator-comparison-values-4a8bca5dfcf7c1ab.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    Fix ``DocumentRecallEvaluator`` and ``DocumentNDCGEvaluator`` crashes when
+    ``document_comparison_field`` points to a list or dictionary in
+    ``Document.meta``. These composite values are now compared and deduplicated
+    consistently with ``DocumentMAPEvaluator``.

--- a/test/components/evaluators/test_document_ndcg.py
+++ b/test/components/evaluators/test_document_ndcg.py
@@ -287,6 +287,42 @@ def test_run_with_nested_meta_comparison():
     assert result["score"] == 1.0
 
 
+@pytest.mark.parametrize(
+    ("ground_truth_value", "retrieved_value", "expected_score"),
+    [
+        (["news", "ai"], ["news", "ai"], 1.0),
+        (["news", "ai"], ["ai", "news"], 0.0),
+        (["news", "ai"], ["news"], 0.0),
+        ({"source": "news", "year": 2024}, {"year": 2024, "source": "news"}, 1.0),
+        ([], [], 1.0),
+        ({}, {}, 1.0),
+        ({"source": {"urls": ["news", "ai"], "year": 2024}}, {"source": {"year": 2024, "urls": ["news", "ai"]}}, 1.0),
+    ],
+)
+def test_run_with_unhashable_meta_comparison(ground_truth_value, retrieved_value, expected_score):
+    evaluator = DocumentNDCGEvaluator(document_comparison_field="meta.value")
+    result = evaluator.run(
+        ground_truth_documents=[[Document(meta={"value": ground_truth_value})]],
+        retrieved_documents=[[Document(meta={"value": retrieved_value})]],
+    )
+
+    assert result["individual_scores"] == [expected_score]
+    assert result["score"] == expected_score
+
+
+def test_run_with_duplicate_unhashable_meta_value_keeps_highest_score():
+    evaluator = DocumentNDCGEvaluator(document_comparison_field="meta.tags")
+    result = evaluator.run(
+        ground_truth_documents=[
+            [Document(meta={"tags": ["news"]}, score=0.5), Document(meta={"tags": ["news"]}, score=1.0)]
+        ],
+        retrieved_documents=[[Document(meta={"tags": ["news"]}), Document(meta={"tags": ["news"]})]],
+    )
+
+    assert result["individual_scores"] == [1.0]
+    assert result["score"] == 1.0
+
+
 def test_run_with_meta_missing_key_treated_as_no_match():
     # Documents missing the meta key should not match anything
     evaluator = DocumentNDCGEvaluator(document_comparison_field="meta.file_id")

--- a/test/components/evaluators/test_document_recall.py
+++ b/test/components/evaluators/test_document_recall.py
@@ -68,6 +68,41 @@ def test_run_with_nested_meta_comparison():
     assert result == {"individual_scores": [0.5], "score": 0.5}
 
 
+@pytest.mark.parametrize(
+    ("ground_truth_value", "retrieved_value", "expected_score"),
+    [
+        (["news", "ai"], ["news", "ai"], 1.0),
+        (["news", "ai"], ["ai", "news"], 0.0),
+        (["news", "ai"], ["news"], 0.0),
+        ({"source": "news", "year": 2024}, {"year": 2024, "source": "news"}, 1.0),
+        ([], [], 1.0),
+        ({}, {}, 1.0),
+        ({"source": {"urls": ["news", "ai"], "year": 2024}}, {"source": {"year": 2024, "urls": ["news", "ai"]}}, 1.0),
+    ],
+)
+@pytest.mark.parametrize("mode", [RecallMode.SINGLE_HIT, RecallMode.MULTI_HIT])
+def test_run_with_unhashable_meta_comparison(ground_truth_value, retrieved_value, expected_score, mode):
+    evaluator = DocumentRecallEvaluator(mode=mode, document_comparison_field="meta.value")
+    result = evaluator.run(
+        ground_truth_documents=[[Document(meta={"value": ground_truth_value})]],
+        retrieved_documents=[[Document(meta={"value": retrieved_value})]],
+    )
+
+    assert result == {"individual_scores": [expected_score], "score": expected_score}
+
+
+def test_run_with_duplicate_unhashable_meta_comparison_values():
+    evaluator = DocumentRecallEvaluator(mode=RecallMode.MULTI_HIT, document_comparison_field="meta.tags")
+    result = evaluator.run(
+        ground_truth_documents=[
+            [Document(meta={"tags": ["news"]}), Document(meta={"tags": ["news"]}), Document(meta={"tags": ["sports"]})]
+        ],
+        retrieved_documents=[[Document(meta={"tags": ["news"]}), Document(meta={"tags": ["news"]})]],
+    )
+
+    assert result == {"individual_scores": [0.5], "score": 0.5}
+
+
 class TestDocumentRecallEvaluatorSingleHit:
     @pytest.fixture
     def evaluator(self):


### PR DESCRIPTION
## Related Issues

No existing issue was found for this behavior.

## Proposed Changes

`Document.meta` supports JSON-serializable values, including lists and dictionaries.
However, when `document_comparison_field` points to such a value:

- `DocumentRecallEvaluator` raises `TypeError` because it stores comparison values in a set.
- `DocumentNDCGEvaluator` raises `TypeError` because it uses comparison values as dictionary keys.

This is inconsistent with `DocumentMAPEvaluator`, which already supports unhashable comparison values.

This change adds a shared internal helper that converts nested list, tuple, and dictionary values into hashable representations while preserving their comparison semantics:

- list and tuple order is preserved;
- dictionary key insertion order is ignored;
- nested containers are supported;
- composite values are compared as complete values, not as element intersections.

Existing deduplication behavior is preserved:

- Recall counts each unique comparison value once.
- NDCG keeps the highest relevance score for duplicate ground-truth values.
- Duplicate retrieved values are credited only once.

## How did you test it?

- Added regression tests for list and dictionary metadata values.
- Added tests for nested values and list ordering.
- Added tests for duplicate values and NDCG relevance-score handling.
- Target evaluator tests: 110 passed.
- Evaluator tests excluding the optional SAS evaluator: 175 passed, 4 skipped.
- Ran Ruff, mypy, Reno lint, and pre-commit successfully.
- SAS model-backed integration tests were intentionally not run because they require model weights.

## Notes for the reviewer

The implementation follows the duplicate-value semantics introduced by
[#12255](https://github.com/deepset-ai/haystack/pull/12255) and
[#11959](https://github.com/deepset-ai/haystack/pull/11959).

This is an internal implementation change with no public API changes.

This PR was fully generated with an AI assistant. The changes have been reviewed and the relevant tests have been run.