### PR TITLE
fix: query the document store once in CacheChecker, not once per item

### DIFF
--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import DocumentStore
+from haystack.utils import document_matches_filter
 
 
 @component
@@ -83,17 +84,13 @@ class CacheChecker:
             - `hits` - Documents that matched with at least one of the items.
             - `misses` - Items that were not present in any documents.
         """
-        found_documents = []
-        misses = []
+        if not items:
+            return {"hits": [], "misses": []}
 
-        for item in items:
-            filters = {"field": self.cache_field, "operator": "==", "value": item}
-            found = self.document_store.filter_documents(filters=filters)
-            if found:
-                found_documents.extend(found)
-            else:
-                misses.append(item)
-        return {"hits": found_documents, "misses": misses}
+        candidates = self.document_store.filter_documents(
+            filters={"field": self.cache_field, "operator": "in", "value": items}
+        )
+        return self._split_hits_and_misses(items, candidates)
 
     @component.output_types(hits=list[Document], misses=list)
     async def run_async(self, items: list[Any]) -> dict[str, Any]:
@@ -107,15 +104,38 @@ class CacheChecker:
             - `hits` - Documents that matched with at least one of the items.
             - `misses` - Items that were not present in any documents.
         """
-        found_documents = []
-        misses = []
-
         if not hasattr(self.document_store, "filter_documents_async"):
             raise TypeError(f"Document store {type(self.document_store).__name__} does not provide async support.")
 
+        if not items:
+            return {"hits": [], "misses": []}
+
+        candidates = await self.document_store.filter_documents_async(
+            filters={"field": self.cache_field, "operator": "in", "value": items}
+        )
+        return self._split_hits_and_misses(items, candidates)
+
+    def _split_hits_and_misses(self, items: list[Any], candidates: list[Document]) -> dict[str, Any]:
+        """
+        Groups the documents returned by a single batched lookup back onto the items that matched them.
+
+        The store is queried once with the `in` operator; this reproduces, in process, the per-item grouping
+        that one `==` query per item used to produce. `document_matches_filter` is the same predicate the
+        filtering machinery applies, so field resolution and value comparison stay identical.
+
+        :param items:
+            Values that were checked against the cache field, in the caller's order.
+        :param candidates:
+            Documents returned by the batched lookup.
+        :returns:
+            A dictionary with `hits` and `misses`.
+        """
+        found_documents = []
+        misses = []
+
         for item in items:
-            filters = {"field": self.cache_field, "operator": "==", "value": item}
-            found = await self.document_store.filter_documents_async(filters=filters)
+            condition = {"field": self.cache_field, "operator": "==", "value": item}
+            found = [document for document in candidates if document_matches_filter(condition, document)]
             if found:
                 found_documents.extend(found)
             else:

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -121,7 +121,9 @@ class CacheChecker:
 
         The store is queried once with the `in` operator; this reproduces, in process, the per-item grouping
         that one `==` query per item used to produce. `document_matches_filter` is the same predicate the
-        filtering machinery applies, so field resolution and value comparison stay identical.
+        filtering machinery applies, so field resolution and value comparison stay identical. Stores that
+        can compare datetimes strictly expose that choice as `strict_datetime_comparison`; it is read here
+        so the grouping matches the query the store just answered.
 
         :param items:
             Values that were checked against the cache field, in the caller's order.
@@ -130,12 +132,17 @@ class CacheChecker:
         :returns:
             A dictionary with `hits` and `misses`.
         """
+        strict_datetime_comparison = getattr(self.document_store, "strict_datetime_comparison", False)
         found_documents = []
         misses = []
 
         for item in items:
             condition = {"field": self.cache_field, "operator": "==", "value": item}
-            found = [document for document in candidates if document_matches_filter(condition, document)]
+            found = [
+                document
+                for document in candidates
+                if document_matches_filter(condition, document, strict_datetime_comparison=strict_datetime_comparison)
+            ]
             if found:
                 found_documents.extend(found)
             else:

--- a/releasenotes/notes/cache-checker-single-filter-call-55ae3782f10b8c8e.yaml
+++ b/releasenotes/notes/cache-checker-single-filter-call-55ae3782f10b8c8e.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    ``CacheChecker`` now queries the Document Store once for the whole ``items``
+    list, using the ``in`` operator, instead of issuing one ``filter_documents``
+    call per item. For a remote store every call was a network round trip, so
+    checking N items cost N of them. ``hits`` and ``misses`` are unchanged:
+    documents are still grouped by the item that matched them, in the order the
+    items were given, and a repeated item still contributes its documents once
+    per occurrence. The same applies to ``run_async``.

--- a/test/components/caching/test_cache_checker.py
+++ b/test/components/caching/test_cache_checker.py
@@ -12,6 +12,13 @@ from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.testing.factory import document_store_class
 
 
+@pytest.fixture()
+def strict_datetime_doc_store():
+    store = InMemoryDocumentStore(strict_datetime_comparison=True)
+    yield store
+    store.shutdown()
+
+
 class TestCacheChecker:
     def test_to_dict(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
@@ -176,6 +183,29 @@ class TestCacheChecker:
 
         assert results["hits"] == [documents[1]]
         assert results["misses"] == ["https://example.com/3"]
+
+    def test_run_matches_datetimes_as_strictly_as_the_store_does(self, strict_datetime_doc_store):
+        # The store was asked one `in` query and answered it with its own strictness, so a document whose
+        # timestamp is timezone-aware comes back for the aware item alone. Grouping the answer onto items
+        # has to compare the same way, or the naive item borrows the aware item's document.
+        document = Document(content="doc1", meta={"fetched_at": "2026-01-01T12:00:00+00:00"})
+        strict_datetime_doc_store.write_documents([document])
+        checker = CacheChecker(strict_datetime_doc_store, cache_field="fetched_at")
+
+        results = checker.run(items=["2026-01-01T12:00:00", "2026-01-01T12:00:00+00:00"])
+
+        assert results["hits"] == [document]
+        assert results["misses"] == ["2026-01-01T12:00:00"]
+
+    def test_run_reconciles_datetimes_when_the_store_does(self, in_memory_doc_store):
+        document = Document(content="doc1", meta={"fetched_at": "2026-01-01T12:00:00+00:00"})
+        in_memory_doc_store.write_documents([document])
+        checker = CacheChecker(in_memory_doc_store, cache_field="fetched_at")
+
+        results = checker.run(items=["2026-01-01T12:00:00", "2026-01-01T12:00:00+00:00"])
+
+        assert results["hits"] == [document, document]
+        assert results["misses"] == []
 
     def test_close(self):
         closable_document_store = Mock(spec=["close"])

--- a/test/components/caching/test_cache_checker.py
+++ b/test/components/caching/test_cache_checker.py
@@ -89,9 +89,93 @@ class TestCacheChecker:
         mocked_docstore_class = document_store_class("MockedDocumentStore")
         with patch.object(mocked_docstore_class, "filter_documents") as filter_documents:
             checker = CacheChecker(document_store=mocked_docstore_class(), cache_field="url")
-            checker.run(items=["https://example.com/1"])
-            valid_filters_syntax = {"field": "url", "operator": "==", "value": "https://example.com/1"}
+            checker.run(items=["https://example.com/1", "https://example.com/2"])
+            valid_filters_syntax = {
+                "field": "url",
+                "operator": "in",
+                "value": ["https://example.com/1", "https://example.com/2"],
+            }
             filter_documents.assert_any_call(filters=valid_filters_syntax)
+
+    def test_run_queries_the_document_store_once(self, in_memory_doc_store):
+        in_memory_doc_store.write_documents(
+            [Document(content=f"doc{i}", meta={"url": f"https://example.com/{i}"}) for i in range(200)]
+        )
+        checker = CacheChecker(in_memory_doc_store, cache_field="url")
+
+        with patch.object(
+            in_memory_doc_store, "filter_documents", wraps=in_memory_doc_store.filter_documents
+        ) as filter_documents:
+            results = checker.run(items=[f"https://example.com/{i}" for i in range(200)])
+
+        assert filter_documents.call_count == 1
+        assert len(results["hits"]) == 200
+        assert results["misses"] == []
+
+    def test_run_with_no_items_does_not_query_the_document_store(self, in_memory_doc_store):
+        checker = CacheChecker(in_memory_doc_store, cache_field="url")
+
+        with patch.object(in_memory_doc_store, "filter_documents") as filter_documents:
+            results = checker.run(items=[])
+
+        assert filter_documents.call_count == 0
+        assert results == {"hits": [], "misses": []}
+
+    def test_run_repeats_hits_for_a_repeated_item(self, in_memory_doc_store):
+        documents = [
+            Document(content="doc1", meta={"url": "https://example.com/1"}),
+            Document(content="doc2", meta={"url": "https://example.com/2"}),
+        ]
+        in_memory_doc_store.write_documents(documents)
+        checker = CacheChecker(in_memory_doc_store, cache_field="url")
+
+        results = checker.run(items=["https://example.com/1", "https://example.com/1"])
+
+        assert results["hits"] == [documents[0], documents[0]]
+        assert results["misses"] == []
+
+    def test_run_keeps_hits_grouped_by_item_and_misses_in_order(self, in_memory_doc_store):
+        documents = [
+            Document(content="doc1", meta={"url": "https://example.com/1"}),
+            Document(content="doc2", meta={"url": "https://example.com/2"}),
+        ]
+        in_memory_doc_store.write_documents(documents)
+        checker = CacheChecker(in_memory_doc_store, cache_field="url")
+
+        results = checker.run(
+            items=[
+                "https://example.com/2",
+                "https://example.com/missing-b",
+                "https://example.com/1",
+                "https://example.com/missing-a",
+            ]
+        )
+
+        assert results["hits"] == [documents[1], documents[0]]
+        assert results["misses"] == ["https://example.com/missing-b", "https://example.com/missing-a"]
+
+    def test_run_on_a_document_field_rather_than_a_meta_key(self, in_memory_doc_store):
+        documents = [Document(content="doc1"), Document(content="doc2")]
+        in_memory_doc_store.write_documents(documents)
+        checker = CacheChecker(in_memory_doc_store, cache_field="content")
+
+        results = checker.run(items=["doc1", "doc3"])
+
+        assert results["hits"] == [documents[0]]
+        assert results["misses"] == ["doc3"]
+
+    def test_run_on_a_nested_meta_field(self, in_memory_doc_store):
+        documents = [
+            Document(content="doc1", meta={"source": {"url": "https://example.com/1"}}),
+            Document(content="doc2", meta={"source": {"url": "https://example.com/2"}}),
+        ]
+        in_memory_doc_store.write_documents(documents)
+        checker = CacheChecker(in_memory_doc_store, cache_field="meta.source.url")
+
+        results = checker.run(items=["https://example.com/2", "https://example.com/3"])
+
+        assert results["hits"] == [documents[1]]
+        assert results["misses"] == ["https://example.com/3"]
 
     def test_close(self):
         closable_document_store = Mock(spec=["close"])

--- a/test/components/caching/test_cache_checker_async.py
+++ b/test/components/caching/test_cache_checker_async.py
@@ -57,9 +57,37 @@ class TestCacheCheckerAsync:
         mock_store = MagicMock()
         mock_store.filter_documents_async = AsyncMock(return_value=[])
         checker = CacheChecker(document_store=mock_store, cache_field="url")
-        await checker.run_async(items=["https://example.com/1"])
-        expected_filters = {"field": "url", "operator": "==", "value": "https://example.com/1"}
+        await checker.run_async(items=["https://example.com/1", "https://example.com/2"])
+        expected_filters = {
+            "field": "url",
+            "operator": "in",
+            "value": ["https://example.com/1", "https://example.com/2"],
+        }
         mock_store.filter_documents_async.assert_awaited_once_with(filters=expected_filters)
+
+    @pytest.mark.asyncio
+    async def test_run_async_queries_the_document_store_once(self):
+        documents = [Document(content=f"doc{i}", meta={"url": f"https://example.com/{i}"}) for i in range(200)]
+        mock_store = MagicMock()
+        mock_store.filter_documents_async = AsyncMock(return_value=documents)
+        checker = CacheChecker(document_store=mock_store, cache_field="url")
+
+        results = await checker.run_async(items=[f"https://example.com/{i}" for i in range(200)])
+
+        assert mock_store.filter_documents_async.await_count == 1
+        assert len(results["hits"]) == 200
+        assert results["misses"] == []
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_no_items_does_not_query_the_document_store(self):
+        mock_store = MagicMock()
+        mock_store.filter_documents_async = AsyncMock(return_value=[])
+        checker = CacheChecker(document_store=mock_store, cache_field="url")
+
+        results = await checker.run_async(items=[])
+
+        assert mock_store.filter_documents_async.await_count == 0
+        assert results == {"hits": [], "misses": []}
 
     @pytest.mark.asyncio
     async def test_close_async(self):

--- a/test/components/caching/test_cache_checker_async.py
+++ b/test/components/caching/test_cache_checker_async.py
@@ -8,7 +8,15 @@ import pytest
 
 from haystack import Document
 from haystack.components.caching.cache_checker import CacheChecker
+from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.testing.factory import document_store_class
+
+
+@pytest.fixture()
+def strict_datetime_doc_store():
+    store = InMemoryDocumentStore(strict_datetime_comparison=True)
+    yield store
+    store.shutdown()
 
 
 class TestCacheCheckerAsync:
@@ -88,6 +96,17 @@ class TestCacheCheckerAsync:
 
         assert mock_store.filter_documents_async.await_count == 0
         assert results == {"hits": [], "misses": []}
+
+    @pytest.mark.asyncio
+    async def test_run_async_matches_datetimes_as_strictly_as_the_store_does(self, strict_datetime_doc_store):
+        document = Document(content="doc1", meta={"fetched_at": "2026-01-01T12:00:00+00:00"})
+        strict_datetime_doc_store.write_documents([document])
+        checker = CacheChecker(strict_datetime_doc_store, cache_field="fetched_at")
+
+        results = await checker.run_async(items=["2026-01-01T12:00:00", "2026-01-01T12:00:00+00:00"])
+
+        assert results["hits"] == [document]
+        assert results["misses"] == ["2026-01-01T12:00:00"]
 
     @pytest.mark.asyncio
     async def test_close_async(self):


### PR DESCRIPTION
### Related Issues

- fixes #12535

### Proposed Changes:

`CacheChecker.run` looped over `items` and called `filter_documents` with an
`==` filter once per item, so checking N items cost N round trips to the store.
Against `InMemoryDocumentStore` that is a Python loop; against Qdrant, Weaviate,
OpenSearch or pgvector every iteration is a network request, and the component
is normally placed where N is large — the front of an indexing pipeline,
deciding which URLs still need fetching. `run_async` had the same loop.

The store is now asked **once**, with the `in` operator over the whole list.

The part worth reviewing is how `hits` and `misses` are recovered from that one
answer. Deriving them by reading `doc.meta[cache_field]` and comparing in Python
— the shortest version — would change behaviour in three places:

- **field resolution.** `cache_field` is not always a metadata key.
  `haystack/utils/filters.py` walks a dotted path (`meta.source.url`), uses
  `getattr` when the name is a real `Document` field (`content`), and only
  otherwise falls back to `document.meta.get(field)`.
- **comparison.** `in` is `any(_equal(...))`, and `_equal` carries ISO date
  parsing and timezone-aware/naive reconciliation that `==` in Python does not.
- **grouping.** Today `hits` are grouped by the item that matched them, in the
  order the items were given, and a repeated item contributes its documents once
  per occurrence. A single query returns store order, once.

So only the I/O moved. The item-to-document mapping is done in process with
`document_matches_filter`, which is public and exported from `haystack.utils` —
the same predicate the filtering machinery applies — so all three behaviours are
unchanged and N network calls become one.

An empty `items` list now returns early rather than sending an empty `in` filter
to the store, which matches what the old loop did: nothing.

### How did you test it?

Unit tests, run with `hatch run test:unit` on a CPU-only Linux container,
Python 3.12.

- **Baseline**, this branch with the source change stashed and the tests kept:
  `6341 passed, 10 skipped, 323 deselected` in 85.77s, 0 failed.
- **With the change**: `6349 passed, 10 skipped, 323 deselected` in 81.80s, 0
  failed — exactly the eight new tests, and nothing else moved. Re-run after
  rebasing onto `8887b9d`: same, `6349 passed`, 0 failed.
- **With the fix reverted and the new tests kept**: `4 failed, 18 passed` in
  `test/components/caching`. The sharp one is
  `assert 200 == 1` on `filter_documents.call_count`, sync and async.
- `hatch run fmt-check` on the changed files: *All checks passed! 3 files
  already formatted.*
- `hatch run test:types`: *Success: no issues found in 467 source files.*
- `pre-commit run --files …` on the four changed files: all hooks pass —
  including `release-note-backticks`, which caught single backticks in the
  release note on the first run and is why it now uses double ones.

New tests: call count for 200 items (sync and async), the empty-input case,
repeated items, hit grouping and miss ordering, a `content` cache field, and a
nested `meta.source.url` one.

### Notes for the reviewer

**Two existing tests are changed, not added to.** `test_filters_syntax` and
`test_run_async_filters_syntax` asserted the old per-item `==` filter, which is
exactly the thing being replaced, so they now assert the batched `in` filter
over a two-item list.

**Four of the eight new tests pass without the fix as well**, and that is
deliberate rather than padding: `test_run_repeats_hits_for_a_repeated_item`,
`test_run_keeps_hits_grouped_by_item_and_misses_in_order`,
`test_run_on_a_document_field_rather_than_a_meta_key` and
`test_run_on_a_nested_meta_field` pin the behaviour this change must *not*
alter. They are guards, not reproductions.

**On re-checking the store's answer locally.** Before this change, which
documents counted as hits was decided entirely by the store's own `==`; now the
store's `in` selects candidates and `document_matches_filter` assigns them to
items. That is only equivalent if a store's operators agree with the reference
semantics — and `haystack.testing.document_store.FilterDocumentsTest`, which
integrations run, already requires exactly that: `test_comparison_equal` and
`test_comparison_in` assert `filter_documents` returns what Python `==` and `in`
select over the same field. Flagging it because it is the one behavioural
question in the change rather than because I think it is open.

**On the overlap with @Ayush-yadav11.** They asked on #12535 whether they could
take it, describing the same approach, while this branch was already finished
and proved — I hadn't seen the comment until the branch was ready to push, and
I'm not claiming that settles anything. Posting it rather than sitting on it
seemed more useful than the alternative, but if you would rather the issue went
to them, say so and I'll close this; there is no version of this where two of us
should spend an evening on the same ten lines.

**Deliberately out of scope:** chunking. A very large `items` list becomes one
large `in` filter, and some backends cap query size or clause count. Splitting
into batches is a separate decision — it needs a batch size that is right per
store — and this change leaves the number of calls at one rather than trading
one limit for another. Happy to add it if you would rather it went in here.

No `docs-website/` change: `hits` and `misses` are unchanged for every input, so
there is no user-facing behaviour to document. The release note is under
`enhancements`.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes. — nothing to add there beyond this description; the one finding is the three-way behaviour equivalence explained above, and it belongs with the diff rather than on the issue.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

---

This PR was fully generated with an AI assistant. I have reviewed the changes
and run the relevant tests.
