### PR TITLE
fix: preserve unsplit markdown headers during secondary split

### DIFF
--- a/haystack/components/preprocessors/markdown_header_splitter.py
+++ b/haystack/components/preprocessors/markdown_header_splitter.py
@@ -237,12 +237,6 @@ class MarkdownHeaderSplitter:
 
             content_for_splitting: str = doc.content
 
-            if not self.keep_headers:  # skip header extraction if keep_headers
-                # extract header information
-                header_match = re.match(self._header_pattern, doc.content)
-                if header_match:
-                    content_for_splitting = doc.content[header_match.end() :]
-
             # track page from meta
             current_page = doc.meta.get("page_number", 1)
 

--- a/test/components/preprocessors/test_markdown_header_splitter.py
+++ b/test/components/preprocessors/test_markdown_header_splitter.py
@@ -284,6 +284,24 @@ def test_secondary_split_keeps_content_before_code_fence_comment():
     assert "some intro text" in combined
 
 
+def test_secondary_split_keeps_excluded_leading_header():
+    splitter = MarkdownHeaderSplitter(
+        keep_headers=False, header_split_levels=[2], secondary_split="word", split_length=5
+    )
+    docs = splitter.run(documents=[Document(content="# Title\nsome content here")])["documents"]
+
+    assert docs[0].content == "# Title\nsome content here"
+    assert "header" not in docs[0].meta
+
+
+def test_secondary_split_keeps_header_only_document():
+    splitter = MarkdownHeaderSplitter(keep_headers=False, secondary_split="word", split_length=5)
+    docs = splitter.run(documents=[Document(content="# Alpha\n# Beta")])["documents"]
+
+    assert docs[0].content == "# Alpha\n# Beta"
+    assert "header" not in docs[0].meta
+
+
 # Error and edge case handling
 def test_non_text_document():
     """Test that the component correctly handles non-text documents."""


### PR DESCRIPTION
### Related Issues

- fixes #12477

### Proposed Changes:

`MarkdownHeaderSplitter` already removes matched headers during the primary header split when `keep_headers=False`. The secondary splitting stage repeated a header-strip step on every chunk, which only takes effect on fallback documents that were not actually split by a configured header. In those fallback paths the header is not stored in metadata, so the leading header was silently dropped.

This removes the redundant secondary-stage header stripping and adds regression tests for both fallback cases:

- a leading header whose level is excluded by `header_split_levels`
- a document that contains only headers

### How did you test it?

- `uv run --with pytest pytest test/components/preprocessors/test_markdown_header_splitter.py -q`
- `uv run --with ruff ruff format --check haystack/components/preprocessors/markdown_header_splitter.py test/components/preprocessors/test_markdown_header_splitter.py`
- `uv run --with ruff ruff check haystack/components/preprocessors/markdown_header_splitter.py test/components/preprocessors/test_markdown_header_splitter.py`
- `git diff --check`

### Notes for the reviewer

The pytest run passes with 41 tests. It emits two existing PytestConfigWarning entries about unknown asyncio config options in this sparse local test environment.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.