### PR TITLE
feat: relax OpenAI and HF chat message conversions

### DIFF
--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -994,7 +994,7 @@ def _convert_chat_message_to_responses_api_format(message: ChatMessage) -> list[
     files = message.files
 
     has_content = any([text_contents, tool_calls, tool_call_results, images, reasonings, files])
-    # An assistant reply with no content part serializes with empty content, which the API accepts.
+    # We convert an assistant message with no content part into a message with empty content, which the API accepts
     if not has_content and not message.is_from(ChatRole.ASSISTANT):
         raise ValueError(
             f"A `ChatMessage` from `{message._role.value}` must contain at least one `TextContent`, `ToolCall`, "
@@ -1071,8 +1071,7 @@ def _convert_chat_message_to_responses_api_format(message: ChatMessage) -> list[
             formatted_tool_calls.append(openai_tool_call)
         formatted_messages.extend(formatted_tool_calls)
 
-    # System and assistant messages. The API rejects an input item with no `content`, so an assistant reply that
-    # produced no item is sent with the empty content that joining no texts yields.
+    # system and assistant messages
     if text_contents or not formatted_messages:
         openai_msg["content"] = " ".join(text_contents)
         formatted_messages.append(openai_msg)

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -16,6 +16,7 @@ from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.utils import _normalize_messages, _serialize_object
 from haystack.dataclasses import (
     ChatMessage,
+    ChatRole,
     ComponentInfo,
     FileContent,
     ImageContent,
@@ -992,7 +993,10 @@ def _convert_chat_message_to_responses_api_format(message: ChatMessage) -> list[
     reasonings = message.reasonings
     files = message.files
 
-    if not any([text_contents, tool_calls, tool_call_results, images, reasonings, files]):
+    has_content = any([text_contents, tool_calls, tool_call_results, images, reasonings, files])
+    # An assistant reply can legitimately carry nothing: a Chat Generator that discards a malformed tool call returns
+    # one. It serializes with empty content, which the API accepts.
+    if not has_content and not message.is_from(ChatRole.ASSISTANT):
         raise ValueError(
             """A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, `ToolCallResult`,
               `ImageContent`, `FileContent`, or `ReasoningContent`."""
@@ -1067,8 +1071,9 @@ def _convert_chat_message_to_responses_api_format(message: ChatMessage) -> list[
             formatted_tool_calls.append(openai_tool_call)
         formatted_messages.extend(formatted_tool_calls)
 
-    # system and assistant messages
-    if text_contents:
+    # System and assistant messages. The API rejects an input item with no `content`, so an assistant reply that
+    # produced no item at all is still sent, with the empty content that joining no texts yields.
+    if text_contents or not formatted_messages:
         openai_msg["content"] = " ".join(text_contents)
         formatted_messages.append(openai_msg)
 

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -994,8 +994,8 @@ def _convert_chat_message_to_responses_api_format(message: ChatMessage) -> list[
     files = message.files
 
     has_content = any([text_contents, tool_calls, tool_call_results, images, reasonings, files])
-    # An assistant reply can legitimately carry nothing: a Chat Generator that discards a malformed tool call returns
-    # one. It serializes with empty content, which the API accepts.
+    # An assistant reply with no content part serializes with empty content, which the API accepts. A Chat
+    # Generator that discards a malformed tool call returns such a reply.
     if not has_content and not message.is_from(ChatRole.ASSISTANT):
         raise ValueError(
             """A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, `ToolCallResult`,
@@ -1072,7 +1072,7 @@ def _convert_chat_message_to_responses_api_format(message: ChatMessage) -> list[
         formatted_messages.extend(formatted_tool_calls)
 
     # System and assistant messages. The API rejects an input item with no `content`, so an assistant reply that
-    # produced no item at all is still sent, with the empty content that joining no texts yields.
+    # produced no item is sent with the empty content that joining no texts yields.
     if text_contents or not formatted_messages:
         openai_msg["content"] = " ".join(text_contents)
         formatted_messages.append(openai_msg)

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -994,12 +994,12 @@ def _convert_chat_message_to_responses_api_format(message: ChatMessage) -> list[
     files = message.files
 
     has_content = any([text_contents, tool_calls, tool_call_results, images, reasonings, files])
-    # An assistant reply with no content part serializes with empty content, which the API accepts. A Chat
-    # Generator that discards a malformed tool call returns such a reply.
+    # An assistant reply with no content part serializes with empty content, which the API accepts.
     if not has_content and not message.is_from(ChatRole.ASSISTANT):
         raise ValueError(
-            """A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, `ToolCallResult`,
-              `ImageContent`, `FileContent`, or `ReasoningContent`."""
+            f"A `ChatMessage` from `{message._role.value}` must contain at least one `TextContent`, `ToolCall`, "
+            "`ToolCallResult`, `ImageContent`, `FileContent`, or `ReasoningContent`. Only assistant messages can "
+            "be empty."
         )
     if len(tool_call_results) > 0 and len(message._content) > 1:
         raise ValueError(

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -647,8 +647,7 @@ class ChatMessage:
             `id` attribute.
         """
         has_content = bool(self.texts or self.tool_calls or self.tool_call_results or self.images or self.files)
-        # An assistant reply with nothing this format carries serializes with empty content, which the API accepts.
-        # Reasoning is dropped here as it is on any other message.
+        # We convert an assistant message with no content part into a message with empty content, which the API accepts
         if not has_content and not self.is_from(ChatRole.ASSISTANT):
             raise ValueError(
                 f"A `ChatMessage` from `{self._role.value}` must contain at least one `TextContent`, `ToolCall`, "

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -647,18 +647,13 @@ class ChatMessage:
             `id` attribute.
         """
         has_content = bool(self.texts or self.tool_calls or self.tool_call_results or self.images or self.files)
-        # An assistant reply with no content part serializes with empty content, which the API accepts.
-        if not has_content:
-            if self.reasonings:
-                raise ValueError(
-                    "A `ChatMessage` carrying only `ReasoningContent` cannot be converted, because the OpenAI Chat "
-                    "Completions format has no reasoning field."
-                )
-            if not self.is_from(ChatRole.ASSISTANT):
-                raise ValueError(
-                    f"A `ChatMessage` from `{self._role.value}` must contain at least one `TextContent`, `ToolCall`, "
-                    "`ToolCallResult`, `ImageContent`, or `FileContent`. Only assistant messages can be empty."
-                )
+        # An assistant reply with nothing this format carries serializes with empty content, which the API accepts.
+        # Reasoning is dropped here as it is on any other message.
+        if not has_content and not self.is_from(ChatRole.ASSISTANT):
+            raise ValueError(
+                f"A `ChatMessage` from `{self._role.value}` must contain at least one `TextContent`, `ToolCall`, "
+                "`ToolCallResult`, `ImageContent`, or `FileContent`. Only assistant messages can be empty."
+            )
         if len(self.tool_call_results) > 0 and len(self._content) > 1:
             raise ValueError(
                 "For OpenAI compatibility, a `ChatMessage` with a `ToolCallResult` cannot contain any other content."

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -734,9 +734,6 @@ class ChatMessage:
         # OpenAI Chat Completions API does not support reasoning content, so we ignore it
         if self.texts:
             openai_msg["content"] = self.texts[0]
-        elif not self.tool_calls:
-            # The API rejects an assistant message with no `content` key, so send it explicitly empty.
-            openai_msg["content"] = ""
         if self.tool_calls:
             openai_tool_calls = []
             for tc in self.tool_calls:
@@ -751,6 +748,9 @@ class ChatMessage:
                     raise ValueError("`ToolCall` must have a non-null `id` attribute to be used with OpenAI.")
                 openai_tool_calls.append(openai_tool_call)
             openai_msg["tool_calls"] = openai_tool_calls
+        # The API rejects a message carrying neither content nor tool calls, so send empty content for it.
+        if "content" not in openai_msg and "tool_calls" not in openai_msg:
+            openai_msg["content"] = ""
         return openai_msg
 
     @staticmethod

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -646,7 +646,11 @@ class ChatMessage:
             If the message format is invalid, or if `require_tool_call_ids` is True and any Tool Call is missing an
             `id` attribute.
         """
-        if not self.texts and not self.tool_calls and not self.tool_call_results and not self.images and not self.files:
+        has_content = bool(self.texts or self.tool_calls or self.tool_call_results or self.images or self.files)
+        # An assistant reply can legitimately carry nothing this format represents: a Chat Generator that discards a
+        # malformed tool call returns one, and reasoning is not part of this format. Those serialize with empty
+        # content, which the API accepts.
+        if not has_content and not self.is_from(ChatRole.ASSISTANT):
             raise ValueError(
                 "A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, "
                 "`ToolCallResult`, `ImageContent`, or `FileContent`."
@@ -731,6 +735,9 @@ class ChatMessage:
         # OpenAI Chat Completions API does not support reasoning content, so we ignore it
         if self.texts:
             openai_msg["content"] = self.texts[0]
+        elif not self.tool_calls:
+            # The API rejects an assistant message with no `content` key, so send it explicitly empty.
+            openai_msg["content"] = ""
         if self.tool_calls:
             openai_tool_calls = []
             for tc in self.tool_calls:

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -647,10 +647,9 @@ class ChatMessage:
             `id` attribute.
         """
         has_content = bool(self.texts or self.tool_calls or self.tool_call_results or self.images or self.files)
-        # An assistant reply with no content part serializes with empty content, which the API accepts. A Chat
-        # Generator that discards a malformed tool call returns such a reply.
-        is_contentless_assistant_reply = not self._content and self.is_from(ChatRole.ASSISTANT)
-        if not has_content and not is_contentless_assistant_reply:
+        # An assistant reply with no content part serializes with empty content, which the API accepts. A reply
+        # carrying only reasoning raises, since this format has no reasoning field.
+        if not has_content and (self.reasonings or not self.is_from(ChatRole.ASSISTANT)):
             raise ValueError(
                 "A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, "
                 "`ToolCallResult`, `ImageContent`, or `FileContent`."

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -647,10 +647,10 @@ class ChatMessage:
             `id` attribute.
         """
         has_content = bool(self.texts or self.tool_calls or self.tool_call_results or self.images or self.files)
-        # An assistant reply can legitimately carry nothing this format represents: a Chat Generator that discards a
-        # malformed tool call returns one, and reasoning is not part of this format. Those serialize with empty
-        # content, which the API accepts.
-        if not has_content and not self.is_from(ChatRole.ASSISTANT):
+        # An assistant reply with no content part serializes with empty content, which the API accepts. A Chat
+        # Generator that discards a malformed tool call returns such a reply.
+        is_contentless_assistant_reply = not self._content and self.is_from(ChatRole.ASSISTANT)
+        if not has_content and not is_contentless_assistant_reply:
             raise ValueError(
                 "A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, "
                 "`ToolCallResult`, `ImageContent`, or `FileContent`."
@@ -773,7 +773,9 @@ class ChatMessage:
             raise ValueError(f"Unsupported role: {role}")
 
         if role == "assistant":
-            if not content and not tool_calls:
+            # An empty string is valid content for an assistant message: that is how a reply with nothing to send
+            # is serialized. Other falsy content requires tool calls.
+            if not content and content != "" and not tool_calls:
                 raise ValueError("For assistant messages, either `content` or `tool_calls` must be present.")
             if tool_calls:
                 for tc in tool_calls:

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -647,13 +647,18 @@ class ChatMessage:
             `id` attribute.
         """
         has_content = bool(self.texts or self.tool_calls or self.tool_call_results or self.images or self.files)
-        # An assistant reply with no content part serializes with empty content, which the API accepts. A reply
-        # carrying only reasoning raises, since this format has no reasoning field.
-        if not has_content and (self.reasonings or not self.is_from(ChatRole.ASSISTANT)):
-            raise ValueError(
-                "A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, "
-                "`ToolCallResult`, `ImageContent`, or `FileContent`."
-            )
+        # An assistant reply with no content part serializes with empty content, which the API accepts.
+        if not has_content:
+            if self.reasonings:
+                raise ValueError(
+                    "A `ChatMessage` carrying only `ReasoningContent` cannot be converted, because the OpenAI Chat "
+                    "Completions format has no reasoning field."
+                )
+            if not self.is_from(ChatRole.ASSISTANT):
+                raise ValueError(
+                    f"A `ChatMessage` from `{self._role.value}` must contain at least one `TextContent`, `ToolCall`, "
+                    "`ToolCallResult`, `ImageContent`, or `FileContent`. Only assistant messages can be empty."
+                )
         if len(self.tool_call_results) > 0 and len(self._content) > 1:
             raise ValueError(
                 "For OpenAI compatibility, a `ChatMessage` with a `ToolCallResult` cannot contain any other content."

--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -70,8 +70,7 @@ def convert_message_to_hf_format(message: ChatMessage) -> dict[str, Any]:
     non_reasoning_content = [c for c in message._content if not isinstance(c, ReasoningContent)]
 
     has_content = bool(text_contents or tool_calls or tool_call_results or images)
-    # An assistant reply with nothing this format carries is sent with empty content, which the API accepts.
-    # Reasoning is dropped here as it is on any other message.
+    # We convert an assistant message with no content part into a message with empty content, which the API accepts
     if not has_content and not message.is_from(ChatRole.ASSISTANT):
         raise ValueError(
             f"A `ChatMessage` from `{message._role.value}` must contain at least one `TextContent`, `ToolCall`, "

--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -70,18 +70,13 @@ def convert_message_to_hf_format(message: ChatMessage) -> dict[str, Any]:
     non_reasoning_content = [c for c in message._content if not isinstance(c, ReasoningContent)]
 
     has_content = bool(text_contents or tool_calls or tool_call_results or images)
-    # An assistant reply with no content part is sent with empty content, which the API accepts.
-    if not has_content:
-        if message.reasonings:
-            raise ValueError(
-                "A `ChatMessage` carrying only `ReasoningContent` cannot be converted, because the Hugging Face "
-                "chat format does not carry reasoning."
-            )
-        if not message.is_from(ChatRole.ASSISTANT):
-            raise ValueError(
-                f"A `ChatMessage` from `{message._role.value}` must contain at least one `TextContent`, `ToolCall`, "
-                "`ToolCallResult`, or `ImageContent`. Only assistant messages can be empty."
-            )
+    # An assistant reply with nothing this format carries is sent with empty content, which the API accepts.
+    # Reasoning is dropped here as it is on any other message.
+    if not has_content and not message.is_from(ChatRole.ASSISTANT):
+        raise ValueError(
+            f"A `ChatMessage` from `{message._role.value}` must contain at least one `TextContent`, `ToolCall`, "
+            "`ToolCallResult`, or `ImageContent`. Only assistant messages can be empty."
+        )
     if len(tool_call_results) > 0 and len(non_reasoning_content) > 1:
         raise ValueError(
             "For compatibility with the Hugging Face API, a `ChatMessage` with a `ToolCallResult` "

--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -5,7 +5,7 @@
 from typing import Any
 
 from haystack import logging
-from haystack.dataclasses import ChatMessage, ImageContent, ReasoningContent, TextContent
+from haystack.dataclasses import ChatMessage, ChatRole, ImageContent, ReasoningContent, TextContent
 from haystack.lazy_imports import LazyImport
 
 with LazyImport(message="Run 'pip install \"transformers[torch]\"'") as torch_import:
@@ -69,7 +69,10 @@ def convert_message_to_hf_format(message: ChatMessage) -> dict[str, Any]:
     # ReasoningContent is for human transparency only, not sent to the API
     non_reasoning_content = [c for c in message._content if not isinstance(c, ReasoningContent)]
 
-    if not text_contents and not tool_calls and not tool_call_results and not images:
+    has_content = bool(text_contents or tool_calls or tool_call_results or images)
+    # An assistant reply with no content part is sent with the empty content this format always includes. A reply
+    # carrying only reasoning raises, since reasoning is not sent to the API.
+    if not has_content and (message.reasonings or not message.is_from(ChatRole.ASSISTANT)):
         raise ValueError(
             "A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, `ToolCallResult`, or `ImageContent`."
         )

--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -70,12 +70,18 @@ def convert_message_to_hf_format(message: ChatMessage) -> dict[str, Any]:
     non_reasoning_content = [c for c in message._content if not isinstance(c, ReasoningContent)]
 
     has_content = bool(text_contents or tool_calls or tool_call_results or images)
-    # An assistant reply with no content part is sent with the empty content this format always includes. A reply
-    # carrying only reasoning raises, since reasoning is not sent to the API.
-    if not has_content and (message.reasonings or not message.is_from(ChatRole.ASSISTANT)):
-        raise ValueError(
-            "A `ChatMessage` must contain at least one `TextContent`, `ToolCall`, `ToolCallResult`, or `ImageContent`."
-        )
+    # An assistant reply with no content part is sent with empty content, which the API accepts.
+    if not has_content:
+        if message.reasonings:
+            raise ValueError(
+                "A `ChatMessage` carrying only `ReasoningContent` cannot be converted, because the Hugging Face "
+                "chat format does not carry reasoning."
+            )
+        if not message.is_from(ChatRole.ASSISTANT):
+            raise ValueError(
+                f"A `ChatMessage` from `{message._role.value}` must contain at least one `TextContent`, `ToolCall`, "
+                "`ToolCallResult`, or `ImageContent`. Only assistant messages can be empty."
+            )
     if len(tool_call_results) > 0 and len(non_reasoning_content) > 1:
         raise ValueError(
             "For compatibility with the Hugging Face API, a `ChatMessage` with a `ToolCallResult` "

--- a/releasenotes/notes/openai-converters-contentless-assistant-4d8b21fa9c603e57.yaml
+++ b/releasenotes/notes/openai-converters-contentless-assistant-4d8b21fa9c603e57.yaml
@@ -1,10 +1,10 @@
 ---
 fixes:
   - |
-    The OpenAI Chat Completions and Responses converters no longer raise on an assistant message that has no content
-    parts. A Chat Generator that discards a malformed tool call returns such a reply, which previously raised a
-    ``ValueError`` about the message needing at least one content part. It is now sent with empty content, which the
-    API accepts, so the LLM call that follows it goes through: in ``Agent``, for example, the reply stays in the
-    message history and its ``meta`` remains available. ``ChatMessage.from_openai_dict_format`` accepts the same
-    empty content, so such a message round-trips. Messages from other roles still raise, since they cannot
-    legitimately be empty.
+    The OpenAI Chat Completions and Responses converters no longer raise on an assistant message with no content
+    parts, which a Chat Generator returns when it discards a malformed tool call. It is sent with empty content,
+    which the APIs accept, so the next LLM call goes through. ``ChatMessage.from_openai_dict_format`` accepts the
+    same empty content, so such a message round-trips.
+  - |
+    The Hugging Face message converter no longer raises on an assistant message with no content parts, and sends it
+    with empty content instead.

--- a/releasenotes/notes/openai-converters-contentless-assistant-4d8b21fa9c603e57.yaml
+++ b/releasenotes/notes/openai-converters-contentless-assistant-4d8b21fa9c603e57.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    The OpenAI Chat Completions and Responses converters no longer raise on an assistant message that carries no
+    content the format can represent. A Chat Generator that discards a malformed tool call returns such a reply, and
+    a reply carrying only reasoning is in the same position for Chat Completions, which has no reasoning field.
+    Both are now sent with empty content, which the API accepts, instead of raising ``A ``ChatMessage`` must contain at
+    least one ``TextContent``, ``ToolCall``, ``ToolCallResult``, ``ImageContent``, or ``FileContent``.`` This unbreaks the LLM
+    call that follows such a reply, for example in ``Agent``, where the reply is kept in the message history so its
+    ``meta`` remains available. Messages from other roles still raise, since they cannot legitimately be empty.

--- a/releasenotes/notes/openai-converters-contentless-assistant-4d8b21fa9c603e57.yaml
+++ b/releasenotes/notes/openai-converters-contentless-assistant-4d8b21fa9c603e57.yaml
@@ -1,10 +1,10 @@
 ---
 fixes:
   - |
-    The OpenAI Chat Completions and Responses converters no longer raise on an assistant message that carries no
-    content the format can represent. A Chat Generator that discards a malformed tool call returns such a reply, and
-    a reply carrying only reasoning is in the same position for Chat Completions, which has no reasoning field.
-    Both are now sent with empty content, which the API accepts, instead of raising ``A ``ChatMessage`` must contain at
-    least one ``TextContent``, ``ToolCall``, ``ToolCallResult``, ``ImageContent``, or ``FileContent``.`` This unbreaks the LLM
-    call that follows such a reply, for example in ``Agent``, where the reply is kept in the message history so its
-    ``meta`` remains available. Messages from other roles still raise, since they cannot legitimately be empty.
+    The OpenAI Chat Completions and Responses converters no longer raise on an assistant message that has no content
+    parts. A Chat Generator that discards a malformed tool call returns such a reply, which previously raised a
+    ``ValueError`` about the message needing at least one content part. It is now sent with empty content, which the
+    API accepts, so the LLM call that follows it goes through: in ``Agent``, for example, the reply stays in the
+    message history and its ``meta`` remains available. ``ChatMessage.from_openai_dict_format`` accepts the same
+    empty content, so such a message round-trips. Messages from other roles still raise, since they cannot
+    legitimately be empty.

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -191,20 +191,6 @@ class ToolAssertingChatGenerator:
         return {"replies": [message]}
 
 
-@component
-class SerializingChatGenerator:
-    """Serializes the incoming history the way a real generator does, then returns the next scripted reply."""
-
-    def __init__(self, replies: list[ChatMessage]):
-        self.replies = list(replies)
-
-    @component.output_types(replies=list[ChatMessage])
-    def run(self, messages: list[ChatMessage], tools: list[Tool] | Toolset | None = None, **kwargs) -> dict[str, Any]:
-        for message in messages:
-            message.to_openai_dict_format()
-        return {"replies": [self.replies.pop(0)]}
-
-
 def _parallel_tool_calling_generator() -> MockChatGenerator:
     """Requests two `weather_tool` calls on the first turn, then returns a plain reply so the agent loop exits."""
     return MockChatGenerator(
@@ -1121,21 +1107,6 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 2
         assert result["last_message"].text == "The weather is sunny."
-
-    def test_contentless_assistant_message_stays_sendable(self, weather_tool):
-        # A discarded malformed tool call leaves a reply with no content parts. The agent keeps it in the history and
-        # keeps looping, so the reply must serialize for the next LLM call rather than raise.
-        generator = SerializingChatGenerator(
-            replies=[ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
-        )
-        agent = Agent(chat_generator=generator, tools=[weather_tool], exit_conditions=["text"])
-
-        result = agent.run(messages=[ChatMessage.from_user("What's the weather?")])
-
-        assert result["step_count"] == 2
-        assert result["last_message"].text == "The weather is sunny."
-        # The reply stays in the history, so callers reading each message's meta still see the turn.
-        assert len(result["messages"]) == 3
 
     @pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
     @pytest.mark.parametrize("text", ["", "Partial answer."])

--- a/test/components/agents/test_agent.py
+++ b/test/components/agents/test_agent.py
@@ -191,6 +191,20 @@ class ToolAssertingChatGenerator:
         return {"replies": [message]}
 
 
+@component
+class SerializingChatGenerator:
+    """Serializes the incoming history the way a real generator does, then returns the next scripted reply."""
+
+    def __init__(self, replies: list[ChatMessage]):
+        self.replies = list(replies)
+
+    @component.output_types(replies=list[ChatMessage])
+    def run(self, messages: list[ChatMessage], tools: list[Tool] | Toolset | None = None, **kwargs) -> dict[str, Any]:
+        for message in messages:
+            message.to_openai_dict_format()
+        return {"replies": [self.replies.pop(0)]}
+
+
 def _parallel_tool_calling_generator() -> MockChatGenerator:
     """Requests two `weather_tool` calls on the first turn, then returns a plain reply so the agent loop exits."""
     return MockChatGenerator(
@@ -1107,6 +1121,21 @@ class TestAgentExitConditions:
 
         assert result["step_count"] == 2
         assert result["last_message"].text == "The weather is sunny."
+
+    def test_contentless_assistant_message_stays_sendable(self, weather_tool):
+        # A discarded malformed tool call leaves a reply with no content parts. The agent keeps it in the history and
+        # keeps looping, so the reply must serialize for the next LLM call rather than raise.
+        generator = SerializingChatGenerator(
+            replies=[ChatMessage.from_assistant(text=None), ChatMessage.from_assistant("The weather is sunny.")]
+        )
+        agent = Agent(chat_generator=generator, tools=[weather_tool], exit_conditions=["text"])
+
+        result = agent.run(messages=[ChatMessage.from_user("What's the weather?")])
+
+        assert result["step_count"] == 2
+        assert result["last_message"].text == "The weather is sunny."
+        # The reply stays in the history, so callers reading each message's meta still see the turn.
+        assert len(result["messages"]) == 3
 
     @pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
     @pytest.mark.parametrize("text", ["", "Partial answer."])

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -889,8 +889,9 @@ class TestOpenAIChatGenerator:
     )
     @pytest.mark.integration
     def test_live_run(self) -> None:
-
-        chat_messages = [ChatMessage.from_user("What's the capital of France")]
+        # The trailing assistant message has no content parts, as a reply whose only tool call was discarded does.
+        # It serializes with empty content, so this also checks the API accepts that, not just the converter.
+        chat_messages = [ChatMessage.from_user("What's the capital of France"), ChatMessage.from_assistant(text=None)]
         component = OpenAIChatGenerator(model="gpt-4.1-nano", generation_kwargs={"n": 1})
         results = component.run(chat_messages)
         assert len(results["replies"]) == 1
@@ -906,24 +907,7 @@ class TestOpenAIChatGenerator:
         reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
     )
     @pytest.mark.integration
-    def test_live_run_with_contentless_assistant_message(self) -> None:
-        # A discarded malformed tool call leaves a reply with no content parts, which serializes with empty
-        # content. This checks the API accepts it, not just the converter.
-        chat_messages = [ChatMessage.from_user("What's the capital of France"), ChatMessage.from_assistant(text=None)]
-        component = OpenAIChatGenerator(model="gpt-4.1-nano")
-        results = component.run(chat_messages)
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        assert message.text is not None
-        assert "Paris" in message.text
-
-    @pytest.mark.skipif(
-        not os.environ.get("OPENAI_API_KEY", None),
-        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
-    )
-    @pytest.mark.integration
     def test_live_run_with_response_format_pydantic_model(self, calendar_event_model: type) -> None:
-
         chat_messages = [
             ChatMessage.from_user("The marketing summit takes place on October12th at the Hilton Hotel downtown.")
         ]

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -906,6 +906,22 @@ class TestOpenAIChatGenerator:
         reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
     )
     @pytest.mark.integration
+    def test_live_run_with_contentless_assistant_message(self) -> None:
+        # A discarded malformed tool call leaves a reply with no content parts, which serializes with empty
+        # content. This checks the API accepts it, not just the converter.
+        chat_messages = [ChatMessage.from_user("What's the capital of France"), ChatMessage.from_assistant(text=None)]
+        component = OpenAIChatGenerator(model="gpt-4.1-nano")
+        results = component.run(chat_messages)
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert message.text is not None
+        assert "Paris" in message.text
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
     def test_live_run_with_response_format_pydantic_model(self, calendar_event_model: type) -> None:
 
         chat_messages = [

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -779,6 +779,17 @@ class TestIntegration:
         assert message.meta["id"] is not None
         assert message.meta["logprobs"] is not None
 
+    def test_live_run_with_contentless_assistant_message(self) -> None:
+        # A discarded malformed tool call leaves a reply with no content parts, which serializes with empty
+        # content. This checks the API accepts it, not just the converter.
+        chat_messages = [ChatMessage.from_user("What's the capital of France"), ChatMessage.from_assistant(text=None)]
+        component = OpenAIResponsesChatGenerator(model="gpt-4.1-nano")
+        results = component.run(chat_messages)
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert message.text is not None
+        assert "paris" in message.text.lower()
+
     def test_live_run_with_reasoning(self) -> None:
 
         chat_messages = [ChatMessage.from_user("Explain in 2 lines why is there a Moon?")]

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -764,7 +764,9 @@ class TestRun:
 class TestIntegration:
     def test_live_run(self) -> None:
 
-        chat_messages = [ChatMessage.from_user("What's the capital of France")]
+        # The trailing assistant message has no content parts, as a reply whose only tool call was discarded does.
+        # It serializes with empty content, so this also checks the API accepts that, not just the converter.
+        chat_messages = [ChatMessage.from_user("What's the capital of France"), ChatMessage.from_assistant(text=None)]
         component = OpenAIResponsesChatGenerator(
             model="gpt-4.1-nano", generation_kwargs={"include": ["message.output_text.logprobs"]}
         )
@@ -778,17 +780,6 @@ class TestIntegration:
         assert message.meta["usage"]["total_tokens"] > 0
         assert message.meta["id"] is not None
         assert message.meta["logprobs"] is not None
-
-    def test_live_run_with_contentless_assistant_message(self) -> None:
-        # A discarded malformed tool call leaves a reply with no content parts, which serializes with empty
-        # content. This checks the API accepts it, not just the converter.
-        chat_messages = [ChatMessage.from_user("What's the capital of France"), ChatMessage.from_assistant(text=None)]
-        component = OpenAIResponsesChatGenerator(model="gpt-4.1-nano")
-        results = component.run(chat_messages)
-        assert len(results["replies"]) == 1
-        message: ChatMessage = results["replies"][0]
-        assert message.text is not None
-        assert "paris" in message.text.lower()
 
     def test_live_run_with_reasoning(self) -> None:
 

--- a/test/components/generators/chat/test_openai_responses_conversion.py
+++ b/test/components/generators/chat/test_openai_responses_conversion.py
@@ -1562,9 +1562,21 @@ class TestResponseToChatMessage:
             }
         ]
 
-    def test_convert_invalid(self) -> None:
+    def test_convert_contentless_assistant_message(self) -> None:
+        # A Chat Generator that discards a malformed tool call returns a contentless reply. The API rejects an input
+        # item with no `content`, so it is sent with empty content.
+        message = ChatMessage.from_assistant(text=None)
+        assert _convert_chat_message_to_responses_api_format(message) == [{"role": "assistant", "content": ""}]
 
-        message = ChatMessage(_role=ChatRole.ASSISTANT, _content=[])
+    def test_convert_reasoning_only_message_adds_no_empty_message(self) -> None:
+        # Reasoning already produces an input item, so no empty assistant message is appended alongside it.
+        message = ChatMessage.from_assistant(reasoning="thinking")
+        assert _convert_chat_message_to_responses_api_format(message) == [
+            {"summary": [{"text": "thinking", "type": "summary_text"}]}
+        ]
+
+    def test_convert_invalid(self) -> None:
+        message = ChatMessage(_role=ChatRole.USER, _content=[])
         with pytest.raises(ValueError):
             _convert_chat_message_to_responses_api_format(message)
 

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -955,15 +955,18 @@ class TestToOpenaiDictFormat:
             "name": "Assistant1",
         }
 
-    @pytest.mark.parametrize(
-        "message",
-        [ChatMessage.from_assistant(text=None), ChatMessage.from_assistant(reasoning="only reasoning")],
-        ids=["contentless", "reasoning_only"],
-    )
-    def test_to_openai_dict_format_assistant_message_without_representable_content(self, message):
-        # A Chat Generator that discards a malformed tool call returns a contentless reply, and reasoning is not part
-        # of this format. The API rejects an assistant message with no `content` key, so both send empty content.
+    def test_to_openai_dict_format_contentless_assistant_message(self):
+        # A Chat Generator that discards a malformed tool call returns a reply with no content parts. The API rejects
+        # an assistant message with no `content` key, so it is sent with empty content, and it round-trips.
+        message = ChatMessage.from_assistant(text=None)
         assert message.to_openai_dict_format() == {"role": "assistant", "content": ""}
+        assert ChatMessage.from_openai_dict_format({"role": "assistant", "content": ""}).text == ""
+
+    def test_to_openai_dict_format_reasoning_only_assistant_message_raises(self):
+        # This format has no reasoning field, so a reply carrying only reasoning has nothing to send.
+        message = ChatMessage.from_assistant(reasoning="only reasoning")
+        with pytest.raises(ValueError):
+            message.to_openai_dict_format()
 
     def test_to_openai_dict_format_invalid(self):
         message = ChatMessage(_role=ChatRole.USER, _content=[])

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -955,8 +955,18 @@ class TestToOpenaiDictFormat:
             "name": "Assistant1",
         }
 
+    @pytest.mark.parametrize(
+        "message",
+        [ChatMessage.from_assistant(text=None), ChatMessage.from_assistant(reasoning="only reasoning")],
+        ids=["contentless", "reasoning_only"],
+    )
+    def test_to_openai_dict_format_assistant_message_without_representable_content(self, message):
+        # A Chat Generator that discards a malformed tool call returns a contentless reply, and reasoning is not part
+        # of this format. The API rejects an assistant message with no `content` key, so both send empty content.
+        assert message.to_openai_dict_format() == {"role": "assistant", "content": ""}
+
     def test_to_openai_dict_format_invalid(self):
-        message = ChatMessage(_role=ChatRole.ASSISTANT, _content=[])
+        message = ChatMessage(_role=ChatRole.USER, _content=[])
         with pytest.raises(ValueError):
             message.to_openai_dict_format()
 

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -962,11 +962,11 @@ class TestToOpenaiDictFormat:
         assert message.to_openai_dict_format() == {"role": "assistant", "content": ""}
         assert ChatMessage.from_openai_dict_format({"role": "assistant", "content": ""}).text == ""
 
-    def test_to_openai_dict_format_reasoning_only_assistant_message_raises(self):
-        # This format has no reasoning field, so a reply carrying only reasoning has nothing to send.
+    def test_to_openai_dict_format_reasoning_only_assistant_message(self):
+        # Reasoning is dropped by this format, so a reply carrying only reasoning is sent with empty content, the
+        # same as a reply carrying reasoning alongside text.
         message = ChatMessage.from_assistant(reasoning="only reasoning")
-        with pytest.raises(ValueError):
-            message.to_openai_dict_format()
+        assert message.to_openai_dict_format() == {"role": "assistant", "content": ""}
 
     def test_to_openai_dict_format_invalid(self):
         message = ChatMessage(_role=ChatRole.USER, _content=[])

--- a/test/utils/test_hf.py
+++ b/test/utils/test_hf.py
@@ -56,11 +56,11 @@ def test_convert_contentless_assistant_message_to_hf_format():
     assert convert_message_to_hf_format(message) == {"role": "assistant", "content": ""}
 
 
-def test_convert_reasoning_only_assistant_message_to_hf_format_raises():
-    # Reasoning is not sent to the API, so a reply carrying only reasoning has nothing to send.
+def test_convert_reasoning_only_assistant_message_to_hf_format():
+    # Reasoning is dropped by this format, so a reply carrying only reasoning is sent with empty content, the same
+    # as a reply carrying reasoning alongside text.
     message = ChatMessage.from_assistant(reasoning="only reasoning")
-    with pytest.raises(ValueError):
-        convert_message_to_hf_format(message)
+    assert convert_message_to_hf_format(message) == {"role": "assistant", "content": ""}
 
 
 def test_convert_message_to_hf_invalid():

--- a/test/utils/test_hf.py
+++ b/test/utils/test_hf.py
@@ -49,8 +49,22 @@ def test_convert_message_to_hf_format():
     assert convert_message_to_hf_format(message) == {"role": "tool", "content": tool_result}
 
 
+def test_convert_contentless_assistant_message_to_hf_format():
+    # A Chat Generator that discards a malformed tool call returns a reply with no content parts. This format always
+    # carries a content field, so the reply is sent with it empty.
+    message = ChatMessage.from_assistant(text=None)
+    assert convert_message_to_hf_format(message) == {"role": "assistant", "content": ""}
+
+
+def test_convert_reasoning_only_assistant_message_to_hf_format_raises():
+    # Reasoning is not sent to the API, so a reply carrying only reasoning has nothing to send.
+    message = ChatMessage.from_assistant(reasoning="only reasoning")
+    with pytest.raises(ValueError):
+        convert_message_to_hf_format(message)
+
+
 def test_convert_message_to_hf_invalid():
-    message = ChatMessage(_role=ChatRole.ASSISTANT, _content=[])
+    message = ChatMessage(_role=ChatRole.USER, _content=[])
     with pytest.raises(ValueError):
         convert_message_to_hf_format(message)
 


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/12541

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

- The OpenAI Chat Completions and Responses converters no longer raise on an assistant message with no content parts, which a Chat Generator returns when it discards a malformed tool call. It is sent with empty content, which the APIs accept, so the next LLM call goes through. ``ChatMessage.from_openai_dict_format`` accepts the same empty content, so such a message round-trips.
- The Hugging Face message converter no longer raises on an assistant message with no content parts, and sends it with empty content instead.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests and expanded existing ones. 

Also tested some of the HuggingFace integration components locally to check that their chat templates and models worked with empty assistant messages. E.g.

- `TransformersChatGenerator` with `HuggingFaceTB/SmolLM2-135M-Instruct` worked
- `HuggingFaceAPIChatGenerator` with `Qwen/Qwen2.5-72B-Instruct` and `meta-llama/Llama-3.1-8B-Instruct` worked

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

Integrations that support empty content:
- watsonx with `ibm/granite-4-h-small` works. no changes needed since it uses the openai conversion util method
- litellm with `openai/gpt-4.1-nano` works. no changes needed since it uses the openai conversion util method
- cometapi. no changes needed inherits from `OpenAIChatGenerator`
- stackit. no changes needed inherits from `OpenAIChatGenerator`
- aimlapi. no changes needed inherits from `OpenAIChatGenerator`

Integrations that support empty content but will need an update:
- anthropic with `claude-opus-5` if we relax the converter
- ollama with `qwen3:0.6b` if we relax the converter
- llama_cpp with `Qwen2.5-0.5B-Instruct-GGUF` if we relax the converter
- google gen-ai works if we relax the converter

Integrations that don't support empty content
- mistral raises a 400 error if the history looks like `[user, assistant("")]`, `[user, assistant("Paris is")]` or `[user, assistant(""), user]`
- perplexity raises a 400 error if the history looks like `[user, assistant("")]`, or `[user, assistant(""), user]`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
