### PR TITLE
feat: add pipeline run recording with deterministic replay

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -4,8 +4,10 @@
 
 import asyncio
 import contextlib
+import time
 from collections.abc import AsyncGenerator, AsyncIterator, Mapping
-from typing import Any, ClassVar, cast
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast, overload
 
 from haystack import logging, tracing
 from haystack.core.component import Component
@@ -36,6 +38,10 @@ from haystack.utils.async_utils import _execute_component_async
 from haystack.utils.misc import _get_output_dir
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from haystack.recording.replay import ReplayMode
+    from haystack.recording.run import PipelineRun
 
 
 class _EndOfStream:
@@ -196,6 +202,36 @@ class Pipeline(PipelineBase):
 
             return component_output
 
+    @overload
+    def run(
+        self,
+        data: dict[str, Any],
+        include_outputs_from: set[str] | None = None,
+        *,
+        break_point: Breakpoint | None = None,
+        pipeline_snapshot: PipelineSnapshot | None = None,
+        snapshot_callback: SnapshotCallback | None = None,
+        record: Literal[False] = False,
+        replay: PipelineRun | str | Path | None = None,
+        replay_mode: str | ReplayMode = "strict",
+        replay_side_effecting_components: set[str] | None = None,
+    ) -> dict[str, Any]: ...
+
+    @overload
+    def run(
+        self,
+        data: dict[str, Any],
+        include_outputs_from: set[str] | None = None,
+        *,
+        break_point: Breakpoint | None = None,
+        pipeline_snapshot: PipelineSnapshot | None = None,
+        snapshot_callback: SnapshotCallback | None = None,
+        record: Literal[True],
+        replay: PipelineRun | str | Path | None = None,
+        replay_mode: str | ReplayMode = "strict",
+        replay_side_effecting_components: set[str] | None = None,
+    ) -> tuple[dict[str, Any], PipelineRun]: ...
+
     @mark_deserialization_internal
     def run(  # noqa: PLR0915, PLR0912, C901
         self,
@@ -205,7 +241,11 @@ class Pipeline(PipelineBase):
         break_point: Breakpoint | None = None,
         pipeline_snapshot: PipelineSnapshot | None = None,
         snapshot_callback: SnapshotCallback | None = None,
-    ) -> dict[str, Any]:
+        record: bool = False,
+        replay: Any | None = None,
+        replay_mode: str | Any = "strict",
+        replay_side_effecting_components: set[str] | None = None,
+    ) -> dict[str, Any] | tuple[dict[str, Any], Any]:
         """
         Runs the Pipeline with given input data.
 
@@ -326,6 +366,41 @@ class Pipeline(PipelineBase):
             When a pipeline_breakpoint is triggered. Contains the component name, state, and partial results.
         """
         pipeline_running(self)  # telemetry
+
+        # --- recording / replay setup (lazy imports to avoid circular) ---
+        recording_ctx = None
+        replay_store = None
+        # resolve replay
+        if replay is not None:
+            from haystack.recording.replay import ReplayMode as _ReplayMode
+            from haystack.recording.replay import ReplayStore as _ReplayStore
+
+            # normalize replay_mode
+            if isinstance(replay_mode, str):
+                try:
+                    _mode = _ReplayMode(replay_mode.lower())
+                except ValueError as e:
+                    raise ValueError(f"Invalid replay_mode '{replay_mode}', expected 'strict' or 'loose'") from e
+            else:
+                _mode = replay_mode
+            replay_store = _ReplayStore.from_run(replay, mode=_mode, explicit_set=replay_side_effecting_components)
+            # validate signature for STRICT
+            if _mode == _ReplayMode.STRICT:
+                replay_store.validate_signature(self)
+
+        if record:
+            from haystack.recording.recorder import RecordingContext as _RecordingContext
+            from haystack.recording.recorder import compute_pipeline_signature as _compute_sig
+
+            recording_ctx = _RecordingContext()
+            # store signature for later use
+            _recording_signature = _compute_sig(self)
+            _recording_start_perf = time.perf_counter()
+            _recording_start_wall = time.time()
+        else:
+            _recording_signature = ""
+            _recording_start_perf = 0.0
+            _recording_start_wall = 0.0
 
         if (
             break_point
@@ -467,6 +542,84 @@ class Pipeline(PipelineBase):
                 # initialization
                 component_inputs = self._add_missing_input_defaults(component_inputs, component["input_sockets"])
 
+                # --- replay check ---
+                _replay_hit = False
+                _replay_record = None
+                if replay_store is not None:
+                    instance = component["instance"]
+                    try:
+                        from haystack.core.serialization import generate_qualified_class_name as _gqcn
+
+                        _qualname = _gqcn(type(instance))
+                    except Exception:
+                        _qualname = f"{type(instance).__module__}.{type(instance).__name__}"
+                    if replay_store.should_replay(component_name, _qualname, instance):
+                        _replay_record = replay_store.pop(component_name)
+                        if _replay_record is not None:
+                            _replay_hit = True
+                        else:
+                            from haystack.recording.replay import ReplayMode as _RM
+
+                            if replay_store.mode == _RM.STRICT:
+                                from haystack.recording.replay import ReplayMismatchError as _RME
+
+                                raise _RME(
+                                    f"No recorded output for component '{component_name}' at visit "
+                                    f"{component_visits[component_name]}"
+                                )
+                            # LOOSE: fall through to live execution
+
+                if _replay_hit and _replay_record is not None:
+                    # Replay path: use recorded outputs without calling instance.run
+                    visit_index = component_visits[component_name]
+                    component_visits[component_name] += 1
+                    component_outputs = _replay_record.outputs
+                    # tracing span for replayed component
+                    with PipelineBase._create_component_span(
+                        component_name=component_name,
+                        instance=component["instance"],
+                        inputs=component_inputs,
+                        parent_span=span,
+                    ) as _rspan:
+                        _rspan.set_tag(_COMPONENT_VISITS, component_visits[component_name])
+                        _rspan.set_content_tag(_COMPONENT_OUTPUT, component_outputs)
+                    # recording for replayed component
+                    if recording_ctx is not None:
+                        from haystack.recording.recorder import _extract_usage as _eu
+
+                        usage = _replay_record.usage if _replay_record.usage is not None else _eu(component_outputs)
+                        # use recorded duration if available, else 0
+                        _dur = _replay_record.duration_s if _replay_record.duration_s is not None else 0.0
+                        _started = time.time()
+                        _ended = _started + _dur
+                        recording_ctx.add_from_parts(
+                            component_name=component_name,
+                            visit_index=visit_index,
+                            inputs=component_inputs,
+                            outputs=component_outputs,
+                            duration_s=_dur,
+                            started_at=_started,
+                            ended_at=_ended,
+                            usage=usage,
+                        )
+                    # write outputs
+                    component_pipeline_outputs = self._write_component_outputs(
+                        component_name=component_name,
+                        component_outputs=component_outputs,
+                        inputs=inputs,
+                        receivers=cached_receivers[component_name],
+                        include_outputs_from=include_outputs_from,
+                    )
+                    if component_pipeline_outputs or component_name in include_outputs_from:
+                        pipeline_outputs[component_name] = component_pipeline_outputs
+                    if self._is_queue_stale(priority_queue):
+                        priority_queue = self._fill_queue(ordered_component_names, inputs, component_visits)
+                    continue
+
+                # --- live execution with timing and recording ---
+                _visit_index_before = component_visits[component_name]
+                _t0_perf = time.perf_counter()
+                _t0_wall = time.time()
                 try:
                     component_outputs = self._run_component(
                         component_name=component_name,
@@ -509,6 +662,23 @@ class Pipeline(PipelineBase):
                     error.pipeline_snapshot_file_path = full_file_path
                     raise error
 
+                _dur_s = time.perf_counter() - _t0_perf
+                _t1_wall = time.time()
+                if recording_ctx is not None:
+                    from haystack.recording.recorder import _extract_usage as _eu2
+
+                    usage = _eu2(component_outputs)
+                    recording_ctx.add_from_parts(
+                        component_name=component_name,
+                        visit_index=_visit_index_before,
+                        inputs=component_inputs,
+                        outputs=component_outputs,
+                        duration_s=_dur_s,
+                        started_at=_t0_wall,
+                        ended_at=_t1_wall,
+                        usage=usage,
+                    )
+
                 # Updates global input state with component outputs and returns outputs that should go to
                 # pipeline outputs.
                 component_pipeline_outputs = self._write_component_outputs(
@@ -534,6 +704,70 @@ class Pipeline(PipelineBase):
 
             # Set here so the tag reflects the final outputs.
             span.set_content_tag("haystack.pipeline.output_data", pipeline_outputs)
+
+            # --- build PipelineRun if recording ---
+            if recording_ctx is not None:
+                # aggregate usage
+                from haystack.components.agents.utils import _accumulate_usage as _acc
+                from haystack.recording.recorder import _estimate_cost as _est_cost
+                from haystack.recording.recorder import _extract_model as _ext_model
+                from haystack.recording.run import PipelineRun as _PR
+                from haystack.version import __version__ as _hv
+
+                total_usage: dict[str, Any] = {}
+                first = True
+                cost_by_component: dict[str, float] = {}
+                total_cost = 0.0
+                # components dict
+                comps_dict = recording_ctx.get_components_dict()
+                # also compute per-component timeline already
+                timeline_sorted = recording_ctx.get_timeline_sorted()
+                # build usage aggregation and cost
+                for cname, recs in comps_dict.items():
+                    comp_usage: dict[str, Any] = {}
+                    comp_first = True
+                    comp_cost = 0.0
+                    for rec in recs:
+                        if rec.usage:
+                            if comp_first:
+                                comp_usage = dict(rec.usage)
+                                comp_first = False
+                            else:
+                                comp_usage = _acc(comp_usage, rec.usage)
+                            # cost per record
+                            model = _ext_model(rec.outputs)
+                            c = _est_cost(rec.usage, model)
+                            comp_cost += c
+                    if comp_usage:
+                        if first:
+                            total_usage = dict(comp_usage)
+                            first = False
+                        else:
+                            total_usage = _acc(total_usage, comp_usage)
+                    cost_by_component[cname] = comp_cost
+                    total_cost += comp_cost
+
+                # fallback: if no cost_by_component yet but total_usage empty, keep total 0
+                from datetime import datetime, timezone
+
+                created = datetime.now(timezone.utc).isoformat()
+                run = _PR(
+                    run_id=str(__import__("uuid").uuid4()),
+                    pipeline_signature=_recording_signature,
+                    input_data=_deepcopy_with_exceptions(data),
+                    output_data=_deepcopy_with_exceptions(pipeline_outputs),
+                    components=comps_dict,
+                    timeline=timeline_sorted,
+                    usage=total_usage,
+                    cost_estimate={"total": total_cost, "by_component": cost_by_component},
+                    created_at=created,
+                    haystack_version=_hv,
+                    format="v1",
+                )
+                # close context
+                with contextlib.suppress(Exception):
+                    recording_ctx.close()
+                return (pipeline_outputs, run)  # type: ignore[return-value]
 
             return pipeline_outputs
 
@@ -790,10 +1024,44 @@ class Pipeline(PipelineBase):
         task = asyncio.create_task(_runner())
         running_tasks[task] = component_name
 
+    @overload
+    async def run_async_generator(
+        self,
+        data: dict[str, Any],
+        include_outputs_from: set[str] | None = None,
+        concurrency_limit: int = 4,
+        *,
+        record: Literal[False] = False,
+        replay: Any | None = None,
+        replay_mode: str | Any = "strict",
+        replay_side_effecting_components: set[str] | None = None,
+    ) -> AsyncGenerator[dict[str, Any], None]: ...
+
+    @overload
+    async def run_async_generator(
+        self,
+        data: dict[str, Any],
+        include_outputs_from: set[str] | None = None,
+        concurrency_limit: int = 4,
+        *,
+        record: Literal[True],
+        replay: Any | None = None,
+        replay_mode: str | Any = "strict",
+        replay_side_effecting_components: set[str] | None = None,
+    ) -> AsyncGenerator[tuple[dict[str, Any], Any], None]: ...
+
     @mark_deserialization_internal
-    async def run_async_generator(  # noqa: PLR0915,C901
-        self, data: dict[str, Any], include_outputs_from: set[str] | None = None, concurrency_limit: int = 4
-    ) -> AsyncGenerator[dict[str, Any], None]:
+    async def run_async_generator(  # noqa: PLR0915,C901,ARG002
+        self,
+        data: dict[str, Any],
+        include_outputs_from: set[str] | None = None,
+        concurrency_limit: int = 4,
+        *,
+        record: bool = False,
+        replay: Any | None = None,
+        replay_mode: str | Any = "strict",
+        replay_side_effecting_components: set[str] | None = None,
+    ) -> AsyncGenerator[dict[str, Any] | tuple[dict[str, Any], Any], None]:
         """
         Executes the pipeline step by step asynchronously, yielding partial outputs when any component finishes.
 
@@ -887,6 +1155,16 @@ class Pipeline(PipelineBase):
         """
         if concurrency_limit < 1:
             raise ValueError("concurrency_limit must be greater than or equal to 1.")
+
+        # mark replay params as used to silence ARG002
+        _ = (replay_mode, replay_side_effecting_components)
+        if record or replay is not None:
+            raise NotImplementedError(
+                "Recording and replay are currently only supported for synchronous "
+                "Pipeline.run(). Use pipeline.run(data, record=True) for recording and "
+                "pipeline.run(data, replay=..., record=False) for replay. "
+                "Async recording will be added in a future release."
+            )
 
         pipeline_running(self)  # telemetry
 
@@ -1080,10 +1358,44 @@ class Pipeline(PipelineBase):
                 # This is a no-op on normal completion and on a component error, since no tasks are left running by then
                 await self._cancel_in_flight_tasks(running_tasks, scheduled_components)
 
-    @mark_deserialization_internal
+    @overload
     async def run_async(
-        self, data: dict[str, Any], include_outputs_from: set[str] | None = None, concurrency_limit: int = 4
-    ) -> dict[str, Any]:
+        self,
+        data: dict[str, Any],
+        include_outputs_from: set[str] | None = None,
+        concurrency_limit: int = 4,
+        *,
+        record: Literal[False] = False,
+        replay: Any | None = None,
+        replay_mode: str | Any = "strict",
+        replay_side_effecting_components: set[str] | None = None,
+    ) -> dict[str, Any]: ...
+
+    @overload
+    async def run_async(
+        self,
+        data: dict[str, Any],
+        include_outputs_from: set[str] | None = None,
+        concurrency_limit: int = 4,
+        *,
+        record: Literal[True],
+        replay: Any | None = None,
+        replay_mode: str | Any = "strict",
+        replay_side_effecting_components: set[str] | None = None,
+    ) -> tuple[dict[str, Any], Any]: ...
+
+    @mark_deserialization_internal
+    async def run_async(  # noqa: ARG002
+        self,
+        data: dict[str, Any],
+        include_outputs_from: set[str] | None = None,
+        concurrency_limit: int = 4,
+        *,
+        record: bool = False,
+        replay: Any | None = None,
+        replay_mode: str | Any = "strict",
+        replay_side_effecting_components: set[str] | None = None,
+    ) -> dict[str, Any] | tuple[dict[str, Any], Any]:
         """
         Provides an asynchronous interface to run the pipeline with provided input data.
 
@@ -1191,6 +1503,12 @@ class Pipeline(PipelineBase):
         :raises PipelineMaxComponentRuns:
             If a Component reaches the maximum number of times it can be run in this Pipeline.
         """
+        _ = (replay_mode, replay_side_effecting_components)
+        if record or replay is not None:
+            raise NotImplementedError(
+                "Recording and replay are currently only supported for synchronous Pipeline.run(). "
+                "Use pipeline.run(data, record=True) for recording."
+            )
         final: dict[str, Any] = {}
         async for partial in self.run_async_generator(
             data=data, concurrency_limit=concurrency_limit, include_outputs_from=include_outputs_from

--- a/haystack/recording/__init__.py
+++ b/haystack/recording/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack.recording.replay import (
+    DEFAULT_SIDE_EFFECTING_QUALNAMES,
+    ReplayMismatchError,
+    ReplayMode,
+    ReplayStore,
+    is_side_effecting,
+)
+from haystack.recording.run import (
+    ComponentRecord,
+    PipelineRun,
+    RecordingError,
+    TimelineEntry,
+    aggregate_usage,
+    load_run,
+)
+
+__all__ = [
+    "ComponentRecord",
+    "DEFAULT_SIDE_EFFECTING_QUALNAMES",
+    "PipelineRun",
+    "RecordingError",
+    "ReplayMismatchError",
+    "ReplayMode",
+    "ReplayStore",
+    "TimelineEntry",
+    "aggregate_usage",
+    "is_side_effecting",
+    "load_run",
+]

--- a/haystack/recording/recorder.py
+++ b/haystack/recording/recorder.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import contextvars
+import hashlib
+import json
+import threading
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from haystack import logging
+from haystack.core.pipeline.utils import _deepcopy_with_exceptions
+from haystack.dataclasses import ChatMessage
+from haystack.recording.run import ComponentRecord, TimelineEntry
+
+logger = logging.getLogger(__name__)
+
+# ContextVar for async propagation
+_recording_context_var: contextvars.ContextVar[Any] = contextvars.ContextVar("haystack_recording_context", default=None)
+
+
+def _first_numeric(usage: dict[str, Any], keys: tuple[str, ...]) -> int:
+    for key in keys:
+        value = usage.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            return int(value)
+    return 0
+
+
+def _extract_usage(outputs: Mapping[str, Any]) -> dict[str, Any] | None:  # noqa: C901 PLR0912
+    """
+    Extract usage dict from component outputs.
+
+    Handles:
+    - Chat generators: {"replies": [ChatMessage(meta={"usage": ...})]}
+    - Embedders: {"meta": {"usage": {...}}}
+    - Generic: {"usage": {...}}
+    """
+    if not isinstance(outputs, Mapping):
+        return None
+
+    # ChatMessage list paths
+    for key in ("replies", "answers"):
+        val = outputs.get(key)
+        if isinstance(val, list) and val and isinstance(val[0], ChatMessage):
+            from haystack.components.agents.utils import _accumulate_usage
+
+            acc: dict[str, Any] | None = None
+            for msg in val:
+                if not isinstance(msg, ChatMessage):
+                    continue
+                meta = getattr(msg, "meta", None)
+                if not isinstance(meta, dict):
+                    continue
+                u = meta.get("usage")
+                if isinstance(u, dict):
+                    if acc is None:
+                        acc = dict(u)
+                    else:
+                        acc = _accumulate_usage(acc, u)
+            if acc is not None:
+                return acc
+
+    # Embedder path: {"meta": {"usage": {...}}}
+    meta = outputs.get("meta")
+    if isinstance(meta, dict):
+        u = meta.get("usage")
+        if isinstance(u, dict):
+            return dict(u)
+
+    # Fallback top-level usage
+    u = outputs.get("usage")
+    if isinstance(u, dict):
+        return dict(u)
+
+    # Search any ChatMessage nested inside values
+    for v in outputs.values():
+        if isinstance(v, list) and v and isinstance(v[0], ChatMessage):
+            from haystack.components.agents.utils import _accumulate_usage
+
+            acc = None
+            for msg in v:
+                if isinstance(msg, ChatMessage):
+                    meta = getattr(msg, "meta", None)
+                    if isinstance(meta, dict) and isinstance(meta.get("usage"), dict):
+                        u = meta["usage"]
+                        if acc is None:
+                            acc = dict(u)
+                        else:
+                            acc = _accumulate_usage(acc, u)
+            if acc is not None:
+                return acc
+
+    return None
+
+
+def _extract_model(outputs: Mapping[str, Any]) -> str | None:
+    """Try to extract model name from outputs for cost estimation."""
+    if not isinstance(outputs, Mapping):
+        return None
+    # ChatMessage path
+    for key in ("replies", "answers"):
+        val = outputs.get(key)
+        if isinstance(val, list) and val and isinstance(val[0], ChatMessage):
+            for msg in val:
+                if isinstance(msg, ChatMessage):
+                    meta = getattr(msg, "meta", None)
+                    if isinstance(meta, dict) and isinstance(meta.get("model"), str):
+                        return meta["model"]
+    meta = outputs.get("meta")
+    if isinstance(meta, dict) and isinstance(meta.get("model"), str):
+        return meta["model"]
+    # Also check usage dict model?
+    return None
+
+
+# Pricing per 1M tokens in USD
+_PRICING_PER_1M: dict[str, dict[str, float]] = {
+    "gpt-4o": {"input": 2.5, "output": 10.0},
+    "gpt-4o-mini": {"input": 0.15, "output": 0.6},
+    "gpt-4.1": {"input": 2.0, "output": 8.0},
+    "gpt-4.1-mini": {"input": 0.4, "output": 1.6},
+    "gpt-3.5-turbo": {"input": 0.5, "output": 1.5},
+    "gpt-3.5": {"input": 0.5, "output": 1.5},
+    "text-embedding-ada-002": {"input": 0.1, "output": 0.0},
+    "text-embedding-3-small": {"input": 0.02, "output": 0.0},
+    "text-embedding-3-large": {"input": 0.13, "output": 0.0},
+    "mock-model": {"input": 0.0, "output": 0.0},
+    "mock": {"input": 0.0, "output": 0.0},
+}
+
+
+def _estimate_cost(usage: dict[str, Any] | None, model: str | None = None) -> float:
+    """Estimate cost in USD from usage dict and model."""
+    if not isinstance(usage, dict):
+        return 0.0
+    # extract prompt/completion tokens with fallback keys
+    prompt = _first_numeric(usage, ("prompt_tokens", "input_tokens"))
+    completion = _first_numeric(usage, ("completion_tokens", "output_tokens"))
+    # if both zero but total_tokens present, treat as prompt for embedder
+    if prompt == 0 and completion == 0:
+        total = usage.get("total_tokens")
+        if isinstance(total, (int, float)) and not isinstance(total, bool):
+            prompt = int(total)
+    # Determine pricing
+    model_l = (model or "").lower()
+    pricing: dict[str, float] | None = None
+    # exact match first
+    for key, price in _PRICING_PER_1M.items():
+        if key.lower() in model_l:
+            pricing = price
+            break
+    if pricing is None:
+        # check embedding generic
+        if "embedding" in model_l or "ada" in model_l:
+            pricing = {"input": 0.1, "output": 0.0}
+        else:
+            pricing = {"input": 0.0, "output": 0.0}
+    return (prompt * pricing["input"] + completion * pricing["output"]) / 1_000_000
+
+
+def compute_pipeline_signature(pipeline: Any) -> str:
+    """Hash of sorted component qualnames + connections."""
+
+    def _fallback_qname(cls: type) -> str:
+        return f"{cls.__module__}.{cls.__name__}"
+
+    try:
+        from haystack.core.serialization import generate_qualified_class_name
+    except Exception:
+        generate_qualified_class_name = _fallback_qname  # type: ignore
+
+    nodes = []
+    for name in sorted(pipeline.graph.nodes.keys()):
+        instance = pipeline.graph.nodes[name].get("instance")
+        if instance is not None:
+            try:
+                qname = generate_qualified_class_name(type(instance))
+            except Exception:
+                qname = f"{type(instance).__module__}.{type(instance).__name__}"
+        else:
+            qname = "unknown"
+        nodes.append(f"{name}:{qname}")
+    edges = []
+    for sender, receiver, edge_data in sorted(pipeline.graph.edges(data=True)):
+        from_socket = edge_data.get("from_socket")
+        to_socket = edge_data.get("to_socket")
+        from_name = getattr(from_socket, "name", str(from_socket)) if from_socket else "unknown"
+        to_name = getattr(to_socket, "name", str(to_socket)) if to_socket else "unknown"
+        edges.append(f"{sender}.{from_name}->{receiver}.{to_name}")
+    raw = json.dumps({"nodes": nodes, "edges": edges}, sort_keys=True)
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+class RecordingContext:
+    """Thread-safe collector for recording."""
+
+    def __init__(self) -> None:  # noqa: D107
+        self.records: list[ComponentRecord] = []
+        self.timeline: list[TimelineEntry] = []
+        self._lock = threading.Lock()
+        self.start_perf = time.perf_counter()
+        self.start_wall = time.time()
+        # also set contextvar
+        self._token = _recording_context_var.set(self)
+
+    def add(self, record: ComponentRecord, timeline_entry: TimelineEntry) -> None:
+        """Add a record and timeline entry."""
+        with self._lock:
+            self.records.append(record)
+            self.timeline.append(timeline_entry)
+
+    def add_from_parts(
+        self,
+        component_name: str,
+        visit_index: int,
+        inputs: dict[str, Any],
+        outputs: Mapping[str, Any],
+        duration_s: float,
+        started_at: float,
+        ended_at: float,
+        usage: dict[str, Any] | None = None,
+    ) -> None:
+        """Add from individual parts, constructing record and entry."""
+        rec = ComponentRecord(
+            component_name=component_name,
+            visit_index=visit_index,
+            inputs=_deepcopy_with_exceptions(inputs),
+            outputs=_deepcopy_with_exceptions(dict(outputs)),
+            duration_s=duration_s,
+            usage=usage,
+        )
+        entry = TimelineEntry(
+            component_name=component_name,
+            visit_index=visit_index,
+            duration_s=duration_s,
+            started_at=started_at,
+            ended_at=ended_at,
+        )
+        self.add(rec, entry)
+
+    def close(self) -> None:
+        """Reset the contextvar."""
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            _recording_context_var.reset(self._token)
+
+    @staticmethod
+    def current() -> RecordingContext | None:
+        """Return current context from ContextVar."""
+        return _recording_context_var.get()
+
+    def get_components_dict(self) -> dict[str, list[ComponentRecord]]:
+        """Return components dict sorted by visit_index."""
+        d: dict[str, list[ComponentRecord]] = {}
+        with self._lock:
+            for rec in self.records:
+                d.setdefault(rec.component_name, []).append(rec)
+        # sort each list by visit_index
+        for lst in d.values():
+            lst.sort(key=lambda r: r.visit_index)
+        return d
+
+    def get_timeline_sorted(self) -> list[TimelineEntry]:
+        """Return timeline sorted by started_at."""
+        with self._lock:
+            return sorted(self.timeline, key=lambda e: e.started_at)

--- a/haystack/recording/replay.py
+++ b/haystack/recording/replay.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from haystack import logging
+from haystack.recording.run import PipelineRun, RecordingError
+
+logger = logging.getLogger(__name__)
+
+
+class ReplayMode(str, Enum):
+    STRICT = "strict"
+    LOOSE = "loose"
+
+
+class ReplayMismatchError(RecordingError):
+    """Raised when replay validation fails in STRICT mode."""
+
+
+DEFAULT_SIDE_EFFECTING_QUALNAMES: frozenset[str] = frozenset(
+    {
+        "haystack.components.generators.chat.openai.OpenAIChatGenerator",
+        "haystack.components.generators.openai.OpenAIGenerator",
+        "haystack.components.generators.chat.openai_responses.OpenAIResponsesChatGenerator",
+        "haystack.components.retrievers.in_memory.bm25_retriever.InMemoryBM25Retriever",
+        "haystack.components.retrievers.in_memory.embedding_retriever.InMemoryEmbeddingRetriever",
+        "haystack.components.embedders.openai_text_embedder.OpenAITextEmbedder",
+        "haystack.components.embedders.openai_document_embedder.OpenAIDocumentEmbedder",
+        "haystack.components.embedders.sentence_transformers_text_embedder.SentenceTransformersTextEmbedder",
+        "haystack.components.fetchers.link_content.LinkContentFetcher",
+        "haystack.components.websearch.serper_dev.SerperDevWebSearch",
+        "haystack.components.agents.agent.Agent",
+    }
+)
+
+
+def is_side_effecting(instance: Any) -> bool:
+    """Hybrid check for side-effecting components."""
+    # explicit instance marker
+    if getattr(instance, "__haystack_side_effecting__", False):
+        return True
+    # also check type marker
+    if getattr(type(instance), "__haystack_side_effecting__", False):
+        return True
+    # check is_side_effecting attribute
+    try:
+        val = getattr(instance, "is_side_effecting", None)
+        if isinstance(val, bool) and val:
+            return True
+        if val is not None and not isinstance(val, bool) and not callable(val) and bool(val):
+            return True
+    except Exception:
+        pass
+
+    # qualname check
+    try:
+        from haystack.core.serialization import generate_qualified_class_name
+
+        qname = generate_qualified_class_name(type(instance))
+    except Exception:
+        qname = f"{type(instance).__module__}.{type(instance).__name__}"
+    return qname in DEFAULT_SIDE_EFFECTING_QUALNAMES
+
+
+class ReplayStore:
+    """Wraps PipelineRun for deterministic replay."""
+
+    def __init__(
+        self, run: PipelineRun, mode: ReplayMode = ReplayMode.STRICT, explicit_set: set[str] | None = None
+    ) -> None:
+        self.run = run
+        self.mode = mode
+        self.explicit_set = explicit_set
+        # cursor per component
+        self._cursors: dict[str, int] = {}
+        # quick map for validation
+        self._components = run.components
+
+    @classmethod
+    def from_run(
+        cls,
+        replay: PipelineRun | str | Path | dict[str, Any],
+        mode: ReplayMode | str = ReplayMode.STRICT,
+        explicit_set: set[str] | None = None,
+    ) -> ReplayStore:
+        """Create ReplayStore from run object or path."""
+        # resolve mode
+        if isinstance(mode, str):
+            try:
+                mode_enum = ReplayMode(mode.lower())
+            except ValueError:
+                raise ValueError(f"Invalid replay_mode '{mode}', expected 'strict' or 'loose'")
+        else:
+            mode_enum = mode
+
+        # resolve run
+        run_obj: PipelineRun
+        if isinstance(replay, PipelineRun):
+            run_obj = replay
+        elif isinstance(replay, (str, Path)):
+            p = Path(replay)
+            if not p.exists():
+                raise FileNotFoundError(f"Replay file not found: {p}")
+            run_obj = PipelineRun.load(p)
+        elif isinstance(replay, dict):
+            run_obj = PipelineRun.from_dict(replay)
+        else:
+            raise ValueError(f"Unsupported replay type: {type(replay)}")  # noqa: TRY004
+        return cls(run=run_obj, mode=mode_enum, explicit_set=explicit_set)
+
+    def should_replay(self, component_name: str, qualname: str, instance: Any) -> bool:
+        """Return True if component should be replayed."""
+        if self.explicit_set is not None:
+            return component_name in self.explicit_set
+        # check instance markers
+        if getattr(instance, "__haystack_side_effecting__", False):
+            return True
+        if getattr(type(instance), "__haystack_side_effecting__", False):
+            return True
+        # check is_side_effecting attribute
+        try:
+            v = getattr(instance, "is_side_effecting", None)
+            if isinstance(v, bool) and v:
+                return True
+            if v is not None and not callable(v) and bool(v):
+                return True
+        except Exception:
+            pass
+        if qualname in DEFAULT_SIDE_EFFECTING_QUALNAMES:
+            return True
+        # fallback to is_side_effecting helper
+        return is_side_effecting(instance)
+
+    def pop(self, component_name: str) -> Any | None:
+        """Get next recorded output for component, advancing cursor."""
+        records = self._components.get(component_name)
+        if not records:
+            return None
+        idx = self._cursors.get(component_name, 0)
+        if idx >= len(records):
+            return None
+        rec = records[idx]
+        self._cursors[component_name] = idx + 1
+        return rec
+
+    def get_replay_output(self, component_name: str) -> Mapping[str, Any] | None:
+        """Get replay output for component."""
+        rec = self.pop(component_name)
+        if rec is None:
+            return None
+        return rec.outputs
+
+    def peek(self, component_name: str) -> Any | None:
+        """Peek next record without advancing cursor."""
+        records = self._components.get(component_name)
+        if not records:
+            return None
+        idx = self._cursors.get(component_name, 0)
+        if idx >= len(records):
+            return None
+        return records[idx]
+
+    def validate_signature(self, pipeline: Any) -> None:
+        """Validate pipeline signature in STRICT mode."""
+        if self.mode != ReplayMode.STRICT:
+            return
+        from haystack.recording.recorder import compute_pipeline_signature
+
+        current = compute_pipeline_signature(pipeline)
+        recorded = self.run.pipeline_signature
+        if recorded and current != recorded:
+            raise ReplayMismatchError(
+                f"Pipeline signature mismatch: recorded={recorded} current={current}. "
+                "Pipeline graph changed since recording. Use replay_mode='loose' to ignore."
+            )
+        # Also check component names set matches
+        recorded_names = set(self.run.components.keys())
+        # For pipelines that have components not executed (e.g., conditional branches not taken),
+        # the recorded set may be subset of graph nodes. Only check that recorded components exist in graph.
+        current_names = set(pipeline.graph.nodes.keys())
+        missing = recorded_names - current_names
+        if missing:
+            raise ReplayMismatchError(
+                f"Recorded components {missing} not found in current pipeline. "
+                "Pipeline components changed since recording."
+            )

--- a/haystack/recording/run.py
+++ b/haystack/recording/run.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from haystack import logging
+from haystack.utils.base_serialization import _deserialize_value_with_schema, _serialize_value_with_schema
+
+try:
+    from haystack.version import __version__ as haystack_version
+except Exception:
+    haystack_version = "unknown"
+
+logger = logging.getLogger(__name__)
+
+RECORDING_FORMAT = "v1"
+
+
+class RecordingError(Exception):
+    """Base error for recording operations."""
+
+
+@dataclass
+class ComponentRecord:
+    """Record for a single component execution."""
+
+    component_name: str
+    visit_index: int
+    inputs: dict[str, Any]
+    outputs: dict[str, Any]
+    duration_s: float
+    usage: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dict."""
+        return {
+            "component_name": self.component_name,
+            "visit_index": self.visit_index,
+            "inputs": _serialize_value_with_schema(self.inputs),
+            "outputs": _serialize_value_with_schema(dict(self.outputs)),
+            "duration_s": self.duration_s,
+            "usage": self.usage,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ComponentRecord:
+        """Deserialize from dict."""
+        inputs = data.get("inputs")
+        outputs = data.get("outputs")
+        # inputs/outputs are stored as serialized envelope
+        if isinstance(inputs, dict) and "serialization_schema" in inputs and "serialized_data" in inputs:
+            inputs = _deserialize_value_with_schema(inputs)
+        if isinstance(outputs, dict) and "serialization_schema" in outputs and "serialized_data" in outputs:
+            outputs = _deserialize_value_with_schema(outputs)
+        return cls(
+            component_name=data["component_name"],
+            visit_index=data["visit_index"],
+            inputs=inputs if isinstance(inputs, dict) else {},
+            outputs=outputs if isinstance(outputs, dict) else {},
+            duration_s=data.get("duration_s", 0.0),
+            usage=data.get("usage"),
+        )
+
+
+@dataclass
+class TimelineEntry:
+    """Timeline entry for a component execution."""
+
+    component_name: str
+    visit_index: int
+    duration_s: float
+    started_at: float
+    ended_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TimelineEntry:
+        """Deserialize from dict."""
+        return cls(**data)
+
+
+def _aggregate_usage(usages: list[dict[str, Any] | None]) -> dict[str, Any]:
+    """Aggregate list of usage dicts using recursive accumulation."""
+    from haystack.components.agents.utils import _accumulate_usage  # lazy to avoid circular
+
+    total: dict[str, Any] = {}
+    first = True
+    for u in usages:
+        if not isinstance(u, dict):
+            continue
+        if first:
+            # deep copy to avoid mutating original
+            total = dict(u)
+            first = False
+        else:
+            total = _accumulate_usage(total, u)
+    return total
+
+
+def aggregate_usage(usages: list[dict[str, Any] | None]) -> dict[str, Any]:
+    """Public helper to aggregate usage dicts."""
+    return _aggregate_usage(usages)
+
+
+@dataclass
+class PipelineRun:
+    """Shareable artifact of a pipeline execution."""
+
+    run_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    pipeline_signature: str = ""
+    input_data: dict[str, Any] = field(default_factory=dict)
+    output_data: dict[str, Any] = field(default_factory=dict)
+    components: dict[str, list[ComponentRecord]] = field(default_factory=dict)
+    timeline: list[TimelineEntry] = field(default_factory=list)
+    usage: dict[str, Any] = field(default_factory=dict)
+    cost_estimate: dict[str, Any] = field(default_factory=dict)
+    created_at: str = ""
+    haystack_version: str = haystack_version
+    format: str = RECORDING_FORMAT  # noqa: A003
+
+    def __post_init__(self) -> None:
+        if not self.created_at:
+            from datetime import datetime, timezone
+
+            self.created_at = datetime.now(timezone.utc).isoformat()
+        if not self.run_id:
+            self.run_id = str(uuid.uuid4())
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to plain dict with JSON-serializable leaves."""
+        return {
+            "format": self.format,
+            "run_id": self.run_id,
+            "pipeline_signature": self.pipeline_signature,
+            "created_at": self.created_at,
+            "haystack_version": self.haystack_version,
+            "input_data": _serialize_value_with_schema(self.input_data),
+            "output_data": _serialize_value_with_schema(self.output_data),
+            "components": {name: [rec.to_dict() for rec in records] for name, records in self.components.items()},
+            "timeline": [entry.to_dict() for entry in self.timeline],
+            "usage": self.usage,
+            "cost_estimate": self.cost_estimate,
+        }
+
+    def to_json(self) -> str:
+        """Return JSON string."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PipelineRun:  # noqa: D102
+        """Deserialize from dict."""
+        fmt = data.get("format", RECORDING_FORMAT)
+        if fmt != RECORDING_FORMAT:
+            raise RecordingError(f"Incompatible recording format '{fmt}', expected '{RECORDING_FORMAT}'")
+        input_data = data.get("input_data", {})
+        output_data = data.get("output_data", {})
+        if isinstance(input_data, dict) and "serialization_schema" in input_data and "serialized_data" in input_data:
+            input_data = _deserialize_value_with_schema(input_data)
+        if isinstance(output_data, dict) and "serialization_schema" in output_data and "serialized_data" in output_data:
+            output_data = _deserialize_value_with_schema(output_data)
+        components_raw = data.get("components", {})
+        components: dict[str, list[ComponentRecord]] = {}
+        for name, recs in components_raw.items():
+            components[name] = [ComponentRecord.from_dict(r) for r in recs]
+        timeline_raw = data.get("timeline", [])
+        timeline = [TimelineEntry.from_dict(t) for t in timeline_raw]
+        return cls(
+            run_id=data.get("run_id", str(uuid.uuid4())),
+            pipeline_signature=data.get("pipeline_signature", ""),
+            input_data=input_data if isinstance(input_data, dict) else {},
+            output_data=output_data if isinstance(output_data, dict) else {},
+            components=components,
+            timeline=timeline,
+            usage=data.get("usage", {}),
+            cost_estimate=data.get("cost_estimate", {}),
+            created_at=data.get("created_at", ""),
+            haystack_version=data.get("haystack_version", haystack_version),
+            format=fmt,
+        )
+
+    def save(self, path: str | Path) -> str:
+        """Save to JSON file. Creates parent directories."""
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "w", encoding="utf-8") as f:
+            json.dump(self.to_dict(), f, indent=2)
+        return str(p)
+
+    @classmethod
+    def load(cls, path: str | Path) -> PipelineRun:
+        """Load from JSON file."""
+        p = Path(path)
+        with open(p, encoding="utf-8") as f:
+            data = json.load(f)
+        return cls.from_dict(data)
+
+    # convenience alias used by tests
+    @property
+    def total_usage(self) -> dict[str, Any]:  # noqa: D102
+        """Return total usage."""
+        return self.usage
+
+    @property
+    def total_cost(self) -> float:  # noqa: D102
+        """Return total cost."""
+        if isinstance(self.cost_estimate, dict):
+            return float(self.cost_estimate.get("total", 0.0))
+        return 0.0
+
+
+def load_run(path: str | Path) -> PipelineRun:
+    """Module-level helper to load a PipelineRun from path."""
+    return PipelineRun.load(path)

--- a/releasenotes/notes/recording-replay-f8eac8123565.yaml
+++ b/releasenotes/notes/recording-replay-f8eac8123565.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Added ``haystack.recording`` module for pipeline run recording and deterministic replay.
+    ``Pipeline.run(data, record=True)`` now returns ``(result, run)`` where ``run`` is a ``PipelineRun`` capturing per-component inputs, outputs, durations, token usage and cost estimates.
+    ``PipelineRun`` supports ``save(path)``, ``load(path)``, ``to_dict()``, ``to_json()`` and ``from_dict()`` via ``haystack.recording.load_run``.
+    ``run.usage`` aggregates token usage across components (handling both ``prompt_tokens``/``completion_tokens`` and ``input_tokens``/``output_tokens`` conventions), ``run.cost_estimate`` provides total and per-component cost estimates, and ``run.timeline`` captures per-component durations with wall-clock timestamps.
+    Deterministic replay is available via ``Pipeline.run(data, replay=recorded_run, replay_mode=ReplayMode.STRICT)`` which re-executes routers, builders and other pure components live while replaying side-effecting components (LLMs, retrievers, embedders, web search, agents) from the recorded artifact without network calls.
+    Side-effecting detection uses an explicit ``replay_side_effecting_components`` override, instance markers ``__haystack_side_effecting__``/``is_side_effecting``, and a default allowlist covering ``OpenAIChatGenerator``, ``OpenAIGenerator``, ``OpenAIResponsesChatGenerator``, ``InMemoryBM25Retriever``, ``InMemoryEmbeddingRetriever``, ``OpenAITextEmbedder``, ``OpenAIDocumentEmbedder``, ``SentenceTransformersTextEmbedder``, ``LinkContentFetcher``, ``SerperDevWebSearch`` and ``Agent``.
+    ``ReplayMode.STRICT`` validates the pipeline signature before replay and raises ``ReplayMismatchError`` on mismatch, while ``ReplayMode.LOOSE`` ignores signature and input differences.

--- a/test/recording/test_replay.py
+++ b/test/recording/test_replay.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack import Pipeline, component
+from haystack.dataclasses import ChatMessage
+from haystack.recording import PipelineRun, ReplayMode
+from haystack.recording.replay import DEFAULT_SIDE_EFFECTING_QUALNAMES, ReplayMismatchError, is_side_effecting
+
+
+@component
+class PureBuilder:
+    @component.output_types(prompt=str)
+    def run(self, x: str) -> dict[str, str]:
+        return {"prompt": f"prompt:{x}"}
+
+
+@component
+class SideEffectLLM:
+    __haystack_side_effecting__ = True
+
+    @component.output_types(replies=list)
+    def run(self, prompt: str) -> dict[str, list]:
+        # If this is called during replay, we would know replay failed
+        assert False, "SideEffectLLM should not be called during replay"
+        return {"replies": [ChatMessage.from_assistant("should not happen")]}
+
+
+@component
+class CountingPure:
+    def __init__(self):
+        self.calls = 0
+
+    @component.output_types(out=str)
+    def run(self, x: str) -> dict[str, str]:
+        self.calls += 1
+        return {"out": f"{x}-{self.calls}"}
+
+
+@component
+class CountingSide:
+    __haystack_side_effecting__ = True
+
+    def __init__(self):
+        self.calls = 0
+
+    @component.output_types(out=str)
+    def run(self, x: str) -> dict[str, str]:
+        self.calls += 1
+        return {"out": f"side-{x}-{self.calls}"}
+
+
+def test_replay_strict_reexecutes_routers_and_replays_side_effecting():
+    # Build pipeline: pure -> side (should replay)
+    pipe = Pipeline()
+    builder = PureBuilder()
+    side = SideEffectLLM()
+    # Use a variant that actually returns without assertion for recording phase
+    # so we need a recordable LLM that doesn't assert
+
+    @component
+    class RecordableLLM:
+        __haystack_side_effecting__ = True
+
+        @component.output_types(replies=list)
+        def run(self, prompt: str) -> dict[str, list]:
+            return {
+                "replies": [
+                    ChatMessage.from_assistant(
+                        f"answer for {prompt}",
+                        meta={
+                            "model": "mock-model",
+                            "usage": {"prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4},
+                        },
+                    )
+                ]
+            }
+
+    pipe2 = Pipeline()
+    pipe2.add_component("builder", PureBuilder())
+    pipe2.add_component("llm", RecordableLLM())
+    pipe2.connect("builder", "llm")
+    result, run = pipe2.run({"builder": {"x": "hello"}}, record=True)
+    original_reply = result["llm"]["replies"][0].text
+
+    # Now create replay pipeline with same structure but side component that would fail if called
+    replay_pipe = Pipeline()
+    replay_pipe.add_component("builder", PureBuilder())
+    replay_pipe.add_component("llm", SideEffectLLM())
+    replay_pipe.connect("builder", "llm")
+    # Use replay with strict mode: should replay llm (no network, no assertion)
+    # To avoid signature mismatch, we need same qualnames. SideEffectLLM vs RecordableLLM have different qualnames,
+    # so strict would fail. Use loose for this test or make qualnames match.
+    # Instead use same pipeline instance for strict test.
+
+    # Strict with same pipeline instance (signature matches)
+    result_replay = pipe2.run({"builder": {"x": "hello"}}, replay=run, replay_mode="strict")
+    assert result_replay["llm"]["replies"][0].text == original_reply
+
+    # Verify builder re-executed but llm replayed: use counting components
+    pipe3 = Pipeline()
+    pure = CountingPure()
+    side_c = CountingSide()
+    pipe3.add_component("pure", pure)
+    pipe3.add_component("side", side_c)
+    pipe3.connect("pure", "side")
+    _, rec = pipe3.run({"pure": {"x": "a"}}, record=True)
+    assert pure.calls == 1
+    assert side_c.calls == 1
+    assert rec.components["side"][0].outputs["out"] == "side-a-1-1"
+    # reset counters but keep same pipeline instance for strict
+    pure.calls = 0
+    side_c.calls = 0
+    res = pipe3.run({"pure": {"x": "a"}}, replay=rec, replay_mode="strict")
+    # pure should have run live again, side should be replayed
+    assert pure.calls == 1
+    assert side_c.calls == 0
+    assert res["side"]["out"] == "side-a-1-1"
+
+
+def test_replay_loose_ignores_input_changes():
+    pipe = Pipeline()
+    pure = CountingPure()
+    side = CountingSide()
+    pipe.add_component("pure", pure)
+    pipe.add_component("side", side)
+    pipe.connect("pure", "side")
+    _, rec = pipe.run({"pure": {"x": "first"}}, record=True)
+    assert rec.components["side"][0].outputs["out"] == "side-first-1-1"
+    pure.calls = 0
+    side.calls = 0
+    # loose replay with different input: side still returns recorded value
+    res = pipe.run({"pure": {"x": "different"}}, replay=rec, replay_mode="loose")
+    assert pure.calls == 1
+    assert side.calls == 0
+    assert res["side"]["out"] == "side-first-1-1"
+
+
+def test_replay_explicit_override():
+    # Pure component marked as replayed via explicit set
+    pipe = Pipeline()
+    a = CountingPure()
+    b = CountingPure()
+    pipe.add_component("a", a)
+    pipe.add_component("b", b)
+    pipe.connect("a", "b")
+    _, rec = pipe.run({"a": {"x": "hi"}}, record=True)
+    a.calls = 0
+    b.calls = 0
+    # explicit set says replay only "b", even though neither is side_effecting by default
+    # But "b" should be replayed, "a" live
+    res = pipe.run({"a": {"x": "hi"}}, replay=rec, replay_mode="strict", replay_side_effecting_components={"b"})
+    assert a.calls == 1
+    assert b.calls == 0
+    # empty set means nothing replayed
+    a.calls = 0
+    b.calls = 0
+    res2 = pipe.run({"a": {"x": "hi"}}, replay=rec, replay_mode="strict", replay_side_effecting_components=set())
+    assert a.calls == 1
+    assert b.calls == 1
+
+
+def test_replay_strict_signature_mismatch_raises():
+    pipe1 = Pipeline()
+    pipe1.add_component("a", PureBuilder())
+    pipe1.add_component("b", CountingSide())
+    pipe1.connect("a", "b")
+    _, rec = pipe1.run({"a": {"x": "hi"}}, record=True)
+
+    # Different pipeline graph: missing component
+    pipe2 = Pipeline()
+    pipe2.add_component("a", PureBuilder())
+    # no b component, so signature mismatch
+    with pytest.raises(ReplayMismatchError, match="Pipeline signature mismatch"):
+        pipe2.run({"a": {"x": "hi"}}, replay=rec, replay_mode="strict")
+
+    # Loose should not raise signature mismatch (but will have missing recorded component)
+    # For loose, it will just run live since no side_effecting components to replay? But our pipe2 has only "a" which is not side_effecting,
+    # so replay should just run normally without error
+    res = pipe2.run({"a": {"x": "hi"}}, replay=rec, replay_mode="loose")
+    assert "a" in res
+
+
+def test_replay_no_recorded_output_strict_raises():
+    # Record pipeline with one execution, then try to replay with pipeline that has loop requiring second visit
+    from haystack.components.joiners import BranchJoiner
+
+    @component
+    class Counter:
+        __haystack_side_effecting__ = True
+
+        def __init__(self, limit=2):
+            self.limit = limit
+
+        @component.output_types(next_val=int, done=str)
+        def run(self, value: int) -> dict[str, object]:
+            if value < self.limit:
+                return {"next_val": value + 1}
+            return {"done": f"done {value}"}
+
+    pipe = Pipeline(max_runs_per_component=5)
+    pipe.add_component("joiner", BranchJoiner(int))
+    pipe.add_component("counter", Counter(limit=2))
+    pipe.connect("joiner.value", "counter.value")
+    pipe.connect("counter.next_val", "joiner.value")
+    _, rec = pipe.run({"joiner": {"value": 0}}, record=True)
+    # Now replay with same pipe but strict: should work for 2 loop iterations
+    # If we artificially truncate recorded components, strict should raise when missing
+    # Simulate by manually removing one record
+    rec.components["counter"].pop()
+    with pytest.raises(ReplayMismatchError):
+        pipe.run({"joiner": {"value": 0}}, replay=rec, replay_mode="strict")
+
+
+def test_is_side_effecting_detection():
+    assert is_side_effecting(CountingSide())
+    assert not is_side_effecting(CountingPure())
+    # check default list via fake instance with matching qualname
+    from unittest.mock import MagicMock
+
+    # Create mock with qualname in default list
+    # Use actual OpenAIChatGenerator class if available, else simulate
+    try:
+        from haystack.components.generators.chat.openai import OpenAIChatGenerator
+
+        # Don't instantiate (needs API key), just check qualname string
+        qname = "haystack.components.generators.chat.openai.OpenAIChatGenerator"
+        assert qname in DEFAULT_SIDE_EFFECTING_QUALNAMES
+    except ImportError:
+        pass
+
+    # marker via class attribute
+    @component
+    class Marked:
+        __haystack_side_effecting__ = True
+
+        @component.output_types(out=str)
+        def run(self, x: str):
+            return {"out": x}
+
+    assert is_side_effecting(Marked())
+
+
+def test_replay_with_path_string(tmp_path):
+    pipe = Pipeline()
+    pure = CountingPure()
+    side = CountingSide()
+    pipe.add_component("pure", pure)
+    pipe.add_component("side", side)
+    pipe.connect("pure", "side")
+    _, rec = pipe.run({"pure": {"x": "a"}}, record=True)
+    path = tmp_path / "run.json"
+    rec.save(path)
+    pure.calls = 0
+    side.calls = 0
+    # replay via path string
+    res = pipe.run({"pure": {"x": "a"}}, replay=str(path), replay_mode="strict")
+    assert pure.calls == 1
+    assert side.calls == 0
+    # also via Path object
+    pure.calls = 0
+    side.calls = 0
+    res2 = pipe.run({"pure": {"x": "a"}}, replay=path, replay_mode="strict")
+    assert pure.calls == 1
+    assert side.calls == 0
+
+
+def test_replay_side_effecting_default_list():
+    # Test that default side-effecting components are detected via qualname
+    # Use InMemoryBM25Retriever which is in default list
+    from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+    from haystack.document_stores.in_memory import InMemoryDocumentStore
+    from haystack.dataclasses import Document
+
+    store = InMemoryDocumentStore()
+    store.write_documents([Document(content="hello world"), Document(content="haystack")])
+    retriever = InMemoryBM25Retriever(document_store=store)
+    # is_side_effecting should be True via qualname
+    assert is_side_effecting(retriever) is True
+
+    @component
+    class QueryBuilder:
+        @component.output_types(query=str)
+        def run(self, x: str):
+            return {"query": x}
+
+    pipe = Pipeline()
+    pipe.add_component("builder", QueryBuilder())
+    pipe.add_component("retriever", retriever)
+    pipe.connect("builder.query", "retriever.query")
+    # Record
+    _, rec = pipe.run({"builder": {"x": "hello"}}, record=True)
+    original_docs = rec.components["retriever"][0].outputs["documents"]
+    # Modify store to change retrieval results
+    store.write_documents([Document(content="different")])
+    # Replay should return original docs even though store changed, because retriever is side_effecting and replayed
+    result = pipe.run({"builder": {"x": "hello"}}, replay=rec, replay_mode="strict")
+    assert len(result["retriever"]["documents"]) == len(original_docs)
+    assert result["retriever"]["documents"][0].content == original_docs[0].content

--- a/test/recording/test_run_recording.py
+++ b/test/recording/test_run_recording.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from haystack import Pipeline, component
+from haystack.dataclasses import ChatMessage, Document
+from haystack.recording import PipelineRun, load_run
+
+
+@component
+class TextProducer:
+    @component.output_types(text=str)
+    def run(self, value: str) -> dict[str, str]:
+        return {"text": f"produced:{value}"}
+
+
+@component
+class EchoComponent:
+    @component.output_types(echo=str)
+    def run(self, text: str) -> dict[str, str]:
+        return {"echo": text}
+
+
+@component
+class MockChatGen:
+    """Simple chat generator returning usage."""
+
+    @component.output_types(replies=list)
+    def run(self, prompt: str) -> dict[str, list]:
+        msg = ChatMessage.from_assistant(
+            f"reply to {prompt}",
+            meta={"model": "mock-model", "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}},
+        )
+        return {"replies": [msg]}
+
+
+@component
+class CounterLoop:
+    def __init__(self, limit: int = 3) -> None:
+        self.limit = limit
+
+    @component.output_types(next_val=int, done=str)
+    def run(self, value: int) -> dict[str, object]:
+        if value < self.limit:
+            return {"next_val": value + 1}
+        return {"done": f"finished {value}"}
+
+
+def test_record_returns_tuple_and_preserves_result():
+    pipe = Pipeline()
+    pipe.add_component("p", TextProducer())
+    pipe.add_component("e", EchoComponent())
+    pipe.connect("p", "e")
+    data = {"p": {"value": "hello"}}
+    result_plain = pipe.run(data)
+    result, run = pipe.run(data, record=True)
+    assert result == result_plain
+    assert isinstance(run, PipelineRun)
+    assert run.output_data == result
+    assert run.input_data == data
+    assert run.format == "v1"
+    assert run.pipeline_signature != ""
+    assert run.haystack_version != ""
+
+
+def test_record_captures_per_component_io_and_visits(tmp_path):
+    pipe = Pipeline()
+    pipe.add_component("a", TextProducer())
+    pipe.add_component("b", EchoComponent())
+    pipe.add_component("c", EchoComponent())
+    pipe.connect("a", "b")
+    pipe.connect("b", "c")
+    result, run = pipe.run({"a": {"value": "x"}}, record=True)
+    # three components executed
+    assert len(run.timeline) == 3
+    assert len(run.components) == 3
+    assert "a" in run.components
+    assert run.components["a"][0].inputs == {"value": "x"}
+    assert run.components["a"][0].outputs == {"text": "produced:x"}
+    assert run.components["a"][0].visit_index == 0
+    # ensure save/load roundtrip preserves ChatMessage etc
+    path = tmp_path / "run.json"
+    run.save(path)
+    assert path.exists()
+    loaded = PipelineRun.load(path)
+    assert loaded.run_id == run.run_id
+    assert loaded.pipeline_signature == run.pipeline_signature
+    # also via module helper
+    loaded2 = load_run(path)
+    assert loaded2.run_id == run.run_id
+
+
+def test_record_with_chat_message_serialization(tmp_path):
+    pipe = Pipeline()
+    pipe.add_component("gen", MockChatGen())
+    result, run = pipe.run({"gen": {"prompt": "hello"}}, record=True)
+    # check usage extraction
+    assert "gen" in run.components
+    rec = run.components["gen"][0]
+    assert rec.usage == {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+    # save/load preserves ChatMessage
+    path = tmp_path / "chat_run.json"
+    run.save(path)
+    loaded = PipelineRun.load(path)
+    # outputs should deserialize to ChatMessage
+    replies = loaded.components["gen"][0].outputs["replies"]
+    assert len(replies) == 1
+    assert isinstance(replies[0], ChatMessage)
+    assert replies[0].text == "reply to hello"
+    # also check input_data deserialization
+    assert loaded.output_data["gen"]["replies"][0].text == "reply to hello"
+
+
+def test_timeline_captures_durations():
+    pipe = Pipeline()
+    pipe.add_component("p", TextProducer())
+    pipe.add_component("e", EchoComponent())
+    pipe.connect("p", "e")
+    _, run = pipe.run({"p": {"value": "t"}}, record=True)
+    assert len(run.timeline) == 2
+    for entry in run.timeline:
+        assert entry.duration_s >= 0
+        assert entry.ended_at >= entry.started_at
+        assert entry.component_name in ("p", "e")
+    # timeline sorted by started_at
+    starts = [e.started_at for e in run.timeline]
+    assert starts == sorted(starts)
+
+
+def test_record_loop_multiple_visits():
+    from haystack.components.joiners import BranchJoiner
+
+    pipe = Pipeline(max_runs_per_component=10)
+    pipe.add_component("joiner", BranchJoiner(int))
+    pipe.add_component("counter", CounterLoop(limit=3))
+    pipe.connect("joiner.value", "counter.value")
+    pipe.connect("counter.next_val", "joiner.value")
+    _, run = pipe.run({"joiner": {"value": 0}}, record=True)
+    # joiner visited 4 times (0,1,2,3), counter 4 times
+    assert len(run.components["joiner"]) == 4
+    assert len(run.components["counter"]) == 4
+    assert [r.visit_index for r in run.components["joiner"]] == [0, 1, 2, 3]
+    assert len(run.timeline) == 8
+
+
+def test_save_load_preserves_documents(tmp_path):
+    @component
+    class DocProducer:
+        @component.output_types(documents=list)
+        def run(self, query: str) -> dict[str, list]:
+            return {"documents": [Document(content=f"doc for {query}", meta={"query": query})]}
+
+    pipe = Pipeline()
+    pipe.add_component("retriever", DocProducer())
+    _, run = pipe.run({"retriever": {"query": "hello"}}, record=True)
+    path = tmp_path / "doc_run.json"
+    run.save(path)
+    loaded = PipelineRun.load(path)
+    docs = loaded.components["retriever"][0].outputs["documents"]
+    assert isinstance(docs[0], Document)
+    assert docs[0].content == "doc for hello"
+
+
+def test_record_without_content_tracing_env(monkeypatch):
+    # Ensure recording works even when content tracing disabled
+    monkeypatch.delenv("HAYSTACK_CONTENT_TRACING_ENABLED", raising=False)
+    pipe = Pipeline()
+    pipe.add_component("p", TextProducer())
+    _, run = pipe.run({"p": {"value": "x"}}, record=True)
+    assert run.components["p"][0].inputs == {"value": "x"}
+
+
+def test_to_dict_from_dict_roundtrip():
+    pipe = Pipeline()
+    pipe.add_component("p", TextProducer())
+    _, run = pipe.run({"p": {"value": "a"}}, record=True)
+    d = run.to_dict()
+    assert d["format"] == "v1"
+    assert "run_id" in d
+    restored = PipelineRun.from_dict(d)
+    assert restored.run_id == run.run_id
+    assert restored.usage == run.usage
+    # json roundtrip
+    j = run.to_json()
+    assert json.loads(j)["run_id"] == run.run_id
+
+
+def test_invalid_format_raises(tmp_path):
+    pipe = Pipeline()
+    pipe.add_component("p", TextProducer())
+    _, run = pipe.run({"p": {"value": "a"}}, record=True)
+    d = run.to_dict()
+    d["format"] = "v2"
+    with pytest.raises(Exception, match="Incompatible recording format"):
+        PipelineRun.from_dict(d)

--- a/test/recording/test_usage_aggregation.py
+++ b/test/recording/test_usage_aggregation.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack import Pipeline, component
+from haystack.dataclasses import ChatMessage
+from haystack.recording.recorder import _estimate_cost, _extract_model, _extract_usage, compute_pipeline_signature
+
+
+def test_extract_usage_chat_message():
+    msg1 = ChatMessage.from_assistant(
+        "hello", meta={"usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}}
+    )
+    msg2 = ChatMessage.from_assistant(
+        "hi", meta={"usage": {"prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4}}
+    )
+    outputs = {"replies": [msg1, msg2]}
+    usage = _extract_usage(outputs)
+    # Should accumulate: 5+2=7 prompt, 3+2=5 completion, 8+4=12 total
+    assert usage["prompt_tokens"] == 7
+    assert usage["completion_tokens"] == 5
+    assert usage["total_tokens"] == 12
+
+
+def test_extract_usage_embedder():
+    outputs = {
+        "embedding": [0.1, 0.2],
+        "meta": {"model": "text-embedding-ada-002", "usage": {"prompt_tokens": 10, "total_tokens": 10}},
+    }
+    usage = _extract_usage(outputs)
+    assert usage == {"prompt_tokens": 10, "total_tokens": 10}
+
+
+def test_extract_usage_alternative_keys():
+    # OpenAIResponses uses input_tokens/output_tokens
+    msg = ChatMessage.from_assistant("hi", meta={"usage": {"input_tokens": 7, "output_tokens": 3, "total_tokens": 10}})
+    usage = _extract_usage({"replies": [msg]})
+    assert usage["input_tokens"] == 7
+    assert usage["output_tokens"] == 3
+
+
+def test_extract_usage_no_usage_returns_none():
+    outputs = {"text": "hello"}
+    assert _extract_usage(outputs) is None
+    assert _extract_usage({"replies": []}) is None
+    # ChatMessage without usage
+    msg = ChatMessage.from_assistant("hi")
+    assert _extract_usage({"replies": [msg]}) is None
+
+
+def test_extract_model():
+    msg = ChatMessage.from_assistant("hi", meta={"model": "gpt-4o", "usage": {"prompt_tokens": 1}})
+    model = _extract_model({"replies": [msg]})
+    assert model == "gpt-4o"
+    assert _extract_model({"meta": {"model": "text-embedding-ada-002"}}) == "text-embedding-ada-002"
+    assert _extract_model({"text": "hi"}) is None
+
+
+def test_estimate_cost_gpt4o():
+    usage = {"prompt_tokens": 1_000_000, "completion_tokens": 1_000_000}
+    cost = _estimate_cost(usage, "gpt-4o")
+    assert cost == pytest.approx(12.5)  # 2.5 + 10
+    # gpt-3.5
+    cost2 = _estimate_cost(usage, "gpt-3.5-turbo")
+    assert cost2 == pytest.approx(2.0)  # 0.5 + 1.5
+
+
+def test_estimate_cost_embedding():
+    usage = {"prompt_tokens": 1_000_000, "total_tokens": 1_000_000}
+    cost = _estimate_cost(usage, "text-embedding-ada-002")
+    assert cost == pytest.approx(0.1)
+
+
+def test_estimate_cost_default_zero():
+    usage = {"prompt_tokens": 1000, "completion_tokens": 500}
+    assert _estimate_cost(usage, "unknown-model") == 0.0
+    assert _estimate_cost(None, "gpt-4o") == 0.0
+    assert _estimate_cost({}, "gpt-4o") == 0.0
+
+
+def test_pipeline_run_usage_aggregation():
+    @component
+    class GenA:
+        @component.output_types(replies=list)
+        def run(self, prompt: str):
+            return {
+                "replies": [
+                    ChatMessage.from_assistant(
+                        "a",
+                        meta={
+                            "model": "gpt-4o",
+                            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+                        },
+                    )
+                ]
+            }
+
+    @component
+    class GenB:
+        @component.output_types(replies=list)
+        def run(self, prompt: str):
+            return {
+                "replies": [
+                    ChatMessage.from_assistant(
+                        "b",
+                        meta={
+                            "model": "gpt-4o",
+                            "usage": {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30},
+                        },
+                    )
+                ]
+            }
+
+    pipe = Pipeline()
+    pipe.add_component("a", GenA())
+    pipe.add_component("b", GenB())
+    # No connection, both run independently
+    _, run = pipe.run({"a": {"prompt": "hi"}, "b": {"prompt": "hi"}}, record=True)
+    # total usage should be sum: 30 prompt, 15 completion, 45 total
+    assert run.usage["prompt_tokens"] == 30
+    assert run.usage["completion_tokens"] == 15
+    assert run.usage["total_tokens"] == 45
+    # cost: (30*2.5 + 15*10)/1e6
+    expected_cost = (30 * 2.5 + 15 * 10) / 1_000_000
+    assert run.cost_estimate["total"] == pytest.approx(expected_cost)
+    assert "a" in run.cost_estimate["by_component"]
+    assert "b" in run.cost_estimate["by_component"]
+    assert run.cost_estimate["by_component"]["a"] == pytest.approx((10 * 2.5 + 5 * 10) / 1_000_000)
+    assert run.cost_estimate["by_component"]["b"] == pytest.approx((20 * 2.5 + 10 * 10) / 1_000_000)
+
+
+def test_usage_aggregation_with_mixed_keys():
+    @component
+    class MixedGen:
+        @component.output_types(replies=list)
+        def run(self, prompt: str):
+            # First reply uses prompt/completion, second uses input/output
+            # Actually single reply but test accumulation across components with different conventions
+            return {
+                "replies": [
+                    ChatMessage.from_assistant("a", meta={"usage": {"prompt_tokens": 5, "completion_tokens": 5}})
+                ]
+            }
+
+    @component
+    class MixedGen2:
+        @component.output_types(replies=list)
+        def run(self, prompt: str):
+            return {
+                "replies": [ChatMessage.from_assistant("b", meta={"usage": {"input_tokens": 10, "output_tokens": 5}})]
+            }
+
+    pipe = Pipeline()
+    pipe.add_component("a", MixedGen())
+    pipe.add_component("b", MixedGen2())
+    _, run = pipe.run({"a": {"prompt": "x"}, "b": {"prompt": "x"}}, record=True)
+    # Should aggregate both, but keys remain separate? Our _accumulate_usage keeps both keys
+    # So total will have prompt_tokens, completion_tokens, input_tokens, output_tokens
+    assert run.usage.get("prompt_tokens") == 5
+    assert run.usage.get("input_tokens") == 10
+    # Cost estimate should sum correctly using first numeric helpers
+    # For prompt: first of prompt_tokens/input_tokens -> 5 for first, 10 for second? But total cost calculation uses _first_numeric per usage, not aggregated mixed.
+    # For aggregated usage, _first_numeric will pick prompt_tokens first, so 5, not 15. That's a limitation but acceptable.
+    # Ensure cost is computed per-record then summed, not from aggregated total
+    # So total cost should be (5*2.5+5*10)/1e6 + (10*2.5+5*10)/1e6 if model gpt-4o
+    # But our Gens don't specify model, so cost default 0 -> total 0
+    assert run.cost_estimate["total"] == 0.0
+
+
+def test_compute_pipeline_signature_stable():
+    # Use simple components
+    @component
+    class P1:
+        @component.output_types(out=str)
+        def run(self, x: str):
+            return {"out": x}
+
+    @component
+    class P2:
+        @component.output_types(out=str)
+        def run(self, x: str):
+            return {"out": x}
+
+    pipe1 = Pipeline()
+    pipe1.add_component("a", P1())
+    pipe1.add_component("b", P2())
+    pipe1.connect("a.out", "b.x")
+    sig1 = compute_pipeline_signature(pipe1)
+    sig2 = compute_pipeline_signature(pipe1)
+    assert sig1 == sig2
+    # Different graph should differ
+    pipe2 = Pipeline()
+    pipe2.add_component("a", P1())
+    pipe2.add_component("b", P2())
+    # no connection
+    sig3 = compute_pipeline_signature(pipe2)
+    assert sig1 != sig3
+
+
+def test_cost_estimate_per_component_with_mock():
+    @component
+    class MockGen:
+        @component.output_types(replies=list)
+        def run(self, prompt: str):
+            return {
+                "replies": [
+                    ChatMessage.from_assistant(
+                        "hi", meta={"model": "mock-model", "usage": {"prompt_tokens": 100, "completion_tokens": 50}}
+                    )
+                ]
+            }
+
+    pipe = Pipeline()
+    pipe.add_component("gen", MockGen())
+    _, run = pipe.run({"gen": {"prompt": "hello"}}, record=True)
+    # mock-model cost is 0
+    assert run.cost_estimate["total"] == 0.0
+    assert run.cost_estimate["by_component"]["gen"] == 0.0


### PR DESCRIPTION
### Related Issues

- fixes #11836

### Proposed Changes:

Pipeline runs are ephemeral so LLM failures cannot be reproduced and token usage must be summed manually. This adds opt-in recording on `Pipeline.run(record=True)` that returns a shareable `PipelineRun` artifact with per-component inputs/outputs, durations, usage and cost, and deterministic replay via `replay` with strict/loose validation.

### How did you test it?

Added unit tests for recording, replay and usage aggregation and verified existing pipeline tests still pass.

### Notes for the reviewer

Recording is additive and keeps the default `run` return type unchanged; replay re-executes pure components live and replays side-effecting ones from the artifact. Async `record`/`replay` currently raises `NotImplementedError` with a clear message.

### Checklist

- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings.
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [ ] I have documented my code.
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [ ] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.