### PR TITLE
docs(contributing): add Hybrid RAG Action to community tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ There are several ways you can contribute to Haystack:
 - Contribute to the main Haystack project
 - Contribute an integration on [haystack-core-integrations](https://github.com/deepset-ai/haystack-core-integrations)
 - Contribute to the documentation in [haystack/docs-website](https://github.com/deepset-ai/haystack/tree/main/docs-website)
+- Community integrations & tools: [Hybrid RAG GitHub Action](https://github.com/Cagrik34/hybrid-rag-action) — Zero-dependency GitHub Action combining Okapi BM25 and dense embeddings with RRF for automated repo triage
 
 > [!TIP]
 >👉 **[Check out the full list of issues that are open to contributions](https://github.com/orgs/deepset-ai/projects/14)**


### PR DESCRIPTION
### Summary
Adds [Hybrid RAG Action](https://github.com/Cagrik34/hybrid-rag-action) to community tools.

### Description
`Hybrid RAG Action` is a zero-dependency automated GitHub issue and PR triage tool. It integrates Okapi BM25 sparse keyword retrieval with dense vector cosine similarity fused via Reciprocal Rank Fusion (RRF, $k=60$) to provide exact line citations.