### PR TITLE
fix: fix empty assistant message crash in Agent

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -183,19 +183,14 @@ def _get_model_exit_reason(messages: list[ChatMessage]) -> str | None:
     return None
 
 
-def _add_empty_text_to_contentless_replies(messages: list[ChatMessage]) -> list[ChatMessage]:
+def _drop_contentless_replies(messages: list[ChatMessage]) -> list[ChatMessage]:
     """
-    Ensure every assistant reply has at least an empty string as its text content.
+    Remove replies that have no content parts.
 
-    A Chat Generator that discards a malformed tool call returns a reply with no content parts, which Chat Message
-    converters reject. An empty `TextContent` keeps the history sendable for the next LLM call.
+    A Chat Generator that discards a malformed tool call returns such a reply, which Chat Message converters reject.
+    Leaving it out of the history keeps the next LLM call sendable.
     """
-    return [
-        message
-        if message._content or not message.is_from(ChatRole.ASSISTANT)
-        else ChatMessage.from_assistant(text="", meta=message.meta, name=message.name)
-        for message in messages
-    ]
+    return [message for message in messages if message._content]
 
 
 def _pending_tool_call_messages_from_state(state: State) -> list[ChatMessage]:
@@ -1034,8 +1029,10 @@ class Agent:
                 llm_span.set_content_tag("haystack.agent.step.llm.input", chat_generator_inputs)
                 result = self.chat_generator.run(**chat_generator_inputs)
                 llm_span.set_content_tag("haystack.agent.step.llm.output", result)
-            llm_messages = _add_empty_text_to_contentless_replies(messages=result["replies"])
-            exe_context.state.set("messages", llm_messages)
+            llm_messages = result["replies"]
+            # A contentless reply is kept out of the history because converters reject it. Usage and the exit reason
+            # still come from the raw replies: the call was billed and may have been truncated.
+            exe_context.state.set("messages", _drop_contentless_replies(messages=llm_messages))
             _record_llm_usage(state=exe_context.state, llm_messages=llm_messages)
             _record_context_tokens(state=exe_context.state, llm_messages=llm_messages)
 
@@ -1104,8 +1101,10 @@ class Agent:
                 # which copies the current contextvars context — preserving the active tracing span.
                 result = await _execute_component_async(self.chat_generator, **chat_generator_inputs)
                 llm_span.set_content_tag("haystack.agent.step.llm.output", result)
-            llm_messages = _add_empty_text_to_contentless_replies(messages=result["replies"])
-            exe_context.state.set("messages", llm_messages)
+            llm_messages = result["replies"]
+            # A contentless reply is kept out of the history because converters reject it. Usage and the exit reason
+            # still come from the raw replies: the call was billed and may have been truncated.
+            exe_context.state.set("messages", _drop_contentless_replies(messages=llm_messages))
             _record_llm_usage(state=exe_context.state, llm_messages=llm_messages)
             _record_context_tokens(state=exe_context.state, llm_messages=llm_messages)
 

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -183,16 +183,6 @@ def _get_model_exit_reason(messages: list[ChatMessage]) -> str | None:
     return None
 
 
-def _drop_contentless_replies(messages: list[ChatMessage]) -> list[ChatMessage]:
-    """
-    Remove replies that have no content parts.
-
-    A Chat Generator that discards a malformed tool call returns such a reply, which Chat Message converters reject.
-    Leaving it out of the history keeps the next LLM call sendable.
-    """
-    return [message for message in messages if message._content]
-
-
 def _pending_tool_call_messages_from_state(state: State) -> list[ChatMessage]:
     """
     Return the pending tool-call message after `before_tool` hooks have run.
@@ -1029,20 +1019,25 @@ class Agent:
                 llm_span.set_content_tag("haystack.agent.step.llm.input", chat_generator_inputs)
                 result = self.chat_generator.run(**chat_generator_inputs)
                 llm_span.set_content_tag("haystack.agent.step.llm.output", result)
+            # The replies land in State only after the checks below, which read them from here rather than from
+            # State, so that a reply the run does not end on can be left out of the history.
             llm_messages = result["replies"]
-            # A contentless reply is kept out of the history because converters reject it. Usage and the exit reason
-            # still come from the raw replies: the call was billed and may have been truncated.
-            exe_context.state.set("messages", _drop_contentless_replies(messages=llm_messages))
             _record_llm_usage(state=exe_context.state, llm_messages=llm_messages)
             _record_context_tokens(state=exe_context.state, llm_messages=llm_messages)
 
             # Stop when there are no tools, or the model produced a terminal reply without tool calls.
             model_exit_reason = _get_model_exit_reason(messages=llm_messages)
             if not current_tools or model_exit_reason is not None:
+                # The run ends on this reply, so keep it whole: `exit_reason` stays visible next to the reply.
+                exe_context.state.set("messages", llm_messages)
                 exe_context.counter += 1
                 exe_context.state.set("step_count", exe_context.counter)
                 exe_context.state.set("exit_reason", model_exit_reason or _EXIT_REASON_TEXT)
                 return self._continue_after_exit_hooks(exe_context=exe_context)
+
+            # A Chat Generator that discarded a malformed tool call returns a reply with no content parts, which Chat
+            # Message converters reject. Leave it out so the next LLM call can serialize the history.
+            exe_context.state.set("messages", [message for message in llm_messages if message._content])
 
             _run_hooks(hooks=self.hooks, hook_point=BEFORE_TOOL, state=exe_context.state)
             # Re-read the pending tool calls from State so that any rewrites a before_tool hook made (e.g.
@@ -1101,20 +1096,25 @@ class Agent:
                 # which copies the current contextvars context — preserving the active tracing span.
                 result = await _execute_component_async(self.chat_generator, **chat_generator_inputs)
                 llm_span.set_content_tag("haystack.agent.step.llm.output", result)
+            # The replies land in State only after the checks below, which read them from here rather than from
+            # State, so that a reply the run does not end on can be left out of the history.
             llm_messages = result["replies"]
-            # A contentless reply is kept out of the history because converters reject it. Usage and the exit reason
-            # still come from the raw replies: the call was billed and may have been truncated.
-            exe_context.state.set("messages", _drop_contentless_replies(messages=llm_messages))
             _record_llm_usage(state=exe_context.state, llm_messages=llm_messages)
             _record_context_tokens(state=exe_context.state, llm_messages=llm_messages)
 
             # Stop when there are no tools, or the model produced a terminal reply without tool calls.
             model_exit_reason = _get_model_exit_reason(messages=llm_messages)
             if not current_tools or model_exit_reason is not None:
+                # The run ends on this reply, so keep it whole: `exit_reason` stays visible next to the reply.
+                exe_context.state.set("messages", llm_messages)
                 exe_context.counter += 1
                 exe_context.state.set("step_count", exe_context.counter)
                 exe_context.state.set("exit_reason", model_exit_reason or _EXIT_REASON_TEXT)
                 return await self._continue_after_exit_hooks_async(exe_context=exe_context)
+
+            # A Chat Generator that discarded a malformed tool call returns a reply with no content parts, which Chat
+            # Message converters reject. Leave it out so the next LLM call can serialize the history.
+            exe_context.state.set("messages", [message for message in llm_messages if message._content])
 
             await _run_hooks_async(hooks=self.hooks, hook_point=BEFORE_TOOL, state=exe_context.state)
             # Re-read the pending tool calls from State so that any rewrites a before_tool hook made (e.g.

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -183,6 +183,24 @@ def _get_model_exit_reason(messages: list[ChatMessage]) -> str | None:
     return None
 
 
+def _with_sendable_content(messages: list[ChatMessage]) -> list[ChatMessage]:
+    """
+    Replace assistant replies that carry no content part at all with an empty-text equivalent.
+
+    A Chat Generator that discards a malformed tool call builds its reply with `text=None` and no tool calls, which
+    leaves the message without any content part. `_get_model_exit_reason` deliberately keeps looping on such a reply so
+    the model can recover, but every Chat Message converter rejects a contentless message, so the next LLM call would
+    raise while serializing the history. An empty `TextContent` keeps the history sendable, both for the retry and for
+    any follow-up turn the caller builds from the returned messages.
+    """
+    return [
+        message
+        if message._content or not message.is_from(ChatRole.ASSISTANT)
+        else ChatMessage.from_assistant(text="", meta=message.meta, name=message.name)
+        for message in messages
+    ]
+
+
 def _pending_tool_call_messages_from_state(state: State) -> list[ChatMessage]:
     """
     Return the pending tool-call message after `before_tool` hooks have run.
@@ -1019,7 +1037,7 @@ class Agent:
                 llm_span.set_content_tag("haystack.agent.step.llm.input", chat_generator_inputs)
                 result = self.chat_generator.run(**chat_generator_inputs)
                 llm_span.set_content_tag("haystack.agent.step.llm.output", result)
-            llm_messages = result["replies"]
+            llm_messages = _with_sendable_content(result["replies"])
             exe_context.state.set("messages", llm_messages)
             _record_llm_usage(state=exe_context.state, llm_messages=llm_messages)
             _record_context_tokens(state=exe_context.state, llm_messages=llm_messages)
@@ -1089,7 +1107,7 @@ class Agent:
                 # which copies the current contextvars context — preserving the active tracing span.
                 result = await _execute_component_async(self.chat_generator, **chat_generator_inputs)
                 llm_span.set_content_tag("haystack.agent.step.llm.output", result)
-            llm_messages = result["replies"]
+            llm_messages = _with_sendable_content(result["replies"])
             exe_context.state.set("messages", llm_messages)
             _record_llm_usage(state=exe_context.state, llm_messages=llm_messages)
             _record_context_tokens(state=exe_context.state, llm_messages=llm_messages)

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -183,12 +183,12 @@ def _get_model_exit_reason(messages: list[ChatMessage]) -> str | None:
     return None
 
 
-def _with_sendable_content(messages: list[ChatMessage]) -> list[ChatMessage]:
+def _add_empty_text_to_contentless_replies(messages: list[ChatMessage]) -> list[ChatMessage]:
     """
-    Replace assistant replies that have no content parts with an empty-text equivalent.
+    Ensure every assistant reply has at least an empty string as its text content.
 
-    A Chat Generator that discards a malformed tool call returns such a reply, and every Chat Message converter
-    rejects it. An empty `TextContent` keeps the history sendable for the next LLM call.
+    A Chat Generator that discards a malformed tool call returns a reply with no content parts, which Chat Message
+    converters reject. An empty `TextContent` keeps the history sendable for the next LLM call.
     """
     return [
         message
@@ -1034,7 +1034,7 @@ class Agent:
                 llm_span.set_content_tag("haystack.agent.step.llm.input", chat_generator_inputs)
                 result = self.chat_generator.run(**chat_generator_inputs)
                 llm_span.set_content_tag("haystack.agent.step.llm.output", result)
-            llm_messages = _with_sendable_content(result["replies"])
+            llm_messages = _add_empty_text_to_contentless_replies(messages=result["replies"])
             exe_context.state.set("messages", llm_messages)
             _record_llm_usage(state=exe_context.state, llm_messages=llm_messages)
             _record_context_tokens(state=exe_context.state, llm_messages=llm_messages)
@@ -1104,7 +1104,7 @@ class Agent:
                 # which copies the current contextvars context — preserving the active tracing span.
                 result = await _execute_component_async(self.chat_generator, **chat_generator_inputs)
                 llm_span.set_content_tag("haystack.agent.step.llm.output", result)
-            llm_messages = _with_sendable_content(result["replies"])
+            llm_messages = _add_empty_text_to_contentless_replies(messages=result["replies"])
             exe_context.state.set("messages", llm_messages)
             _record_llm_usage(state=exe_context.state, llm_messages=llm_messages)
             _record_context_tokens(state=exe_context.state, llm_messages=llm_messages)

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -185,13 +185,10 @@ def _get_model_exit_reason(messages: list[ChatMessage]) -> str | None:
 
 def _with_sendable_content(messages: list[ChatMessage]) -> list[ChatMessage]:
     """
-    Replace assistant replies that carry no content part at all with an empty-text equivalent.
+    Replace assistant replies that have no content parts with an empty-text equivalent.
 
-    A Chat Generator that discards a malformed tool call builds its reply with `text=None` and no tool calls, which
-    leaves the message without any content part. `_get_model_exit_reason` deliberately keeps looping on such a reply so
-    the model can recover, but every Chat Message converter rejects a contentless message, so the next LLM call would
-    raise while serializing the history. An empty `TextContent` keeps the history sendable, both for the retry and for
-    any follow-up turn the caller builds from the returned messages.
+    A Chat Generator that discards a malformed tool call returns such a reply, and every Chat Message converter
+    rejects it. An empty `TextContent` keeps the history sendable for the next LLM call.
     """
     return [
         message

--- a/releasenotes/notes/agent-contentless-assistant-reply-3f2a1c9b47d5e086.yaml
+++ b/releasenotes/notes/agent-contentless-assistant-reply-3f2a1c9b47d5e086.yaml
@@ -2,5 +2,7 @@
 fixes:
   - |
     Fixed a crash in ``Agent`` on the LLM call following a reply from which a Chat Generator discarded a malformed
-    tool call. Such a reply has no content parts, which Chat Message converters reject. The ``Agent`` now stores it
-    with an empty ``TextContent``, so the history stays sendable and the model can recover on the next call.
+    tool call. Such a reply has no content parts, which Chat Message converters reject. The ``Agent`` now leaves it
+    out of the message history, so the next call and any follow-up turn built from the returned messages stay
+    sendable. Its token usage is still recorded, and a ``length`` or ``content_filter`` finish reason on it still
+    ends the run.

--- a/releasenotes/notes/agent-contentless-assistant-reply-3f2a1c9b47d5e086.yaml
+++ b/releasenotes/notes/agent-contentless-assistant-reply-3f2a1c9b47d5e086.yaml
@@ -1,11 +1,6 @@
 ---
 fixes:
   - |
-    Fixed a crash in ``Agent`` on the LLM call that follows a reply from which a Chat Generator discarded a malformed
-    tool call. Such a reply is built with ``text=None`` and no tool calls, so it holds no content part at all, and every
-    Chat Message converter rejects it. The ``Agent`` deliberately keeps looping on an empty reply so the model can
-    recover, but it stored the reply unchanged, so the next call raised ``A ``ChatMessage`` must contain at least one
-    ``TextContent``, ``ToolCall``, ``ToolCallResult``, ``ImageContent``, ``FileContent``, or ``ReasoningContent``.`` before any
-    request reached the provider. The ``Agent`` now stores a contentless assistant reply with an empty ``TextContent``,
-    which keeps the history sendable for the retry and for any follow-up turn built from the returned messages. The
-    exit behavior is unchanged: an empty reply still does not satisfy the ``"text"`` exit condition.
+    Fixed a crash in ``Agent`` on the LLM call following a reply from which a Chat Generator discarded a malformed
+    tool call. Such a reply has no content parts, which every Chat Message converter rejects. The ``Agent`` now stores
+    it with an empty ``TextContent``, so the history stays sendable and the model can recover on the next call.

--- a/releasenotes/notes/agent-contentless-assistant-reply-3f2a1c9b47d5e086.yaml
+++ b/releasenotes/notes/agent-contentless-assistant-reply-3f2a1c9b47d5e086.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Fixed a crash in ``Agent`` on the LLM call following a reply from which a Chat Generator discarded a malformed
-    tool call. Such a reply has no content parts, which Chat Message converters reject. The ``Agent`` now leaves it
-    out of the message history, so the next call and any follow-up turn built from the returned messages stay
-    sendable. Its token usage is still recorded, and a ``length`` or ``content_filter`` finish reason on it still
-    ends the run.
+    tool call. Such a reply has no content parts, which Chat Message converters reject. When the run continues, the
+    ``Agent`` now removes it from the message history, so the next call and any follow-up turn built from the
+    returned messages stay sendable. Its token usage is still recorded, and a reply that ends the run (for example
+    with a ``length`` finish reason) is kept, so it stays visible next to ``exit_reason``.

--- a/releasenotes/notes/agent-contentless-assistant-reply-3f2a1c9b47d5e086.yaml
+++ b/releasenotes/notes/agent-contentless-assistant-reply-3f2a1c9b47d5e086.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fixed a crash in ``Agent`` on the LLM call following a reply from which a Chat Generator discarded a malformed
-    tool call. Such a reply has no content parts, which every Chat Message converter rejects. The ``Agent`` now stores
-    it with an empty ``TextContent``, so the history stays sendable and the model can recover on the next call.
+    tool call. Such a reply has no content parts, which Chat Message converters reject. The ``Agent`` now stores it
+    with an empty ``TextContent``, so the history stays sendable and the model can recover on the next call.

--- a/releasenotes/notes/agent-contentless-assistant-reply-3f2a1c9b47d5e086.yaml
+++ b/releasenotes/notes/agent-contentless-assistant-reply-3f2a1c9b47d5e086.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed a crash in ``Agent`` on the LLM call that follows a reply from which a Chat Generator discarded a malformed
+    tool call. Such a reply is built with ``text=None`` and no tool calls, so it holds no content part at all, and every
+    Chat Message converter rejects it. The ``Agent`` deliberately keeps looping on an empty reply so the model can
+    recover, but it stored the reply unchanged, so the next call raised ``A ``ChatMessage`` must contain at least one
+    ``TextContent``, ``ToolCall``, ``ToolCallResult``, ``ImageContent``, ``FileContent``, or ``ReasoningContent``.`` before any
+    request reached the provider. The ``Agent`` now stores a contentless assistant reply with an empty ``TextContent``,
+    which keeps the history sendable for the retry and for any follow-up turn built from the returned messages. The
+    exit behavior is unchanged: an empty reply still does not satisfy the ``"text"`` exit condition.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -1132,11 +1132,11 @@ class TestAgentExitConditions:
         # A discarded malformed tool call leaves a reply with no content parts. The agent must keep looping and keep
         # the history sendable, so the next LLM call can recover.
         generator = SerializingChatGenerator(
-            [ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
+            replies=[ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
         )
         agent = Agent(chat_generator=generator, tools=[weather_tool], exit_conditions=["text"])
 
-        result = agent.run([ChatMessage.from_user("What's the weather?")])
+        result = agent.run(messages=[ChatMessage.from_user("What's the weather?")])
 
         assert result["step_count"] == 2
         assert result["last_message"].text == "The weather is sunny."
@@ -1196,11 +1196,11 @@ class TestAgentExitConditions:
     @pytest.mark.asyncio
     async def test_contentless_assistant_message_keeps_history_sendable_async(self, weather_tool):
         generator = SerializingChatGenerator(
-            [ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
+            replies=[ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
         )
         agent = Agent(chat_generator=generator, tools=[weather_tool], exit_conditions=["text"])
 
-        result = await agent.run_async([ChatMessage.from_user("What's the weather?")])
+        result = await agent.run_async(messages=[ChatMessage.from_user("What's the weather?")])
 
         assert result["step_count"] == 2
         assert result["last_message"].text == "The weather is sunny."

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -191,6 +191,26 @@ class ToolAssertingChatGenerator:
         return {"replies": [message]}
 
 
+@component
+class SerializingChatGenerator:
+    """Serializes the incoming history the way a real generator does, then returns the next scripted reply."""
+
+    def __init__(self, replies: list[ChatMessage]):
+        self.replies = list(replies)
+
+    @component.output_types(replies=list[ChatMessage])
+    def run(self, messages: list[ChatMessage], tools: list[Tool] | Toolset | None = None, **kwargs) -> dict[str, Any]:
+        for message in messages:
+            message.to_openai_dict_format()
+        return {"replies": [self.replies.pop(0)]}
+
+    @component.output_types(replies=list[ChatMessage])
+    async def run_async(
+        self, messages: list[ChatMessage], tools: list[Tool] | Toolset | None = None, **kwargs
+    ) -> dict[str, Any]:
+        return self.run(messages=messages, tools=tools, **kwargs)
+
+
 def _parallel_tool_calling_generator() -> MockChatGenerator:
     """Requests two `weather_tool` calls on the first turn, then returns a plain reply so the agent loop exits."""
     return MockChatGenerator(
@@ -1108,9 +1128,26 @@ class TestAgentExitConditions:
         assert result["step_count"] == 2
         assert result["last_message"].text == "The weather is sunny."
 
+    def test_contentless_assistant_message_keeps_history_sendable(self, weather_tool):
+        # A generator that discards a malformed tool call builds its reply with `text=None` and no tool calls, so the
+        # message carries no content part at all. The agent must keep looping *and* keep the history sendable, so the
+        # next LLM call can recover instead of raising while serializing.
+        generator = SerializingChatGenerator(
+            [ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
+        )
+        agent = Agent(chat_generator=generator, tools=[weather_tool], exit_conditions=["text"])
+
+        result = agent.run([ChatMessage.from_user("What's the weather?")])
+
+        assert result["step_count"] == 2
+        assert result["last_message"].text == "The weather is sunny."
+        # The returned history must not poison a follow-up turn built from it either.
+        for message in result["messages"]:
+            message.to_openai_dict_format()
+
     @pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
-    @pytest.mark.parametrize("text", ["", "Partial answer."])
-    def test_incomplete_model_reply_exits_with_specific_reason(self, weather_tool, finish_reason, text):
+    @pytest.mark.parametrize(("text", "expected_text"), [("", ""), ("Partial answer.", "Partial answer."), (None, "")])
+    def test_incomplete_model_reply_exits_with_specific_reason(self, weather_tool, finish_reason, text, expected_text):
         replies = [
             ChatMessage.from_assistant(text=text, meta={"finish_reason": finish_reason}),
             "Recovered answer that must not be generated.",
@@ -1121,7 +1158,7 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 1
         assert result["exit_reason"] == finish_reason
-        assert result["last_message"].text == text
+        assert result["last_message"].text == expected_text
 
     @pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
     def test_incomplete_model_reply_without_tools_preserves_reason(self, finish_reason):
@@ -1158,9 +1195,25 @@ class TestAgentExitConditions:
         assert result["last_message"].text == "The weather is sunny."
 
     @pytest.mark.asyncio
+    async def test_contentless_assistant_message_keeps_history_sendable_async(self, weather_tool):
+        generator = SerializingChatGenerator(
+            [ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
+        )
+        agent = Agent(chat_generator=generator, tools=[weather_tool], exit_conditions=["text"])
+
+        result = await agent.run_async([ChatMessage.from_user("What's the weather?")])
+
+        assert result["step_count"] == 2
+        assert result["last_message"].text == "The weather is sunny."
+        for message in result["messages"]:
+            message.to_openai_dict_format()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
-    @pytest.mark.parametrize("text", ["", "Partial answer."])
-    async def test_incomplete_model_reply_exits_with_specific_reason_async(self, weather_tool, finish_reason, text):
+    @pytest.mark.parametrize(("text", "expected_text"), [("", ""), ("Partial answer.", "Partial answer."), (None, "")])
+    async def test_incomplete_model_reply_exits_with_specific_reason_async(
+        self, weather_tool, finish_reason, text, expected_text
+    ):
         replies = [
             ChatMessage.from_assistant(text=text, meta={"finish_reason": finish_reason}),
             "Recovered answer that must not be generated.",
@@ -1171,7 +1224,7 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 1
         assert result["exit_reason"] == finish_reason
-        assert result["last_message"].text == text
+        assert result["last_message"].text == expected_text
 
     @pytest.mark.asyncio
     async def test_exits_on_empty_assistant_message_truncated_by_output_limit_async(self, monkeypatch, weather_tool):

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -1128,9 +1128,9 @@ class TestAgentExitConditions:
         assert result["step_count"] == 2
         assert result["last_message"].text == "The weather is sunny."
 
-    def test_contentless_assistant_message_keeps_history_sendable(self, weather_tool):
-        # A discarded malformed tool call leaves a reply with no content parts. The agent must keep looping and keep
-        # the history sendable, so the next LLM call can recover.
+    def test_contentless_assistant_message_is_dropped_from_history(self, weather_tool):
+        # A discarded malformed tool call leaves a reply with no content parts. The agent keeps looping and leaves
+        # that reply out of the history, so the next LLM call and any follow-up turn stay sendable.
         generator = SerializingChatGenerator(
             replies=[ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
         )
@@ -1140,13 +1140,27 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 2
         assert result["last_message"].text == "The weather is sunny."
-        # The returned history must stay usable for a follow-up turn.
+        assert [message.text for message in result["messages"]] == ["What's the weather?", "The weather is sunny."]
         for message in result["messages"]:
             message.to_openai_dict_format()
 
+    def test_contentless_assistant_message_still_exits_on_finish_reason(self, weather_tool):
+        # The reply is dropped, but it still decides the exit: a truncated tool call must not silently retry.
+        replies = [
+            ChatMessage.from_assistant(text=None, meta={"finish_reason": "length"}),
+            ChatMessage.from_assistant("Recovered answer that must not be generated."),
+        ]
+        agent = Agent(chat_generator=MockChatGenerator(replies), tools=[weather_tool])
+
+        result = agent.run(messages=[ChatMessage.from_user("What's the weather?")])
+
+        assert result["step_count"] == 1
+        assert result["exit_reason"] == "length"
+        assert [message.text for message in result["messages"]] == ["What's the weather?"]
+
     @pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
-    @pytest.mark.parametrize(("text", "expected_text"), [("", ""), ("Partial answer.", "Partial answer."), (None, "")])
-    def test_incomplete_model_reply_exits_with_specific_reason(self, weather_tool, finish_reason, text, expected_text):
+    @pytest.mark.parametrize("text", ["", "Partial answer."])
+    def test_incomplete_model_reply_exits_with_specific_reason(self, weather_tool, finish_reason, text):
         replies = [
             ChatMessage.from_assistant(text=text, meta={"finish_reason": finish_reason}),
             "Recovered answer that must not be generated.",
@@ -1157,7 +1171,7 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 1
         assert result["exit_reason"] == finish_reason
-        assert result["last_message"].text == expected_text
+        assert result["last_message"].text == text
 
     @pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
     def test_incomplete_model_reply_without_tools_preserves_reason(self, finish_reason):
@@ -1194,7 +1208,7 @@ class TestAgentExitConditions:
         assert result["last_message"].text == "The weather is sunny."
 
     @pytest.mark.asyncio
-    async def test_contentless_assistant_message_keeps_history_sendable_async(self, weather_tool):
+    async def test_contentless_assistant_message_is_dropped_from_history_async(self, weather_tool):
         generator = SerializingChatGenerator(
             replies=[ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
         )
@@ -1204,15 +1218,28 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 2
         assert result["last_message"].text == "The weather is sunny."
+        assert [message.text for message in result["messages"]] == ["What's the weather?", "The weather is sunny."]
         for message in result["messages"]:
             message.to_openai_dict_format()
 
     @pytest.mark.asyncio
+    async def test_contentless_assistant_message_still_exits_on_finish_reason_async(self, weather_tool):
+        replies = [
+            ChatMessage.from_assistant(text=None, meta={"finish_reason": "length"}),
+            ChatMessage.from_assistant("Recovered answer that must not be generated."),
+        ]
+        agent = Agent(chat_generator=MockChatGenerator(replies), tools=[weather_tool])
+
+        result = await agent.run_async(messages=[ChatMessage.from_user("What's the weather?")])
+
+        assert result["step_count"] == 1
+        assert result["exit_reason"] == "length"
+        assert [message.text for message in result["messages"]] == ["What's the weather?"]
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
-    @pytest.mark.parametrize(("text", "expected_text"), [("", ""), ("Partial answer.", "Partial answer."), (None, "")])
-    async def test_incomplete_model_reply_exits_with_specific_reason_async(
-        self, weather_tool, finish_reason, text, expected_text
-    ):
+    @pytest.mark.parametrize("text", ["", "Partial answer."])
+    async def test_incomplete_model_reply_exits_with_specific_reason_async(self, weather_tool, finish_reason, text):
         replies = [
             ChatMessage.from_assistant(text=text, meta={"finish_reason": finish_reason}),
             "Recovered answer that must not be generated.",
@@ -1223,7 +1250,7 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 1
         assert result["exit_reason"] == finish_reason
-        assert result["last_message"].text == expected_text
+        assert result["last_message"].text == text
 
     @pytest.mark.asyncio
     async def test_exits_on_empty_assistant_message_truncated_by_output_limit_async(self, monkeypatch, weather_tool):

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -1129,9 +1129,8 @@ class TestAgentExitConditions:
         assert result["last_message"].text == "The weather is sunny."
 
     def test_contentless_assistant_message_keeps_history_sendable(self, weather_tool):
-        # A generator that discards a malformed tool call builds its reply with `text=None` and no tool calls, so the
-        # message carries no content part at all. The agent must keep looping *and* keep the history sendable, so the
-        # next LLM call can recover instead of raising while serializing.
+        # A discarded malformed tool call leaves a reply with no content parts. The agent must keep looping and keep
+        # the history sendable, so the next LLM call can recover.
         generator = SerializingChatGenerator(
             [ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
         )
@@ -1141,7 +1140,7 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 2
         assert result["last_message"].text == "The weather is sunny."
-        # The returned history must not poison a follow-up turn built from it either.
+        # The returned history must stay usable for a follow-up turn.
         for message in result["messages"]:
             message.to_openai_dict_format()
 

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -1144,8 +1144,9 @@ class TestAgentExitConditions:
         for message in result["messages"]:
             message.to_openai_dict_format()
 
-    def test_contentless_assistant_message_still_exits_on_finish_reason(self, weather_tool):
-        # The reply is dropped, but it still decides the exit: a truncated tool call must not silently retry.
+    def test_contentless_assistant_message_is_kept_when_it_ends_the_run(self, weather_tool):
+        # A terminal reply is not dropped: the run ends on it, so the caller sees the truncated turn and its meta
+        # next to `exit_reason` instead of a history ending in the user message.
         replies = [
             ChatMessage.from_assistant(text=None, meta={"finish_reason": "length"}),
             ChatMessage.from_assistant("Recovered answer that must not be generated."),
@@ -1156,7 +1157,25 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 1
         assert result["exit_reason"] == "length"
-        assert [message.text for message in result["messages"]] == ["What's the weather?"]
+        assert result["last_message"].is_from(ChatRole.ASSISTANT)
+        assert result["last_message"].meta["finish_reason"] == "length"
+
+    def test_contentless_assistant_message_is_hidden_from_before_tool_hooks(self, weather_tool):
+        # The reply is removed before `before_tool` runs, so hooks never see a message they cannot serialize.
+        seen: list[list[int]] = []
+
+        @hook
+        def capture(state: State) -> None:
+            seen.append([len(message._content) for message in state.data["messages"]])
+
+        generator = SerializingChatGenerator(
+            replies=[ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
+        )
+        agent = Agent(chat_generator=generator, tools=[weather_tool], hooks={"before_tool": [capture]})
+
+        agent.run(messages=[ChatMessage.from_user("What's the weather?")])
+
+        assert seen == [[1]]
 
     @pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
     @pytest.mark.parametrize("text", ["", "Partial answer."])
@@ -1223,7 +1242,7 @@ class TestAgentExitConditions:
             message.to_openai_dict_format()
 
     @pytest.mark.asyncio
-    async def test_contentless_assistant_message_still_exits_on_finish_reason_async(self, weather_tool):
+    async def test_contentless_assistant_message_is_kept_when_it_ends_the_run_async(self, weather_tool):
         replies = [
             ChatMessage.from_assistant(text=None, meta={"finish_reason": "length"}),
             ChatMessage.from_assistant("Recovered answer that must not be generated."),
@@ -1234,7 +1253,8 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 1
         assert result["exit_reason"] == "length"
-        assert [message.text for message in result["messages"]] == ["What's the weather?"]
+        assert result["last_message"].is_from(ChatRole.ASSISTANT)
+        assert result["last_message"].meta["finish_reason"] == "length"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("finish_reason", ["length", "content_filter"])


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/12541

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fixed a crash in ``Agent`` on the LLM call following a reply from which a Chat Generator discarded a malformed tool call. Such a reply has no content parts, which Chat Message converters reject. The ``Agent`` now leaves it out of the message history, so the next call and any follow-up turn built from the returned messages stay sendable. Its token usage is still recorded, and a ``length`` or ``content_filter`` finish reason on it still ends the run.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests, and also tested locally that the model does recover. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
