### PR TITLE
fix: support ComponentTool deserialization in OpenAI and Azure responses chat generators

### DIFF
--- a/haystack/components/generators/chat/azure_responses.py
+++ b/haystack/components/generators/chat/azure_responses.py
@@ -100,7 +100,7 @@ class AzureOpenAIResponsesChatGenerator(OpenAIResponsesChatGenerator):
         generation_kwargs: dict[str, Any] | None = None,
         timeout: float | None = None,
         max_retries: int | None = None,
-        tools: ToolsType | None = None,
+        tools: ToolsType | list[dict] | None = None,
         tools_strict: bool = False,
         http_client_kwargs: dict[str, Any] | None = None,
     ) -> None:
@@ -256,12 +256,15 @@ class AzureOpenAIResponsesChatGenerator(OpenAIResponsesChatGenerator):
 
         # we only deserialize the tools if they are haystack tools
         # because openai tools are not serialized in the same way
-        tools = data["init_parameters"].get("tools")
+        tools = data.get("init_parameters", {}).get("tools")
         if tools and (
             isinstance(tools, dict)
-            and tools.get("type") == "haystack.tools.toolset.Toolset"
+            and "type" in tools
+            and "data" in tools
             or isinstance(tools, list)
-            and tools[0].get("type") == "haystack.tools.tool.Tool"
+            and isinstance(tools[0], dict)
+            and "type" in tools[0]
+            and "data" in tools[0]
         ):
             deserialize_tools_or_toolset_inplace(data["init_parameters"], key="tools")
 

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -364,12 +364,15 @@ class OpenAIResponsesChatGenerator:
         """
         # we only deserialize the tools if they are haystack tools
         # because openai tools are not serialized in the same way
-        tools = data["init_parameters"].get("tools")
+        tools = data.get("init_parameters", {}).get("tools")
         if tools and (
             isinstance(tools, dict)
-            and tools.get("type") == "haystack.tools.toolset.Toolset"
+            and "type" in tools
+            and "data" in tools
             or isinstance(tools, list)
-            and tools[0].get("type") == "haystack.tools.tool.Tool"
+            and isinstance(tools[0], dict)
+            and "type" in tools[0]
+            and "data" in tools[0]
         ):
             deserialize_tools_or_toolset_inplace(data["init_parameters"], key="tools")
 

--- a/releasenotes/notes/fix-responses-chat-generator-tool-deserialization-0d451839b54d81ee.yaml
+++ b/releasenotes/notes/fix-responses-chat-generator-tool-deserialization-0d451839b54d81ee.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed deserialization of ``Tool`` subclasses such as ``ComponentTool`` in
+    ``OpenAIResponsesChatGenerator.from_dict()`` and
+    ``AzureOpenAIResponsesChatGenerator.from_dict()``.

--- a/test/components/generators/chat/test_azure_responses.py
+++ b/test/components/generators/chat/test_azure_responses.py
@@ -354,6 +354,32 @@ class TestSerDe:
         assert len(deserialized_component.tools) == len(tools)
         assert all(isinstance(tool, Tool) for tool in deserialized_component.tools)
 
+    def test_from_dict_with_component_tool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        component_tool = ComponentTool(
+            name="message_extractor", description="Extracts messages", component=MessageExtractor()
+        )
+        generator = AzureOpenAIResponsesChatGenerator(
+            azure_endpoint="some-non-existing-endpoint", tools=[component_tool]
+        )
+        data = generator.to_dict()
+
+        deserialized_generator = AzureOpenAIResponsesChatGenerator.from_dict(data)
+
+        assert deserialized_generator.tools is not None
+        assert isinstance(deserialized_generator.tools[0], ComponentTool)
+        assert deserialized_generator.tools[0].name == "message_extractor"
+
+    def test_from_dict_with_raw_openai_tools(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        raw_tools: list[dict[str, Any]] = [{"type": "function", "name": "custom_func", "parameters": {}}]
+        generator = AzureOpenAIResponsesChatGenerator(azure_endpoint="some-non-existing-endpoint", tools=raw_tools)
+        data = generator.to_dict()
+
+        deserialized_generator = AzureOpenAIResponsesChatGenerator.from_dict(data)
+
+        assert deserialized_generator.tools == raw_tools
+
     def test_pipeline_serialization_deserialization(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -356,6 +356,30 @@ class TestSerDe:
         assert len(deserialized_component.tools) == len(tools)
         assert all(isinstance(tool, Tool) for tool in deserialized_component.tools)
 
+    def test_from_dict_with_component_tool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component_tool = ComponentTool(
+            name="message_extractor", description="Extracts messages", component=MessageExtractor()
+        )
+        generator = OpenAIResponsesChatGenerator(tools=[component_tool])
+        data = generator.to_dict()
+
+        deserialized_generator = OpenAIResponsesChatGenerator.from_dict(data)
+
+        assert deserialized_generator.tools is not None
+        assert isinstance(deserialized_generator.tools[0], ComponentTool)
+        assert deserialized_generator.tools[0].name == "message_extractor"
+
+    def test_from_dict_with_raw_openai_tools(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        raw_tools: list[dict[str, Any]] = [{"type": "function", "name": "custom_func", "parameters": {}}]
+        generator = OpenAIResponsesChatGenerator(tools=raw_tools)
+        data = generator.to_dict()
+
+        deserialized_generator = OpenAIResponsesChatGenerator.from_dict(data)
+
+        assert deserialized_generator.tools == raw_tools
+
 
 @pytest.fixture
 def mock_openai_clients(monkeypatch):


### PR DESCRIPTION
## Related Issues

Closes #12484

## Proposed Changes

* Updated `OpenAIResponsesChatGenerator.from_dict()` and `AzureOpenAIResponsesChatGenerator.from_dict()` to correctly detect serialized Haystack tools using the `{"type": ..., "data": ...}` serialization envelope instead of matching only `"haystack.tools.tool.Tool"`.
* Added support for deserializing `ComponentTool` instances while preserving raw OpenAI tool definitions.
* Added unit tests covering both serialized Haystack tools and raw OpenAI tools.
* Added a release note describing the fix.

## Root Cause

`from_dict()` previously determined whether a tool required deserialization using:

```python
tools[0].get("type") == "haystack.tools.tool.Tool"
```

This fails for `ComponentTool`, whose serialized representation uses:

```python
{
    "type": "haystack.tools.component_tool.ComponentTool",
    "data": {...}
}
```

As a result, the serialized dictionary remained in `tools` instead of being deserialized.

When `run()` was subsequently called, `_prepare_api_call()` interpreted the dictionary as a raw OpenAI tool definition and passed the Haystack serialization structure to the OpenAI API, resulting in a `400 Bad Request`.

## Fix

The implementation now identifies serialized Haystack tools based on the presence of the `"data"` serialization envelope.

This allows `ComponentTool` and other serialized Haystack tools to be deserialized correctly while continuing to support raw OpenAI tool definitions such as:

```python
{
    "type": "function",
    ...
}
```

## Reproducer

```python
from haystack.components.builders import PromptBuilder
from haystack.components.generators.chat.openai_responses import OpenAIResponsesChatGenerator
from haystack.tools import ComponentTool

tool = ComponentTool(
    name="prompt",
    description="Builds prompt",
    component=PromptBuilder(template="hi"),
)

generator = OpenAIResponsesChatGenerator(tools=[tool])
data = generator.to_dict()

restored = OpenAIResponsesChatGenerator.from_dict(data)

assert isinstance(restored.tools[0], ComponentTool)
```

Before the fix:

```text
restored.tools[0] -> dict
```

After the fix:

```text
restored.tools[0] -> ComponentTool
```

## Tests

Ran the affected test suites:

```bash
hatch -e test run pytest \
  test/components/generators/chat/test_openai_responses.py \
  test/components/generators/chat/test_azure_responses.py
```

Result:

```text
63 passed, 23 skipped in 1.42s
```

Also ran the newly added tests specifically:

```bash
hatch -e test run pytest \
  test/components/generators/chat/test_openai_responses.py \
  test/components/generators/chat/test_azure_responses.py \
  -k "test_from_dict_with_component_tool or test_from_dict_with_raw_openai_tools"
```

Result:

```text
4 passed, 82 deselected in 0.34s
```

## Checklist

* [x] Read contributors guidelines and code of conduct
* [x] Added/updated related issue reference
* [x] Added unit tests
* [x] Updated docstrings/documentation where required
* [x] Added release note
* [x] Used conventional commit type in PR title
* [x] Ran pre-commit hooks and fixed reported issues