### PR TITLE
feat(preprocessors): filter short cleaned documents

### DIFF
--- a/docs-website/docs/pipeline-components/preprocessors/documentcleaner.mdx
+++ b/docs-website/docs/pipeline-components/preprocessors/documentcleaner.mdx
@@ -31,6 +31,7 @@ Use `DocumentCleaner` to make text documents more readable. It removes extra whi
 - `remove_empty_lines` removes empty lines from the document.
 - `remove_extra_whitespaces` removes extra whitespaces from the document.
 - `remove_repeated_substrings` removes repeated substrings (headers/footers) from pages in the document. Pages in the text need to be separated by form feed character "\\f", which is supported by [`TextFileToDocument`](../converters/textfiletodocument.mdx), [`AzureOCRDocumentConverter`](../converters/azureocrdocumentconverter.mdx), [`MistralOCRDocumentConverter`](../converters/mistralocrdocumentconverter.mdx), and [`PaddleOCRVLDocumentConverter`](../converters/paddleocrvldocumentconverter.mdx).
+- `min_content_length` drops text documents whose cleaned content is shorter than the configured number of characters after leading and trailing whitespace is stripped. The default value is `0`, which keeps all text documents.
 
 :::note
 `remove_extra_whitespaces` and `remove_empty_lines` work best on plain-text content. If your converter returns Markdown, such as [`AzureDocumentIntelligenceConverter`](../converters/azuredocumentintelligenceconverter.mdx), [`MarkItDownConverter`](../converters/markitdownconverter.mdx), [`MistralOCRDocumentConverter`](../converters/mistralocrdocumentconverter.mdx), or [`PaddleOCRVLDocumentConverter`](../converters/paddleocrvldocumentconverter.mdx), disable those options to preserve headings, tables, lists, and image tags.
@@ -46,7 +47,10 @@ The cleaning steps are executed in the following order:
 4. remove_empty_lines
 5. remove_substrings
 6. remove_regex
-7. remove_repeated_substrings
+7. replace_regexes
+8. remove_repeated_substrings
+9. strip_whitespaces
+10. min_content_length
 
 ## Usage
 
@@ -105,6 +109,7 @@ components:
       remove_regex: null
       remove_repeated_substrings: false
       remove_substrings: null
+      min_content_length: 0
       replace_regexes: null
       strip_whitespaces: false
       unicode_normalization: null

--- a/haystack/components/preprocessors/document_cleaner.py
+++ b/haystack/components/preprocessors/document_cleaner.py
@@ -51,6 +51,7 @@ class DocumentCleaner:
         ascii_only: bool = False,
         strip_whitespaces: bool = False,
         replace_regexes: dict[str, str] | None = None,
+        min_content_length: int = 0,
     ) -> None:
         """
         Initialize DocumentCleaner.
@@ -75,9 +76,13 @@ class DocumentCleaner:
         :param replace_regexes: A dictionary mapping regex patterns to their replacement strings.
             For example, `{r'\\n\\n+': '\\n'}` replaces multiple consecutive newlines with a single newline.
             This is applied after `remove_regex` and allows custom replacements instead of just removal.
+        :param min_content_length: Minimum length of the cleaned document content after stripping leading and trailing
+            whitespace. Documents shorter than this value are dropped. A value of `0` keeps all documents.
         """
 
         self._validate_params(unicode_normalization=unicode_normalization)
+        if min_content_length < 0:
+            raise ValueError("min_content_length must be greater than or equal to 0.")
 
         self.remove_empty_lines = remove_empty_lines
         self.remove_extra_whitespaces = remove_extra_whitespaces
@@ -89,6 +94,7 @@ class DocumentCleaner:
         self.ascii_only = ascii_only
         self.strip_whitespaces = strip_whitespaces
         self.replace_regexes = replace_regexes
+        self.min_content_length = min_content_length
 
     def _validate_params(self, unicode_normalization: str | None) -> None:
         """
@@ -145,6 +151,17 @@ class DocumentCleaner:
                 text = self._remove_repeated_substrings(text)
             if self.strip_whitespaces:
                 text = text.strip()
+
+            cleaned_content = text.strip()
+            if len(cleaned_content) < self.min_content_length:
+                logger.debug(
+                    "Document ID {doc_id} has cleaned content shorter than min_content_length "
+                    "({content_length} < {min_content_length}). Skipping this document.",
+                    doc_id=doc.id,
+                    content_length=len(cleaned_content),
+                    min_content_length=self.min_content_length,
+                )
+                continue
 
             clean_doc = Document(
                 id=doc.id if self.keep_id else "",

--- a/haystack/components/preprocessors/document_cleaner.py
+++ b/haystack/components/preprocessors/document_cleaner.py
@@ -152,16 +152,17 @@ class DocumentCleaner:
             if self.strip_whitespaces:
                 text = text.strip()
 
-            cleaned_content = text.strip()
-            if len(cleaned_content) < self.min_content_length:
-                logger.debug(
-                    "Document ID {doc_id} has cleaned content shorter than min_content_length "
-                    "({content_length} < {min_content_length}). Skipping this document.",
-                    doc_id=doc.id,
-                    content_length=len(cleaned_content),
-                    min_content_length=self.min_content_length,
-                )
-                continue
+            if self.min_content_length:
+                cleaned_content = text.strip()
+                if len(cleaned_content) < self.min_content_length:
+                    logger.debug(
+                        "Document ID {doc_id} has cleaned content shorter than min_content_length "
+                        "({content_length} < {min_content_length}). Skipping this document.",
+                        doc_id=doc.id,
+                        content_length=len(cleaned_content),
+                        min_content_length=self.min_content_length,
+                    )
+                    continue
 
             clean_doc = Document(
                 id=doc.id if self.keep_id else "",

--- a/releasenotes/notes/document-cleaner-min-content-length-8e6c1f2a.yaml
+++ b/releasenotes/notes/document-cleaner-min-content-length-8e6c1f2a.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Add the ``min_content_length`` parameter to ``DocumentCleaner``. After the
+    configured cleaning steps run, text documents shorter than the threshold
+    (ignoring leading and trailing whitespace) are omitted from the output.

--- a/test/components/preprocessors/test_document_cleaner.py
+++ b/test/components/preprocessors/test_document_cleaner.py
@@ -20,12 +20,52 @@ class TestDocumentCleaner:
         assert cleaner.remove_substrings is None
         assert cleaner.remove_regex is None
         assert cleaner.keep_id is False
+        assert cleaner.min_content_length == 0
+
+    def test_init_with_min_content_length(self):
+        cleaner = DocumentCleaner(min_content_length=10)
+        assert cleaner.min_content_length == 10
+
+    def test_init_rejects_negative_min_content_length(self):
+        with pytest.raises(ValueError, match="min_content_length must be greater than or equal to 0"):
+            DocumentCleaner(min_content_length=-1)
 
     def test_non_text_document(self, caplog):
         with caplog.at_level(logging.WARNING):
             cleaner = DocumentCleaner()
             cleaner.run(documents=[Document()])
             assert "DocumentCleaner only cleans text documents but document.content for document ID" in caplog.text
+
+    def test_min_content_length_drops_short_cleaned_documents(self, caplog):
+        cleaner = DocumentCleaner(
+            remove_empty_lines=False,
+            remove_extra_whitespaces=False,
+            remove_substrings=["remove me"],
+            keep_id=True,
+            min_content_length=3,
+        )
+        documents = [
+            Document(content="  remove me  ", id="empty-after-cleaning"),
+            Document(content="  ab  ", id="short"),
+            Document(content="  abc  ", id="at-threshold"),
+            Document(content="  abcd  ", id="long"),
+        ]
+
+        with caplog.at_level(logging.DEBUG):
+            result = cleaner.run(documents=documents)
+
+        assert [doc.id for doc in result["documents"]] == ["at-threshold", "long"]
+        assert [doc.content for doc in result["documents"]] == ["  abc  ", "  abcd  "]
+        assert "empty-after-cleaning" in caplog.text
+        assert "short" in caplog.text
+
+    def test_min_content_length_preserves_documents_with_none_content(self):
+        document = Document(content=None, id="non-text")
+        cleaner = DocumentCleaner(min_content_length=100)
+
+        result = cleaner.run(documents=[document])
+
+        assert result["documents"] == [document]
 
     def test_single_document(self):
         with pytest.raises(TypeError, match="DocumentCleaner expects a List of Documents as input."):

--- a/test/components/preprocessors/test_document_cleaner.py
+++ b/test/components/preprocessors/test_document_cleaner.py
@@ -22,10 +22,6 @@ class TestDocumentCleaner:
         assert cleaner.keep_id is False
         assert cleaner.min_content_length == 0
 
-    def test_init_with_min_content_length(self):
-        cleaner = DocumentCleaner(min_content_length=10)
-        assert cleaner.min_content_length == 10
-
     def test_init_rejects_negative_min_content_length(self):
         with pytest.raises(ValueError, match="min_content_length must be greater than or equal to 0"):
             DocumentCleaner(min_content_length=-1)


### PR DESCRIPTION
### Related Issues

- fixes #12509

### Proposed Changes:

Add an optional `min_content_length` parameter to `DocumentCleaner`. After the existing cleaning steps run, text documents whose trimmed content is shorter than the configured threshold are omitted. The default is `0`, and documents with `content=None` keep their current pass-through behavior. Negative thresholds are rejected during initialization.

The component page now documents the parameter and the release note records the new option.

### How did you test it?

- `UV_CACHE_DIR=/tmp/haystack-uv-cache hatch run test:unit test/components/preprocessors/test_document_cleaner.py -q` (27 passed)
- `UV_CACHE_DIR=/tmp/haystack-uv-cache hatch run test:unit test/core/pipeline/features/test_run.py -q` (116 deselected; pipeline test module completed successfully)
- `UV_CACHE_DIR=/tmp/haystack-uv-cache hatch run fmt-check haystack/components/preprocessors/document_cleaner.py test/components/preprocessors/test_document_cleaner.py` (passed)
- `UV_CACHE_DIR=/tmp/haystack-uv-cache hatch run test:types haystack/components/preprocessors/document_cleaner.py` (passed)
- `pre-commit run --files ...` (passed)
- `git diff --check` (passed)

No provider or network integration was needed for this change.

### Notes for the reviewer

I used an AI assistant to help inspect the issue and draft the patch. I reviewed the final changes and ran the checks listed above.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used a conventional commit type (`feat:`).
- [x] I have documented my code.
- [x] I have added a release note file.
- [x] I have run pre-commit hooks and fixed any issue.
