### PR TITLE
fix: handle top-level JSON scalars in JsonSchemaValidator

### DIFF
--- a/haystack/components/validators/json_schema.py
+++ b/haystack/components/validators/json_schema.py
@@ -129,8 +129,7 @@ class JsonSchemaValidator:
         :return:  A dictionary with the following keys:
             - "validated": A list of messages if the last message is valid.
             - "validation_error": A list of messages if the last message is invalid.
-        :raises ValueError: If no JSON schema is provided or if the message content is not a dictionary or a list of
-            dictionaries.
+        :raises ValueError: If no JSON schema is provided.
         """
         last_message = messages[-1]
         if last_message.text is None:
@@ -249,4 +248,4 @@ class JsonSchemaValidator:
             return new_dict
 
         # If it's neither a list nor a dictionary, return the value directly
-        raise ValueError("Input must be a dictionary or a list of dictionaries.")
+        return data

--- a/releasenotes/notes/fix-json-schema-validator-scalars-a0c8486028aaf710.yaml
+++ b/releasenotes/notes/fix-json-schema-validator-scalars-a0c8486028aaf710.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed ``JsonSchemaValidator`` raising ``ValueError`` on top-level JSON scalars (string, number, boolean, null). Scalars are now passed through to ``jsonschema`` validation, returning ``validated`` when the schema matches the scalar type or ``validation_error`` otherwise, instead of crashing.


### PR DESCRIPTION
### Related Issues

- fixes #12512

### Proposed Changes:

JsonSchemaValidator raised ValueError on valid top-level JSON scalars (string, number, boolean, null) instead of delegating to jsonschema validation. Scalars are now passed through and return validated or validation_error depending on the schema.

### How did you test it?

Reproduced the crash for all four scalar types on main and verified they no longer crash after the fix, with the existing validator tests still passing.

### Notes for the reviewer

Top-level arrays with an array schema still return a spurious validation_error due to the existing batch splitting logic; this is pre-existing and out of scope for this scalar fix.

### Checklist

- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings.
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [ ] I have documented my code.
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [ ] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.