### PR TITLE
test: update OpenAI 3.6 usage metadata expectations

### DIFF
--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -1736,6 +1736,7 @@ def streaming_chunks():
                         "rejected_prediction_tokens": 0,
                         "text_tokens": 42,
                     },
+                    "compute_units": None,
                     "prompt_tokens_details": {
                         "audio_tokens": 0,
                         "cached_tokens": 0,
@@ -2026,6 +2027,7 @@ class TestChatCompletionChunkConversion:
                 "rejected_prediction_tokens": 0,
                 "text_tokens": 42,
             },
+            "compute_units": None,
             "prompt_tokens_details": {
                 "audio_tokens": 0,
                 "cached_tokens": 0,


### PR DESCRIPTION
### Related Issues

- fixes #12519

### Proposed Changes:

OpenAI 3.6.0 added the nullable `compute_units` field to `CompletionUsage`, and Haystack forwards the SDK model's full serialized usage metadata. Update both strict streaming expectations to include that field so the OpenAI chat unit tests match the supported SDK output again.

### How did you test it?

- `hatch run test:unit test/components/generators/chat/test_openai.py -q` — 55 passed, 12 deselected
- `hatch run fmt-check test/components/generators/chat/test_openai.py` — passed
- `hatch run pre-commit run --files test/components/generators/chat/test_openai.py` — all hooks passed

### Notes for the reviewer

This is a test-only compatibility update, so no release note or docstring change is needed.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] Unit tests/docstrings: existing regression expectations were updated; docstrings are not applicable.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] Code documentation: no documentation change is applicable to this test-only update.
- [x] Release note: not required for a test-only change under the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
