### PR TITLE
test: enable mypy typing checks for test/components/preprocessors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ all = 'pytest {args:test}'
 e2e = 'pytest {args:e2e}'
 
 # TODO We want to eventually type the whole test folder
-types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/fuzz/ test/skill_stores/ test/token_counters/ test/components/agents/test_state_class.py test/components/builders/ test/components/caching/ test/components/converters/test_utils.py test/components/embedders/ test/components/evaluators/ test/components/extractors/ test/components/generators/ test/components/joiners/ test/components/query/ test/components/rankers/ test/components/routers/ test/components/samplers/ test/components/validators/ test/components/writers/}"
+types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:haystack test/core/ test/marshal/ test/testing/ test/tracing/ test/tools/ test/hooks/human_in_the_loop test/evaluation test/document_stores test/dataclasses test/utils/ test/fuzz/ test/skill_stores/ test/token_counters/ test/components/agents/test_state_class.py test/components/builders/ test/components/caching/ test/components/converters/test_utils.py test/components/embedders/ test/components/evaluators/ test/components/extractors/ test/components/generators/ test/components/joiners/ test/components/preprocessors/ test/components/query/ test/components/rankers/ test/components/routers/ test/components/samplers/ test/components/validators/ test/components/writers/}"
 
 
 [project.urls]

--- a/test/components/preprocessors/test_csv_document_splitter.py
+++ b/test/components/preprocessors/test_csv_document_splitter.py
@@ -7,6 +7,7 @@ from io import StringIO
 
 import pytest
 from pandas import read_csv
+from pytest import LogCaptureFixture
 
 from haystack import Document
 from haystack.components.preprocessors.csv_document_splitter import CSVDocumentSplitter
@@ -62,14 +63,14 @@ class TestFindSplitIndices:
     def test_find_split_indices_row_two_tables(
         self, splitter: CSVDocumentSplitter, two_tables_sep_by_two_empty_rows: str
     ) -> None:
-        df = read_csv(StringIO(two_tables_sep_by_two_empty_rows), header=None, dtype=object)  # type: ignore
+        df = read_csv(StringIO(two_tables_sep_by_two_empty_rows), header=None, dtype=object)
         result = splitter._find_split_indices(df, split_threshold=2, axis="row")
         assert result == [(2, 3)]
 
     def test_find_split_indices_row_two_tables_with_empty_row(
         self, splitter: CSVDocumentSplitter, three_tables_sep_by_empty_rows: str
     ) -> None:
-        df = read_csv(StringIO(three_tables_sep_by_empty_rows), header=None, dtype=object)  # type: ignore
+        df = read_csv(StringIO(three_tables_sep_by_empty_rows), header=None, dtype=object)
         result = splitter._find_split_indices(df, split_threshold=2, axis="row")
         assert result == [(3, 4)]
 
@@ -84,7 +85,7 @@ X,Y,Z
 ,,
 P,Q,R
 """
-        df = read_csv(StringIO(csv_content), header=None, dtype=object)  # type: ignore
+        df = read_csv(StringIO(csv_content), header=None, dtype=object)
         result = splitter._find_split_indices(df, split_threshold=2, axis="row")
         assert result == [(2, 3), (6, 7)]
 
@@ -108,7 +109,7 @@ X,Y,Z
     def test_find_split_indices_column_two_tables(
         self, splitter: CSVDocumentSplitter, two_tables_sep_by_two_empty_columns: str
     ) -> None:
-        df = read_csv(StringIO(two_tables_sep_by_two_empty_columns), header=None, dtype=object)  # type: ignore
+        df = read_csv(StringIO(two_tables_sep_by_two_empty_columns), header=None, dtype=object)
         result = splitter._find_split_indices(df, split_threshold=1, axis="column")
         assert result == [(2, 3)]
 
@@ -117,7 +118,7 @@ X,Y,Z
 1,,2,,,7,8
 3,,4,,,9,10
 """
-        df = read_csv(StringIO(csv_content), header=None, dtype=object)  # type: ignore
+        df = read_csv(StringIO(csv_content), header=None, dtype=object)
         result = splitter._find_split_indices(df, split_threshold=2, axis="column")
         assert result == [(3, 4)]
 
@@ -126,7 +127,7 @@ X,Y,Z
 1,2,,,7,8,,,11,12
 3,4,,,9,10,,,13,14
 """
-        df = read_csv(StringIO(csv_content), header=None, dtype=object)  # type: ignore
+        df = read_csv(StringIO(csv_content), header=None, dtype=object)
         result = splitter._find_split_indices(df, split_threshold=2, axis="column")
         assert result == [(2, 3), (6, 7)]
 
@@ -386,7 +387,7 @@ E,F,,,G,H
         assert result[1].content == "1,2,3\n"
         assert result[2].content == "X,Y,Z\n"
 
-    def test_split_by_row_with_empty_rows(self, caplog) -> None:
+    def test_split_by_row_with_empty_rows(self, caplog: LogCaptureFixture) -> None:
         splitter = CSVDocumentSplitter(split_mode="row-wise")
         doc = Document(content="")
         with caplog.at_level(logging.ERROR):
@@ -396,4 +397,4 @@ E,F,,,G,H
 
     def test_incorrect_split_mode(self) -> None:
         with pytest.raises(ValueError, match="not recognized"):
-            CSVDocumentSplitter(split_mode="incorrect_mode")
+            CSVDocumentSplitter(split_mode="incorrect_mode")  # type: ignore[arg-type]

--- a/test/components/preprocessors/test_document_cleaner.py
+++ b/test/components/preprocessors/test_document_cleaner.py
@@ -30,7 +30,7 @@ class TestDocumentCleaner:
     def test_single_document(self):
         with pytest.raises(TypeError, match="DocumentCleaner expects a List of Documents as input."):
             cleaner = DocumentCleaner()
-            cleaner.run(documents=Document())
+            cleaner.run(documents=Document())  # type: ignore[arg-type]
 
     def test_empty_list(self):
         cleaner = DocumentCleaner()
@@ -127,6 +127,7 @@ class TestDocumentCleaner:
         )
         text = "PAGE ONE\fThe quick brown fox jumps high\fPAGE THREE"
         result = cleaner.run(documents=[Document(content=text)])["documents"][0]
+        assert result.content is not None
         assert result.content.split("\f")[1] == "The quick brown fox jumps high"
         # With no genuine repeated header/footer, all three pages must round-trip unchanged and in order.
         assert result.content.split("\f") == ["PAGE ONE", "The quick brown fox jumps high", "PAGE THREE"]

--- a/test/components/preprocessors/test_document_preprocessor.py
+++ b/test/components/preprocessors/test_document_preprocessor.py
@@ -7,7 +7,9 @@ from unittest.mock import patch
 import pytest
 
 from haystack import Document, Pipeline
+from haystack.components.preprocessors.document_cleaner import DocumentCleaner
 from haystack.components.preprocessors.document_preprocessor import DocumentPreprocessor
+from haystack.components.preprocessors.document_splitter import DocumentSplitter
 
 
 class TestDocumentPreprocessor:
@@ -33,12 +35,14 @@ class TestDocumentPreprocessor:
         assert preprocessor.output_mapping == {"cleaner.documents": "documents"}
 
         cleaner = preprocessor.pipeline.get_component("cleaner")
+        assert isinstance(cleaner, DocumentCleaner)
         assert cleaner.remove_empty_lines is True
         assert cleaner.remove_extra_whitespaces is True
         assert cleaner.remove_repeated_substrings is False
         assert cleaner.keep_id is True
 
         splitter = preprocessor.pipeline.get_component("splitter")
+        assert isinstance(splitter, DocumentSplitter)
         assert splitter.split_by == "word"
         assert splitter.split_length == 3
         assert splitter.split_overlap == 1
@@ -116,6 +120,7 @@ class TestDocumentPreprocessor:
 
         # Check that the content was cleaned and split
         for doc in processed_docs:
+            assert doc.content is not None
             assert doc.content.strip() == doc.content
             assert len(doc.content.split()) <= 3  # Split length of 3 words
             assert doc.id is not None
@@ -131,4 +136,6 @@ class TestDocumentPreprocessor:
 
         processed_docs = result["documents"]
         assert len(processed_docs) == 3  # Should be split into 3 sentences
-        assert all("." not in doc.content for doc in processed_docs)  # Each doc should be a single sentence
+        for doc in processed_docs:
+            assert doc.content is not None
+            assert "." not in doc.content  # Each doc should be a single sentence

--- a/test/components/preprocessors/test_document_splitter.py
+++ b/test/components/preprocessors/test_document_splitter.py
@@ -48,7 +48,7 @@ class TestSplittingByFunctionOrCharacterRegex:
     def test_single_doc(self):
         with pytest.raises(TypeError, match="DocumentSplitter expects a List of Documents as input."):
             splitter = DocumentSplitter()
-            splitter.run(documents=Document())
+            splitter.run(documents=Document())  # type: ignore[arg-type]
 
     def test_empty_list(self):
         splitter = DocumentSplitter()
@@ -57,7 +57,7 @@ class TestSplittingByFunctionOrCharacterRegex:
 
     def test_unsupported_split_by(self):
         with pytest.raises(ValueError, match="split_by must be one of "):
-            DocumentSplitter(split_by="unsupported")
+            DocumentSplitter(split_by="unsupported")  # type: ignore[arg-type]
 
     def test_undefined_function(self):
         with pytest.raises(ValueError, match="When 'split_by' is set to 'function', a valid 'splitting_function'"):
@@ -117,6 +117,7 @@ class TestSplittingByFunctionOrCharacterRegex:
         result = splitter.run(documents=[Document(content=text)])
         contents = [doc.content for doc in result["documents"]]
         for content in contents:
+            assert content is not None
             assert content in text, f"chunk {content!r} is not present in the source text"
         assert contents == ["a b c ", "c d e f"]
 
@@ -251,6 +252,7 @@ class TestSplittingByFunctionOrCharacterRegex:
         assert docs[0].meta["split_id"] == 0
         assert docs[0].meta["split_idx_start"] == text.index(docs[0].content)
         assert docs[0].meta["_split_overlap"][0]["range"] == (0, 5)
+        assert docs[1].content is not None
         assert docs[1].content[0:5] == "is a "
         # doc 1
         assert docs[1].content == "is a second sentence. And there is a third sentence."
@@ -409,6 +411,7 @@ class TestSplittingByFunctionOrCharacterRegex:
         assert docs[0].meta["split_id"] == 0
         assert docs[0].meta["split_idx_start"] == text.index(docs[0].content)  # 0
         assert docs[0].meta["_split_overlap"][0]["range"] == (0, 23)
+        assert docs[1].content is not None
         assert docs[1].content[0:23] == "some words. There is a "
         # doc 1
         assert docs[1].content == "some words. There is a second sentence. And a third "
@@ -417,6 +420,7 @@ class TestSplittingByFunctionOrCharacterRegex:
         assert docs[1].meta["_split_overlap"][0]["range"] == (20, 43)
         assert docs[1].meta["_split_overlap"][1]["range"] == (0, 29)
         assert docs[0].content[20:43] == "some words. There is a "
+        assert docs[2].content is not None
         assert docs[2].content[0:29] == "second sentence. And a third "
         # doc 2
         assert docs[2].content == "second sentence. And a third sentence."
@@ -747,7 +751,9 @@ class TestSplittingNLTKSentenceSplitter:
             documents[0].content
             == "This is a test sentence with many many words that exceeds the split length and should not be repeated. "
         )
+        assert documents[1].content is not None
         assert "This is a test sentence with many many words" not in documents[1].content
+        assert documents[2].content is not None
         assert "This is a test sentence with many many words" not in documents[2].content
 
     def test_run_split_by_word_respect_sentence_boundary_with_split_overlap_and_page_breaks(self) -> None:

--- a/test/components/preprocessors/test_embedding_based_document_splitter.py
+++ b/test/components/preprocessors/test_embedding_based_document_splitter.py
@@ -59,7 +59,7 @@ class TestEmbeddingBasedDocumentSplitter:
         splitter.sentence_splitter = Mock()
 
         with pytest.raises(TypeError, match="expects a List of Documents"):
-            splitter.run(documents="not a list")
+            splitter.run(documents="not a list")  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
     async def test_run_invalid_input_async(self) -> None:
@@ -68,7 +68,7 @@ class TestEmbeddingBasedDocumentSplitter:
         splitter.sentence_splitter = AsyncMock()
 
         with pytest.raises(TypeError, match="expects a List of Documents"):
-            await splitter.run_async(documents="not a list")
+            await splitter.run_async(documents="not a list")  # type: ignore[arg-type]
 
     def test_run_document_with_none_content(self):
         mock_embedder = Mock()
@@ -185,7 +185,7 @@ class TestEmbeddingBasedDocumentSplitter:
         splitter = EmbeddingBasedDocumentSplitter(document_embedder=mock_embedder)
 
         sentence_groups = ["Group 1 ", "Group 2 ", "Group 3"]
-        split_points = []
+        split_points: list[int] = []
 
         splits = splitter._create_splits_from_points(sentence_groups, split_points)
         assert splits == ["Group 1 Group 2 Group 3"]
@@ -313,6 +313,7 @@ class TestEmbeddingBasedDocumentSplitter:
         assert documents[2].meta["split_idx_start"] == len("First chunk. ") + len("Second chunk. ")
         # Cross-check: split_idx_start correctly points into the original text
         for doc in documents:
+            assert doc.content is not None
             start = doc.meta["split_idx_start"]
             assert text[start : start + len(doc.content)] == doc.content
 
@@ -351,6 +352,7 @@ class TestEmbeddingBasedDocumentSplitter:
 
         # split_idx_start must point to the correct position in the original text
         for chunk in chunks:
+            assert chunk.content is not None
             start = chunk.meta["split_idx_start"]
             assert text[start : start + len(chunk.content)] == chunk.content
 
@@ -438,11 +440,14 @@ class TestEmbeddingBasedDocumentSplitter:
         # There should be more than one split
         assert len(split_docs) > 1
         # Each split should be non-empty and respect min_length
+        split_contents: list[str] = []
         for split_doc in split_docs:
+            assert split_doc.content is not None
             assert split_doc.content.strip() != ""
             assert len(split_doc.content) >= 30
+            split_contents.append(split_doc.content)
         # The splits should cover the original text
-        combined = "".join([d.content for d in split_docs])
+        combined = "".join(split_contents)
         original = text
         assert combined in original or original in combined
 
@@ -474,11 +479,14 @@ class TestEmbeddingBasedDocumentSplitter:
         # There should be more than one split
         assert len(split_docs) > 1
         # Each split should be non-empty and respect min_length
+        split_contents: list[str] = []
         for split_doc in split_docs:
+            assert split_doc.content is not None
             assert split_doc.content.strip() != ""
             assert len(split_doc.content) >= 30
+            split_contents.append(split_doc.content)
         # The splits should cover the original text
-        combined = "".join([d.content for d in split_docs])
+        combined = "".join(split_contents)
         original = text
         assert combined in original or original in combined
 
@@ -612,12 +620,17 @@ The history of software is closely tied to the development of digital computers 
 
         assert len(split_docs) == 1
 
+        split_contents: list[str] = []
+        for split_doc in split_docs:
+            assert split_doc.content is not None
+            split_contents.append(split_doc.content)
+
         # If the chunk cannot be split further, it is allowed to be larger than max_length
         # At least one split should be larger than max_length in this test case
-        assert any(len(split_doc.content) > 1000 for split_doc in split_docs)
+        assert any(len(split_content) > 1000 for split_content in split_contents)
 
         # Verify that the splits cover the original content
-        combined_content = "".join([d.content for d in split_docs])
+        combined_content = "".join(split_contents)
         assert combined_content == text
 
         for i, split_doc in enumerate(split_docs):
@@ -653,12 +666,17 @@ The history of software is closely tied to the development of digital computers 
 
         assert len(split_docs) == 1
 
+        split_contents: list[str] = []
+        for split_doc in split_docs:
+            assert split_doc.content is not None
+            split_contents.append(split_doc.content)
+
         # If the chunk cannot be split further, it is allowed to be larger than max_length
         # At least one split should be larger than max_length in this test case
-        assert any(len(split_doc.content) > 1000 for split_doc in split_docs)
+        assert any(len(split_content) > 1000 for split_content in split_contents)
 
         # Verify that the splits cover the original content
-        combined_content = "".join([d.content for d in split_docs])
+        combined_content = "".join(split_contents)
         assert combined_content == text
 
         for i, split_doc in enumerate(split_docs):
@@ -730,8 +748,13 @@ Artificial intelligence is transforming education by enabling personalized learn
 
         assert len(split_docs) == 11
 
+        split_contents: list[str] = []
+        for split_doc in split_docs:
+            assert split_doc.content is not None
+            split_contents.append(split_doc.content)
+
         # Verify that the splits cover the original content
-        combined_content = "".join([d.content for d in split_docs])
+        combined_content = "".join(split_contents)
         assert combined_content == text
 
         for i, split_doc in enumerate(split_docs):
@@ -813,8 +836,13 @@ Artificial intelligence is transforming education by enabling personalized learn
 
         assert len(split_docs) == 11
 
+        split_contents: list[str] = []
+        for split_doc in split_docs:
+            assert split_doc.content is not None
+            split_contents.append(split_doc.content)
+
         # Verify that the splits cover the original content
-        combined_content = "".join([d.content for d in split_docs])
+        combined_content = "".join(split_contents)
         assert combined_content == text
 
         for i, split_doc in enumerate(split_docs):

--- a/test/components/preprocessors/test_markdown_header_splitter.py
+++ b/test/components/preprocessors/test_markdown_header_splitter.py
@@ -87,7 +87,11 @@ def test_basic_split(sample_text):
     assert subheader123_doc.content == "### Subheader 1.2.3\nContent under header 1.2.3."
 
     # Reconstruct original text
-    reconstructed_doc = "".join([doc.content for doc in split_docs])
+    split_contents: list[str] = []
+    for doc in split_docs:
+        assert doc.content is not None
+        split_contents.append(doc.content)
+    reconstructed_doc = "".join(split_contents)
     assert reconstructed_doc == sample_text
 
 
@@ -115,7 +119,11 @@ def test_keep_headers_preserves_parent_headers_for_first_child():
         ("Header 1.2.2", ["Header 1", "Header 1.2"]),
     ]
     # reconstruct original text
-    reconstructed_text = "".join(doc.content for doc in split_docs)
+    split_contents: list[str] = []
+    for doc in split_docs:
+        assert doc.content is not None
+        split_contents.append(doc.content)
+    reconstructed_text = "".join(split_contents)
     assert reconstructed_text == text
 
 
@@ -522,7 +530,7 @@ class TestCodeBlockExclusion:
 def test_invalid_secondary_split_at_init():
     """Test that an invalid secondary split type raises an error at initialization time."""
     with pytest.raises(ValueError, match="split_by must be one of"):
-        MarkdownHeaderSplitter(secondary_split="invalid_split_type")
+        MarkdownHeaderSplitter(secondary_split="invalid_split_type")  # type: ignore[arg-type]
 
 
 def test_invalid_split_parameters_at_init():
@@ -668,6 +676,7 @@ def test_secondary_split_with_overlap():
     split_docs = result["documents"]
     assert len(split_docs) == 24
 
+    assert split_docs[0].content is not None
     assert split_docs[0].content.startswith("# Introduction")
     assert all("header" in doc.meta for doc in split_docs)
 
@@ -847,14 +856,22 @@ def test_page_break_handling_with_multiple_headers(sample_text_with_page_breaks)
     }
 
     # reconstruct original
-    reconstructed_text = "".join(doc.content for doc in split_docs)
+    split_contents: list[str] = []
+    for doc in split_docs:
+        assert doc.content is not None
+        split_contents.append(doc.content)
+    reconstructed_text = "".join(split_contents)
     assert reconstructed_text == sample_text_with_page_breaks
 
 
 def test_trailing_header_without_content_is_not_dropped():
     text = "# Header 1\nContent 1.\n# Header 2\n"
     docs = MarkdownHeaderSplitter().run(documents=[Document(content=text)])["documents"]
-    assert "".join(doc.content for doc in docs) == text
+    split_contents: list[str] = []
+    for doc in docs:
+        assert doc.content is not None
+        split_contents.append(doc.content)
+    assert "".join(split_contents) == text
     assert docs[-1].content == "# Header 2\n"
     assert docs[-1].meta["header"] == "Header 2"
     assert docs[-1].meta["parent_headers"] == []
@@ -865,7 +882,11 @@ def test_middle_header_without_content_preserves_blank_lines():
     # body and the next contentful header are preserved instead of collapsed to a single newline
     text = "# Header 1\n\n\n# Header 2\nContent.\n"
     docs = MarkdownHeaderSplitter().run(documents=[Document(content=text)])["documents"]
-    assert "".join(doc.content for doc in docs) == text
+    split_contents: list[str] = []
+    for doc in docs:
+        assert doc.content is not None
+        split_contents.append(doc.content)
+    assert "".join(split_contents) == text
 
 
 def test_header_metadata_is_stripped_but_content_is_byte_exact():
@@ -873,11 +894,19 @@ def test_header_metadata_is_stripped_but_content_is_byte_exact():
     docs = MarkdownHeaderSplitter().run(documents=[Document(content=text)])["documents"]
     assert docs[0].meta["header"] == "Header 1"
     # the chunk content keeps the header line's original trailing whitespace
-    assert "".join(doc.content for doc in docs) == text
+    split_contents: list[str] = []
+    for doc in docs:
+        assert doc.content is not None
+        split_contents.append(doc.content)
+    assert "".join(split_contents) == text
 
 
 def test_whitespace_only_trailing_header_has_empty_header_metadata():
     text = "# Header 1\nContent.\n#   \n"
     docs = MarkdownHeaderSplitter().run(documents=[Document(content=text)])["documents"]
-    assert "".join(doc.content for doc in docs) == text
+    split_contents: list[str] = []
+    for doc in docs:
+        assert doc.content is not None
+        split_contents.append(doc.content)
+    assert "".join(split_contents) == text
     assert docs[-1].meta["header"] == ""

--- a/test/components/preprocessors/test_python_code_splitter.py
+++ b/test/components/preprocessors/test_python_code_splitter.py
@@ -313,7 +313,7 @@ class TestDecorators:
         ).lstrip()
         splitter = PythonCodeSplitter(min_effective_lines=1, max_effective_lines=2)
         result = splitter.run(documents=[Document(content=source)])
-        all_decorators = []
+        all_decorators: list[str] = []
         for chunk in result["documents"]:
             all_decorators.extend(chunk.meta.get("decorators") or [])
         assert any("staticmethod" in d for d in all_decorators)

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -32,7 +32,7 @@ def test_init_with_overlap_greater_than_chunk_size():
 
 def test_init_with_invalid_separators():
     with pytest.raises(ValueError):
-        _ = RecursiveDocumentSplitter(separators=[".", 2])
+        _ = RecursiveDocumentSplitter(separators=[".", 2])  # type: ignore[list-item]
 
 
 def test_init_with_negative_split_length():
@@ -102,11 +102,11 @@ def test_run_multiple_new_lines_unit_char():
     assert chunks[2].content == "Final test."
 
 
-def test_run_empty_documents(caplog: LogCaptureFixture):
+def test_run_empty_documents(caplog: LogCaptureFixture) -> None:
     splitter = RecursiveDocumentSplitter(split_length=20, split_overlap=0, separators=["."])
     empty_doc = Document(content="")
-    doc_chunks = splitter.run([empty_doc])
-    doc_chunks = doc_chunks["documents"]
+    result = splitter.run([empty_doc])
+    doc_chunks = result["documents"]
     assert len(doc_chunks) == 0
     assert "has an empty content. Skipping this document." in caplog.text
 
@@ -128,8 +128,8 @@ def test_run_using_custom_sentence_tokenizer():
 AI, in its broadest sense, is intelligence exhibited by machines, particularly computer systems.
 AI technology is widely used throughout industry, government, and science. Some high-profile applications include advanced web search engines (e.g., Google Search); recommendation systems (used by YouTube, Amazon, and Netflix); interacting via human speech (e.g., Google Assistant, Siri, and Alexa); autonomous vehicles (e.g., Waymo); generative and creative tools (e.g., ChatGPT and AI art); and superhuman play and analysis in strategy games (e.g., chess and Go)."""  # noqa: E501
 
-    chunks = splitter.run([Document(content=text)])
-    chunks = chunks["documents"]
+    result = splitter.run([Document(content=text)])
+    chunks = result["documents"]
 
     assert len(chunks) == 4
     assert chunks[0].content == "Artificial intelligence (AI) - Introduction\n\n"
@@ -198,8 +198,8 @@ def test_run_split_by_word_count_page_breaks_split_unit_char():
     splitter = RecursiveDocumentSplitter(split_length=19, split_overlap=0, separators=[" "], split_unit="char")
     text = "This is some text. \f This text is on another page. \f This is the last pag3."
     doc = Document(content=text)
-    doc_chunks = splitter.run([doc])
-    doc_chunks = doc_chunks["documents"]
+    result = splitter.run([doc])
+    doc_chunks = result["documents"]
 
     assert len(doc_chunks) == 5
     assert doc_chunks[0].content == "This is some text. "
@@ -370,8 +370,8 @@ def test_run_split_document_with_overlap_character_unit():
     text = """A simple sentence1. A bright sentence2. A clever sentence3"""
 
     doc = Document(content=text)
-    doc_chunks = splitter.run([doc])
-    doc_chunks = doc_chunks["documents"]
+    result = splitter.run([doc])
+    doc_chunks = result["documents"]
 
     assert len(doc_chunks) == 5
     assert doc_chunks[0].content == "A simple sentence1."
@@ -414,8 +414,8 @@ def test_run_split_document_with_overlap_and_fallback_character_unit():
     text = "A simple sentence1. Short. Short."
 
     doc = Document(content=text)
-    doc_chunks = splitter.run([doc])
-    doc_chunks = doc_chunks["documents"]
+    result = splitter.run([doc])
+    doc_chunks = result["documents"]
 
     assert len(doc_chunks) == 8
     assert doc_chunks[0].content == "A simple"
@@ -434,6 +434,7 @@ def test_run_separator_exists_but_split_length_too_small_fall_back_to_character_
     result = splitter.run(documents=[doc])
     assert len(result["documents"]) == 10
     for doc in result["documents"]:
+        assert doc.content is not None
         if re.escape(doc.content) not in ["\\ "]:
             assert len(doc.content) == 2
 
@@ -445,6 +446,7 @@ def test_run_fallback_to_character_chunking_by_default_length_too_short():
     doc = Document(content=text)
     chunks = splitter.run([doc])["documents"]
     for chunk in chunks:
+        assert chunk.content is not None
         assert len(chunk.content) <= 2
 
 
@@ -455,6 +457,7 @@ def test_run_fallback_to_word_chunking_by_default_length_too_short():
     doc = Document(content=text)
     chunks = splitter.run([doc])["documents"]
     for chunk in chunks:
+        assert chunk.content is not None
         assert splitter._chunk_length(chunk.content) <= 2
 
 
@@ -545,8 +548,8 @@ def test_run_split_by_word_count_page_breaks_word_unit():
     splitter = RecursiveDocumentSplitter(split_length=4, split_overlap=0, separators=[" "], split_unit="word")
     text = "This is some text. \f This text is on another page. \f This is the last pag3."
     doc = Document(content=text)
-    doc_chunks = splitter.run([doc])
-    doc_chunks = doc_chunks["documents"]
+    result = splitter.run([doc])
+    doc_chunks = result["documents"]
 
     assert len(doc_chunks) == 5
     assert doc_chunks[0].content == "This is some text. "
@@ -741,6 +744,7 @@ def test_run_split_by_dot_and_overlap_1_word_unit_split_idx_start():
     chunks = splitter.run([Document(content=text)])["documents"]
     assert len(chunks) == 5
     for chunk in chunks:
+        assert chunk.content is not None
         # split_idx_start must equal the character index of the chunk content in the original text
         assert chunk.meta["split_idx_start"] == text.index(chunk.content), (
             f"Wrong split_idx_start for chunk {chunk.content!r}: "
@@ -952,12 +956,12 @@ def test_run_split_by_token_with_sentence_tokenizer():
 
 
 @pytest.mark.integration
-def test_run_split_by_token_with_empty_document(caplog: LogCaptureFixture):
+def test_run_split_by_token_with_empty_document(caplog: LogCaptureFixture) -> None:
     splitter = RecursiveDocumentSplitter(split_length=4, separators=["."], split_unit="token")
 
     empty_doc = Document(content="")
-    doc_chunks = splitter.run([empty_doc])
-    doc_chunks = doc_chunks["documents"]
+    result = splitter.run([empty_doc])
+    doc_chunks = result["documents"]
 
     assert len(doc_chunks) == 0
     assert "has an empty content. Skipping this document." in caplog.text
@@ -973,6 +977,7 @@ def test_run_split_by_token_with_fallback():
 
     assert len(chunks) > 1
     for chunk in chunks:
+        assert chunk.content is not None
         assert splitter._chunk_length(chunk.content) <= 2
 
 
@@ -1022,15 +1027,19 @@ def test_run_complex_text_with_multiple_separators():
 
     assert len(chunks) == 4
 
+    assert chunks[0].content is not None
     assert len(chunks[0].content) == 152
     assert chunks[0].content.startswith("A")
 
+    assert chunks[1].content is not None
     assert len(chunks[1].content) == 101
     assert chunks[1].content.startswith("B")
 
+    assert chunks[2].content is not None
     assert len(chunks[2].content) == 107
     assert chunks[2].content.startswith("B")
 
+    assert chunks[3].content is not None
     assert len(chunks[3].content) == 152
     assert chunks[3].content.startswith("C")
     assert chunks[3].content.endswith("D" * 50)
@@ -1132,8 +1141,12 @@ def test_fallback_overlap_word_unit():
     # Each chunk must share 1 word with its neighbour
     assert len(result) > 1
     for i in range(len(result) - 1):
-        prev_words = result[i].content.split()
-        next_words = result[i + 1].content.split()
+        prev_content = result[i].content
+        next_content = result[i + 1].content
+        assert prev_content is not None
+        assert next_content is not None
+        prev_words = prev_content.split()
+        next_words = next_content.split()
         # The last word of chunk i must appear at the start of chunk i+1
         assert prev_words[-1] == next_words[0], (
             f"No overlap between chunk {i} ({contents[i]!r}) and chunk {i + 1} ({contents[i + 1]!r})"
@@ -1151,6 +1164,7 @@ def test_fallback_overlap_token_unit():
     # Each chunk should be at most 4 tokens; overlap means more than 1 chunk
     assert len(result) > 1
     for chunk in result:
+        assert chunk.content is not None
         assert splitter._chunk_length(chunk.content) <= 4
 
 
@@ -1160,8 +1174,12 @@ def test_word_fallback_does_not_count_multichar_whitespace_as_words():
     splitter = RecursiveDocumentSplitter(split_length=1, split_overlap=0, split_unit="word", separators=["\n\n"])
     chunks = splitter.run([Document(content="hello  world")])["documents"]
     # Exactly one real word per chunk and no whitespace-only chunk.
-    assert [chunk.content.strip() for chunk in chunks] == ["hello", "world"]
-    assert all(chunk.content.strip() for chunk in chunks)
+    stripped_contents: list[str] = []
+    for chunk in chunks:
+        assert chunk.content is not None
+        stripped_contents.append(chunk.content.strip())
+    assert stripped_contents == ["hello", "world"]
+    assert all(stripped_contents)
 
 
 def test_fallback_word_unit_no_trailing_whitespace_only_chunk():
@@ -1169,4 +1187,6 @@ def test_fallback_word_unit_no_trailing_whitespace_only_chunk():
     splitter = RecursiveDocumentSplitter(split_length=1, split_overlap=0, split_unit="word", separators=["\n\n"])
     result = splitter.run([Document(content="hello world ")])["documents"]
 
-    assert all(doc.content.strip() for doc in result)
+    for doc in result:
+        assert doc.content is not None
+        assert doc.content.strip()

--- a/test/components/preprocessors/test_sentence_tokenizer.py
+++ b/test/components/preprocessors/test_sentence_tokenizer.py
@@ -64,7 +64,7 @@ def test_read_abbreviations_existing_file(tmp_path, mock_file_content):
         assert result == ["Mr.", "Dr.", "Prof."]
 
 
-def test_read_abbreviations_missing_file(caplog: LogCaptureFixture):
+def test_read_abbreviations_missing_file(caplog: LogCaptureFixture) -> None:
     with patch("haystack.components.preprocessors.sentence_tokenizer.Path") as mock_path:
         mock_path.return_value.parent.parent = Path("/nonexistent")
         result = SentenceSplitter._read_abbreviations("pt")


### PR DESCRIPTION
### Related Issues

- part of #10396

Claimed in [this comment](https://github.com/deepset-ai/haystack/issues/10396#issuecomment-5460998049).

### Proposed Changes:

`test/components/preprocessors/` was not in the repository mypy target, so its 13 modules were not checked by `hatch run test:types`. This adds the path and fixes the errors that surfaced.

The baseline was 265 errors, but 206 of them were in `test_recursive_splitter.py` alone, cascading from one pattern repeated seven times where the dict returned by `run()` was rebound to the list it contains:

```python
doc_chunks = splitter.run([doc])
doc_chunks = doc_chunks["documents"]   # dict -> list, same name
```

Naming the two values separately drops that file from 206 errors to 26, and the directory from 265 to 85.

The remaining 85 are mostly `Document.content` being `str | None`. AGENTS.md asks to avoid `type: ignore`, casts and assertions where possible and to explain them where they are necessary, so:

- **Narrowing `assert ... is not None`** before first use, where the value was already being dereferenced. `cast(str, ...)` would type-check equally well but keeps the old behaviour of failing with a `TypeError` from inside a comprehension; the assert names the expectation at the point it is made. `cast` also appears only twice in all of `test/`.
- **Comprehensions and generators over `.content` expanded into loops.** A narrowing in an enclosing block does not reach a comprehension's own scope, even when the comprehension reuses the same name, so the assert has to live inside the iteration. The alternative already merged in this campaign is #12433's in-comprehension filter plus a compensating `assert len(filtered) == len(docs)`. That is two lines instead of four, but it is only equivalent as long as every one of the 14 sites remembers the length guard; dropping it silently skips elements. I went with the loop because it cannot be got wrong site-by-site — happy to convert to the filter idiom if you prefer the smaller diff.
- **`any(...)` kept as `any(...)`** over the collected list rather than expanded into per-element asserts, since turning an existential check into a universal one would change what the test claims.

Two smaller groups:

- Six `# type: ignore` comments on `read_csv(...)` in `test_csv_document_splitter.py` are stale. `warn_unused_ignores` flags them as soon as the directory enters the target, so removing them is required rather than optional.
- Eight tests pass a wrong type on purpose to assert the raised error. Those keep the value and carry a specific ignore code (`[arg-type]` / `[list-item]`), never a bare one.

`test_document_preprocessor.py` needed a different fix: `Pipeline.get_component()` returns the `Component` protocol, so the attribute reads failed. An `isinstance` narrowing resolves it, the same way #12343 and #12319 did.

No test assertion, expected value, or input datum changed. Assert counts per file only go up or stay flat.

### How did you test it?

- `hatch run test:types` -> `Success: no issues found in 481 source files` (468 before).
- `hatch run test:unit test/components/preprocessors/` -> 361 passed, 19 deselected — identical to the counts on `main` before the change.
- `hatch run test:integration test/components/preprocessors/` -> 9 passed, 10 skipped. The 10 skipped are the `OPENAI_API_KEY`-gated embedding-splitter tests; six of the edits land in those bodies, so they are covered by mypy and collection but were not executed. To check those six anyway I ran their pre- and post-change versions side by side against a stubbed embedder over a range of mutated outputs, and the two behave identically.
- `hatch run fmt-check` -> clean across the repo (6787 files).

### Notes for the reviewer

This and my #12481 both add a directory to the same `types = ` line, so whichever lands second will conflict there and I will rebase it — no need to sequence them on my account.

Nine open PRs add tests to these files (#12284, #12346, #12356, #12373, #12424, #12431, #12434, #12468, #12478). All are pure additions and a three-way merge against each is clean in both orders, so this does not block them. Two of them (#12284, #12478) add a `Document.content` dereference that mypy will start checking once this lands; I will leave them a note so their CI does not go red unexpectedly.

No release note: CONTRIBUTING.md scopes the requirement to user-facing changes and notes that tests-only changes can carry `ignore-for-release-notes` — happy for you to add the label if you would rather have it explicit.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings - n/a, test-only typing change with no behavior or public API change.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- [x] I have documented my code.
- [ ] I have added a release note file - not needed here, see above.
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
