### PR TITLE
fix: handle unhashable metadata in MetaFieldRanker

### DIFF
--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -335,8 +335,7 @@ class MetaFieldRanker:
         if meta_value_type is None:
             return [d.meta[self.meta_field] for d in docs_with_meta_field]
 
-        unique_meta_values = {doc.meta[self.meta_field] for doc in docs_with_meta_field}
-        if not all(isinstance(meta_value, str) for meta_value in unique_meta_values):
+        if not all(isinstance(doc.meta[self.meta_field], str) for doc in docs_with_meta_field):
             logger.warning(
                 "The parameter <meta_value_type> is currently set to '{meta_field}', but not all of meta values in the "
                 "provided Documents with IDs {document_ids} are strings.\n"

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -183,6 +183,20 @@ class TestMetaFieldRanker:
                 "provided Documents with IDs 1,2,3 are strings." in caplog.text
             )
 
+    @pytest.mark.parametrize("meta_value", [[1, 2, 3], {"score": 5}])
+    def test_warning_meta_value_type_with_unhashable_value(self, meta_value, caplog):
+        ranker = MetaFieldRanker(meta_field="rating", meta_value_type="float")
+        docs_before = [
+            Document(id="1", content="abc", meta={"rating": meta_value}),
+            Document(id="2", content="def", meta={"rating": 5}),
+        ]
+
+        with caplog.at_level(logging.WARNING):
+            output = ranker.run(documents=docs_before)
+
+        assert output["documents"] == docs_before
+        assert "not all of meta values in the provided Documents with IDs 1,2 are strings." in caplog.text
+
     def test_raises_value_error_if_wrong_ranking_mode(self):
         with pytest.raises(ValueError):
             MetaFieldRanker(meta_field="rating", ranking_mode="wrong_mode")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

`MetaFieldRanker` now checks metadata values directly instead of building a set before verifying that values are strings. This prevents `TypeError` for unhashable metadata such as lists and dictionaries when `meta_value_type` is configured.

## Changes

- Preserve the existing warning and fallback behavior for non-string metadata.
- Add regression coverage for list and dictionary metadata values.

## Tests

- `uv run pytest test/components/rankers/test_metafield.py -q` (43 passed)
- `uv run ruff check --isolated haystack/components/rankers/meta_field.py test/components/rankers/test_metafield.py` (passed)
- `git diff --check` (passed)

The repository-configured Ruff command could not parse the current `pyproject.toml` because the installed Ruff does not recognize `RUF104`; isolated Ruff checks passed. The repository format check reports both touched files would be reformatted by the installed formatter, so the patch intentionally preserves the existing file formatting and remains minimal.
