### PR TITLE
fix: preserve constant scores in DocumentJoiner

### DIFF
--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -238,15 +238,16 @@ class DocumentJoiner:
             min_score = mean_score - 3 * std_dev
             max_score = mean_score + 3 * std_dev
             delta_score = max_score - min_score
+            scores_vary = min(scores_list) != max(scores_list)
 
-            # if all docs have the same score delta_score is 0, the docs are uninformative for the query
+            # If all docs have the same score, rescaling cannot add information; preserve their original scores.
             rescaled_lists.append(
                 [
                     replace(
                         doc,
                         score=((doc.score if doc.score is not None else 0) - min_score) / delta_score
-                        if delta_score != 0.0
-                        else 0.0,
+                        if scores_vary and delta_score != 0.0
+                        else (doc.score if doc.score is not None else 0.0),
                     )
                     for doc in documents
                 ]

--- a/releasenotes/notes/document-joiner-preserve-constant-scores-12507.yaml
+++ b/releasenotes/notes/document-joiner-preserve-constant-scores-12507.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Preserve original document scores in ``DocumentJoiner`` distribution-based rank
+    fusion when an input list contains a single document or has zero score variance.

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -276,19 +276,36 @@ class TestDocumentJoiner:
         ]
         output = joiner.run([documents_1, documents_2])
         assert len(output["documents"]) == 7
-        expected_document_ids = [
-            doc.id
-            for doc in [
-                Document(content="a", score=0),
-                Document(content="b", score=0),
-                Document(content="c", score=0),
-                Document(content="d", score=0.44),
-                Document(content="e", score=0.60),
-                Document(content="f", score=0.76, meta={"key": "value"}),
-                Document(content="g", score=0.33),
-            ]
+        scores_by_content = {doc.content: doc.score for doc in output["documents"]}
+        assert scores_by_content["a"] == pytest.approx(0.3386256939)
+        assert scores_by_content["b"] == pytest.approx(0.2)
+        assert scores_by_content["c"] == pytest.approx(0.2)
+
+    @pytest.mark.parametrize("score", [0.95, 0.0, -0.5, None])
+    def test_distribution_based_rank_fusion_preserves_single_document_score(self, score):
+        joiner = DocumentJoiner(join_mode="distribution_based_rank_fusion")
+
+        output = joiner.run([[Document(content="a", score=score)]])
+
+        assert output["documents"][0].score == (score if score is not None else 0.0)
+
+    def test_distribution_based_rank_fusion_preserves_constant_score_when_joining_varied_list(self):
+        joiner = DocumentJoiner(join_mode="distribution_based_rank_fusion")
+        shared = Document(content="shared", score=0.8)
+        constant_documents = [shared, Document(content="constant", score=0.8)]
+        varied_documents = [
+            Document(id=shared.id, content="shared", score=0.5),
+            Document(content="low", score=0.0),
+            Document(content="high", score=1.0),
         ]
-        assert all(doc.id in expected_document_ids for doc in output["documents"])
+
+        output = joiner.run([constant_documents, varied_documents])
+
+        scores_by_content = {doc.content: doc.score for doc in output["documents"]}
+        assert scores_by_content["shared"] == pytest.approx(0.8)
+        assert scores_by_content["constant"] == pytest.approx(0.8)
+        assert scores_by_content["low"] == pytest.approx(0.2958758548)
+        assert scores_by_content["high"] == pytest.approx(0.7041241452)
 
     def test_run_with_distribution_based_rank_fusion_join_mode_with_none_score(self):
         # Documents with score=None (e.g. from a non-scoring source) must not crash DBSF;


### PR DESCRIPTION
> [!IMPORTANT]
> Draft pending DBSF zero-variance semantics. Preserving raw constant scores can break cross-retriever scale normalization; see the design analysis in [#12507](https://github.com/deepset-ai/haystack/issues/12507#issuecomment-5466667012). No further code changes will be pushed until a maintainer confirms the intended fallback.

### Related Issues

- fixes #12507

### Proposed Changes:

`DocumentJoiner` normalized a score list with zero variance to `0.0`. This erased valid ranking information for single-document inputs and for lists whose documents all have the same score.

This PR preserves the original score when every score in an input list is equal, while keeping the existing distribution-based normalization for lists with varying scores. The explicit min/max comparison also avoids treating floating-point noise from a constant list as meaningful variance.

Regression coverage includes:

- single documents with positive, zero, negative, and missing scores;
- multiple documents with identical scores;
- mixed constant-score and varying-score lists;
- duplicate documents across lists;
- unchanged normalization for non-constant score distributions.

### How did you test it?

- DocumentJoiner unit tests: 45 passed
- Ruff lint: passed
- Ruff format check: passed
- Reno release-note lint: passed
- `git diff --check`: passed

### Notes for the reviewer

The change intentionally preserves the input score for a zero-variance list rather than mapping it to an arbitrary normalized value. This matches the expected behavior described in #12507 and avoids discarding the only available ranking signal.

This PR was fully generated with an AI assistant. The changes were reviewed and the relevant tests and quality checks listed above were run.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have linked the related issue and documented the behavior change.
- [x] I have added unit tests.
- [x] I have used a conventional commit title.
- [x] I have added a release note.
- [x] I have run the relevant formatting, lint, and test checks.