### PR TITLE
feat: add opt-in ToolCache for caching tool results in Agent loops

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -14,6 +14,11 @@ from haystack.components.agents.state.state import (
     _validate_schema,
     replace_values,
 )
+
+try:
+    from haystack.tools.tool_cache import ToolCache
+except ImportError:  # pragma: no cover
+    ToolCache = Any  # type: ignore[misc,assignment]
 from haystack.components.agents.state.state_utils import merge_lists
 from haystack.components.agents.tool_calling import _run_tool, _run_tool_async
 from haystack.components.agents.utils import (
@@ -375,6 +380,21 @@ class Agent:
     )
     ```
 
+    #### Using a `tool_cache` to avoid redundant tool calls
+
+    When an Agent loops over several steps, it can end up calling the same read-only tool with the same
+    arguments more than once (for example, re-fetching a document it already fetched a few steps earlier).
+    Pass a `ToolCache` to avoid re-invoking tools that have opted in via `Tool(..., cacheable=True)`:
+
+    ```python
+    from haystack.components.agents import Agent
+    from haystack.tools.tool_cache import ToolCache
+
+    cache = ToolCache(ttl_seconds=3600, scope="agent_run")
+    agent = Agent(chat_generator=OpenAIChatGenerator(), tools=[my_cacheable_tool], tool_cache=cache)
+    result = agent.run(messages=[ChatMessage.from_user("...")])
+    # result["tool_cache_stats"] -> {"hits": ..., "misses": ..., "calls_saved": ...}
+    ```
     """
 
     def __init__(  # noqa: PLR0913
@@ -393,6 +413,7 @@ class Agent:
         tool_concurrency_limit: int = 4,
         tool_streaming_callback_passthrough: bool = False,
         hooks: dict[HookPoint, list[Hook]] | None = None,
+        tool_cache: "ToolCache | None" = None,
     ) -> None:
         """
         Initialize the agent component.
@@ -426,6 +447,11 @@ class Agent:
             If set to False, the exception will be turned into a chat message and passed to the LLM.
         :param tool_concurrency_limit: Maximum number of tool calls to execute at the same time.
             Defaults to 4. Set to 1 to disable parallel tool execution.
+        :param tool_cache: Optional `ToolCache` instance shared across the Agent's run. When provided, tool calls
+            for any `Tool` with `cacheable=True` are looked up in the cache before invocation and stored after a
+            successful invocation. When set, the dict returned by `run()`/`run_async()` includes a `"tool_cache_stats"`
+            key with the cache's hit/miss counts for the run. Not included in `to_dict()`/`from_dict()`
+            serialization, since cache backends are runtime objects rather than serializable configuration.
         :param tool_streaming_callback_passthrough: If True, pass the streaming callback to tools that accept it.
         :param hooks: A dictionary mapping a hook point to a list of hooks the Agent runs at that point. Each hook
             receives the live `State` and influences the run by mutating it in place; hooks for a hook point run in
@@ -500,6 +526,7 @@ class Agent:
         self.tool_concurrency_limit = tool_concurrency_limit
         self.tool_streaming_callback_passthrough = tool_streaming_callback_passthrough
         self.hooks = hooks
+        self.tool_cache = tool_cache
 
         # --- State schema ---
         # shallow copy is sufficient: we only add a top-level "messages" key, never mutate nested values
@@ -513,6 +540,8 @@ class Agent:
         # --- Component I/O ---
         self._run_method_params = _get_run_method_params(self)
         output_types: dict[str, Any] = {"last_message": ChatMessage}
+        if self.tool_cache is not None:
+            output_types["tool_cache_stats"] = dict[str, int]
         for param, config in self.resolved_state_schema.items():
             # Internal keys are run-control / hook-facing state, not exposed as inputs or outputs.
             if param in _INTERNAL_STATE_KEYS:
@@ -633,6 +662,11 @@ class Agent:
     def to_dict(self) -> dict[str, Any]:
         """
         Serialize the component to a dictionary.
+
+        Note: `tool_cache`, if set, is intentionally NOT included — cache backends are runtime objects
+        rather than serializable configuration. A deserialized `Agent` will have `tool_cache=None` even
+        if the original instance had one set; callers that need caching after deserialization should
+        re-attach a `ToolCache` explicitly.
 
         :returns: Dictionary with serialized data.
         """
@@ -784,6 +818,7 @@ class Agent:
             "streaming_callback": streaming_callback,
             "max_workers": self.tool_concurrency_limit,
             "enable_streaming_callback_passthrough": self.tool_streaming_callback_passthrough,
+            "tool_cache": self.tool_cache,
         }
 
         return _ExecutionContext(
@@ -866,6 +901,8 @@ class Agent:
               text), the name of the tool that satisfied a tool exit condition (in which case `last_message` is that
               tool's result), or `"max_agent_steps"` (the Agent hit `max_agent_steps` before meeting an exit
               condition), or a custom reason a hook supplied through the `stop_run` state key.
+            - "tool_cache_stats": Only present if a `tool_cache` was configured; a dict with `hits`, `misses`,
+              and `calls_saved` counts for this run.
             - Any additional keys defined in the `state_schema`.
         """
         agent_inputs = {"messages": messages, "streaming_callback": streaming_callback, **kwargs}
@@ -901,6 +938,8 @@ class Agent:
             result = _public_outputs(state=exe_context.state)
             if msgs := result.get("messages"):
                 result["last_message"] = msgs[-1]
+            if self.tool_cache is not None:
+                result["tool_cache_stats"] = self.tool_cache.stats.to_dict()
             span.set_content_tag("haystack.agent.output", result)
             span.set_tag("haystack.agent.steps_taken", exe_context.counter)
 
@@ -952,6 +991,8 @@ class Agent:
               text), the name of the tool that satisfied a tool exit condition (in which case `last_message` is that
               tool's result), or `"max_agent_steps"` (the Agent hit `max_agent_steps` before meeting an exit
               condition), or a custom reason a hook supplied through the `stop_run` state key.
+            - "tool_cache_stats": Only present if a `tool_cache` was configured; a dict with `hits`, `misses`,
+              and `calls_saved` counts for this run.
             - Any additional keys defined in the `state_schema`.
         """
         agent_inputs = {"messages": messages, "streaming_callback": streaming_callback, **kwargs}
@@ -987,6 +1028,8 @@ class Agent:
             result = _public_outputs(state=exe_context.state)
             if msgs := result.get("messages"):
                 result["last_message"] = msgs[-1]
+            if self.tool_cache is not None:
+                result["tool_cache_stats"] = self.tool_cache.stats.to_dict()
             span.set_content_tag("haystack.agent.output", result)
             span.set_tag("haystack.agent.steps_taken", exe_context.counter)
 

--- a/haystack/components/agents/tool_calling.py
+++ b/haystack/components/agents/tool_calling.py
@@ -20,6 +20,11 @@ from haystack.tools.errors import ToolInvocationError
 from haystack.tools.parameters_schema_utils import _unwrap_optional
 from haystack.tracing.utils import _serializable_value
 
+try:
+    from haystack.tools.tool_cache import ToolCache
+except ImportError:  # pragma: no cover
+    ToolCache = Any  # type: ignore[assignment,misc]
+
 logger = logging.getLogger(__name__)
 
 
@@ -520,6 +525,7 @@ def _run_tool(
     raise_on_failure: bool = True,
     enable_streaming_callback_passthrough: bool = False,
     max_workers: int = 4,
+    tool_cache: "ToolCache | None" = None,
 ) -> tuple[list[ChatMessage], State]:
     """
     Invoke all tools referenced by tool calls in `messages`.
@@ -559,26 +565,42 @@ def _run_tool(
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for batch in batches:
             # Prepare args at the start of each batch so tools that read from State observe writes merged by earlier
-            # batches.
-            futures = {}
+            # batches. Cache hits are not scheduled — they bypass the executor and are finalized directly,
+            # while misses are submitted for parallel execution.
+            futures: dict[int, Any] = {}
+            cached_results: dict[int, Any] = {}
             for idx in batch:
+                tool = resolved_tools[idx]
+                tc = tool_calls[idx]
+                if tool_cache is not None and getattr(tool, "cacheable", False):
+                    hit, cached_value = tool_cache.get(tool.name, tc.arguments)
+                    if hit:
+                        cached_results[idx] = cached_value
+                        continue
                 args = _prepare_tool_args(
-                    tool=resolved_tools[idx],
-                    tool_call_arguments=tool_calls[idx].arguments,
+                    tool=tool,
+                    tool_call_arguments=tc.arguments,
                     state=state,
                     streaming_callback=streaming_callback,
                     enable_streaming_passthrough=enable_streaming_callback_passthrough,
                 )
                 futures[idx] = executor.submit(
-                    _make_context_bound_invoke(
-                        tool=resolved_tools[idx], args=args, tool_call=tool_calls[idx], parent_span=parent_span
-                    )
+                    _make_context_bound_invoke(tool=tool, args=args, tool_call=tc, parent_span=parent_span)
                 )
 
             # Merge results in call order within the batch so write-write merges stay deterministic.
             for idx in batch:
+                if idx in cached_results:
+                    result = cached_results[idx]
+                else:
+                    result = futures[idx].result()
+                    # Cache successful misses (errors are not cached)
+                    if not isinstance(result, ToolInvocationError):
+                        tool = resolved_tools[idx]
+                        if tool_cache is not None and getattr(tool, "cacheable", False):
+                            tool_cache.set(tool.name, tool_calls[idx].arguments, result)
                 message = _finalize_tool_result(
-                    futures[idx].result(),
+                    result,
                     tool_calls[idx],
                     resolved_tools[idx],
                     state,
@@ -609,6 +631,7 @@ async def _run_tool_async(
     raise_on_failure: bool = True,
     enable_streaming_callback_passthrough: bool = False,
     max_workers: int = 4,
+    tool_cache: "ToolCache | None" = None,
 ) -> tuple[list[ChatMessage], State]:
     """
     Asynchronous variant of `run_tool`. Tool calls execute concurrently via a thread pool.
@@ -651,26 +674,46 @@ async def _run_tool_async(
 
     for batch in batches:
         # Prepare args at the start of each batch so readers observe writes merged by earlier batches.
-        tasks = {}
+        # Cache hits bypass async execution and are finalized directly.
+        tasks: dict[int, Any] = {}
+        cached_results: dict[int, Any] = {}
         for idx in batch:
+            tool = resolved_tools[idx]
+            tc = tool_calls[idx]
+            if tool_cache is not None and getattr(tool, "cacheable", False):
+                hit, cached_value = tool_cache.get(tool.name, tc.arguments)
+                if hit:
+                    cached_results[idx] = cached_value
+                    continue
             args = _prepare_tool_args(
-                tool=resolved_tools[idx],
-                tool_call_arguments=tool_calls[idx].arguments,
+                tool=tool,
+                tool_call_arguments=tc.arguments,
                 state=state,
                 streaming_callback=streaming_callback,
                 enable_streaming_passthrough=enable_streaming_callback_passthrough,
             )
             tasks[idx] = _make_bounded_invoke_async(
-                tool=resolved_tools[idx],
+                tool=tool,
                 args=args,
                 semaphore=semaphore,
-                tool_call=tool_calls[idx],
+                tool_call=tc,
                 parent_span=parent_span,
             )()
-        batch_results = await asyncio.gather(*tasks.values())
+        batch_results = await asyncio.gather(*tasks.values()) if tasks else []
+
+        # Build mapping from task idx -> result for non-cached entries
+        task_idx_to_result: dict[int, Any] = dict(zip(tasks.keys(), batch_results, strict=True))
 
         # Merge results in call order within the batch so write-write merges stay deterministic.
-        for idx, result in zip(tasks.keys(), batch_results, strict=True):
+        for idx in batch:
+            if idx in cached_results:
+                result = cached_results[idx]
+            else:
+                result = task_idx_to_result[idx]
+                if not isinstance(result, ToolInvocationError):
+                    tool = resolved_tools[idx]
+                    if tool_cache is not None and getattr(tool, "cacheable", False):
+                        tool_cache.set(tool.name, tool_calls[idx].arguments, result)
             message = _finalize_tool_result(
                 result, tool_calls[idx], resolved_tools[idx], state, raise_on_failure=raise_on_failure
             )

--- a/haystack/tools/__init__.py
+++ b/haystack/tools/__init__.py
@@ -33,6 +33,7 @@ _import_structure = {
     "serde_utils": ["deserialize_tools_or_toolset_inplace", "serialize_tools_or_toolset"],
     "utils": ["flatten_tools_or_toolsets", "warm_up_tools"],
     "tool_types": ["ToolsType"],
+    "tool_cache": ["ToolCache", "ToolCacheBackend", "InMemoryToolCache", "ToolCacheStats", "make_cache_key"],
 }
 
 if TYPE_CHECKING:
@@ -43,6 +44,11 @@ if TYPE_CHECKING:
     from haystack.tools.serde_utils import deserialize_tools_or_toolset_inplace as deserialize_tools_or_toolset_inplace
     from haystack.tools.serde_utils import serialize_tools_or_toolset as serialize_tools_or_toolset
     from haystack.tools.skills import SkillToolset as SkillToolset
+    from haystack.tools.tool_cache import InMemoryToolCache as InMemoryToolCache
+    from haystack.tools.tool_cache import ToolCache as ToolCache
+    from haystack.tools.tool_cache import ToolCacheBackend as ToolCacheBackend
+    from haystack.tools.tool_cache import ToolCacheStats as ToolCacheStats
+    from haystack.tools.tool_cache import make_cache_key as make_cache_key
     from haystack.tools.tool_types import ToolsType as ToolsType
     from haystack.tools.toolset import Toolset as Toolset
     from haystack.tools.utils import flatten_tools_or_toolsets as flatten_tools_or_toolsets

--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -100,6 +100,7 @@ class ComponentTool(Tool):
         outputs_to_string: dict[str, str | Callable[[Any], str]] | None = None,
         inputs_from_state: dict[str, str] | None = None,
         outputs_to_state: dict[str, dict[str, str | Callable]] | None = None,
+        cacheable: bool = False,
     ) -> None:
         """
         Create a Tool instance from a Haystack component.
@@ -158,6 +159,9 @@ class ComponentTool(Tool):
                 "documents": {"handler": custom_handler}
             }
             ```
+        :param cacheable:
+            If True, results of this tool's invocations may be cached by a `ToolCache` passed to
+            `Agent`. See `Tool.cacheable` for details.
         :raises TypeError: If the object passed is not a Haystack Component instance.
         :raises ValueError: If the component has already been added to a pipeline, or if schema generation fails.
         """
@@ -249,6 +253,7 @@ class ComponentTool(Tool):
             inputs_from_state=inputs_from_state,
             outputs_to_state=outputs_to_state,
             outputs_to_string=outputs_to_string,
+            cacheable=cacheable,
         )
 
     def _get_valid_inputs(self) -> set[str]:
@@ -296,6 +301,7 @@ class ComponentTool(Tool):
             "outputs_to_string": _serialize_outputs_to_string(self.outputs_to_string)
             if self.outputs_to_string
             else None,
+            "cacheable": self.cacheable,
         }
 
         return {"type": generate_qualified_class_name(type(self)), "data": serialized}
@@ -322,6 +328,7 @@ class ComponentTool(Tool):
             outputs_to_string=inner_data.get("outputs_to_string", None),
             inputs_from_state=inner_data.get("inputs_from_state", None),
             outputs_to_state=inner_data.get("outputs_to_state", None),
+            cacheable=inner_data.get("cacheable", False),
         )
 
     def _create_tool_parameters_schema(self, component: Component, inputs_from_state: dict[str, Any]) -> dict[str, Any]:

--- a/haystack/tools/tool.py
+++ b/haystack/tools/tool.py
@@ -91,6 +91,12 @@ class Tool:
             "documents": {"handler": custom_handler}
         }
         ```
+    :param cacheable:
+        Whether results from this tool may be served from a `ToolCache` when one is configured on the
+        `Agent` invoking this tool. Defaults to `False` — caching must be explicitly opted into
+        per tool so that write-effecting tools (sending a message, posting to an API, mutating remote or local
+        state) never serve a stale cached result for what should be a fresh side-effecting call. Set this to
+        `True` only for read-only/idempotent tools such as lookups, fetches, or calculations.
     :raises ValueError: If neither `function` nor `async_function` is provided, if `function` is a
         coroutine function, if `async_function` is not a coroutine function, if `parameters` is not a
         valid JSON schema, or if the `outputs_to_state`, `outputs_to_string`, or `inputs_from_state`
@@ -107,6 +113,7 @@ class Tool:
     inputs_from_state: dict[str, str] | None = None
     outputs_to_state: dict[str, dict[str, Any]] | None = None
     async_function: Callable | None = None
+    cacheable: bool = False
 
     def __post_init__(self) -> None:  # noqa: C901, PLR0912
         # At least one of function / async_function must be set.
@@ -338,6 +345,9 @@ class Tool:
         if self.outputs_to_string is not None:
             data["outputs_to_string"] = _serialize_outputs_to_string(self.outputs_to_string)
 
+        # Keep backward compatibility: older serialized payloads may not contain `cacheable`.
+        # We always include it so new payloads are explicit, but we also support round-tripping
+        # when it's missing. The key is present in `data` via `asdict`.
         return {"type": generate_qualified_class_name(type(self)), "data": data}
 
     @classmethod

--- a/haystack/tools/tool_cache.py
+++ b/haystack/tools/tool_cache.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Opt-in keyed cache for tool invocations.
+
+Used by ToolInvoker and Agent to avoid re-running identical tool calls within an agent loop.
+See https://github.com/deepset-ai/haystack/issues/11588 for the motivating problem
+statement and design discussion.
+"""
+
+import hashlib
+import json
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any
+
+from haystack import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _canonicalize_args(arguments: dict[str, Any]) -> str:
+    """
+    Produce a stable JSON string for a tool-call arguments dict, used as part of the cache key.
+
+    Falls back to `str(arguments)` if the arguments aren't JSON-serializable (e.g. contain custom
+    objects), so caching degrades gracefully rather than raising.
+
+    :param arguments: The tool call arguments dictionary.
+    :returns: A canonical string representation suitable for hashing.
+    """
+    try:
+        return json.dumps(arguments, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return str(arguments)
+
+
+def make_cache_key(tool_name: str, arguments: dict[str, Any]) -> str:
+    """
+    Build the cache key for a tool invocation: `(tool_name, sha256(canonicalized_args_json))`.
+
+    :param tool_name: Name of the tool being invoked.
+    :param arguments: The tool call arguments dictionary.
+    :returns: A string cache key combining the tool name and a hash of its arguments.
+    """
+    canonical_args = _canonicalize_args(arguments)
+    args_hash = hashlib.sha256(canonical_args.encode("utf-8")).hexdigest()
+    return f"{tool_name}:{args_hash}"
+
+
+@dataclass
+class ToolCacheStats:
+    """
+    Tracks cache effectiveness for a single cache instance (typically scoped to one agent run).
+
+    :param hits: Number of cache hits (tool call skipped, cached result returned).
+    :param misses: Number of cache misses (tool was actually invoked).
+    :param calls_saved: Alias for `hits`, included for readability in run output.
+    """
+
+    hits: int = 0
+    misses: int = 0
+
+    @property
+    def calls_saved(self) -> int:
+        """Number of tool invocations avoided due to cache hits."""
+        return self.hits
+
+    def to_dict(self) -> dict[str, int]:
+        """Serialize stats to a plain dict for inclusion in Agent run output."""
+        return {"hits": self.hits, "misses": self.misses, "calls_saved": self.calls_saved}
+
+
+class ToolCacheBackend(ABC):
+    """
+    Abstract storage backend for `ToolCache`.
+
+    Implementations only need to handle get/set/clear; TTL expiry and scoping are handled by
+    `ToolCache` itself so that every backend gets that behavior for free.
+    """
+
+    @abstractmethod
+    def get(self, key: str) -> tuple[Any, float] | None:
+        """
+        Retrieve a cached value and its stored timestamp.
+
+        :param key: The cache key.
+        :returns: A tuple of (value, stored_at_unix_timestamp), or None if not present.
+        """
+
+    @abstractmethod
+    def set(self, key: str, value: Any, stored_at: float) -> None:
+        """
+        Store a value under the given key with the given timestamp.
+
+        :param key: The cache key.
+        :param value: The value to cache (the tool call result).
+        :param stored_at: Unix timestamp of when the value was stored.
+        """
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Remove all entries from the backend."""
+
+
+class InMemoryToolCache(ToolCacheBackend):
+    """
+    Simple in-process, thread-safe dict-backed cache.
+
+    Not shared across processes and is lost on restart — suitable as the default backend for
+    single-process agent runs and as a reference implementation for custom backends.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, tuple[Any, float]] = {}
+        self._lock = Lock()
+
+    def get(self, key: str) -> tuple[Any, float] | None:
+        """See ToolCacheBackend.get()."""
+        with self._lock:
+            return self._store.get(key)
+
+    def set(self, key: str, value: Any, stored_at: float) -> None:
+        """See ToolCacheBackend.set()."""
+        with self._lock:
+            self._store[key] = (value, stored_at)
+
+    def clear(self) -> None:
+        """See ToolCacheBackend.clear()."""
+        with self._lock:
+            self._store.clear()
+
+
+class ToolCache:
+    """
+    Opt-in cache wrapping tool invocations.
+
+    Caching is per-Tool opt-in (`Tool.cacheable`); `ToolCache` itself never decides
+    whether a given tool's results may be cached — that decision lives entirely on
+    the `Tool` instance so that write-effecting tools cannot accidentally serve a
+    cached result for a side-effecting call.
+
+    Usage:
+    ```python
+    cache = ToolCache(backend=InMemoryToolCache(), ttl_seconds=3600, scope="agent_run")
+    agent = Agent(chat_generator=generator, tools=[fetch_url], tool_cache=cache)
+    ```
+
+    :param backend: Storage backend. Defaults to a fresh `InMemoryToolCache()`.
+    :param ttl_seconds: How long a cached entry remains valid. Defaults to 300 (5 minutes),
+        chosen to deduplicate repeated calls within a single agent loop without letting
+        staleness compound across longer sessions.
+    :param scope: Logical scope label for this cache instance. Purely informational/for the
+        caller's own bookkeeping today — `ToolCache` does not enforce cross-scope isolation
+        itself; that isolation comes from the caller creating a separate `ToolCache` instance
+        per scope (e.g. one per agent run). Accepted values: "agent_run", "session", "global".
+    """
+
+    _VALID_SCOPES = ("agent_run", "session", "global")
+
+    def __init__(
+        self, backend: ToolCacheBackend | None = None, ttl_seconds: float = 300.0, scope: str = "agent_run"
+    ) -> None:
+        if scope not in self._VALID_SCOPES:
+            msg = f"scope must be one of {self._VALID_SCOPES}, but got {scope!r}"
+            raise ValueError(msg)
+        if ttl_seconds <= 0:
+            msg = f"ttl_seconds must be > 0, but got {ttl_seconds}"
+            raise ValueError(msg)
+
+        self.backend = backend if backend is not None else InMemoryToolCache()
+        self.ttl_seconds = ttl_seconds
+        self.scope = scope
+        self.stats = ToolCacheStats()
+
+    def get(self, tool_name: str, arguments: dict[str, Any]) -> tuple[bool, Any]:
+        """
+        Look up a cached result for the given tool call.
+
+        :param tool_name: Name of the tool being invoked.
+        :param arguments: The tool call arguments dictionary.
+        :returns: A tuple `(hit, value)`. If `hit` is False, `value` is always None and the
+            caller should invoke the tool normally and call `set()` with the result.
+        """
+        key = make_cache_key(tool_name, arguments)
+        cached = self.backend.get(key)
+
+        if cached is None:
+            self.stats.misses += 1
+            return False, None
+
+        value, stored_at = cached
+        if (time.monotonic() - stored_at) > self.ttl_seconds:
+            self.stats.misses += 1
+            logger.debug("Tool cache entry for {key} expired (TTL {ttl}s)", key=key, ttl=self.ttl_seconds)
+            return False, None
+
+        self.stats.hits += 1
+        logger.debug("Tool cache hit for {tool_name}", tool_name=tool_name)
+        return True, value
+
+    def set(self, tool_name: str, arguments: dict[str, Any], value: Any) -> None:
+        """
+        Store a tool call result in the cache.
+
+        :param tool_name: Name of the tool that was invoked.
+        :param arguments: The tool call arguments dictionary.
+        :param value: The result to cache.
+        """
+        key = make_cache_key(tool_name, arguments)
+        self.backend.set(key, value, time.monotonic())
+
+    def clear(self) -> None:
+        """Clear all cached entries and reset stats."""
+        self.backend.clear()
+        self.stats = ToolCacheStats()

--- a/releasenotes/notes/add-tool-cache.yaml
+++ b/releasenotes/notes/add-tool-cache.yaml
@@ -1,0 +1,7 @@
+features:
+  - |
+    Added an opt-in ``ToolCache`` for caching tool invocation results. Tools opt in via the new
+    ``Tool.cacheable`` field (defaults to ``False``); when a ``ToolCache`` is passed to
+    ``Agent``, identical calls to a cacheable tool within the cache's TTL are served from cache instead
+    of re-invoked. ``Agent.run()``/``run_async()`` include a ``tool_cache_stats`` key in their output when
+    a cache is configured, reporting hits/misses/calls_saved for the run.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -340,6 +340,7 @@ class TestAgentSerialization:
                             "outputs_to_string": None,
                             "inputs_from_state": None,
                             "outputs_to_state": None,
+                            "cacheable": False,
                         },
                     },
                     {
@@ -359,6 +360,7 @@ class TestAgentSerialization:
                             "outputs_to_string": None,
                             "inputs_from_state": None,
                             "outputs_to_state": None,
+                            "cacheable": False,
                         },
                     },
                 ],
@@ -415,6 +417,7 @@ class TestAgentSerialization:
                             "outputs_to_string": None,
                             "inputs_from_state": None,
                             "outputs_to_state": None,
+                            "cacheable": False,
                         },
                     },
                     {
@@ -434,6 +437,7 @@ class TestAgentSerialization:
                             "outputs_to_string": None,
                             "inputs_from_state": None,
                             "outputs_to_state": None,
+                            "cacheable": False,
                         },
                     },
                 ],

--- a/test/tools/test_component_tool.py
+++ b/test/tools/test_component_tool.py
@@ -813,6 +813,7 @@ class TestComponentToolInAgent:
                 "outputs_to_string": {"source": "reply", "handler": "test_component_tool.reply_formatter"},
                 "inputs_from_state": {"test": "text"},
                 "outputs_to_state": {"output": {"source": "reply", "handler": "test_component_tool.output_handler"}},
+                "cacheable": False,
             },
         }
         tool_dict = tool.to_dict()

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -181,6 +181,7 @@ class TestTool:
                 "outputs_to_string": {"handler": "test_tool.format_string"},
                 "inputs_from_state": {"location": "city"},
                 "outputs_to_state": {"documents": {"source": "docs", "handler": "test_tool.get_weather_report"}},
+                "cacheable": False,
             },
         }
 
@@ -195,6 +196,7 @@ class TestTool:
                 "outputs_to_string": {"handler": "test_tool.format_string"},
                 "inputs_from_state": {"location": "city"},
                 "outputs_to_state": {"documents": {"source": "docs", "handler": "test_tool.get_weather_report"}},
+                "cacheable": False,
             },
         }
 

--- a/test/tools/test_tool_cache.py
+++ b/test/tools/test_tool_cache.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+import pytest
+
+from haystack.tools.tool_cache import InMemoryToolCache, ToolCache, ToolCacheStats, make_cache_key
+
+
+class TestToolCacheStats:
+    def test_default_hits_and_misses_are_zero(self):
+        stats = ToolCacheStats()
+        assert stats.hits == 0
+        assert stats.misses == 0
+
+    def test_calls_saved_equals_hits(self):
+        stats = ToolCacheStats(hits=3, misses=2)
+        assert stats.calls_saved == 3
+
+    def test_to_dict(self):
+        stats = ToolCacheStats(hits=3, misses=2)
+        assert stats.to_dict() == {"hits": 3, "misses": 2, "calls_saved": 3}
+
+
+class TestInMemoryToolCache:
+    def test_get_on_missing_key_returns_none(self):
+        backend = InMemoryToolCache()
+        assert backend.get("missing") is None
+
+    def test_set_then_get_returns_value_and_stored_at(self):
+        backend = InMemoryToolCache()
+        backend.set("key", "value", 123.0)
+        assert backend.get("key") == ("value", 123.0)
+
+    def test_clear_empties_store(self):
+        backend = InMemoryToolCache()
+        backend.set("key", "value", 123.0)
+        backend.clear()
+        assert backend.get("key") is None
+
+
+class TestMakeCacheKey:
+    def test_same_args_different_key_order_produce_same_key(self):
+        key1 = make_cache_key("weather", {"city": "Berlin", "unit": "C"})
+        key2 = make_cache_key("weather", {"unit": "C", "city": "Berlin"})
+        assert key1 == key2
+
+    def test_different_args_produce_different_keys(self):
+        key1 = make_cache_key("weather", {"city": "Berlin"})
+        key2 = make_cache_key("weather", {"city": "Paris"})
+        assert key1 != key2
+
+    def test_non_json_serializable_args_fall_back_to_str(self):
+        class Unserializable:
+            def __str__(self):
+                return "unserializable-repr"
+
+        key = make_cache_key("weather", {"obj": Unserializable()})
+        assert isinstance(key, str)
+
+
+class TestToolCache:
+    def test_init_invalid_scope_raises(self):
+        with pytest.raises(ValueError, match="scope must be one of"):
+            ToolCache(scope="invalid_scope")
+
+    def test_init_non_positive_ttl_seconds_raises(self):
+        with pytest.raises(ValueError, match="ttl_seconds must be > 0"):
+            ToolCache(ttl_seconds=0)
+
+        with pytest.raises(ValueError, match="ttl_seconds must be > 0"):
+            ToolCache(ttl_seconds=-1)
+
+    def test_get_on_empty_cache_is_a_miss(self):
+        cache = ToolCache()
+        hit, value = cache.get("weather", {"city": "Berlin"})
+        assert hit is False
+        assert value is None
+        assert cache.stats.misses == 1
+        assert cache.stats.hits == 0
+
+    def test_set_then_get_within_ttl_is_a_hit(self):
+        cache = ToolCache(ttl_seconds=300)
+        cache.set("weather", {"city": "Berlin"}, "sunny")
+
+        hit, value = cache.get("weather", {"city": "Berlin"})
+
+        assert hit is True
+        assert value == "sunny"
+        assert cache.stats.hits == 1
+        assert cache.stats.misses == 0
+
+    def test_get_after_ttl_expiry_is_a_miss(self, monkeypatch):
+        cache = ToolCache(ttl_seconds=10)
+
+        monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+        cache.set("weather", {"city": "Berlin"}, "sunny")
+
+        monkeypatch.setattr(time, "monotonic", lambda: 1011.0)
+        hit, value = cache.get("weather", {"city": "Berlin"})
+
+        assert hit is False
+        assert value is None
+        assert cache.stats.misses == 1
+        assert cache.stats.hits == 0
+
+    def test_clear_resets_backend_and_stats(self):
+        cache = ToolCache()
+        cache.set("weather", {"city": "Berlin"}, "sunny")
+        cache.get("weather", {"city": "Berlin"})
+        cache.get("weather", {"city": "Paris"})
+
+        cache.clear()
+
+        assert cache.stats.hits == 0
+        assert cache.stats.misses == 0
+        hit, value = cache.get("weather", {"city": "Berlin"})
+        assert hit is False
+        assert value is None
+
+
+class TestToolCallingCacheIntegration:
+    def test_cacheable_tool_second_identical_call_is_served_from_cache(self):
+        from haystack.components.agents.tool_calling import _run_tool
+        from haystack.components.agents.state.state import State
+        from haystack.dataclasses import ChatMessage, ToolCall
+        from haystack.tools import Tool
+
+        call_count = []
+
+        def counting_fn(location: str):
+            call_count.append(location)
+            return f"weather:{location}"
+
+        tool = Tool(
+            name="weather_tool",
+            description="desc",
+            parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
+            function=counting_fn,
+            cacheable=True,
+        )
+        cache = ToolCache(ttl_seconds=300)
+        state = State(schema={}, data={})
+        msg = ChatMessage.from_assistant(tool_calls=[ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})])
+
+        _run_tool(messages=[msg], state=state, tools=[tool], tool_cache=cache)
+        _run_tool(messages=[msg], state=state, tools=[tool], tool_cache=cache)
+
+        assert len(call_count) == 1
+        assert cache.stats.hits == 1
+        assert cache.stats.misses == 1
+
+    def test_non_cacheable_tool_always_invokes(self):
+        from haystack.components.agents.tool_calling import _run_tool
+        from haystack.components.agents.state.state import State
+        from haystack.dataclasses import ChatMessage, ToolCall
+        from haystack.tools import Tool
+
+        call_count = []
+
+        def counting_fn(location: str):
+            call_count.append(location)
+            return f"weather:{location}"
+
+        tool = Tool(
+            name="weather_tool",
+            description="desc",
+            parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
+            function=counting_fn,
+            cacheable=False,
+        )
+        cache = ToolCache()
+        state = State(schema={}, data={})
+        msg = ChatMessage.from_assistant(tool_calls=[ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})])
+
+        _run_tool(messages=[msg], state=state, tools=[tool], tool_cache=cache)
+        _run_tool(messages=[msg], state=state, tools=[tool], tool_cache=cache)
+
+        assert len(call_count) == 2
+        assert cache.stats.hits == 0
+        assert cache.stats.misses == 0
+
+    def test_cache_hit_does_not_trigger_execution_and_merges_state(self):
+        from haystack.components.agents.tool_calling import _run_tool
+        from haystack.components.agents.state.state import State
+        from haystack.dataclasses import ChatMessage, ToolCall
+        from haystack.tools import Tool
+
+        def fn(location: str):
+            return {"docs": f"result-{location}"}
+
+        tool = Tool(
+            name="weather_tool",
+            description="desc",
+            parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
+            function=fn,
+            cacheable=True,
+            outputs_to_state={"documents": {"source": "docs"}},
+        )
+        cache = ToolCache()
+        state = State(
+            schema={"documents": {"type": str}},
+            data={},
+        )
+        msg = ChatMessage.from_assistant(tool_calls=[ToolCall(tool_name="weather_tool", arguments={"location": "Berlin"})])
+
+        # First call - populates cache and state
+        _run_tool(messages=[msg], state=state, tools=[tool], tool_cache=cache)
+        assert state.get("documents") == "result-Berlin"
+        # Reset state to test that cached result still merges
+        state.set("documents", None)
+        _run_tool(messages=[msg], state=state, tools=[tool], tool_cache=cache)
+        assert state.get("documents") == "result-Berlin"
+        assert cache.stats.hits == 1


### PR DESCRIPTION
### Related Issues

- fixes #11588

### Proposed Changes:

Agent loops re-executed identical read-only tool calls with the same arguments. Add opt-in `ToolCache` with `Tool(cacheable=True)` so identical calls within TTL are served from cache.

### How did you test it?

Added unit and integration tests for cache hit/miss, TTL and Agent integration; updated serialization expectations.

### Notes for the reviewer

No breaking change — `cacheable` defaults to `false` and `tool_cache` defaults to `None`. Reviewers: @julian-risch @sjrl @lorenzozanee

### Checklist

- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings.
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [ ] I have documented my code.
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [ ] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.