### PR TITLE
fix: preserve unsplit markdown headers during secondary split

### DIFF
--- a/haystack/components/preprocessors/markdown_header_splitter.py
+++ b/haystack/components/preprocessors/markdown_header_splitter.py
@@ -237,12 +237,6 @@ class MarkdownHeaderSplitter:
 
             content_for_splitting: str = doc.content
 
-            if not self.keep_headers:  # skip header extraction if keep_headers
-                # extract header information
-                header_match = re.match(self._header_pattern, doc.content)
-                if header_match:
-                    content_for_splitting = doc.content[header_match.end() :]
-
             # track page from meta
             current_page = doc.meta.get("page_number", 1)
 

--- a/releasenotes/notes/preserve-unsplit-markdown-headers-54e93f48d246ea6f.yaml
+++ b/releasenotes/notes/preserve-unsplit-markdown-headers-54e93f48d246ea6f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Preserve leading Markdown headers that are excluded by ``header_split_levels``
+    when applying a secondary split with ``keep_headers=False``.

--- a/test/components/preprocessors/test_markdown_header_splitter.py
+++ b/test/components/preprocessors/test_markdown_header_splitter.py
@@ -284,6 +284,24 @@ def test_secondary_split_keeps_content_before_code_fence_comment():
     assert "some intro text" in combined
 
 
+def test_secondary_split_keeps_excluded_leading_header():
+    splitter = MarkdownHeaderSplitter(
+        keep_headers=False, header_split_levels=[2], secondary_split="word", split_length=5
+    )
+    docs = splitter.run(documents=[Document(content="# Title\nsome content here")])["documents"]
+
+    assert docs[0].content == "# Title\nsome content here"
+    assert "header" not in docs[0].meta
+
+
+def test_secondary_split_keeps_header_only_document():
+    splitter = MarkdownHeaderSplitter(keep_headers=False, secondary_split="word", split_length=5)
+    docs = splitter.run(documents=[Document(content="# Alpha\n# Beta")])["documents"]
+
+    assert docs[0].content == "# Alpha\n# Beta"
+    assert "header" not in docs[0].meta
+
+
 # Error and edge case handling
 def test_non_text_document():
     """Test that the component correctly handles non-text documents."""


### PR DESCRIPTION
### Related Issues

No linked issue; this fixes a content-loss edge case in `MarkdownHeaderSplitter`.

### Proposed Changes

When `keep_headers=False`, primary splitting already removes only headers selected by `header_split_levels`. The secondary-split path then ran a second broad header regex over every intermediate document, which also removed leading headers intentionally excluded from those levels. Header-only documents could consequently lose all content.

This removes that redundant extraction so secondary splitting receives the exact content produced by primary splitting. It adds regressions for an excluded leading H1 and a header-only document.

### How did you test it?

- `uv run pytest test/components/preprocessors/test_markdown_header_splitter.py -q` (41 passed)
- `uvx ruff check haystack/components/preprocessors/markdown_header_splitter.py test/components/preprocessors/test_markdown_header_splitter.py`
- `uvx ruff format --check haystack/components/preprocessors/markdown_header_splitter.py test/components/preprocessors/test_markdown_header_splitter.py`
- `git diff --check upstream/main...HEAD`

### Notes for the reviewer

The removed block was redundant with primary header extraction and ignored `header_split_levels`. The release-note YAML follows the existing Reno format; local `reno lint` could not complete because this checkout is a blob-filtered partial clone and Reno/Dulwich requires missing historical objects.

### Checklist

- [x] Added focused unit tests.
- [x] Added a release note.
- [x] Ran the component test file and Ruff checks.
- [x] Used a conventional commit PR title.