### PR TITLE
feat: support image and file content writing for tool result offload

### DIFF
--- a/docs-website/docs/pipeline-components/agents-1/tool-result-offloading.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/tool-result-offloading.mdx
@@ -33,13 +33,24 @@ The system is composed of these layers:
 - **Policy** - decides *whether* a given result is offloaded. Built-in policies: `AlwaysOffload`, `NeverOffload`, `OffloadOverChars`.
 - **Store** - decides *where* the full result lives. The built-in `FileSystemToolResultStore` writes results to the local file system.
 
-When a result is offloaded, the hook writes the full text to the store and rebuilds the message with a one-line pointer in its place:
+When a result is offloaded, the hook writes each part of it to the store and rebuilds the message with a compact pointer in its place. A result that is a single text — by far the most common case — gets a one-line pointer:
 
 ```
-Tool result offloaded to '/abs/path/tool_results/2_search_call-123.txt' (18234 characters). Preview: Fusion startups reported...
+Tool result offloaded to text (18234 characters) at '/abs/path/tool_results/2_search_call-123_0.txt'. Preview: Fusion startups reported...
 ```
 
-The pointer carries the store reference, the original length, and a preview of the first `preview_chars` characters (200 by default, configurable on the hook), so the model knows roughly what was offloaded and where to find it.
+The pointer carries the store reference, the original size, and, for text, a preview of the first `preview_chars` characters (200 by default, configurable on the hook), so the model knows roughly what was offloaded and where to find it.
+
+A result made of several parts — any mix of text, images, and files — is written one store entry per part, and the pointer lists all of them:
+
+```
+Tool result offloaded to 3 files:
+1. text (412 characters) at '/abs/path/tool_results/2_fetch_call-123_0.txt'. Preview: Quarterly report attached...
+2. image/png (48210 bytes) at '/abs/path/tool_results/2_fetch_call-123_1.png'
+3. application/pdf named 'q3.pdf' (1048576 bytes) at '/abs/path/tool_results/2_fetch_call-123_2.pdf'
+```
+
+Images and files are stored as raw bytes, decoded from their base64 payload — that payload is often the largest single thing in an Agent's context, so moving it out of the conversation is where offloading pays off most.
 
 ## Usage
 
@@ -108,10 +119,12 @@ offload_hook = ToolResultOffloadHook(
 
 ### What is offloaded
 
-The hook only offloads **successful, text** tool results:
+The hook only offloads **successful** tool results:
 
 - Error results — including rejections produced by a `before_tool` [Human-in-the-Loop](./human-in-the-loop.mdx) hook — are always left in context, so the model sees what went wrong.
-- Non-text results (image or file content) are left in context; supporting only text is a deliberate choice for now. A warning is logged when a non-text result has a matching offload policy.
+- Text, image, and file results are all offloaded. Each part of a result gets its own store entry, so every text, image, and file stays usable on its own.
+- The file extension of an image or file comes from its `filename` when it has one, and from its `mime_type` otherwise (falling back to `.bin` when neither yields an extension).
+- Policies see the result as the text and base64 payloads of all its parts joined together, so a threshold such as `OffloadOverChars` measures the context the result actually occupies.
 - Each result is offloaded at most once, even though the hook runs on every tool step. This also means two offload hooks registered under `after_tool` won't offload each other's pointers.
 
 ## Policies
@@ -146,11 +159,13 @@ The protocol provides default `to_dict` / `from_dict` implementations, so a poli
 
 ### `FileSystemToolResultStore`
 
-`FileSystemToolResultStore(root=...)` writes each offloaded result to a file under its root directory and returns the absolute file path as the reference. The directory is created on first write. Store keys are derived from the step count, tool name, and tool call ID (for example `2_search_call-123.txt`), so results from different tools and steps do not collide. A key that would resolve outside the root directory is rejected.
+`FileSystemToolResultStore(root=...)` writes each offloaded result to a file under its root directory and returns the absolute file path as the reference. The directory is created on first write. Store keys are derived from the step count, tool name, tool call ID, and the position of the part within the result (for example `2_search_call-123_0.txt`), so results from different tools and steps do not collide. A key that would resolve outside the root directory is rejected.
+
+Text is written UTF-8 encoded and read back as a string; images and files are written as raw bytes and read back as `bytes`.
 
 ### Custom store
 
-Subclass the `ToolResultStore` protocol to target other backends, such as object storage or an isolated sandbox file system. A store needs two methods: `write(key=..., content=...)` persists the content and returns an opaque reference string, and `read(reference)` resolves that reference back to the content:
+Subclass the `ToolResultStore` protocol to target other backends, such as object storage or an isolated sandbox file system. A store needs two methods: `write(key=..., content=...)` persists the content and returns a reference string, and `read(reference)` resolves that reference back to the content. Only the store interprets a reference — everyone else passes it back to `read` unchanged. `content` is a string for text and `bytes` for an offloaded image or file, so a store has to handle both:
 
 ```python
 from haystack.hooks.tool_result_offloading import ToolResultStore
@@ -160,13 +175,13 @@ class InMemoryToolResultStore(ToolResultStore):
     """Keep offloaded results in a dict - useful for tests."""
 
     def __init__(self) -> None:
-        self._data: dict[str, str] = {}
+        self._data: dict[str, str | bytes] = {}
 
-    def write(self, *, key: str, content: str) -> str:
+    def write(self, *, key: str, content: str | bytes) -> str:
         self._data[key] = content
         return key
 
-    def read(self, reference: str) -> str:
+    def read(self, reference: str) -> str | bytes:
         return self._data[reference]
 ```
 
@@ -206,10 +221,13 @@ def read_offloaded_result(
     path: Annotated[str, "Absolute path of an offloaded tool result"],
 ) -> str:
     """Read back the full content of an offloaded tool result."""
-    return FileSystemToolResultStore(root="tool_results").read(path)
+    content = FileSystemToolResultStore(root="tool_results").read(path)
+    if isinstance(content, bytes):
+        return f"'{path}' holds {len(content)} bytes of binary content and cannot be read as text."
+    return content
 ```
 
-With this tool available, the Agent can work with a compact conversation and selectively re-read only the offloaded results it actually needs — instead of carrying every full result in context on every LLM call.
+With this tool available, the Agent can work with a compact conversation and selectively re-read only the offloaded results it actually needs — instead of carrying every full result in context on every LLM call. An offloaded image or file comes back as `bytes`; to put one back in front of the model, a tool can return it as an `ImageContent` or `FileContent` block instead of as text.
 
 ## Serialization
 

--- a/docs-website/docs/pipeline-components/agents-1/tool-result-offloading.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/tool-result-offloading.mdx
@@ -33,15 +33,15 @@ The system is composed of these layers:
 - **Policy** - decides *whether* a given result is offloaded. Built-in policies: `AlwaysOffload`, `NeverOffload`, `OffloadOverChars`.
 - **Store** - decides *where* the full result lives. The built-in `FileSystemToolResultStore` writes results to the local file system.
 
-When a result is offloaded, the hook writes each part of it to the store and rebuilds the message with a compact pointer in its place. A result that is a single text gets a one-line pointer:
+When a result is offloaded, the hook writes each part of it to the store and rebuilds the message with a compact pointer in its place. For example:
 
 ```
-Tool result offloaded to text (18234 characters) at '/abs/path/tool_results/2_search_call-123_0.txt'. Preview: Fusion startups reported...
+Tool result offloaded to text (18234 characters) at '/abs/path/tool_results/2_search_call-123.txt'. Preview: Fusion startups reported...
 ```
 
 The pointer carries the store reference, the original size, and, for text, a preview of the first `preview_chars` characters (200 by default, configurable on the hook), so the model knows roughly what was offloaded and where to find it.
 
-A result made of several parts — any mix of text, images, and files — is written one store entry per part, and the pointer lists all of them:
+A result made of several parts — any mix of text, images, and files — gets one store entry and one pointer line per part:
 
 ```
 Tool result offloaded to 3 files:
@@ -125,7 +125,7 @@ The hook only offloads **successful** tool results:
 - Text, image, and file results are all offloaded. Each part of a result gets its own store entry, so every text, image, and file stays usable on its own.
 - Image and file content only goes to a store that declares `supports_binary_content`. With a text-only store, a result carrying an image or a file stays in context and a warning is logged.
 - The file extension of an image or file comes from its `filename` when it has one, and from its `mime_type` otherwise (falling back to `.bin` when neither yields an extension).
-- Policies see the result as the text and base64 payloads of all its parts joined together, so a threshold such as `OffloadOverChars` measures the context the result actually occupies.
+- Policies see the result as the text and base64 payloads of all its parts joined together.
 - Each result is offloaded at most once, even though the hook runs on every tool step. This also means two offload hooks registered under `after_tool` won't offload each other's pointers.
 
 ## Policies
@@ -186,7 +186,7 @@ class InMemoryToolResultStore(ToolResultStore):
         return self._data[reference]
 ```
 
-A store like this one only holds text, which is all it will ever be given: `supports_binary_content` defaults to `False`, and the hook leaves image and file results in context rather than handing a text-only store bytes it cannot write. A store that *can* hold bytes — a file system, object storage — sets the flag and widens `content` to `str | bytes`, and `read` returns whatever it stored:
+A store like this one only ever receives text: `supports_binary_content` defaults to `False`, so the hook leaves image and file results in context rather than handing it bytes it cannot write. A store that can hold bytes sets the flag and widens both signatures:
 
 ```python
 class BinaryCapableStore(ToolResultStore):

--- a/docs-website/docs/pipeline-components/agents-1/tool-result-offloading.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/tool-result-offloading.mdx
@@ -123,6 +123,7 @@ The hook only offloads **successful** tool results:
 
 - Error results — including rejections produced by a `before_tool` [Human-in-the-Loop](./human-in-the-loop.mdx) hook — are always left in context, so the model sees what went wrong.
 - Text, image, and file results are all offloaded. Each part of a result gets its own store entry, so every text, image, and file stays usable on its own.
+- Image and file content only goes to a store that declares `supports_binary_content`. With a text-only store, a result carrying an image or a file stays in context and a warning is logged.
 - The file extension of an image or file comes from its `filename` when it has one, and from its `mime_type` otherwise (falling back to `.bin` when neither yields an extension).
 - Policies see the result as the text and base64 payloads of all its parts joined together, so a threshold such as `OffloadOverChars` measures the context the result actually occupies.
 - Each result is offloaded at most once, even though the hook runs on every tool step. This also means two offload hooks registered under `after_tool` won't offload each other's pointers.
@@ -159,13 +160,13 @@ The protocol provides default `to_dict` / `from_dict` implementations, so a poli
 
 ### `FileSystemToolResultStore`
 
-`FileSystemToolResultStore(root=...)` writes each offloaded result to a file under its root directory and returns the absolute file path as the reference. The directory is created on first write. Store keys are derived from the step count, tool name, tool call ID, and the position of the part within the result (for example `2_search_call-123_0.txt`), so results from different tools and steps do not collide. A key that would resolve outside the root directory is rejected.
+`FileSystemToolResultStore(root=...)` writes each offloaded result to a file under its root directory and returns the absolute file path as the reference. The directory is created on first write. Store keys are derived from the step count, tool name, and tool call ID (for example `2_search_call-123.txt`), plus the position of the part within the result when it spans several entries (`2_search_call-123_1.png`), so results from different tools and steps do not collide. A key that would resolve outside the root directory is rejected.
 
 Text is written UTF-8 encoded and read back as a string; images and files are written as raw bytes and read back as `bytes`.
 
 ### Custom store
 
-Subclass the `ToolResultStore` protocol to target other backends, such as object storage or an isolated sandbox file system. A store needs two methods: `write(key=..., content=...)` persists the content and returns a reference string, and `read(reference)` resolves that reference back to the content. Only the store interprets a reference — everyone else passes it back to `read` unchanged. `content` is a string for text and `bytes` for an offloaded image or file, so a store has to handle both:
+Subclass the `ToolResultStore` protocol to target other backends, such as object storage or an isolated sandbox file system. A store needs two methods: `write(key=..., content=...)` persists the content and returns a reference string, and `read(reference)` resolves that reference back to the content. Only the store interprets a reference — everyone else passes it back to `read` unchanged:
 
 ```python
 from haystack.hooks.tool_result_offloading import ToolResultStore
@@ -175,14 +176,25 @@ class InMemoryToolResultStore(ToolResultStore):
     """Keep offloaded results in a dict - useful for tests."""
 
     def __init__(self) -> None:
-        self._data: dict[str, str | bytes] = {}
+        self._data: dict[str, str] = {}
 
-    def write(self, *, key: str, content: str | bytes) -> str:
+    def write(self, *, key: str, content: str) -> str:
         self._data[key] = content
         return key
 
-    def read(self, reference: str) -> str | bytes:
+    def read(self, reference: str) -> str:
         return self._data[reference]
+```
+
+A store like this one only holds text, which is all it will ever be given: `supports_binary_content` defaults to `False`, and the hook leaves image and file results in context rather than handing a text-only store bytes it cannot write. A store that *can* hold bytes — a file system, object storage — sets the flag and widens `content` to `str | bytes`, and `read` returns whatever it stored:
+
+```python
+class BinaryCapableStore(ToolResultStore):
+    supports_binary_content = True
+
+    def write(self, *, key: str, content: str | bytes) -> str: ...
+
+    def read(self, reference: str) -> str | bytes: ...
 ```
 
 Like `OffloadPolicy`, the protocol provides default `to_dict` / `from_dict` implementations covering stores whose constructor takes no arguments; implement both methods for stores with constructor arguments.

--- a/docs-website/docs/pipeline-components/agents-1/tool-result-offloading.mdx
+++ b/docs-website/docs/pipeline-components/agents-1/tool-result-offloading.mdx
@@ -33,7 +33,7 @@ The system is composed of these layers:
 - **Policy** - decides *whether* a given result is offloaded. Built-in policies: `AlwaysOffload`, `NeverOffload`, `OffloadOverChars`.
 - **Store** - decides *where* the full result lives. The built-in `FileSystemToolResultStore` writes results to the local file system.
 
-When a result is offloaded, the hook writes each part of it to the store and rebuilds the message with a compact pointer in its place. A result that is a single text — by far the most common case — gets a one-line pointer:
+When a result is offloaded, the hook writes each part of it to the store and rebuilds the message with a compact pointer in its place. A result that is a single text gets a one-line pointer:
 
 ```
 Tool result offloaded to text (18234 characters) at '/abs/path/tool_results/2_search_call-123_0.txt'. Preview: Fusion startups reported...
@@ -50,7 +50,7 @@ Tool result offloaded to 3 files:
 3. application/pdf named 'q3.pdf' (1048576 bytes) at '/abs/path/tool_results/2_fetch_call-123_2.pdf'
 ```
 
-Images and files are stored as raw bytes, decoded from their base64 payload — that payload is often the largest single thing in an Agent's context, so moving it out of the conversation is where offloading pays off most.
+Images and files are stored as raw bytes, decoded from their base64 payload. A base64 payload is a costly way to carry a file through a conversation, so moving one out can free up a substantial part of the context window.
 
 ## Usage
 

--- a/haystack/hooks/tool_result_offloading/hooks.py
+++ b/haystack/hooks/tool_result_offloading/hooks.py
@@ -2,46 +2,29 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 import json
+import mimetypes
+from pathlib import Path
 from typing import Any
 
-from haystack import logging
 from haystack.components.agents.state.state import State
 from haystack.components.agents.state.state_utils import replace_values
 from haystack.core.serialization import default_from_dict, default_to_dict
-from haystack.dataclasses import ChatMessage, TextContent
-from haystack.dataclasses.chat_message import ToolCallResultContentT
+from haystack.dataclasses import ChatMessage, FileContent, ImageContent, TextContent
 from haystack.hooks.tool_result_offloading.types import OffloadPolicy, ToolResultStore
 from haystack.utils.deserialization import deserialize_component_inplace
 
-logger = logging.getLogger(__name__)
+# Extension used for a binary block whose MIME type is unknown or maps to no known extension.
+_FALLBACK_EXTENSION = ".bin"
 
-# Meta key marking an already-offloaded tool-result message (its value is the store reference). The offloaded pointer
-# is itself a tool result in the trailing block the hook scans, so this marker stops a second offload hook registered
-# under `after_tool` from offloading the pointer text again and writing a junk file.
+# Meta key marking an already-offloaded tool-result message; its value is the list of store references written. Stops
+# a second `after_tool` offload hook from offloading the pointer text again, since the pointer is itself a tool result.
 _OFFLOADED_META_KEY = "tool_result_offloaded"
 
 # Key under which a per-run store override may be supplied via the Agent's `hook_context` (e.g. a request-scoped
 # sandbox filesystem).
 RESULT_STORE_CONTEXT_KEY = "tool_result_store"
-
-
-def _result_store_key(tool_name: str, tool_call_id: str | None, step: int, index: int) -> str:
-    """
-    Build a per-result store key that is stable and unique within a run.
-
-    Combining the step, tool name, and tool call id keeps results from different tools and different steps from
-    colliding. When the tool call carries no id (it is optional and not every generator sets it), the result's
-    position in the step's batch is used instead, so two id-less calls to the same tool in the same step do not
-    collide.
-
-    :param tool_name: The name of the tool that produced the result.
-    :param tool_call_id: The id of the originating tool call, or None when the call carried no id.
-    :param step: The Agent's current step count.
-    :param index: The result's position within this step's batch of tool results, used when `tool_call_id` is None.
-    :returns: A file-name-like key for the store, e.g. `2_web_search_call-123.txt`.
-    """
-    return f"{step}_{tool_name}_{tool_call_id or f'call{index}'}.txt"
 
 
 def _fresh_tool_results_start(messages: list[ChatMessage]) -> int:
@@ -62,23 +45,18 @@ def _fresh_tool_results_start(messages: list[ChatMessage]) -> int:
     return index
 
 
-def _offloadable_text(content: ToolCallResultContentT) -> str | None:
+def _content_block_payload(content_block: TextContent | ImageContent | FileContent) -> str:
     """
-    Return the text of a tool result if it can be offloaded as text, otherwise None.
+    Return the string a content block contributes to the conversation.
 
-    A plain string is returned as-is; a non-empty sequence made up entirely of `TextContent` blocks is concatenated
-    into a single string. Anything else (e.g. a result containing image or file content) returns None and is left in
-    context.
+    For an image or a file this is the base64 payload, which is what actually occupies the context window.
 
-    :param content: The tool result content to inspect.
-    :returns: The offloadable text, or None when the content is not purely text.
+    :param content_block: The content block to inspect.
+    :returns: The content block's text or base64 payload.
     """
-    if isinstance(content, str):
-        return content
-    texts = [block.text for block in content if isinstance(block, TextContent)]
-    if texts and len(texts) == len(content):
-        return "".join(texts)
-    return None
+    if isinstance(content_block, TextContent):
+        return content_block.text
+    return content_block.base64_image if isinstance(content_block, ImageContent) else content_block.base64_data
 
 
 def _serialize_offload_strategies(strategies: dict[str | tuple[str, ...], OffloadPolicy]) -> dict[str, Any]:
@@ -158,10 +136,11 @@ class ToolResultOffloadHook:
     any tool without a more specific entry. More specific keys win. A tool with no matching key (and no `"*"`) is not
     offloaded.
 
-    Only successful, text tool output is offloaded. Error results (including `before_tool` human-in-the-loop
-    rejections) are always left in context. Non-text results (image or file content) are also left in context, and a
-    warning is logged when such a result has a matching offload policy; supporting only text is a deliberate choice
-    for now. Each result is offloaded at most once, even though the hook runs on every tool step.
+    Only successful tool output is offloaded; error results (including `before_tool` human-in-the-loop rejections) are
+    always left in context. Each part of a result is written to its own store entry, so every text, image, and file
+    stays usable on its own - the base64 payload of an image or a file is often the largest thing in the conversation.
+    The pointer names a single-part result on one line and lists the entries of a multi-part one. Each result is
+    offloaded at most once, even though the hook runs on every tool step.
 
     The hook keeps no mutable state, so a single instance can be shared across concurrent runs. The constructor
     `store`, however, is shared by every run that does not override it — fine for single-user or local use, but in a
@@ -187,8 +166,9 @@ class ToolResultOffloadHook:
         :param store: Where offloaded results are written. Can be overridden per run via `hook_context`.
         :param offload_strategies: Mapping of tool name (or a tuple of tool names, or the wildcard `"*"`) to the
             `OffloadPolicy` that decides whether that tool's results are offloaded.
-        :param preview_chars: Number of leading characters of the original result to include in the pointer left in
-            the conversation, so the model knows roughly what was offloaded.
+        :param preview_chars: Number of leading characters of each offloaded text to include in the pointer left in
+            the conversation, so the model knows roughly what was offloaded. Image and file blocks are described by
+            their MIME type and size instead.
         """
         self.store = store
         self.offload_strategies = offload_strategies
@@ -217,29 +197,25 @@ class ToolResultOffloadHook:
         :returns: None. The hook mutates `state` in place.
         """
         messages = state.data.get("messages") or []
-        start = _fresh_tool_results_start(messages)
+        start = _fresh_tool_results_start(messages=messages)
         if start == len(messages):
             return
-        store = self._resolve_store(state)
+
+        # A run may carry its own store in `hook_context` - the hook instance is shared across concurrent runs, so
+        # isolating users from each other means giving each run its own store rather than each its own hook.
+        hook_context = state.data.get("hook_context") or {}
+        store = hook_context.get(RESULT_STORE_CONTEXT_KEY, self.store)
+
         rewritten: list[ChatMessage] = list(messages[:start])
         changed = False
         for index, message in enumerate(messages[start:]):
-            new_message = self._maybe_offload(message, store, state, index)
+            new_message = self._maybe_offload(message=message, store=store, state=state, index=index)
             rewritten.append(new_message)
             changed = changed or new_message is not message
+
+        # Only write back to state when at least one message changed
         if changed:
-            state.set("messages", rewritten, handler_override=replace_values)
-
-    def _resolve_store(self, state: State) -> ToolResultStore:
-        """
-        Return the store to write to for this run.
-
-        :param state: The Agent's live `State`, whose `hook_context` may carry a per-run store override under
-            `RESULT_STORE_CONTEXT_KEY`.
-        :returns: The per-run store from `hook_context` if provided, otherwise the store the hook was built with.
-        """
-        context = state.data.get("hook_context") or {}
-        return context.get(RESULT_STORE_CONTEXT_KEY, self.store)
+            state.set(key="messages", value=rewritten, handler_override=replace_values)
 
     def _policy_for(self, tool_name: str) -> OffloadPolicy | None:
         """
@@ -264,11 +240,11 @@ class ToolResultOffloadHook:
 
         A message is left as-is when it is not a tool result, when the result is an error (including `before_tool`
         human-in-the-loop rejections), when it was already offloaded (e.g. another offload hook under `after_tool`
-        handled it), when no policy applies, when the result is non-text (contains image or file content), or when the
-        policy declines to offload.
+        handled it), when no policy applies, when the result is empty, or when the policy declines to offload.
 
-        Otherwise the result text is written to `store` and the message is rebuilt with a pointer in place of the full
-        result, preserving its origin and error flag and marking it offloaded.
+        Otherwise the result is written to `store` and the message is rebuilt with a pointer in place of the full
+        result, preserving its origin and error flag and marking it offloaded. Each part of the result goes to its own
+        store entry.
 
         :param message: The message to consider offloading.
         :param store: The store to write the result to.
@@ -283,48 +259,103 @@ class ToolResultOffloadHook:
             return message
 
         tool_name = result.origin.tool_name
-        policy = self._policy_for(tool_name)
+        policy = self._policy_for(tool_name=tool_name)
 
         # If no policy applies, leave the result in context
         if policy is None:
             return message
 
-        # A policy matched, so an offload was wanted. Offloading only supports text results (a string or a sequence
-        # of TextContent) for now, by design; leave image/file content in context and warn since the intent was to
-        # offload it.
-        text = _offloadable_text(result.result)
-        if text is None:
-            logger.warning(
-                "Tool '{tool}' produced a non-text result; leaving it in context. Result offloading currently "
-                "supports text results only.",
-                tool=tool_name,
-            )
+        # A plain string result is handled as a single text block, so everything below has one shape to work with.
+        content_blocks: list[TextContent | ImageContent | FileContent] = (
+            [TextContent(text=result.result)] if isinstance(result.result, str) else list(result.result)
+        )
+        if not content_blocks:
             return message
 
-        # If the policy declines to offload, leave the result in context
-        if not policy.should_offload(tool_name, text, state):
+        # The policy sizes up the result by the string it occupies in the conversation, which for an image or a file
+        # block is its base64 payload.
+        payload = "".join(_content_block_payload(content_block=content_block) for content_block in content_blocks)
+        if not policy.should_offload(tool_name=tool_name, result=payload, state=state):
             return message
 
-        key = _result_store_key(tool_name, result.origin.id, state.data.get("step_count", 0), index)
-        reference = store.write(key=key, content=text)
+        # Step, tool name, and call id keep results from different tools and steps from colliding. A tool call id is
+        # optional, so an id-less call falls back to its position in this step's batch.
+        step = state.data.get("step_count", 0)
+        prefix = f"{step}_{tool_name}_{result.origin.id or f'call{index}'}"
+        references, pointer = self._offload_content_blocks(content_blocks=content_blocks, store=store, prefix=prefix)
+
         return ChatMessage.from_tool(
-            tool_result=self._pointer(reference, text),
+            tool_result=pointer,
             origin=result.origin,
             error=result.error,
-            meta={**message.meta, _OFFLOADED_META_KEY: reference},
+            meta={**message.meta, _OFFLOADED_META_KEY: references},
         )
 
-    def _pointer(self, reference: str, result: str) -> str:
+    def _offload_content_blocks(
+        self, content_blocks: list[TextContent | ImageContent | FileContent], store: ToolResultStore, prefix: str
+    ) -> tuple[list[str], str]:
         """
-        Build the compact pointer that replaces a full result in the conversation.
+        Write a result's content blocks to the store and build the pointer that replaces them in the conversation.
 
-        :param reference: The store reference the result was written to.
-        :param result: The original result string, used for its length and a leading preview.
-        :returns: A one-line pointer carrying the reference, the result length, and a `preview_chars`-long preview.
+        Every content block goes to its own store entry, so each text, image, or file stays usable on its own. A
+        result that is a single block - the common case - gets a one-line pointer; a result with several gets one
+        numbered line per entry.
+
+        :param content_blocks: The result's content blocks, in order.
+        :param store: The store to write to.
+        :param prefix: The result's store key prefix, to which the block position and extension are appended.
+        :returns: The store references written, and the pointer text for the conversation.
         """
-        ellip = "..." if len(result) > self.preview_chars else ""
-        preview = result[: self.preview_chars]
-        return f"Tool result offloaded to '{reference}' ({len(result)} characters). Preview: {preview}{ellip}"
+        references: list[str] = []
+        descriptions: list[str] = []
+        for position, content_block in enumerate(content_blocks):
+            reference, description = self._offload_content_block(
+                content_block=content_block, store=store, key_prefix=f"{prefix}_{position}"
+            )
+            references.append(reference)
+            descriptions.append(description)
+
+        if len(descriptions) == 1:
+            return references, f"Tool result offloaded to {descriptions[0]}"
+
+        numbered = [f"{position}. {description}" for position, description in enumerate(descriptions, start=1)]
+        return references, "\n".join([f"Tool result offloaded to {len(descriptions)} files:", *numbered])
+
+    def _offload_content_block(
+        self, content_block: TextContent | ImageContent | FileContent, store: ToolResultStore, key_prefix: str
+    ) -> tuple[str, str]:
+        """
+        Write a single content block to the store and describe where it went.
+
+        :param content_block: The content block to offload.
+        :param store: The store to write to.
+        :param key_prefix: The content block's store key without its extension.
+        :returns: The store reference the content block was written to, and a one-line description for the pointer.
+        """
+        if isinstance(content_block, TextContent):
+            text = content_block.text
+            reference = store.write(key=f"{key_prefix}.txt", content=text)
+            # An ellipsis marks a preview that was cut short, so the model can tell it is not the whole text.
+            preview = f"{text[: self.preview_chars]}{'...' if len(text) > self.preview_chars else ''}"
+            return reference, f"text ({len(text)} characters) at '{reference}'. Preview: {preview}"
+
+        if isinstance(content_block, ImageContent):
+            data = base64.b64decode(content_block.base64_image)
+            label = content_block.mime_type or "image"
+            filename = None
+        else:
+            data = base64.b64decode(content_block.base64_data)
+            label = content_block.mime_type or "file"
+            filename = content_block.filename
+
+        # What the tool called the file wins over its MIME type. Only the suffix is taken, so a tool-supplied name
+        # cannot influence where in the store the content block lands.
+        mime_extension = mimetypes.guess_extension(content_block.mime_type) if content_block.mime_type else None
+        extension = (Path(filename).suffix if filename else "") or mime_extension or _FALLBACK_EXTENSION
+        reference = store.write(key=f"{key_prefix}{extension}", content=data)
+
+        named = f" named '{filename}'" if filename else ""
+        return reference, f"{label}{named} ({len(data)} bytes) at '{reference}'"
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -335,7 +366,7 @@ class ToolResultOffloadHook:
         return default_to_dict(
             self,
             store=self.store.to_dict(),
-            offload_strategies=_serialize_offload_strategies(self.offload_strategies),
+            offload_strategies=_serialize_offload_strategies(strategies=self.offload_strategies),
             preview_chars=self.preview_chars,
         )
 
@@ -351,5 +382,5 @@ class ToolResultOffloadHook:
         if init_params.get("store") is not None:
             deserialize_component_inplace(init_params, key="store")
         if init_params.get("offload_strategies") is not None:
-            init_params["offload_strategies"] = _deserialize_offload_strategies(init_params["offload_strategies"])
+            init_params["offload_strategies"] = _deserialize_offload_strategies(data=init_params["offload_strategies"])
         return default_from_dict(cls, data)

--- a/haystack/hooks/tool_result_offloading/hooks.py
+++ b/haystack/hooks/tool_result_offloading/hooks.py
@@ -140,13 +140,10 @@ class ToolResultOffloadHook:
     any tool without a more specific entry. More specific keys win. A tool with no matching key (and no `"*"`) is not
     offloaded.
 
-    Only successful tool output is offloaded; error results (including `before_tool` human-in-the-loop rejections) are
-    always left in context. Each part of a result is written to its own store entry, so every text, image, and file
-    stays usable on its own - a base64 payload is a costly way to carry an image or a file through a conversation.
-    The pointer names a single-part result on one line and lists the entries of a multi-part one. A result with image
-    or file content is only offloaded to a store that sets `supports_binary_content`; with a text-only store it stays
-    in context and a warning is logged. Each result is offloaded at most once, even though the hook runs on every tool
-    step.
+    Only successful tool output is offloaded; error results are always left in context. Each part of a result is
+    written to its own store entry and the pointer says where each one went. Image and file content is only offloaded
+    to a store that sets `supports_binary_content`; with a text-only store the result stays in context and a warning
+    is logged. Each result is offloaded at most once, even though the hook runs on every tool step.
 
     The hook keeps no mutable state, so a single instance can be shared across concurrent runs. The constructor
     `store`, however, is shared by every run that does not override it — fine for single-user or local use, but in a
@@ -207,8 +204,8 @@ class ToolResultOffloadHook:
         if start == len(messages):
             return
 
-        # A run may carry its own store in `hook_context` - the hook instance is shared across concurrent runs, so
-        # isolating users from each other means giving each run its own store rather than each its own hook.
+        # The hook instance is shared across concurrent runs, so a run isolates itself by carrying its own store in
+        # `hook_context`.
         hook_context = state.data.get("hook_context") or {}
         store = hook_context.get(RESULT_STORE_CONTEXT_KEY, self.store)
 
@@ -317,14 +314,12 @@ class ToolResultOffloadHook:
         """
         Write a result's content blocks to the store and build the pointer that replaces them in the conversation.
 
-        Every content block goes to its own store entry, so each text, image, or file stays usable on its own. A
-        result that is a single block gets a one-line pointer and keeps `prefix` as its key; a result with several
-        gets one numbered line per entry and a key carrying each block's position.
+        Every content block goes to its own store entry. A single block keeps `prefix` as its key and gets a one-line
+        pointer; several blocks get position-suffixed keys and one numbered pointer line each.
 
         :param content_blocks: The result's content blocks, in order.
         :param store: The store to write to.
-        :param prefix: The result's store key prefix, to which the extension - and the block position, for a result
-            spanning several entries - is appended.
+        :param prefix: The result's store key prefix, as described above.
         :returns: The store references written, and the pointer text for the conversation.
         """
         references: list[str] = []
@@ -370,8 +365,7 @@ class ToolResultOffloadHook:
             label = content_block.mime_type or "file"
             filename = content_block.filename
 
-        # What the tool called the file wins over its MIME type. Only the suffix is taken, so a tool-supplied name
-        # cannot influence where in the store the content block lands.
+        # What the tool called the file wins over its MIME type. Only the suffix is taken.
         mime_extension = mimetypes.guess_extension(content_block.mime_type) if content_block.mime_type else None
         extension = (Path(filename).suffix if filename else "") or mime_extension or _FALLBACK_EXTENSION
         reference = store.write(key=f"{key_prefix}{extension}", content=data)

--- a/haystack/hooks/tool_result_offloading/hooks.py
+++ b/haystack/hooks/tool_result_offloading/hooks.py
@@ -138,7 +138,7 @@ class ToolResultOffloadHook:
 
     Only successful tool output is offloaded; error results (including `before_tool` human-in-the-loop rejections) are
     always left in context. Each part of a result is written to its own store entry, so every text, image, and file
-    stays usable on its own - the base64 payload of an image or a file is often the largest thing in the conversation.
+    stays usable on its own - a base64 payload is a costly way to carry an image or a file through a conversation.
     The pointer names a single-part result on one line and lists the entries of a multi-part one. Each result is
     offloaded at most once, even though the hook runs on every tool step.
 
@@ -298,8 +298,7 @@ class ToolResultOffloadHook:
         Write a result's content blocks to the store and build the pointer that replaces them in the conversation.
 
         Every content block goes to its own store entry, so each text, image, or file stays usable on its own. A
-        result that is a single block - the common case - gets a one-line pointer; a result with several gets one
-        numbered line per entry.
+        result that is a single block gets a one-line pointer; a result with several gets one numbered line per entry.
 
         :param content_blocks: The result's content blocks, in order.
         :param store: The store to write to.

--- a/haystack/hooks/tool_result_offloading/hooks.py
+++ b/haystack/hooks/tool_result_offloading/hooks.py
@@ -8,6 +8,7 @@ import mimetypes
 from pathlib import Path
 from typing import Any
 
+from haystack import logging
 from haystack.components.agents.state.state import State
 from haystack.components.agents.state.state_utils import replace_values
 from haystack.core.serialization import default_from_dict, default_to_dict
@@ -18,8 +19,11 @@ from haystack.utils.deserialization import deserialize_component_inplace
 # Extension used for a binary block whose MIME type is unknown or maps to no known extension.
 _FALLBACK_EXTENSION = ".bin"
 
-# Meta key marking an already-offloaded tool-result message; its value is the list of store references written. Stops
-# a second `after_tool` offload hook from offloading the pointer text again, since the pointer is itself a tool result.
+logger = logging.getLogger(__name__)
+
+# Meta key marking an already-offloaded tool-result message; its value is the list of store references written.
+# Stops a second `after_tool` offload hook from offloading the pointer text again, since the pointer is itself a
+# tool result.
 _OFFLOADED_META_KEY = "tool_result_offloaded"
 
 # Key under which a per-run store override may be supplied via the Agent's `hook_context` (e.g. a request-scoped
@@ -139,8 +143,10 @@ class ToolResultOffloadHook:
     Only successful tool output is offloaded; error results (including `before_tool` human-in-the-loop rejections) are
     always left in context. Each part of a result is written to its own store entry, so every text, image, and file
     stays usable on its own - a base64 payload is a costly way to carry an image or a file through a conversation.
-    The pointer names a single-part result on one line and lists the entries of a multi-part one. Each result is
-    offloaded at most once, even though the hook runs on every tool step.
+    The pointer names a single-part result on one line and lists the entries of a multi-part one. A result with image
+    or file content is only offloaded to a store that sets `supports_binary_content`; with a text-only store it stays
+    in context and a warning is logged. Each result is offloaded at most once, even though the hook runs on every tool
+    step.
 
     The hook keeps no mutable state, so a single instance can be shared across concurrent runs. The constructor
     `store`, however, is shared by every run that does not override it — fine for single-user or local use, but in a
@@ -240,7 +246,8 @@ class ToolResultOffloadHook:
 
         A message is left as-is when it is not a tool result, when the result is an error (including `before_tool`
         human-in-the-loop rejections), when it was already offloaded (e.g. another offload hook under `after_tool`
-        handled it), when no policy applies, when the result is empty, or when the policy declines to offload.
+        handled it), when no policy applies, when the result is empty, when the result carries image or file content
+        that `store` cannot store, or when the policy declines to offload.
 
         Otherwise the result is written to `store` and the message is rebuilt with a pointer in place of the full
         result, preserving its origin and error flag and marking it offloaded. Each part of the result goes to its own
@@ -272,6 +279,19 @@ class ToolResultOffloadHook:
         if not content_blocks:
             return message
 
+        # Check whether the store can store binary content before offloading an image or file result. A text-only store
+        # leaves the result in context and logs a warning.
+        if not getattr(store, "supports_binary_content", False) and not all(
+            isinstance(content_block, TextContent) for content_block in content_blocks
+        ):
+            logger.warning(
+                "Tool '{tool}' produced a result with image or file content, but {store} does not support binary "
+                "content; leaving the result in context.",
+                tool=tool_name,
+                store=type(store).__name__,
+            )
+            return message
+
         # The policy sizes up the result by the string it occupies in the conversation, which for an image or a file
         # block is its base64 payload.
         payload = "".join(_content_block_payload(content_block=content_block) for content_block in content_blocks)
@@ -298,18 +318,21 @@ class ToolResultOffloadHook:
         Write a result's content blocks to the store and build the pointer that replaces them in the conversation.
 
         Every content block goes to its own store entry, so each text, image, or file stays usable on its own. A
-        result that is a single block gets a one-line pointer; a result with several gets one numbered line per entry.
+        result that is a single block gets a one-line pointer and keeps `prefix` as its key; a result with several
+        gets one numbered line per entry and a key carrying each block's position.
 
         :param content_blocks: The result's content blocks, in order.
         :param store: The store to write to.
-        :param prefix: The result's store key prefix, to which the block position and extension are appended.
+        :param prefix: The result's store key prefix, to which the extension - and the block position, for a result
+            spanning several entries - is appended.
         :returns: The store references written, and the pointer text for the conversation.
         """
         references: list[str] = []
         descriptions: list[str] = []
+        single = len(content_blocks) == 1
         for position, content_block in enumerate(content_blocks):
             reference, description = self._offload_content_block(
-                content_block=content_block, store=store, key_prefix=f"{prefix}_{position}"
+                content_block=content_block, store=store, key_prefix=prefix if single else f"{prefix}_{position}"
             )
             references.append(reference)
             descriptions.append(description)

--- a/haystack/hooks/tool_result_offloading/stores.py
+++ b/haystack/hooks/tool_result_offloading/stores.py
@@ -22,7 +22,7 @@ class FileSystemToolResultStore(ToolResultStore):
     ```
 
     Binary content is supported too: `write` takes bytes (an offloaded image or file) and `read` returns them
-    unchanged, while text content round trips as a string.
+    unchanged.
     """
 
     supports_binary_content = True

--- a/haystack/hooks/tool_result_offloading/stores.py
+++ b/haystack/hooks/tool_result_offloading/stores.py
@@ -20,6 +20,9 @@ class FileSystemToolResultStore(ToolResultStore):
     reference = store.write(key="search_1.txt", content="...")
     store.read(reference)
     ```
+
+    Binary content is supported too: `write` takes bytes (an offloaded image or file) and `read` returns them
+    unchanged, while text content round trips as a string.
     """
 
     def __init__(self, root: str | Path) -> None:
@@ -49,35 +52,47 @@ class FileSystemToolResultStore(ToolResultStore):
             raise ValueError(f"{subject} '{path_like}' resolves outside the store root '{root}'.")
         return resolved
 
-    def write(self, *, key: str, content: str) -> str:
+    def write(self, *, key: str, content: str | bytes) -> str:
         """
         Write `content` to `<root>/<key>`, creating parent directories, and return the file path.
+
+        Text is written UTF-8 encoded; bytes (an offloaded image or file) are written verbatim.
 
         The resolved target must stay within the root directory: a `key` that escapes it (e.g. containing `../` or an
         absolute path) is rejected, so a tool-provided key cannot write outside the store.
 
         :param key: Relative file name for the result within the store root.
-        :param content: The tool result to persist.
+        :param content: The tool result to persist, as text or as raw bytes.
         :returns: The absolute path the content was written to, as a string, for use with `read`.
         :raises ValueError: If `key` resolves to a location outside the store root.
         """
         path = self._resolve_in_root(key, subject="Result key")
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content, encoding="utf-8")
+        if isinstance(content, bytes):
+            path.write_bytes(content)
+        else:
+            path.write_text(content, encoding="utf-8")
         return str(path)
 
-    def read(self, reference: str) -> str:
+    def read(self, reference: str) -> str | bytes:
         """
         Read back the content previously written to `reference`.
 
-        The resolved reference must stay within the store root: callers must treat it as an opaque
-        store-scoped reference, not as an arbitrary filesystem path.
+        A file whose bytes are valid UTF-8 is returned as a string, so text results round trip unchanged; anything
+        else (an offloaded image or file) is returned as raw bytes.
+
+        The resolved reference must stay within the store root: it is a store-scoped reference returned by `write`,
+        to be passed back unchanged, not an arbitrary filesystem path callers can build themselves.
 
         :param reference: A store reference returned by `write`.
-        :returns: The stored content.
+        :returns: The stored content, as text when it decodes as UTF-8 and as bytes otherwise.
         :raises ValueError: If `reference` resolves to a location outside the store root.
         """
-        return self._resolve_in_root(reference, subject="Result reference").read_text(encoding="utf-8")
+        data = self._resolve_in_root(reference, subject="Result reference").read_bytes()
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError:
+            return data
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/haystack/hooks/tool_result_offloading/stores.py
+++ b/haystack/hooks/tool_result_offloading/stores.py
@@ -25,6 +25,8 @@ class FileSystemToolResultStore(ToolResultStore):
     unchanged, while text content round trips as a string.
     """
 
+    supports_binary_content = True
+
     def __init__(self, root: str | Path) -> None:
         """
         Initialize the store with the root directory results are written under.

--- a/haystack/hooks/tool_result_offloading/types/protocol.py
+++ b/haystack/hooks/tool_result_offloading/types/protocol.py
@@ -15,12 +15,19 @@ class ToolResultStore(Protocol):
     Implementations decide where and how the content lives (local disk, an isolated sandbox filesystem, object
     storage, ...). `write` returns a reference string that the Agent puts in the conversation in place of the full
     result; `read` resolves that reference back to the original content. Only the store interprets a reference -
-    callers pass it back to `read` unchanged. Content is a string for text results and bytes for the image and file
-    blocks of a result, so implementations must handle both.
+    callers pass it back to `read` unchanged.
+
+    A store that can hold binary content sets `supports_binary_content` to True and accepts bytes in `write`. A store
+    that can only hold text leaves it False, and the hook then leaves image and file results in the conversation
+    rather than handing the store something it cannot store.
 
     Implement both `to_dict` and `from_dict` to make a custom store serializable; the default implementations below
     cover stores whose constructor takes no arguments.
     """
+
+    # Whether `write` accepts bytes. False by default, so a store that only deals in text needs no changes and
+    # simply never receives the image and file content of a tool result.
+    supports_binary_content: bool = False
 
     def write(self, *, key: str, content: str | bytes) -> str:
         """
@@ -28,8 +35,9 @@ class ToolResultStore(Protocol):
 
         :param key: A stable, per-result identifier the hook derives from the tool call (e.g. a file name). It carries
             an extension matching the content, so a store that maps keys to files can use it as-is.
-        :param content: The tool result to persist. Text results arrive as a string; image and file results arrive as
-            the decoded bytes of their base64 payload.
+        :param content: The tool result to persist. Text arrives as a string. Image and file content arrives as the
+            decoded bytes of its base64 payload, and only when the store sets `supports_binary_content` to True - a
+            text-only store may narrow this parameter to `str`.
         :returns: A reference string (e.g. a path or URI) that `read` can later resolve.
         """
         ...
@@ -40,7 +48,7 @@ class ToolResultStore(Protocol):
 
         :param reference: A reference string returned by `write`.
         :returns: The stored content: a string for content written as text, bytes for binary content such as an
-            offloaded image or file.
+            offloaded image or file. A store that does not support binary content only ever returns a string.
         """
         ...
 

--- a/haystack/hooks/tool_result_offloading/types/protocol.py
+++ b/haystack/hooks/tool_result_offloading/types/protocol.py
@@ -13,25 +13,35 @@ class ToolResultStore(Protocol):
     A place a `ToolResultOffloadHook` writes offloaded tool results to, and reads them back from.
 
     Implementations decide where and how the content lives (local disk, an isolated sandbox filesystem, object
-    storage, ...). `write` returns an opaque reference string that the Agent puts in the conversation in place of the
-    full result; `read` resolves that reference back to the original content.
+    storage, ...). `write` returns a reference string that the Agent puts in the conversation in place of the full
+    result; `read` resolves that reference back to the original content. Only the store interprets a reference -
+    callers pass it back to `read` unchanged. Content is a string for text results and bytes for the image and file
+    blocks of a result, so implementations must handle both.
 
     Implement both `to_dict` and `from_dict` to make a custom store serializable; the default implementations below
     cover stores whose constructor takes no arguments.
     """
 
-    def write(self, *, key: str, content: str) -> str:
+    def write(self, *, key: str, content: str | bytes) -> str:
         """
-        Persist `content` under `key` and return an opaque reference to it.
+        Persist `content` under `key` and return a reference to it.
 
-        :param key: A stable, per-result identifier the hook derives from the tool call (e.g. a file name).
-        :param content: The tool result to persist.
+        :param key: A stable, per-result identifier the hook derives from the tool call (e.g. a file name). It carries
+            an extension matching the content, so a store that maps keys to files can use it as-is.
+        :param content: The tool result to persist. Text results arrive as a string; image and file results arrive as
+            the decoded bytes of their base64 payload.
         :returns: A reference string (e.g. a path or URI) that `read` can later resolve.
         """
         ...
 
-    def read(self, reference: str) -> str:
-        """Return the content previously stored under `reference`."""
+    def read(self, reference: str) -> str | bytes:
+        """
+        Return the content previously stored under `reference`.
+
+        :param reference: A reference string returned by `write`.
+        :returns: The stored content: a string for content written as text, bytes for binary content such as an
+            offloaded image or file.
+        """
         ...
 
     def to_dict(self) -> dict[str, Any]:
@@ -60,7 +70,9 @@ class OffloadPolicy(Protocol):
         Return whether the given tool result should be offloaded.
 
         :param tool_name: The name of the tool that produced the result.
-        :param result: The tool result as a string (the content that would otherwise stay in the conversation).
+        :param result: The tool result as a string (the content that would otherwise stay in the conversation). For a
+            result carrying image or file blocks, this is the text and base64 payloads of all its blocks joined
+            together, so its length reflects the context the result actually occupies.
         :param state: The Agent's live `State`, for policies that decide based on run context.
         :returns: True to offload the result to the store, False to leave it in context.
         """

--- a/haystack/hooks/tool_result_offloading/types/protocol.py
+++ b/haystack/hooks/tool_result_offloading/types/protocol.py
@@ -17,16 +17,15 @@ class ToolResultStore(Protocol):
     result; `read` resolves that reference back to the original content. Only the store interprets a reference -
     callers pass it back to `read` unchanged.
 
-    A store that can hold binary content sets `supports_binary_content` to True and accepts bytes in `write`. A store
-    that can only hold text leaves it False, and the hook then leaves image and file results in the conversation
-    rather than handing the store something it cannot store.
+    A store that sets `supports_binary_content` takes bytes in `write` and gives them back from `read`. One that
+    leaves it False is only ever given text, and image and file results stay in the conversation instead.
 
     Implement both `to_dict` and `from_dict` to make a custom store serializable; the default implementations below
     cover stores whose constructor takes no arguments.
     """
 
-    # Whether `write` accepts bytes. False by default, so a store that only deals in text needs no changes and
-    # simply never receives the image and file content of a tool result.
+    # Whether the store handles binary content: `write` accepting bytes and `read` returning them. When False, the
+    # store is only ever given text, and the image and file content of a tool result stays in the conversation.
     supports_binary_content: bool = False
 
     def write(self, *, key: str, content: str | bytes) -> str:

--- a/releasenotes/notes/offload-non-text-tool-results-77d79166e4df3e99.yaml
+++ b/releasenotes/notes/offload-non-text-tool-results-77d79166e4df3e99.yaml
@@ -16,15 +16,20 @@ enhancements:
         2. image/png (48210 bytes) at '/abs/path/tool_results/2_fetch_call-123_1.png'
         3. application/pdf named 'q3.pdf' (1048576 bytes) at '/abs/path/tool_results/2_fetch_call-123_2.pdf'
 
+    Binary content is opt-in per store, via a new ``supports_binary_content`` attribute on the ``ToolResultStore``
+    protocol. ``FileSystemToolResultStore`` sets it; a store that can only hold text leaves it at its ``False``
+    default and never receives bytes, so a result carrying an image or a file stays in context and a warning is
+    logged, exactly as before this release. Existing custom stores therefore keep working unchanged.
+
     Offload policies receive the text and base64 payloads of all parts joined together, so a threshold such as
     ``OffloadOverChars`` measures the context the result actually occupies.
 upgrade:
   - |
-    The ``ToolResultStore`` protocol now carries binary content: ``write`` takes ``content: str | bytes`` and
-    ``read`` returns ``str | bytes``. This affects you only if you implemented the protocol yourself - widen both
-    signatures, persisting and returning bytes unchanged, or offloading an image or a file will fail in your store.
-    ``FileSystemToolResultStore`` already handles both.
+    The ``tool_result_offloaded`` meta key that the hook sets on an offloaded message now always holds a list of
+    store references rather than a single reference string, since a result can span several entries. Code reading
+    that key (for example to re-read an offloaded result) should index into the list.
 
-    The ``tool_result_offloaded`` meta key now holds a list of store references rather than a single one, since a
-    result can span several entries. Store keys gained the part's position (``2_search_call-123_0.txt``) and the
-    pointer text was reworded to name what it points at.
+    ``ToolResultStore.write`` is now typed ``content: str | bytes`` and ``read`` returns ``str | bytes``. Neither
+    changes what a text-only store receives or returns at runtime, but a store that subclasses the protocol and
+    annotates ``content: str`` may need a type-checker annotation update. To store binary content, set
+    ``supports_binary_content = True`` on the store and handle bytes in ``write``.

--- a/releasenotes/notes/offload-non-text-tool-results-77d79166e4df3e99.yaml
+++ b/releasenotes/notes/offload-non-text-tool-results-77d79166e4df3e99.yaml
@@ -1,0 +1,39 @@
+---
+enhancements:
+  - |
+    ``ToolResultOffloadHook`` now offloads tool results carrying ``ImageContent`` or ``FileContent``, not just text.
+    Previously such a result was left in context in full, even though the base64 payload of an image or a file is
+    often the single largest thing in an Agent's conversation.
+
+    Each part of a result now gets its own store entry - images and files decoded from base64 to raw bytes - so every
+    text, image, and file stays usable on its own. A result that is a single text still gets a one-line pointer; a
+    result with several parts gets one line per entry, so the model sees where every piece went:
+
+    .. code-block::
+
+        Tool result offloaded to 3 files:
+        1. text (412 characters) at '/abs/path/tool_results/2_fetch_call-123_0.txt'. Preview: Quarterly report...
+        2. image/png (48210 bytes) at '/abs/path/tool_results/2_fetch_call-123_1.png'
+        3. application/pdf named 'q3.pdf' (1048576 bytes) at '/abs/path/tool_results/2_fetch_call-123_2.pdf'
+
+    An image or file is stored under the extension of its ``filename`` when it has one and of its ``mime_type``
+    otherwise, falling back to ``.bin``. Offload policies now receive the text and base64 payloads of all parts
+    joined together, so a threshold such as ``OffloadOverChars`` measures the context the result actually occupies.
+upgrade:
+  - |
+    The ``ToolResultStore`` protocol now carries binary content: ``write`` takes ``content: str | bytes`` and
+    ``read`` returns ``str | bytes``. ``FileSystemToolResultStore`` handles both - it writes text UTF-8 encoded and
+    bytes verbatim, and ``read`` returns a string when the stored bytes decode as UTF-8 and raw bytes otherwise.
+
+    You are affected only if you implemented the ``ToolResultStore`` protocol yourself. Widen your ``write``
+    signature to accept ``bytes`` and persist them without encoding, and widen ``read`` to return them unchanged;
+    without this, offloading a tool result containing an image or a file will fail in your store.
+
+    The ``tool_result_offloaded`` meta key that the hook sets on an offloaded message now holds a list of store
+    references rather than a single reference string, since one result can be split across several entries. Code
+    reading that key (for example to re-read an offloaded result) should index into the list.
+
+    Store keys and the pointer text changed shape as a result. A key now ends in the position of the part within the
+    result (``2_search_call-123_0.txt`` rather than ``2_search_call-123.txt``), and the pointer names what it points
+    at (``Tool result offloaded to text (18234 characters) at '...'. Preview: ...``). Both are read by the model
+    rather than parsed, so this matters only if you built tooling on their exact wording.

--- a/releasenotes/notes/offload-non-text-tool-results-77d79166e4df3e99.yaml
+++ b/releasenotes/notes/offload-non-text-tool-results-77d79166e4df3e99.yaml
@@ -2,12 +2,10 @@
 enhancements:
   - |
     ``ToolResultOffloadHook`` now offloads tool results carrying ``ImageContent`` or ``FileContent``, not just text.
-    Previously such a result was left in context in full, and a base64 payload is a costly way to carry an image or
-    a file through a conversation.
 
     Each part of a result gets its own store entry, with images and files decoded from base64 to raw bytes, under the
-    extension of its ``filename`` when it has one and of its ``mime_type`` otherwise (falling back to ``.bin``). A
-    single-part result still gets a one-line pointer; a result with several parts gets one line per entry:
+    extension of its ``filename`` when it has one and of its ``mime_type`` otherwise (falling back to ``.bin``). For
+    example:
 
     .. code-block::
 
@@ -16,20 +14,16 @@ enhancements:
         2. image/png (48210 bytes) at '/abs/path/tool_results/2_fetch_call-123_1.png'
         3. application/pdf named 'q3.pdf' (1048576 bytes) at '/abs/path/tool_results/2_fetch_call-123_2.pdf'
 
-    Binary content is opt-in per store, via a new ``supports_binary_content`` attribute on the ``ToolResultStore``
-    protocol. ``FileSystemToolResultStore`` sets it; a store that can only hold text leaves it at its ``False``
-    default and never receives bytes, so a result carrying an image or a file stays in context and a warning is
-    logged, exactly as before this release. Existing custom stores therefore keep working unchanged.
+    Binary content is opt-in, via a new ``supports_binary_content`` attribute on the ``ToolResultStore`` protocol
+    that ``FileSystemToolResultStore`` sets. A store leaving it at its ``False`` default never receives bytes: images
+    and files stay in context with a warning, as before, so existing custom stores keep working unchanged.
 
-    Offload policies receive the text and base64 payloads of all parts joined together, so a threshold such as
-    ``OffloadOverChars`` measures the context the result actually occupies.
+    Offload policies receive the text and base64 payloads of all parts joined together.
 upgrade:
   - |
     The ``tool_result_offloaded`` meta key that the hook sets on an offloaded message now always holds a list of
     store references rather than a single reference string, since a result can span several entries. Code reading
     that key (for example to re-read an offloaded result) should index into the list.
 
-    ``ToolResultStore.write`` is now typed ``content: str | bytes`` and ``read`` returns ``str | bytes``. Neither
-    changes what a text-only store receives or returns at runtime, but a store that subclasses the protocol and
-    annotates ``content: str`` may need a type-checker annotation update. To store binary content, set
-    ``supports_binary_content = True`` on the store and handle bytes in ``write``.
+    ``ToolResultStore.write`` and ``read`` are typed ``str | bytes``. Nothing changes at runtime for a text-only
+    store, but one that subclasses the protocol and annotates ``content: str`` may need a type-checker fix.

--- a/releasenotes/notes/offload-non-text-tool-results-77d79166e4df3e99.yaml
+++ b/releasenotes/notes/offload-non-text-tool-results-77d79166e4df3e99.yaml
@@ -2,12 +2,12 @@
 enhancements:
   - |
     ``ToolResultOffloadHook`` now offloads tool results carrying ``ImageContent`` or ``FileContent``, not just text.
-    Previously such a result was left in context in full, even though the base64 payload of an image or a file is
-    often the single largest thing in an Agent's conversation.
+    Previously such a result was left in context in full, and a base64 payload is a costly way to carry an image or
+    a file through a conversation.
 
-    Each part of a result now gets its own store entry - images and files decoded from base64 to raw bytes - so every
-    text, image, and file stays usable on its own. A result that is a single text still gets a one-line pointer; a
-    result with several parts gets one line per entry, so the model sees where every piece went:
+    Each part of a result gets its own store entry, with images and files decoded from base64 to raw bytes, under the
+    extension of its ``filename`` when it has one and of its ``mime_type`` otherwise (falling back to ``.bin``). A
+    single-part result still gets a one-line pointer; a result with several parts gets one line per entry:
 
     .. code-block::
 
@@ -16,24 +16,15 @@ enhancements:
         2. image/png (48210 bytes) at '/abs/path/tool_results/2_fetch_call-123_1.png'
         3. application/pdf named 'q3.pdf' (1048576 bytes) at '/abs/path/tool_results/2_fetch_call-123_2.pdf'
 
-    An image or file is stored under the extension of its ``filename`` when it has one and of its ``mime_type``
-    otherwise, falling back to ``.bin``. Offload policies now receive the text and base64 payloads of all parts
-    joined together, so a threshold such as ``OffloadOverChars`` measures the context the result actually occupies.
+    Offload policies receive the text and base64 payloads of all parts joined together, so a threshold such as
+    ``OffloadOverChars`` measures the context the result actually occupies.
 upgrade:
   - |
     The ``ToolResultStore`` protocol now carries binary content: ``write`` takes ``content: str | bytes`` and
-    ``read`` returns ``str | bytes``. ``FileSystemToolResultStore`` handles both - it writes text UTF-8 encoded and
-    bytes verbatim, and ``read`` returns a string when the stored bytes decode as UTF-8 and raw bytes otherwise.
+    ``read`` returns ``str | bytes``. This affects you only if you implemented the protocol yourself - widen both
+    signatures, persisting and returning bytes unchanged, or offloading an image or a file will fail in your store.
+    ``FileSystemToolResultStore`` already handles both.
 
-    You are affected only if you implemented the ``ToolResultStore`` protocol yourself. Widen your ``write``
-    signature to accept ``bytes`` and persist them without encoding, and widen ``read`` to return them unchanged;
-    without this, offloading a tool result containing an image or a file will fail in your store.
-
-    The ``tool_result_offloaded`` meta key that the hook sets on an offloaded message now holds a list of store
-    references rather than a single reference string, since one result can be split across several entries. Code
-    reading that key (for example to re-read an offloaded result) should index into the list.
-
-    Store keys and the pointer text changed shape as a result. A key now ends in the position of the part within the
-    result (``2_search_call-123_0.txt`` rather than ``2_search_call-123.txt``), and the pointer names what it points
-    at (``Tool result offloaded to text (18234 characters) at '...'. Preview: ...``). Both are read by the model
-    rather than parsed, so this matters only if you built tooling on their exact wording.
+    The ``tool_result_offloaded`` meta key now holds a list of store references rather than a single one, since a
+    result can span several entries. Store keys gained the part's position (``2_search_call-123_0.txt``) and the
+    pointer text was reworded to name what it points at.

--- a/releasenotes/notes/offload-non-text-tool-results-77d79166e4df3e99.yaml
+++ b/releasenotes/notes/offload-non-text-tool-results-77d79166e4df3e99.yaml
@@ -14,11 +14,13 @@ enhancements:
         2. image/png (48210 bytes) at '/abs/path/tool_results/2_fetch_call-123_1.png'
         3. application/pdf named 'q3.pdf' (1048576 bytes) at '/abs/path/tool_results/2_fetch_call-123_2.pdf'
 
-    Binary content is opt-in, via a new ``supports_binary_content`` attribute on the ``ToolResultStore`` protocol
-    that ``FileSystemToolResultStore`` sets. A store leaving it at its ``False`` default never receives bytes: images
-    and files stay in context with a warning, as before, so existing custom stores keep working unchanged.
+    Binary content is opt-in, via a new ``supports_binary_content`` attribute on the ``ToolResultStore`` protocol,
+    which ``FileSystemToolResultStore`` sets to ``True``. A store leaving it at its ``False`` default never receives
+    bytes: images and files stay in context with a warning, as before, so existing custom stores keep working
+    unchanged.
 
-    Offload policies receive the text and base64 payloads of all parts joined together.
+    An offload policy receives the result as a single string: the text and base64 payloads of all its parts
+    concatenated.
 upgrade:
   - |
     The ``tool_result_offloaded`` meta key that the hook sets on an offloaded message now always holds a list of

--- a/test/hooks/tool_result_offloading/test_hooks.py
+++ b/test/hooks/tool_result_offloading/test_hooks.py
@@ -20,6 +20,7 @@ from haystack.hooks.tool_result_offloading import (
     NeverOffload,
     OffloadOverChars,
     ToolResultOffloadHook,
+    ToolResultStore,
 )
 from haystack.tools import tool
 
@@ -45,6 +46,20 @@ PNG_BYTES = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
 )
 PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n\xde\xad\xbe\xef\n%%EOF\n"
+
+
+class TextOnlyToolResultStore(ToolResultStore):
+    """A store predating binary support: it only knows how to hold text and never declares otherwise."""
+
+    def __init__(self) -> None:
+        self.data: dict[str, str] = {}
+
+    def write(self, *, key: str, content: str) -> str:
+        self.data[key] = content
+        return key
+
+    def read(self, reference: str) -> str:
+        return self.data[reference]
 
 
 def _image_block() -> ImageContent:
@@ -214,6 +229,29 @@ class TestToolResultOffloadHookBehavior:
 
         assert over_state.data["messages"][0].tool_call_result.result.startswith("Tool result offloaded")
         assert under_state.data["messages"][0].tool_call_result.result == [image]
+
+    def test_text_only_store_still_offloads_text(self, caplog):
+        store = TextOnlyToolResultStore()
+        hook = ToolResultOffloadHook(store=store, offload_strategies={"*": AlwaysOffload()})
+        state = _state_with_messages([_tool_message("a", "A" * 50)])
+
+        hook.run(state)
+
+        offloaded = state.data["messages"][0]
+        assert offloaded.tool_call_result.result.startswith("Tool result offloaded")
+        assert store.read(offloaded.meta["tool_result_offloaded"][0]) == "A" * 50
+        assert not caplog.records
+
+    def test_text_only_store_leaves_image_and_file_results_in_context(self, caplog):
+        hook = ToolResultOffloadHook(store=TextOnlyToolResultStore(), offload_strategies={"*": AlwaysOffload()})
+        content = [TextContent("caption"), _file_block()]
+        message = ChatMessage.from_tool(tool_result=content, origin=ToolCall(tool_name="a", arguments={}, id="1"))
+        state = _state_with_messages([message])
+
+        hook.run(state)
+
+        assert state.data["messages"][0].tool_call_result.result == content
+        assert "does not support binary content" in caplog.text
 
     def test_empty_result_is_not_offloaded(self, tmp_path):
         hook = ToolResultOffloadHook(

--- a/test/hooks/tool_result_offloading/test_hooks.py
+++ b/test/hooks/tool_result_offloading/test_hooks.py
@@ -128,20 +128,6 @@ class TestToolResultOffloadHookBehavior:
         hook.run(state)
         assert state.data["messages"][0].tool_call_result.result == "boom"
 
-    def test_each_text_content_gets_its_own_entry(self, tmp_path):
-        store = FileSystemToolResultStore(root=tmp_path)
-        hook = ToolResultOffloadHook(store=store, offload_strategies={"*": AlwaysOffload()})
-        message = ChatMessage.from_tool(
-            tool_result=[TextContent("A" * 30), TextContent("B" * 30)],
-            origin=ToolCall(tool_name="a", arguments={}, id="1"),
-        )
-        state = _state_with_messages([message])
-        hook.run(state)
-        offloaded = state.data["messages"][0]
-        references = offloaded.meta["tool_result_offloaded"]
-        assert offloaded.tool_call_result.result.startswith("Tool result offloaded to 2 files:")
-        assert [store.read(reference) for reference in references] == ["A" * 30, "B" * 30]
-
     def test_mixed_result_offloads_every_block_to_its_own_entry(self, tmp_path):
         store = FileSystemToolResultStore(root=tmp_path)
         hook = ToolResultOffloadHook(store=store, offload_strategies={"*": AlwaysOffload()}, preview_chars=4)
@@ -161,21 +147,6 @@ class TestToolResultOffloadHookBehavior:
         assert f"1. text (7 characters) at '{references[0]}'. Preview: capt..." in pointer
         assert f"2. image/png ({len(PNG_BYTES)} bytes) at '{references[1]}'" in pointer
         assert f"3. application/pdf named 'report.pdf' ({len(PDF_BYTES)} bytes) at '{references[2]}'" in pointer
-
-    def test_binary_only_result_is_offloaded(self, tmp_path):
-        store = FileSystemToolResultStore(root=tmp_path)
-        hook = ToolResultOffloadHook(store=store, offload_strategies={"*": AlwaysOffload()})
-        message = ChatMessage.from_tool(
-            tool_result=[_file_block()], origin=ToolCall(tool_name="a", arguments={}, id="1")
-        )
-        state = _state_with_messages([message])
-        hook.run(state)
-        offloaded = state.data["messages"][0]
-        reference = offloaded.meta["tool_result_offloaded"][0]
-        assert offloaded.tool_call_result.result == (
-            f"Tool result offloaded to application/pdf named 'report.pdf' ({len(PDF_BYTES)} bytes) at '{reference}'"
-        )
-        assert store.read(reference) == PDF_BYTES
 
     @pytest.mark.parametrize(
         "block, expected_extension",
@@ -217,25 +188,6 @@ class TestToolResultOffloadHookBehavior:
         keeping_hook.run(under_state)
         assert over_state.data["messages"][0].tool_call_result.result.startswith("Tool result offloaded")
         assert under_state.data["messages"][0].tool_call_result.result == [image]
-
-    def test_text_only_store_still_offloads_text(self, caplog):
-        store = TextOnlyToolResultStore()
-        hook = ToolResultOffloadHook(store=store, offload_strategies={"*": AlwaysOffload()})
-        state = _state_with_messages([_tool_message("a", "A" * 50)])
-        hook.run(state)
-        offloaded = state.data["messages"][0]
-        assert offloaded.tool_call_result.result.startswith("Tool result offloaded")
-        assert store.read(offloaded.meta["tool_result_offloaded"][0]) == "A" * 50
-        assert not caplog.records
-
-    def test_text_only_store_leaves_image_and_file_results_in_context(self, caplog):
-        hook = ToolResultOffloadHook(store=TextOnlyToolResultStore(), offload_strategies={"*": AlwaysOffload()})
-        content = [TextContent("caption"), _file_block()]
-        message = ChatMessage.from_tool(tool_result=content, origin=ToolCall(tool_name="a", arguments={}, id="1"))
-        state = _state_with_messages([message])
-        hook.run(state)
-        assert state.data["messages"][0].tool_call_result.result == content
-        assert "does not support binary content" in caplog.text
 
     def test_empty_result_is_not_offloaded(self, tmp_path):
         hook = ToolResultOffloadHook(
@@ -327,6 +279,27 @@ class TestToolResultOffloadHookBehavior:
         hook.run(state)
         assert (tmp_path / "request").exists()
         assert not (tmp_path / "default").exists()
+
+
+class TestToolResultOffloadHookWithTextOnlyStore:
+    def test_text_results_are_still_offloaded(self, caplog):
+        store = TextOnlyToolResultStore()
+        hook = ToolResultOffloadHook(store=store, offload_strategies={"*": AlwaysOffload()})
+        state = _state_with_messages([_tool_message("a", "A" * 50)])
+        hook.run(state)
+        offloaded = state.data["messages"][0]
+        assert offloaded.tool_call_result.result.startswith("Tool result offloaded")
+        assert store.read(offloaded.meta["tool_result_offloaded"][0]) == "A" * 50
+        assert not caplog.records
+
+    def test_image_and_file_results_stay_in_context(self, caplog):
+        hook = ToolResultOffloadHook(store=TextOnlyToolResultStore(), offload_strategies={"*": AlwaysOffload()})
+        content = [TextContent("caption"), _file_block()]
+        message = ChatMessage.from_tool(tool_result=content, origin=ToolCall(tool_name="a", arguments={}, id="1"))
+        state = _state_with_messages([message])
+        hook.run(state)
+        assert state.data["messages"][0].tool_call_result.result == content
+        assert "does not support binary content" in caplog.text
 
 
 class TestToolResultOffloadHookSerde:

--- a/test/hooks/tool_result_offloading/test_hooks.py
+++ b/test/hooks/tool_result_offloading/test_hooks.py
@@ -282,7 +282,7 @@ class TestToolResultOffloadHookBehavior:
 
 
 class TestToolResultOffloadHookWithTextOnlyStore:
-    def test_text_results_are_still_offloaded(self, caplog):
+    def test_text_results_are_offloaded(self, caplog):
         store = TextOnlyToolResultStore()
         hook = ToolResultOffloadHook(store=store, offload_strategies={"*": AlwaysOffload()})
         state = _state_with_messages([_tool_message("a", "A" * 50)])

--- a/test/hooks/tool_result_offloading/test_hooks.py
+++ b/test/hooks/tool_result_offloading/test_hooks.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 from pathlib import Path
 from typing import Annotated
 from unittest.mock import AsyncMock, MagicMock
@@ -11,7 +12,7 @@ import pytest
 from haystack.components.agents import Agent
 from haystack.components.agents.state.state import State
 from haystack.components.generators.chat import MockChatGenerator
-from haystack.dataclasses import ChatMessage, ImageContent, TextContent, ToolCall
+from haystack.dataclasses import ChatMessage, FileContent, ImageContent, TextContent, ToolCall
 from haystack.hooks.tool_result_offloading import (
     RESULT_STORE_CONTEXT_KEY,
     AlwaysOffload,
@@ -36,6 +37,23 @@ def _state_with_messages(messages: list[ChatMessage]) -> State:
 def _tool_message(tool_name: str, result: str, *, error: bool = False, call_id: str = "c1") -> ChatMessage:
     return ChatMessage.from_tool(
         tool_result=result, origin=ToolCall(tool_name=tool_name, arguments={}, id=call_id), error=error
+    )
+
+
+# A 1x1 PNG and a minimal PDF: real binary payloads that do not decode as UTF-8, so they exercise the binary path.
+PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n\xde\xad\xbe\xef\n%%EOF\n"
+
+
+def _image_block() -> ImageContent:
+    return ImageContent(base64_image=base64.b64encode(PNG_BYTES).decode("utf-8"), mime_type="image/png")
+
+
+def _file_block(filename: str | None = "report.pdf") -> FileContent:
+    return FileContent(
+        base64_data=base64.b64encode(PDF_BYTES).decode("utf-8"), mime_type="application/pdf", filename=filename
     )
 
 
@@ -95,7 +113,7 @@ class TestToolResultOffloadHookBehavior:
         hook.run(state)
         assert state.data["messages"][0].tool_call_result.result == "boom"
 
-    def test_offloads_sequence_of_text_content(self, tmp_path):
+    def test_each_text_content_gets_its_own_entry(self, tmp_path):
         store = FileSystemToolResultStore(root=tmp_path)
         hook = ToolResultOffloadHook(store=store, offload_strategies={"*": AlwaysOffload()})
         message = ChatMessage.from_tool(
@@ -103,21 +121,108 @@ class TestToolResultOffloadHookBehavior:
             origin=ToolCall(tool_name="a", arguments={}, id="1"),
         )
         state = _state_with_messages([message])
-        hook.run(state)
-        offloaded = state.data["messages"][0]
-        assert offloaded.tool_call_result.result.startswith("Tool result offloaded")
-        assert "60 characters" in offloaded.tool_call_result.result
-        assert store.read(offloaded.meta["tool_result_offloaded"]) == "A" * 30 + "B" * 30
 
-    def test_result_with_image_content_is_not_offloaded(self, tmp_path):
+        hook.run(state)
+
+        offloaded = state.data["messages"][0]
+        references = offloaded.meta["tool_result_offloaded"]
+        assert offloaded.tool_call_result.result.startswith("Tool result offloaded to 2 files:")
+        assert [store.read(reference) for reference in references] == ["A" * 30, "B" * 30]
+
+    def test_mixed_result_offloads_every_block_to_its_own_entry(self, tmp_path):
+        store = FileSystemToolResultStore(root=tmp_path)
+        hook = ToolResultOffloadHook(store=store, offload_strategies={"*": AlwaysOffload()}, preview_chars=4)
+        content = [TextContent("caption"), _image_block(), _file_block()]
+        message = ChatMessage.from_tool(tool_result=content, origin=ToolCall(tool_name="a", arguments={}, id="1"))
+        state = _state_with_messages([message])
+
+        hook.run(state)
+
+        offloaded = state.data["messages"][0]
+        references = offloaded.meta["tool_result_offloaded"]
+        assert len(references) == 3
+        assert [Path(reference).name for reference in references] == ["1_a_1_0.txt", "1_a_1_1.png", "1_a_1_2.pdf"]
+        assert store.read(references[0]) == "caption"
+        assert store.read(references[1]) == PNG_BYTES
+        assert store.read(references[2]) == PDF_BYTES
+
+        pointer = offloaded.tool_call_result.result
+        assert pointer.startswith("Tool result offloaded to 3 files:")
+        assert f"1. text (7 characters) at '{references[0]}'. Preview: capt..." in pointer
+        assert f"2. image/png ({len(PNG_BYTES)} bytes) at '{references[1]}'" in pointer
+        assert f"3. application/pdf named 'report.pdf' ({len(PDF_BYTES)} bytes) at '{references[2]}'" in pointer
+
+    def test_binary_only_result_is_offloaded(self, tmp_path):
+        store = FileSystemToolResultStore(root=tmp_path)
+        hook = ToolResultOffloadHook(store=store, offload_strategies={"*": AlwaysOffload()})
+        message = ChatMessage.from_tool(
+            tool_result=[_file_block()], origin=ToolCall(tool_name="a", arguments={}, id="1")
+        )
+        state = _state_with_messages([message])
+
+        hook.run(state)
+
+        offloaded = state.data["messages"][0]
+        reference = offloaded.meta["tool_result_offloaded"][0]
+        assert offloaded.tool_call_result.result == (
+            f"Tool result offloaded to application/pdf named 'report.pdf' ({len(PDF_BYTES)} bytes) at '{reference}'"
+        )
+        assert store.read(reference) == PDF_BYTES
+
+    @pytest.mark.parametrize(
+        "block, expected_extension",
+        [
+            pytest.param(FileContent(base64_data="aGk=", mime_type="text/csv", filename=None), ".csv", id="mime_type"),
+            pytest.param(
+                FileContent(base64_data="aGk=", mime_type="application/pdf", filename="notes.md"), ".md", id="filename"
+            ),
+            pytest.param(FileContent(base64_data="aGk=", mime_type=None, filename=None), ".bin", id="fallback"),
+        ],
+    )
+    def test_binary_block_extension(self, tmp_path, block, expected_extension):
         hook = ToolResultOffloadHook(
             store=FileSystemToolResultStore(root=tmp_path), offload_strategies={"*": AlwaysOffload()}
         )
-        content = [TextContent("caption"), ImageContent(base64_image="aGVsbG8=", mime_type="image/png")]
-        message = ChatMessage.from_tool(tool_result=content, origin=ToolCall(tool_name="a", arguments={}, id="1"))
+        message = ChatMessage.from_tool(tool_result=[block], origin=ToolCall(tool_name="a", arguments={}, id="1"))
+        state = _state_with_messages([message])
+
+        hook.run(state)
+
+        reference = state.data["messages"][0].meta["tool_result_offloaded"][0]
+        assert Path(reference).suffix == expected_extension
+
+    def test_policy_sizes_result_by_its_base64_payload(self, tmp_path):
+        # The base64 payload is what occupies the context window, so a threshold below it must trigger an offload
+        # while one above it must not.
+        image = _image_block()
+        payload_length = len(image.base64_image)
+        message = ChatMessage.from_tool(tool_result=[image], origin=ToolCall(tool_name="a", arguments={}, id="1"))
+
+        offloading_hook = ToolResultOffloadHook(
+            store=FileSystemToolResultStore(root=tmp_path / "over"),
+            offload_strategies={"*": OffloadOverChars(payload_length - 1)},
+        )
+        keeping_hook = ToolResultOffloadHook(
+            store=FileSystemToolResultStore(root=tmp_path / "under"),
+            offload_strategies={"*": OffloadOverChars(payload_length)},
+        )
+
+        over_state = _state_with_messages([message])
+        offloading_hook.run(over_state)
+        under_state = _state_with_messages([message])
+        keeping_hook.run(under_state)
+
+        assert over_state.data["messages"][0].tool_call_result.result.startswith("Tool result offloaded")
+        assert under_state.data["messages"][0].tool_call_result.result == [image]
+
+    def test_empty_result_is_not_offloaded(self, tmp_path):
+        hook = ToolResultOffloadHook(
+            store=FileSystemToolResultStore(root=tmp_path), offload_strategies={"*": AlwaysOffload()}
+        )
+        message = ChatMessage.from_tool(tool_result=[], origin=ToolCall(tool_name="a", arguments={}, id="1"))
         state = _state_with_messages([message])
         hook.run(state)
-        assert state.data["messages"][0].tool_call_result.result == content
+        assert state.data["messages"][0].tool_call_result.result == []
         assert not list(Path(tmp_path).iterdir())
 
     def test_id_less_parallel_calls_do_not_collide(self, tmp_path):
@@ -127,7 +232,7 @@ class TestToolResultOffloadHookBehavior:
         second = ChatMessage.from_tool(tool_result="SECOND" * 20, origin=ToolCall(tool_name="a", arguments={}, id=None))
         state = _state_with_messages([first, second])
         hook.run(state)
-        refs = [m.meta["tool_result_offloaded"] for m in state.data["messages"]]
+        refs = [m.meta["tool_result_offloaded"][0] for m in state.data["messages"]]
         assert refs[0] != refs[1]
         assert store.read(refs[0]) == "FIRST" * 20
         assert store.read(refs[1]) == "SECOND" * 20
@@ -167,11 +272,9 @@ class TestToolResultOffloadHookBehavior:
         state = _state_with_messages([_tool_message("a", "ABCDEFGH")])
         hook.run(state)
         message = state.data["messages"][0]
-        reference = message.meta["tool_result_offloaded"]
+        reference = message.meta["tool_result_offloaded"][0]
         pointer = message.tool_call_result.result
-        assert reference in pointer
-        assert "8 characters" in pointer
-        assert "ABCDE..." in pointer
+        assert pointer == f"Tool result offloaded to text (8 characters) at '{reference}'. Preview: ABCDE..."
 
     def test_concurrent_runs_are_isolated_by_per_run_store(self, tmp_path):
         # One shared hook instance, two runs each supplying its own store via hook_context. Even with identical store
@@ -187,8 +290,8 @@ class TestToolResultOffloadHookBehavior:
         state_b.data["hook_context"] = {RESULT_STORE_CONTEXT_KEY: store_b}
         hook.run(state_a)
         hook.run(state_b)
-        ref_a = state_a.data["messages"][0].meta["tool_result_offloaded"]
-        ref_b = state_b.data["messages"][0].meta["tool_result_offloaded"]
+        ref_a = state_a.data["messages"][0].meta["tool_result_offloaded"][0]
+        ref_b = state_b.data["messages"][0].meta["tool_result_offloaded"][0]
         assert store_a.read(ref_a) == "AAA" * 20
         assert store_b.read(ref_b) == "BBB" * 20
         assert not (tmp_path / "shared").exists()

--- a/test/hooks/tool_result_offloading/test_hooks.py
+++ b/test/hooks/tool_result_offloading/test_hooks.py
@@ -41,7 +41,7 @@ def _tool_message(tool_name: str, result: str, *, error: bool = False, call_id: 
     )
 
 
-# A 1x1 PNG and a minimal PDF: real binary payloads that do not decode as UTF-8, so they exercise the binary path.
+# A 1x1 PNG and a minimal PDF.
 PNG_BYTES = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
 )
@@ -49,7 +49,7 @@ PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n\xde\xad\xbe\xef\
 
 
 class TextOnlyToolResultStore(ToolResultStore):
-    """A store predating binary support: it only knows how to hold text and never declares otherwise."""
+    """A store that only holds text, leaving `supports_binary_content` at its False default."""
 
     def __init__(self) -> None:
         self.data: dict[str, str] = {}
@@ -136,9 +136,7 @@ class TestToolResultOffloadHookBehavior:
             origin=ToolCall(tool_name="a", arguments={}, id="1"),
         )
         state = _state_with_messages([message])
-
         hook.run(state)
-
         offloaded = state.data["messages"][0]
         references = offloaded.meta["tool_result_offloaded"]
         assert offloaded.tool_call_result.result.startswith("Tool result offloaded to 2 files:")
@@ -150,9 +148,7 @@ class TestToolResultOffloadHookBehavior:
         content = [TextContent("caption"), _image_block(), _file_block()]
         message = ChatMessage.from_tool(tool_result=content, origin=ToolCall(tool_name="a", arguments={}, id="1"))
         state = _state_with_messages([message])
-
         hook.run(state)
-
         offloaded = state.data["messages"][0]
         references = offloaded.meta["tool_result_offloaded"]
         assert len(references) == 3
@@ -160,7 +156,6 @@ class TestToolResultOffloadHookBehavior:
         assert store.read(references[0]) == "caption"
         assert store.read(references[1]) == PNG_BYTES
         assert store.read(references[2]) == PDF_BYTES
-
         pointer = offloaded.tool_call_result.result
         assert pointer.startswith("Tool result offloaded to 3 files:")
         assert f"1. text (7 characters) at '{references[0]}'. Preview: capt..." in pointer
@@ -174,9 +169,7 @@ class TestToolResultOffloadHookBehavior:
             tool_result=[_file_block()], origin=ToolCall(tool_name="a", arguments={}, id="1")
         )
         state = _state_with_messages([message])
-
         hook.run(state)
-
         offloaded = state.data["messages"][0]
         reference = offloaded.meta["tool_result_offloaded"][0]
         assert offloaded.tool_call_result.result == (
@@ -200,9 +193,7 @@ class TestToolResultOffloadHookBehavior:
         )
         message = ChatMessage.from_tool(tool_result=[block], origin=ToolCall(tool_name="a", arguments={}, id="1"))
         state = _state_with_messages([message])
-
         hook.run(state)
-
         reference = state.data["messages"][0].meta["tool_result_offloaded"][0]
         assert Path(reference).suffix == expected_extension
 
@@ -212,7 +203,6 @@ class TestToolResultOffloadHookBehavior:
         image = _image_block()
         payload_length = len(image.base64_image)
         message = ChatMessage.from_tool(tool_result=[image], origin=ToolCall(tool_name="a", arguments={}, id="1"))
-
         offloading_hook = ToolResultOffloadHook(
             store=FileSystemToolResultStore(root=tmp_path / "over"),
             offload_strategies={"*": OffloadOverChars(payload_length - 1)},
@@ -221,12 +211,10 @@ class TestToolResultOffloadHookBehavior:
             store=FileSystemToolResultStore(root=tmp_path / "under"),
             offload_strategies={"*": OffloadOverChars(payload_length)},
         )
-
         over_state = _state_with_messages([message])
         offloading_hook.run(over_state)
         under_state = _state_with_messages([message])
         keeping_hook.run(under_state)
-
         assert over_state.data["messages"][0].tool_call_result.result.startswith("Tool result offloaded")
         assert under_state.data["messages"][0].tool_call_result.result == [image]
 
@@ -234,9 +222,7 @@ class TestToolResultOffloadHookBehavior:
         store = TextOnlyToolResultStore()
         hook = ToolResultOffloadHook(store=store, offload_strategies={"*": AlwaysOffload()})
         state = _state_with_messages([_tool_message("a", "A" * 50)])
-
         hook.run(state)
-
         offloaded = state.data["messages"][0]
         assert offloaded.tool_call_result.result.startswith("Tool result offloaded")
         assert store.read(offloaded.meta["tool_result_offloaded"][0]) == "A" * 50
@@ -247,9 +233,7 @@ class TestToolResultOffloadHookBehavior:
         content = [TextContent("caption"), _file_block()]
         message = ChatMessage.from_tool(tool_result=content, origin=ToolCall(tool_name="a", arguments={}, id="1"))
         state = _state_with_messages([message])
-
         hook.run(state)
-
         assert state.data["messages"][0].tool_call_result.result == content
         assert "does not support binary content" in caplog.text
 

--- a/test/hooks/tool_result_offloading/test_stores.py
+++ b/test/hooks/tool_result_offloading/test_stores.py
@@ -38,10 +38,17 @@ class TestFileSystemToolResultStore:
         with pytest.raises(ValueError, match="outside the store root"):
             store.write(key=str(tmp_path / "outside.txt"), content="x")
 
-    def test_read_round_trips_written_content(self, tmp_path):
+    @pytest.mark.parametrize(
+        "key, content",
+        [
+            pytest.param("a.txt", "round trip", id="text"),
+            pytest.param("a.png", b"\x89PNG\r\n\x1a\n\xde\xad\xbe\xef", id="bytes"),
+        ],
+    )
+    def test_read_round_trips_written_content(self, tmp_path, key, content):
         store = FileSystemToolResultStore(root=tmp_path)
-        reference = store.write(key="a.txt", content="round trip")
-        assert store.read(reference) == "round trip"
+        reference = store.write(key=key, content=content)
+        assert store.read(reference) == content
 
     def test_read_rejects_parent_traversal_reference(self, tmp_path):
         store = FileSystemToolResultStore(root=tmp_path / "root")


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/557

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

``ToolResultOffloadHook`` now offloads tool results carrying ``ImageContent`` or ``FileContent``, not just text.

Each part of a result gets its own store entry, with images and files decoded from base64 to raw bytes, under the extension of its ``filename`` when it has one and of its ``mime_type`` otherwise (falling back to ``.bin``). For example:

```
Tool result offloaded to 3 files:
1. text (412 characters) at '/abs/path/tool_results/2_fetch_call-123_0.txt'. Preview: Quarterly report...
2. image/png (48210 bytes) at '/abs/path/tool_results/2_fetch_call-123_1.png'
3. application/pdf named 'q3.pdf' (1048576 bytes) at '/abs/path/tool_results/2_fetch_call-123_2.pdf'
```

Binary content is opt-in, via a new ``supports_binary_content`` attribute on the ``ToolResultStore`` protocol, which ``FileSystemToolResultStore`` sets to ``True``. A store leaving it at its ``False`` default never receives bytes: images and files stay in context with a warning, as before, so existing custom stores keep working unchanged.

An offload policy receives the result as a single string: the text and base64 payloads of all its parts concatenated.

**Upgrade**
The ``tool_result_offloaded`` meta key that the hook sets on an offloaded message now always holds a list of store references rather than a single reference string, since a result can span several entries. Code reading that key (for example to re-read an offloaded result) should index into the list.

``ToolResultStore.write`` and ``read`` are typed ``str | bytes``. Nothing changes at runtime for a text-only store, but one that subclasses the protocol and annotates ``content: str`` may need a type-checker fix.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
