### PR TITLE
Fix ComponentTool deserialization in Responses generators

### DIFF
--- a/haystack/components/generators/chat/azure_responses.py
+++ b/haystack/components/generators/chat/azure_responses.py
@@ -259,9 +259,10 @@ class AzureOpenAIResponsesChatGenerator(OpenAIResponsesChatGenerator):
         tools = data["init_parameters"].get("tools")
         if tools and (
             isinstance(tools, dict)
-            and tools.get("type") == "haystack.tools.toolset.Toolset"
+            and "data" in tools
             or isinstance(tools, list)
-            and tools[0].get("type") == "haystack.tools.tool.Tool"
+            and isinstance(tools[0], dict)
+            and "data" in tools[0]
         ):
             deserialize_tools_or_toolset_inplace(data["init_parameters"], key="tools")
 

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -367,9 +367,10 @@ class OpenAIResponsesChatGenerator:
         tools = data["init_parameters"].get("tools")
         if tools and (
             isinstance(tools, dict)
-            and tools.get("type") == "haystack.tools.toolset.Toolset"
+            and "data" in tools
             or isinstance(tools, list)
-            and tools[0].get("type") == "haystack.tools.tool.Tool"
+            and isinstance(tools[0], dict)
+            and "data" in tools[0]
         ):
             deserialize_tools_or_toolset_inplace(data["init_parameters"], key="tools")
 

--- a/test/components/generators/chat/test_azure_responses.py
+++ b/test/components/generators/chat/test_azure_responses.py
@@ -354,6 +354,16 @@ class TestSerDe:
         assert len(deserialized_component.tools) == len(tools)
         assert all(isinstance(tool, Tool) for tool in deserialized_component.tools)
 
+    def test_from_dict_with_component_tool(self, tools: list[Tool], monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        component = AzureOpenAIResponsesChatGenerator(
+            azure_endpoint="some-non-existing-endpoint", tools=[tools[1]]
+        )
+
+        deserialized_component = AzureOpenAIResponsesChatGenerator.from_dict(component.to_dict())
+
+        assert isinstance(deserialized_component.tools[0], ComponentTool)
+
     def test_pipeline_serialization_deserialization(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -356,6 +356,14 @@ class TestSerDe:
         assert len(deserialized_component.tools) == len(tools)
         assert all(isinstance(tool, Tool) for tool in deserialized_component.tools)
 
+    def test_from_dict_with_component_tool(self, tools: list[Tool], monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = OpenAIResponsesChatGenerator(tools=[tools[1]])
+
+        deserialized_component = OpenAIResponsesChatGenerator.from_dict(component.to_dict())
+
+        assert isinstance(deserialized_component.tools[0], ComponentTool)
+
 
 @pytest.fixture
 def mock_openai_clients(monkeypatch):


### PR DESCRIPTION
## Summary

`OpenAIResponsesChatGenerator` and `AzureOpenAIResponsesChatGenerator` only recognized serialized `Tool` and `Toolset` type names when deserializing. Serialized `ComponentTool` instances were therefore left as dictionaries.

This change identifies serialized Haystack tools by their data payload, preserving the existing handling for OpenAI-native tools while restoring `ComponentTool` instances for both Responses generators.

## Tests

- `uv run pytest test/components/generators/chat/test_openai_responses.py::TestSerDe::test_from_dict_with_component_tool test/components/generators/chat/test_azure_responses.py::TestSerDe::test_from_dict_with_component_tool`
- Result: 2 passed

Ruff validation is currently blocked by the repository's existing unsupported `RUF104` rule configuration.
