### PR TITLE
fix: allow top-level JSON scalars in JsonSchemaValidator

### DIFF
--- a/haystack/components/validators/json_schema.py
+++ b/haystack/components/validators/json_schema.py
@@ -249,4 +249,4 @@ class JsonSchemaValidator:
             return new_dict
 
         # If it's neither a list nor a dictionary, return the value directly
-        raise ValueError("Input must be a dictionary or a list of dictionaries.")
+        return data

--- a/haystack/components/validators/json_schema.py
+++ b/haystack/components/validators/json_schema.py
@@ -129,8 +129,8 @@ class JsonSchemaValidator:
         :return:  A dictionary with the following keys:
             - "validated": A list of messages if the last message is valid.
             - "validation_error": A list of messages if the last message is invalid.
-        :raises ValueError: If no JSON schema is provided or if the message content is not a dictionary or a list of
-            dictionaries.
+        :raises ValueError: If the last message has no text content, or if no JSON schema is provided either in
+            the `run` method or in the component init.
         """
         last_message = messages[-1]
         if last_message.text is None:

--- a/releasenotes/notes/fix-json-schema-validator-top-level-scalars-aad3edd4893d584e.yaml
+++ b/releasenotes/notes/fix-json-schema-validator-top-level-scalars-aad3edd4893d584e.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    ``JsonSchemaValidator`` no longer raises ``ValueError`` when the message content is a top-level JSON
+    scalar like ``"hello"``, ``42``, ``true`` or ``null``. The same crash happened for JSON arrays of
+    scalars. Those values now reach the schema validator, which either accepts them or returns the usual
+    ``validation_error`` output.

--- a/test/components/validators/test_json_schema.py
+++ b/test/components/validators/test_json_schema.py
@@ -97,20 +97,17 @@ class TestJsonSchemaValidator:
         # we need this recursive json conversion to validate the message
         assert result["key"][0]["function"]["arguments"]["basehead"] == "main...amzn_chat"
 
-    # Returns top-level scalars directly instead of raising.
     @pytest.mark.parametrize("scalar", ["hello", 42, 3.14, True, None])
     def test_recursive_json_to_object_with_top_level_scalar(self, scalar):
         validator = JsonSchemaValidator()
 
         assert validator._recursive_json_to_object(scalar) == scalar
 
-    # Returns lists of scalars directly instead of raising.
     def test_recursive_json_to_object_with_list_of_scalars(self):
         validator = JsonSchemaValidator()
 
         assert validator._recursive_json_to_object([1, "two", None]) == [1, "two", None]
 
-    #  Validates a message whose content is a top-level JSON scalar matching the schema.
     def test_validates_message_with_top_level_json_scalar(self):
         validator = JsonSchemaValidator(json_schema={"type": "string"})
 
@@ -119,7 +116,6 @@ class TestJsonSchemaValidator:
         assert "validated" in result
         assert len(result["validated"]) == 1
 
-    #  Returns a validation error when a top-level JSON scalar does not match the schema.
     @pytest.mark.parametrize("message_text", ["42", "true", "null"])
     def test_validation_error_for_top_level_json_scalar(self, message_text):
         validator = JsonSchemaValidator(json_schema={"type": "string"})

--- a/test/components/validators/test_json_schema.py
+++ b/test/components/validators/test_json_schema.py
@@ -97,6 +97,38 @@ class TestJsonSchemaValidator:
         # we need this recursive json conversion to validate the message
         assert result["key"][0]["function"]["arguments"]["basehead"] == "main...amzn_chat"
 
+    # Returns top-level scalars directly instead of raising.
+    @pytest.mark.parametrize("scalar", ["hello", 42, 3.14, True, None])
+    def test_recursive_json_to_object_with_top_level_scalar(self, scalar):
+        validator = JsonSchemaValidator()
+
+        assert validator._recursive_json_to_object(scalar) == scalar
+
+    # Returns lists of scalars directly instead of raising.
+    def test_recursive_json_to_object_with_list_of_scalars(self):
+        validator = JsonSchemaValidator()
+
+        assert validator._recursive_json_to_object([1, "two", None]) == [1, "two", None]
+
+    #  Validates a message whose content is a top-level JSON scalar matching the schema.
+    def test_validates_message_with_top_level_json_scalar(self):
+        validator = JsonSchemaValidator(json_schema={"type": "string"})
+
+        result = validator.run([ChatMessage.from_assistant('"hello"')])
+
+        assert "validated" in result
+        assert len(result["validated"]) == 1
+
+    #  Returns a validation error when a top-level JSON scalar does not match the schema.
+    @pytest.mark.parametrize("message_text", ["42", "true", "null"])
+    def test_validation_error_for_top_level_json_scalar(self, message_text):
+        validator = JsonSchemaValidator(json_schema={"type": "string"})
+
+        result = validator.run([ChatMessage.from_assistant(message_text)])
+
+        assert "validation_error" in result
+        assert len(result["validation_error"]) == 1
+
     #  Validates multiple messages against a provided JSON schema successfully.
     def test_validates_multiple_messages_against_json_schema(self, json_schema_github_compare, genuine_fc_message):
         validator = JsonSchemaValidator()


### PR DESCRIPTION
### Related Issues

Closes #12512

### Proposed Changes

`JsonSchemaValidator._recursive_json_to_object` ended with a `raise ValueError("Input must be a dictionary or a list of dictionaries.")`, directly under a comment that said `# If it's neither a list nor a dictionary, return the value directly`. The comment described the intended behaviour and the code did the opposite.

That meant a message whose content was a valid top-level JSON scalar blew up instead of being validated:

```python
JsonSchemaValidator(json_schema={"type": "string"}).run(
    messages=[ChatMessage.from_assistant(text='"hello"')]
)
# ValueError: Input must be a dictionary or a list of dictionaries.
```

`42`, `true` and `null` failed the same way. So did a JSON array of scalars like `[1, 2]`, since the list branch recurses into each item and every item then hit the raise.

This PR makes the method return the value, matching its own comment. Nothing else in the repo referenced that error message, so there was nothing to update alongside it. `run` already wraps a non-list result in a list before passing it to `jsonschema`, so scalars now flow through the normal path and produce either `validated` or a `validation_error`, exactly like every other input shape.

Behaviour on the four cases from the issue, checked against `{"type": "string"}`:

| content | before | after |
| --- | --- | --- |
| `'"hello"'` | `ValueError` | `validated` |
| `'42'` | `ValueError` | `validation_error` |
| `'true'` | `ValueError` | `validation_error` |
| `'null'` | `ValueError` | `validation_error` |
| `'{"name": "John"}'` (control) | `validation_error` | `validation_error` |

Worth flagging that #7457 touched this same method back in 2024, but for the inner case, where a string value inside an object was being converted by mistake. That fix landed and still holds. This is the outer case, which was missed at the time.

### How did you test it?

Added four tests to `test/components/validators/test_json_schema.py`: two on `_recursive_json_to_object` directly, covering top-level scalars and lists of scalars, and two through `run`, covering a scalar that matches the schema and scalars that do not.

Ran locally:

- `hatch run test:unit -k json_schema`: 18 passed
- `hatch run test:types`: no issues found in 468 source files
- `hatch run fmt`: all checks passed

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue

This PR was written with the help of an AI assistant. I have reviewed the change and run the tests and checks listed above.
