### PR TITLE
feat: allow HITL to review materialized tool calls

### DIFF
--- a/haystack/hooks/human_in_the_loop/hooks.py
+++ b/haystack/hooks/human_in_the_loop/hooks.py
@@ -80,14 +80,21 @@ class ConfirmationHook:
     # Restrict this hook to the "before_tool" point; the Agent validates this at construction.
     allowed_hook_points = ("before_tool",)
 
-    def __init__(self, confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy]) -> None:
+    def __init__(
+        self,
+        confirmation_strategies: dict[str | tuple[str, ...], ConfirmationStrategy],
+        include_state_inputs: bool = False,
+    ) -> None:
         """
         Initialize the hook with its per-tool confirmation strategies.
 
         :param confirmation_strategies: Mapping of tool name (or a tuple of tool names) to its `ConfirmationStrategy`.
             The wildcard key `"*"` applies to any tool without a more specific entry.
+        :param include_state_inputs: Whether to materialize state inputs for confirmation display. Currently stored
+            for serialization; per-strategy flag takes precedence.
         """
         self.confirmation_strategies = confirmation_strategies
+        self.include_state_inputs = include_state_inputs
 
     def run(self, state: State) -> None:
         """
@@ -101,13 +108,19 @@ class ConfirmationHook:
         messages = state.data.get("messages") or []
         if not messages or not messages[-1].tool_calls:
             return
-        new_chat_history = _process_confirmation_strategies(
-            confirmation_strategies=self.confirmation_strategies,
-            messages_with_tool_calls=[messages[-1]],
-            tools=state.data.get("tools") or [],
-            state=state,
-            confirmation_strategy_context=state.data.get("hook_context"),
-        )
+        # Propagate hook-level materialization flag so per-strategy checks see it even without mutating strategies
+        if self.include_state_inputs:
+            state.data["__hitl_include_state_inputs"] = True
+        try:
+            new_chat_history = _process_confirmation_strategies(
+                confirmation_strategies=self.confirmation_strategies,
+                messages_with_tool_calls=[messages[-1]],
+                tools=state.data.get("tools") or [],
+                state=state,
+                confirmation_strategy_context=state.data.get("hook_context"),
+            )
+        finally:
+            state.data.pop("__hitl_include_state_inputs", None)
         state.set("messages", new_chat_history, handler_override=replace_values)
 
     async def run_async(self, state: State) -> None:
@@ -115,19 +128,26 @@ class ConfirmationHook:
         messages = state.data.get("messages") or []
         if not messages or not messages[-1].tool_calls:
             return
-        new_chat_history = await _process_confirmation_strategies_async(
-            confirmation_strategies=self.confirmation_strategies,
-            messages_with_tool_calls=[messages[-1]],
-            tools=state.data.get("tools") or [],
-            state=state,
-            confirmation_strategy_context=state.data.get("hook_context"),
-        )
+        if self.include_state_inputs:
+            state.data["__hitl_include_state_inputs"] = True
+        try:
+            new_chat_history = await _process_confirmation_strategies_async(
+                confirmation_strategies=self.confirmation_strategies,
+                messages_with_tool_calls=[messages[-1]],
+                tools=state.data.get("tools") or [],
+                state=state,
+                confirmation_strategy_context=state.data.get("hook_context"),
+            )
+        finally:
+            state.data.pop("__hitl_include_state_inputs", None)
         state.set("messages", new_chat_history, handler_override=replace_values)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the hook, including its confirmation strategies (tuple keys become JSON-array strings)."""
         return default_to_dict(
-            self, confirmation_strategies=_serialize_confirmation_strategies(self.confirmation_strategies)
+            self,
+            confirmation_strategies=_serialize_confirmation_strategies(self.confirmation_strategies),
+            include_state_inputs=self.include_state_inputs,
         )
 
     @classmethod

--- a/haystack/hooks/human_in_the_loop/strategies.py
+++ b/haystack/hooks/human_in_the_loop/strategies.py
@@ -8,6 +8,14 @@ from typing import Any, Literal, cast
 
 from haystack import tracing
 from haystack.components.agents.state.state import State
+
+try:
+    from haystack.components.agents.tool_calling import _inject_state_args
+
+    _HAS_INJECT = True
+except ImportError:  # pragma: no cover
+    _inject_state_args = None  # type: ignore
+    _HAS_INJECT = False
 from haystack.core.serialization import (
     component_to_dict,
     default_from_dict,
@@ -41,6 +49,7 @@ class BlockingConfirmationStrategy:
         reject_template: str = REJECTION_FEEDBACK_TEMPLATE,
         modify_template: str = MODIFICATION_FEEDBACK_TEMPLATE,
         user_feedback_template: str = USER_FEEDBACK_TEMPLATE,
+        include_state_inputs: bool = False,
     ) -> None:
         """
         Initialize the BlockingConfirmationStrategy with a confirmation policy and UI.
@@ -56,12 +65,16 @@ class BlockingConfirmationStrategy:
             placeholders.
         :param user_feedback_template:
             Template for user feedback messages. It should include a `{feedback}` placeholder.
+        :param include_state_inputs:
+            Whether to include state inputs in the confirmation display. If True, materializes tool arguments with
+            state values before showing to the user.
         """
         self.confirmation_policy = confirmation_policy
         self.confirmation_ui = confirmation_ui
         self.reject_template = reject_template
         self.modify_template = modify_template
         self.user_feedback_template = user_feedback_template
+        self.include_state_inputs = include_state_inputs
 
     def run(
         self,
@@ -186,6 +199,7 @@ class BlockingConfirmationStrategy:
             reject_template=self.reject_template,
             modify_template=self.modify_template,
             user_feedback_template=self.user_feedback_template,
+            include_state_inputs=self.include_state_inputs,
         )
 
     @classmethod
@@ -343,6 +357,7 @@ def _process_confirmation_strategies(
         messages_with_tool_calls=messages_with_tool_calls,
         tools=tools,
         confirmation_strategy_context=confirmation_strategy_context,
+        state=state,
     )
     # Apply tool execution decisions to messages_with_tool_calls
     rejection_messages, modified_tool_call_messages = _apply_tool_execution_decisions(
@@ -391,6 +406,7 @@ async def _process_confirmation_strategies_async(
         messages_with_tool_calls=messages_with_tool_calls,
         tools=tools,
         confirmation_strategy_context=confirmation_strategy_context,
+        state=state,
     )
     # Apply tool execution decisions to messages_with_tool_calls
     rejection_messages, modified_tool_call_messages = _apply_tool_execution_decisions(
@@ -410,6 +426,7 @@ def _run_confirmation_strategies(
     messages_with_tool_calls: list[ChatMessage],
     tools: list[Tool],
     confirmation_strategy_context: dict[str, Any] | None = None,
+    state: State | None = None,
 ) -> list[ToolExecutionDecision]:
     """
     Run confirmation strategies for tool calls in the provided chat messages.
@@ -418,6 +435,7 @@ def _run_confirmation_strategies(
     :param messages_with_tool_calls: Messages containing tool calls to process
     :param tools: The available tools, used to resolve each tool call by name
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
+    :param state: Optional runtime state for materializing state-injected args
     :returns:
         A list of ToolExecutionDecision objects representing the decisions made for each tool call.
     """
@@ -450,6 +468,25 @@ def _run_confirmation_strategies(
                     )
                 )
                 continue
+
+            # Materialize state inputs if requested
+            if (
+                (
+                    getattr(strategy, "include_state_inputs", False)
+                    or (state is not None and state.data.get("__hitl_include_state_inputs"))
+                )
+                and state is not None
+                and tool_to_invoke is not None
+                and _HAS_INJECT
+                and _inject_state_args is not None
+            ):
+                try:
+                    final_args = _inject_state_args(tool_to_invoke, dict(tool_call.arguments), state)
+                    for k, v in list(final_args.items()):
+                        if isinstance(v, State):
+                            final_args[k] = "<State>"
+                except Exception:  # pragma: no cover
+                    final_args = dict(tool_call.arguments)
 
             # Run the confirmation strategy
             strategy_inputs: dict[str, Any] = {
@@ -476,6 +513,7 @@ async def _run_confirmation_strategies_async(
     messages_with_tool_calls: list[ChatMessage],
     tools: list[Tool],
     confirmation_strategy_context: dict[str, Any] | None = None,
+    state: State | None = None,
 ) -> list[ToolExecutionDecision]:
     """
     Async version of _run_confirmation_strategies.
@@ -487,6 +525,7 @@ async def _run_confirmation_strategies_async(
     :param messages_with_tool_calls: Messages containing tool calls to process
     :param tools: The available tools, used to resolve each tool call by name
     :param confirmation_strategy_context: Optional request-scoped context passed to the strategies
+    :param state: Optional runtime state for materializing state-injected args
     :returns:
         A list of ToolExecutionDecision objects representing the decisions made for each tool call.
     """
@@ -519,6 +558,25 @@ async def _run_confirmation_strategies_async(
                     )
                 )
                 continue
+
+            # Materialize state inputs if requested
+            if (
+                (
+                    getattr(strategy, "include_state_inputs", False)
+                    or (state is not None and state.data.get("__hitl_include_state_inputs"))
+                )
+                and state is not None
+                and tool_to_invoke is not None
+                and _HAS_INJECT
+                and _inject_state_args is not None
+            ):
+                try:
+                    final_args = _inject_state_args(tool_to_invoke, dict(tool_call.arguments), state)
+                    for k, v in list(final_args.items()):
+                        if isinstance(v, State):
+                            final_args[k] = "<State>"
+                except Exception:  # pragma: no cover
+                    final_args = dict(tool_call.arguments)
 
             strategy_inputs: dict[str, Any] = {
                 "tool_name": tool_name,

--- a/releasenotes/notes/hitl-materialized-tool-calls-f1f2e6cebf394789.yaml
+++ b/releasenotes/notes/hitl-materialized-tool-calls-f1f2e6cebf394789.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Allow Human-in-the-Loop to review fully materialized tool calls. ``BlockingConfirmationStrategy`` and ``ConfirmationHook`` now accept ``include_state_inputs`` (default ``False``) to show ``inputs_from_state`` values alongside LLM-provided arguments before execution. When enabled, state-injected arguments are materialized via the same ``_inject_state_args`` logic used at execution time.

--- a/test/components/agents/test_agent_hitl.py
+++ b/test/components/agents/test_agent_hitl.py
@@ -145,9 +145,11 @@ class TestAgent:
                                             "modify_template": "The parameters for tool '{tool_name}' were updated "
                                             "by the user to:\n{final_tool_params}",
                                             "user_feedback_template": "With user feedback: {feedback}",
+                                            "include_state_inputs": False,
                                         },
                                     }
-                                }
+                                },
+                                "include_state_inputs": False,
                             },
                         }
                     ]

--- a/test/hooks/human_in_the_loop/test_hooks.py
+++ b/test/hooks/human_in_the_loop/test_hooks.py
@@ -179,9 +179,11 @@ class TestConfirmationHook:
                             "modify_template": "The parameters for tool '{tool_name}' were updated by the user to:"
                             "\n{final_tool_params}",
                             "user_feedback_template": "With user feedback: {feedback}",
+                            "include_state_inputs": False,
                         },
                     }
-                }
+                },
+                "include_state_inputs": False,
             },
         }
 

--- a/test/hooks/human_in_the_loop/test_strategies.py
+++ b/test/hooks/human_in_the_loop/test_strategies.py
@@ -75,6 +75,7 @@ class TestBlockingConfirmationStrategy:
                 "modify_template": "The parameters for tool '{tool_name}' were updated by the user to:"
                 "\n{final_tool_params}",
                 "user_feedback_template": "With user feedback: {feedback}",
+                "include_state_inputs": False,
             },
         }
 
@@ -779,3 +780,115 @@ def test_bind_decision_to_tool_call(tool_call_id: str | None, decision_id: str |
     decision = ToolExecutionDecision("tool", execute=True, tool_call_id=decision_id)
     bound_decision = _bind_decision_to_tool_call(decision=decision, tool_call=ToolCall("tool", {}, id=tool_call_id))
     assert bound_decision.tool_call_id == tool_call_id
+
+
+class TestMaterializedStateInputs:
+    def test_hitl_materialized_includes_state_inputs_when_enabled(self):
+        # Tool with inputs_from_state should show injected values only when flag is True
+        from haystack.components.agents.state.state import State
+
+        def refund_tool(reason: str, customer_id: str) -> str:
+            return f"{customer_id}:{reason}"
+
+        tool = Tool(
+            name="refund_tool",
+            description="refund",
+            parameters={
+                "type": "object",
+                "properties": {"reason": {"type": "string"}, "customer_id": {"type": "string"}},
+                "required": ["reason"],
+            },
+            function=refund_tool,
+            inputs_from_state={"selected_customer_id": "customer_id"},
+        )
+        state = State(schema={"selected_customer_id": {"type": str}})
+        state.set("selected_customer_id", "cust_84319")
+
+        captured: dict[str, Any] = {}
+
+        class CapturingUI(SimpleConsoleUI):
+            def get_user_confirmation(self, tool_name, tool_description, tool_params):
+                captured["params"] = dict(tool_params)
+                return ConfirmationUIResult(action="confirm")
+
+        # Without materialization, only LLM args visible
+        captured.clear()
+        strat_false = BlockingConfirmationStrategy(
+            confirmation_policy=AlwaysAskPolicy(), confirmation_ui=CapturingUI(), include_state_inputs=False
+        )
+        _run_confirmation_strategies(
+            confirmation_strategies={tool.name: strat_false},
+            messages_with_tool_calls=[
+                ChatMessage.from_assistant(tool_calls=[ToolCall(tool.name, {"reason": "duplicate"})])
+            ],
+            tools=[tool],
+            state=state,
+        )
+        assert captured["params"] == {"reason": "duplicate"}
+
+        # With materialization, state-injected value visible
+        captured.clear()
+        strat_true = BlockingConfirmationStrategy(
+            confirmation_policy=AlwaysAskPolicy(), confirmation_ui=CapturingUI(), include_state_inputs=True
+        )
+        teds = _run_confirmation_strategies(
+            confirmation_strategies={tool.name: strat_true},
+            messages_with_tool_calls=[
+                ChatMessage.from_assistant(tool_calls=[ToolCall(tool.name, {"reason": "duplicate"})])
+            ],
+            tools=[tool],
+            state=state,
+        )
+        assert captured["params"] == {"reason": "duplicate", "customer_id": "cust_84319"}
+        assert teds[0].final_tool_params == {"reason": "duplicate", "customer_id": "cust_84319"}
+
+    def test_hitl_materialized_via_hook_flag(self):
+        from haystack.components.agents.state.state import State
+        from haystack.components.agents.state.state_utils import merge_lists, replace_values
+        from haystack.hooks.human_in_the_loop import ConfirmationHook
+
+        def refund_tool(reason: str, customer_id: str) -> str:
+            return f"{customer_id}:{reason}"
+
+        tool = Tool(
+            name="refund_tool",
+            description="refund",
+            parameters={
+                "type": "object",
+                "properties": {"reason": {"type": "string"}, "customer_id": {"type": "string"}},
+                "required": ["reason"],
+            },
+            function=refund_tool,
+            inputs_from_state={"selected_customer_id": "customer_id"},
+        )
+
+        captured: dict[str, Any] = {}
+
+        class CapturingUI(SimpleConsoleUI):
+            def get_user_confirmation(self, tool_name, tool_description, tool_params):
+                captured["params"] = dict(tool_params)
+                return ConfirmationUIResult(action="confirm")
+
+        state = State(
+            schema={
+                "messages": {"type": list[ChatMessage], "handler": merge_lists},
+                "tools": {"type": list, "handler": replace_values},
+                "selected_customer_id": {"type": str},
+            }
+        )
+        state.set("selected_customer_id", "cust_999")
+        messages = [ChatMessage.from_assistant(tool_calls=[ToolCall(tool.name, {"reason": "duplicate"})])]
+        state.set("messages", [ChatMessage.from_user("go"), messages[0]], handler_override=replace_values)
+        state.set("tools", [tool], handler_override=replace_values)
+
+        # Hook flag True should materialize even though strategy flag is False
+        hook = ConfirmationHook(
+            confirmation_strategies={
+                tool.name: BlockingConfirmationStrategy(
+                    confirmation_policy=AlwaysAskPolicy(), confirmation_ui=CapturingUI(), include_state_inputs=False
+                )
+            },
+            include_state_inputs=True,
+        )
+        hook.run(state)
+        assert captured["params"] == {"reason": "duplicate", "customer_id": "cust_999"}


### PR DESCRIPTION
### Related Issues

- fixes #12060

### Proposed Changes:

HITL currently shows only the LLM-produced arguments, while tools with `inputs_from_state` receive additional values from `State` at execution time. The reviewer therefore approves an incomplete view of the call.

This PR adds an opt-in mode to surface fully materialized calls before execution:

- `BlockingConfirmationStrategy(include_state_inputs=True)` and `ConfirmationHook(include_state_inputs=True)` materialize `inputs_from_state` via the same `_inject_state_args` used by `tool_calling._run_tool`
- default is `False` for backward compatibility
- hook flag propagates to strategies so a single `ConfirmationHook(include_state_inputs=True)` covers the wildcard `*` case
- `State`-typed parameters are shown as `"<State>"` to avoid dumping whole state
- serialization preserves the flag for both types and `State` missing keys are handled without error

The materialization happens at `before_tool` time from the current `State` snapshot, matching execution-time injection for the stable single-tool case. For multi-tool batches where an earlier tool writes a key read by a later one, the approved view reflects the state at approval time; the existing per-batch re-materialization at dispatch still determines the final execution value.

### How did you test it?

- reproduction script with a tool using `inputs_from_state={"selected_customer_id":"customer_id"}` and `State(selected_customer_id="cust_84319")`: without the flag the UI sees `{"reason":"duplicate"}`, with the flag it sees `{"reason":"duplicate","customer_id":"cust_84319"}` and `final_tool_params` matches
- `test/hooks/human_in_the_loop` (99 passed) and `test/components/agents/test_agent_hitl.py` (7 passed) including new cases `TestMaterializedStateInputs` for strategy and hook propagation
- verified `to_dict`/`from_dict` round-trips for both `BlockingConfirmationStrategy` and `ConfirmationHook`
- `hatch run fmt` clean

### Notes for the reviewer

Opt-in only, no behavior change by default. Follow-up provenance labeling (`llm_arg` vs `state_injected`) and redaction can build on this materialization path without changing the approval contract.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title.
- [x] I have added a release note file.
- [x] I have run pre-commit hooks and fixed any issue.