### PR TITLE
fix: clear stale metadata extraction errors after successful retries

### DIFF
--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -377,9 +377,9 @@ class LLMMetadataExtractor:
 
             for key in parsed_metadata:
                 new_meta[key] = parsed_metadata[key]
-                # Remove metadata_extraction_error and metadata_extraction_response if present from previous runs
-                new_meta.pop("metadata_extraction_error", None)
-                new_meta.pop("metadata_extraction_response", None)
+            # Remove metadata_extraction_error and metadata_extraction_response if present from previous runs.
+            new_meta.pop("metadata_extraction_error", None)
+            new_meta.pop("metadata_extraction_response", None)
             successful_documents.append(replace(document, meta=new_meta))
         return successful_documents, failed_documents
 

--- a/releasenotes/notes/clear-stale-llm-metadata-retry-errors-778a9d314d7459d1.yaml
+++ b/releasenotes/notes/clear-stale-llm-metadata-retry-errors-778a9d314d7459d1.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Clear stale ``metadata_extraction_error`` and ``metadata_extraction_response``
+    fields when an ``LLMMetadataExtractor`` retry succeeds with an empty JSON object.

--- a/releasenotes/notes/clear-stale-llm-metadata-retry-errors-778a9d314d7459d1.yaml
+++ b/releasenotes/notes/clear-stale-llm-metadata-retry-errors-778a9d314d7459d1.yaml
@@ -1,5 +1,8 @@
 ---
 fixes:
   - |
-    Clear stale ``metadata_extraction_error`` and ``metadata_extraction_response``
-    fields when an ``LLMMetadataExtractor`` retry succeeds with an empty JSON object.
+    ``LLMMetadataExtractor`` now removes the ``metadata_extraction_error`` and
+    ``metadata_extraction_response`` keys from a document's metadata on every successful
+    extraction, in both ``run`` and ``run_async``. Previously, when a document from
+    ``failed_documents`` was re-run and the LLM returned an empty JSON object ``{}``, the
+    document ended up in ``documents`` still carrying both keys from the earlier failed attempt.

--- a/test/components/extractors/test_llm_metadata_extractor.py
+++ b/test/components/extractors/test_llm_metadata_extractor.py
@@ -283,6 +283,37 @@ class TestLLMMetadataExtractor:
         assert result["documents"] == []
         assert result["failed_documents"] == []
 
+    def test_run_clears_failure_metadata_after_successful_empty_json_retry(self) -> None:
+        extractor = LLMMetadataExtractor(
+            prompt="prompt {{document.content}}", chat_generator=MockChatGenerator(responses=["not json", "{}"])
+        )
+
+        first_result = extractor.run(documents=[Document(content="content", meta={"source": "retry"})])
+        failed_document = first_result["failed_documents"][0]
+        assert "metadata_extraction_error" in failed_document.meta
+        assert "metadata_extraction_response" in failed_document.meta
+
+        retry_result = extractor.run(documents=first_result["failed_documents"])
+
+        assert retry_result["failed_documents"] == []
+        assert retry_result["documents"][0].meta == {"source": "retry"}
+
+    @pytest.mark.asyncio
+    async def test_run_async_clears_failure_metadata_after_successful_empty_json_retry(self) -> None:
+        extractor = LLMMetadataExtractor(
+            prompt="prompt {{document.content}}", chat_generator=MockChatGenerator(responses=["not json", "{}"])
+        )
+
+        first_result = await extractor.run_async(documents=[Document(content="content", meta={"source": "retry"})])
+        failed_document = first_result["failed_documents"][0]
+        assert "metadata_extraction_error" in failed_document.meta
+        assert "metadata_extraction_response" in failed_document.meta
+
+        retry_result = await extractor.run_async(documents=first_result["failed_documents"])
+
+        assert retry_result["failed_documents"] == []
+        assert retry_result["documents"][0].meta == {"source": "retry"}
+
     def test_run_with_document_content_none(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         # Mock the chat generator to prevent actual LLM calls


### PR DESCRIPTION
### Related Issues

- fixes #12532

### Proposed Changes

The failure metadata cleanup in `LLMMetadataExtractor` ran inside the loop over parsed metadata keys. A retry that returned a valid empty JSON object therefore left `metadata_extraction_error` and `metadata_extraction_response` on the successful document.

Move that cleanup after metadata is applied so every successful parse, including `{}`, clears stale failure state. The change includes synchronous and asynchronous regression tests for a failed extraction followed by an empty-JSON retry.

### How did you test it?

- `uvx hatch env run -e test -- pytest -q test/components/extractors/test_llm_metadata_extractor.py` (29 passed, 2 skipped)
- `uvx hatch run fmt-check haystack/components/extractors/llm_metadata_extractor.py test/components/extractors/test_llm_metadata_extractor.py`
- `uvx hatch -e test run types haystack/components/extractors/llm_metadata_extractor.py`
- `uvx hatch run reno lint .`
- `uvx hatch run pre-commit run --files haystack/components/extractors/llm_metadata_extractor.py test/components/extractors/test_llm_metadata_extractor.py releasenotes/notes/clear-stale-llm-metadata-retry-errors-778a9d314d7459d1.yaml`

### Notes for the reviewer

`{}` is valid when `expected_keys` is not configured and represents a successful extraction with no metadata to add. Public behavior and documentation remain unchanged, so no docstring update is needed.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests.
- [x] I have used a conventional commit title.
- [x] I have documented the user-facing fix through a release note.
- [x] I have run pre-commit hooks and fixed all issues.