### PR TITLE
Add the missing ImageContent docs page to the sidebar

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -79,6 +79,7 @@ export default {
           items: [
             'concepts/data-classes/chatmessage',
             'concepts/data-classes/filecontent',
+            'concepts/data-classes/imagecontent',
           ],
         },
         {

--- a/docs-website/versioned_sidebars/version-2.30-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.30-sidebars.json
@@ -74,7 +74,8 @@
           },
           "items": [
             "concepts/data-classes/chatmessage",
-            "concepts/data-classes/filecontent"
+            "concepts/data-classes/filecontent",
+            "concepts/data-classes/imagecontent"
           ]
         },
         {

--- a/docs-website/versioned_sidebars/version-2.31-sidebars.json
+++ b/docs-website/versioned_sidebars/version-2.31-sidebars.json
@@ -75,7 +75,8 @@
           },
           "items": [
             "concepts/data-classes/chatmessage",
-            "concepts/data-classes/filecontent"
+            "concepts/data-classes/filecontent",
+            "concepts/data-classes/imagecontent"
           ]
         },
         {

--- a/docs-website/versioned_sidebars/version-3.0-sidebars.json
+++ b/docs-website/versioned_sidebars/version-3.0-sidebars.json
@@ -74,7 +74,8 @@
           },
           "items": [
             "concepts/data-classes/chatmessage",
-            "concepts/data-classes/filecontent"
+            "concepts/data-classes/filecontent",
+            "concepts/data-classes/imagecontent"
           ]
         },
         {

--- a/docs-website/versioned_sidebars/version-3.1-sidebars.json
+++ b/docs-website/versioned_sidebars/version-3.1-sidebars.json
@@ -74,7 +74,8 @@
           },
           "items": [
             "concepts/data-classes/chatmessage",
-            "concepts/data-classes/filecontent"
+            "concepts/data-classes/filecontent",
+            "concepts/data-classes/imagecontent"
           ]
         },
         {


### PR DESCRIPTION
### Proposed Changes:

Dataclass [ImageContent](https://docs.haystack.deepset.ai/docs/imagecontent) docs page was here, but it was not listed in the sidebar
Added the page to the sidebar of unstable and some stable docs sites retrospectively

### How did you test it?

Ran the docs site locally

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
