### PR TITLE
fix: handle unhashable MetaFieldRanker values

### DIFF
--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -335,8 +335,7 @@ class MetaFieldRanker:
         if meta_value_type is None:
             return [d.meta[self.meta_field] for d in docs_with_meta_field]
 
-        unique_meta_values = {doc.meta[self.meta_field] for doc in docs_with_meta_field}
-        if not all(isinstance(meta_value, str) for meta_value in unique_meta_values):
+        if not all(isinstance(doc.meta[self.meta_field], str) for doc in docs_with_meta_field):
             logger.warning(
                 "The parameter <meta_value_type> is currently set to '{meta_field}', but not all of meta values in the "
                 "provided Documents with IDs {document_ids} are strings.\n"

--- a/releasenotes/notes/fix-unhashable-meta-field-ranker-values-9e69f72.yaml
+++ b/releasenotes/notes/fix-unhashable-meta-field-ranker-values-9e69f72.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed ``MetaFieldRanker`` raising a ``TypeError`` when ``meta_value_type`` is set and a document contains
+    an unhashable metadata value, such as a list or dictionary. These values now follow the existing warning
+    and original-document fallback behavior.

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -183,6 +183,18 @@ class TestMetaFieldRanker:
                 "provided Documents with IDs 1,2,3 are strings." in caplog.text
             )
 
+    @pytest.mark.parametrize("meta_value", [[1, 2, 3], {"score": 5}])
+    def test_warning_meta_value_type_with_unhashable_value(self, meta_value, caplog):
+        ranker = MetaFieldRanker(meta_field="rating", meta_value_type="float")
+        docs_before = [
+            Document(id="1", content="abc", meta={"rating": meta_value}),
+            Document(id="2", content="abc", meta={"rating": "1.2"}),
+        ]
+        with caplog.at_level(logging.WARNING):
+            output = ranker.run(documents=docs_before)
+        assert output["documents"] == docs_before
+        assert "not all of meta values in the provided Documents with IDs 1,2 are strings" in caplog.text
+
     def test_raises_value_error_if_wrong_ranking_mode(self):
         with pytest.raises(ValueError):
             MetaFieldRanker(meta_field="rating", ranking_mode="wrong_mode")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary / Problem

Closes #12488. `MetaFieldRanker` raised `TypeError` when `meta_value_type` was configured and a document contained an unhashable metadata value such as a list or dictionary.

## Changes

- Check metadata values directly with `all()` instead of building a set.
- Add regression coverage for list and dictionary metadata values, including the warning and original-document fallback.

## Tests

- `uv run --with pytest --with pytest-cov python -m pytest test/components/rankers/test_metafield.py -q` (43 passed)
- `git diff --check`

## Compatibility / Known limitations

Valid string metadata parsing is unchanged. Unhashable non-string values now follow the existing warning and fallback path instead of raising during validation. Full repository checks were not run because this is a focused two-file change.

Issue: https://github.com/deepset-ai/haystack/issues/12488
