### PR TITLE
test: derive expected OpenAI usage dicts from the streamed model

### DIFF
--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -1300,6 +1300,22 @@ class TestOpenAIChatGenerator:
         assert all(isinstance(ts, Toolset) for ts in deserialized.tools)
 
 
+# The OpenAI SDK regularly adds fields to its usage models and `_serialize_object` picks up all of them,
+# so hardcoded expected dicts go stale on every additive release. Deriving them from the same model the
+# fixtures stream keeps the assertions exact without needing an update each time.
+STREAMED_USAGE = CompletionUsage(
+    completion_tokens=42,
+    prompt_tokens=282,
+    total_tokens=324,
+    completion_tokens_details=CompletionTokensDetails(
+        accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0, text_tokens=42
+    ),
+    prompt_tokens_details=PromptTokensDetails(
+        audio_tokens=0, cached_tokens=0, cache_write_tokens=0, image_tokens=0, text_tokens=282
+    ),
+)
+
+
 @pytest.fixture
 def chat_completion_chunks():
     return [
@@ -1515,21 +1531,7 @@ def chat_completion_chunks():
             object="chat.completion.chunk",
             service_tier="default",
             system_fingerprint="fp_54eb4bd693",
-            usage=CompletionUsage(
-                completion_tokens=42,
-                prompt_tokens=282,
-                total_tokens=324,
-                completion_tokens_details=CompletionTokensDetails(
-                    accepted_prediction_tokens=0,
-                    audio_tokens=0,
-                    reasoning_tokens=0,
-                    rejected_prediction_tokens=0,
-                    text_tokens=42,
-                ),
-                prompt_tokens_details=PromptTokensDetails(
-                    audio_tokens=0, cached_tokens=0, cache_write_tokens=0, image_tokens=0, text_tokens=282
-                ),
-            ),
+            usage=STREAMED_USAGE,
         ),
     ]
 
@@ -1721,30 +1723,7 @@ def streaming_chunks():
             finish_reason="tool_calls",
         ),
         StreamingChunk(
-            content="",
-            meta={
-                "model": "gpt-5-mini",
-                "received_at": ANY,
-                "usage": {
-                    "completion_tokens": 42,
-                    "prompt_tokens": 282,
-                    "total_tokens": 324,
-                    "completion_tokens_details": {
-                        "accepted_prediction_tokens": 0,
-                        "audio_tokens": 0,
-                        "reasoning_tokens": 0,
-                        "rejected_prediction_tokens": 0,
-                        "text_tokens": 42,
-                    },
-                    "prompt_tokens_details": {
-                        "audio_tokens": 0,
-                        "cached_tokens": 0,
-                        "cache_write_tokens": 0,
-                        "image_tokens": 0,
-                        "text_tokens": 282,
-                    },
-                },
-            },
+            content="", meta={"model": "gpt-5-mini", "received_at": ANY, "usage": STREAMED_USAGE.model_dump()}
         ),
     ]
 
@@ -2015,25 +1994,7 @@ class TestChatCompletionChunkConversion:
         assert result.meta["finish_reason"] == "tool_calls"
         assert result.meta["index"] == 0
         assert result.meta["completion_start_time"] is not None
-        assert result.meta["usage"] == {
-            "completion_tokens": 42,
-            "prompt_tokens": 282,
-            "total_tokens": 324,
-            "completion_tokens_details": {
-                "accepted_prediction_tokens": 0,
-                "audio_tokens": 0,
-                "reasoning_tokens": 0,
-                "rejected_prediction_tokens": 0,
-                "text_tokens": 42,
-            },
-            "prompt_tokens_details": {
-                "audio_tokens": 0,
-                "cached_tokens": 0,
-                "cache_write_tokens": 0,
-                "image_tokens": 0,
-                "text_tokens": 282,
-            },
-        }
+        assert result.meta["usage"] == STREAMED_USAGE.model_dump()
 
     def test_convert_usage_chunk_to_streaming_chunk(self) -> None:
 


### PR DESCRIPTION
### Related Issues

- fixes #12519

`openai` 3.6.0 added `compute_units` to `CompletionUsage`. `_serialize_object` serializes usage with `model_dump()`, so the new field lands in `meta["usage"]` and the two exact-dict assertions in `test/components/generators/chat/test_openai.py` fail 

The same thing happened in #12374 for `PromptTokensDetails.cache_write_tokens` and `.image_tokens`. Re-transcribing the 3.6.0 shape would just queue up the next breakage.

### Proposed Changes:

- Add `CompletionUsage` that the `chat_completion_chunks` fixture streams into a module-level `STREAMED_USAGE` constant
- Derive the two expected dicts from `STREAMED_USAGE.model_dump()`

### How did you test it?

Ran unit tests

### Notes for the reviewer

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings. — no new tests; this repairs two existing ones, which is the whole change.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code. — comment on `STREAMED_USAGE` explaining why the expected dicts are derived.
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes). — n/a, test-only change with no user-facing effect.
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
