### PR TITLE
fix: fix type checks

### DIFF
--- a/test/components/preprocessors/test_document_splitter.py
+++ b/test/components/preprocessors/test_document_splitter.py
@@ -250,12 +250,14 @@ class TestSplittingByFunctionOrCharacterRegex:
 
     def test_split_by_function_tracks_page_numbers(self):
         splitter = DocumentSplitter(split_by="function", splitting_function=lambda s: s.split("\f"))
-        text = "First chunk.\fSecond chunk.\fThird chunk."
+        chunks = ["First chunk.", "Second chunk.", "Third chunk."]
+        text = "\f".join(chunks)
         docs = splitter.run(documents=[Document(content=text)])["documents"]
 
+        assert [doc.content for doc in docs] == chunks
         assert [doc.meta["page_number"] for doc in docs] == [1, 2, 3]
         assert [doc.meta["split_id"] for doc in docs] == [0, 1, 2]
-        assert [doc.meta["split_idx_start"] for doc in docs] == [text.index(doc.content) for doc in docs]
+        assert [doc.meta["split_idx_start"] for doc in docs] == [text.index(chunk) for chunk in chunks]
 
     def test_split_by_function_with_transformed_splits(self):
         # The splits don't appear verbatim in the source, so they cannot be located in it


### PR DESCRIPTION
### Related Issues

- fixes failing type checks https://github.com/deepset-ai/haystack/actions/runs/33477686885/job/99761268447

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Recently added type checking to the preprocessor folder and this was missed.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Ran type checks

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
