### PR TITLE
fix: report per-document conversion failures in DocumentToImageContent

### DIFF
--- a/haystack/components/converters/image/document_to_image.py
+++ b/haystack/components/converters/image/document_to_image.py
@@ -113,23 +113,34 @@ class DocumentToImageContent:
         :returns:
             Dictionary containing one key:
             - "image_contents": ImageContents created from the processed documents. These contain base64-encoded image
-                data and metadata. The order corresponds to order of input documents.
+                data and metadata. The order corresponds to order of input documents. A document that cannot be
+                converted, because it is missing the required metadata keys, has an invalid file path or has an
+                unsupported MIME type, produces None in its position and a logged warning naming it, so that a
+                batch mixing convertible and unconvertible documents still returns the convertible ones.
         :raises ValueError:
-            If any document is missing the required metadata keys, has an invalid file path, or has an unsupported
-            MIME type. The error message will specify which document and what information is missing or incorrect.
+            If a document's file path escapes the configured `root_path`. This is a rejected path traversal rather
+            than a property of one document, so it is raised rather than reported per document.
         """
         if not documents:
             return {"image_contents": []}
 
         images_source_info = _extract_image_sources_info(
-            documents=documents, file_path_meta_field=self.file_path_meta_field, root_path=self.root_path
+            documents=documents,
+            file_path_meta_field=self.file_path_meta_field,
+            root_path=self.root_path,
+            raise_on_failure=False,
         )
 
         image_contents: list[ImageContent | None] = [None] * len(documents)
 
         pdf_page_infos: list[_PDFPageInfo] = []
 
+        # `images_source_info` has one entry per input document, so `doc_idx` indexes `documents` and
+        # `image_contents` as well. Failed documents are None here and keep their None in the output.
         for doc_idx, image_source_info in enumerate(images_source_info):
+            if image_source_info is None:
+                continue
+
             mime_type = image_source_info["mime_type"]
             path = image_source_info["path"]
             if mime_type == "application/pdf":

--- a/haystack/components/converters/image/image_utils.py
+++ b/haystack/components/converters/image/image_utils.py
@@ -222,74 +222,122 @@ class _ImageSourceInfo(TypedDict):
     page_number: NotRequired[int]  # Only present for PDF documents
 
 
+class _PathTraversalError(ValueError):
+    """
+    Raised when a document's file path resolves outside the configured root_path.
+
+    A subclass of ValueError, so callers that already expect one are unaffected. It exists so that a traversal
+    attempt can be told apart from the other validation failures: those describe one document's data and may be
+    reported per document, while this one is a security signal about the input as a whole and is raised even
+    when the caller asked for per-document reporting.
+    """
+
+
+def _extract_single_image_source_info(doc: Document, file_path_meta_field: str, root_path: str) -> _ImageSourceInfo:
+    """
+    Extracts the image source information from a single document.
+
+    :param doc: The document to extract image source information from.
+    :param file_path_meta_field: The metadata field in the Document that contains the file path to the image or PDF.
+    :param root_path: The root directory path where document files are located.
+
+    :returns:
+        An _ImageSourceInfo dictionary containing the path and type of the image.
+        If the image is a PDF, the dictionary also contains the page number.
+    :raises ValueError: If the document is missing the file_path_meta_field key in its metadata, the file path is
+        invalid, the MIME type is not supported, or the page number is missing for a PDF document.
+    :raises _PathTraversalError: If root_path is set and the resolved file path lies outside it.
+    """
+    file_path = doc.meta.get(file_path_meta_field)
+    if file_path is None:
+        raise ValueError(
+            f"Document with ID '{doc.id}' is missing the '{file_path_meta_field}' key in its metadata."
+            f" Please ensure that the documents you are trying to convert have this key set."
+        )
+
+    resolved_file_path = Path(root_path, file_path)
+
+    # When root_path is set, ensure the resolved path stays within it to block path-traversal
+    # payloads (e.g. "../../etc/passwd") coming from document metadata. When root_path is unset,
+    # file paths are treated as absolute by design and no containment check is applied; callers that
+    # process untrusted metadata should configure root_path (see component docstrings).
+    if root_path:
+        resolved_file_path = resolved_file_path.resolve()
+        resolved_root = Path(root_path).resolve()
+        if not resolved_file_path.is_relative_to(resolved_root):
+            raise _PathTraversalError(
+                f"Document with ID '{doc.id}' has a file path '{file_path}' that escapes the "
+                f"configured root '{root_path}'. Resolved path: '{resolved_file_path}'."
+            )
+
+    if not resolved_file_path.is_file():
+        raise ValueError(
+            f"Document with ID '{doc.id}' has an invalid file path '{resolved_file_path}'. "
+            f"Please ensure that the documents you are trying to convert have valid file paths."
+        )
+
+    mime_type = doc.meta.get("mime_type") or mimetypes.guess_type(resolved_file_path)[0]
+    if mime_type not in IMAGE_MIME_TYPES:
+        raise ValueError(
+            f"Document with file path '{resolved_file_path}' has an unsupported MIME type '{mime_type}'. "
+            f"Please ensure that the documents you are trying to convert are of the supported "
+            f"types: {', '.join(IMAGE_MIME_TYPES)}."
+        )
+
+    image_info: _ImageSourceInfo = {"path": resolved_file_path, "mime_type": mime_type}
+
+    # If mimetype is PDF we also need the page number to be able to convert the right page
+    if mime_type == "application/pdf":
+        page_number = doc.meta.get("page_number")
+        if page_number is None:
+            raise ValueError(
+                f"Document with ID '{doc.id}' comes from the PDF file '{resolved_file_path}' but is missing "
+                f"the 'page_number' key in its metadata. Please ensure that PDF documents you are trying to "
+                f"convert have this key set."
+            )
+        image_info["page_number"] = page_number
+
+    return image_info
+
+
 def _extract_image_sources_info(
-    documents: list[Document], file_path_meta_field: str, root_path: str
-) -> list[_ImageSourceInfo]:
+    documents: list[Document], file_path_meta_field: str, root_path: str, *, raise_on_failure: bool = True
+) -> list[_ImageSourceInfo | None]:
     """
     Extracts the image source information from the documents.
 
     :param documents: List of documents to extract image source information from.
     :param file_path_meta_field: The metadata field in the Document that contains the file path to the image or PDF.
     :param root_path: The root directory path where document files are located.
+    :param raise_on_failure: If True, a document that fails validation raises ValueError and no information is
+        returned for any document. If False, the failure is logged as a warning and that document's entry is None,
+        so a caller can report the failure per document and still process the rest of the batch. A path-traversal
+        attempt raises in both cases.
 
     :returns:
-        A list of _ImageSourceInfo dictionaries, each containing the path and type of the image.
-        If the image is a PDF, the dictionary also contains the page number.
+        A list with one entry per input document, in the same order. Each entry is an _ImageSourceInfo dictionary
+        containing the path and type of the image, and for a PDF also the page number. An entry is None only when
+        raise_on_failure is False and that document failed validation.
     :raises ValueError: If the document is missing the file_path_meta_field key in its metadata, the file path is
-        invalid, the MIME type is not supported, or the page number is missing for a PDF document.
+        invalid, the MIME type is not supported, or the page number is missing for a PDF document, and
+        raise_on_failure is True.
+    :raises _PathTraversalError: If root_path is set and a resolved file path lies outside it, whatever
+        raise_on_failure is set to.
     """
-    images_source_info: list[_ImageSourceInfo] = []
+    images_source_info: list[_ImageSourceInfo | None] = []
     for doc in documents:
-        file_path = doc.meta.get(file_path_meta_field)
-        if file_path is None:
-            raise ValueError(
-                f"Document with ID '{doc.id}' is missing the '{file_path_meta_field}' key in its metadata."
-                f" Please ensure that the documents you are trying to convert have this key set."
-            )
-
-        resolved_file_path = Path(root_path, file_path)
-
-        # When root_path is set, ensure the resolved path stays within it to block path-traversal
-        # payloads (e.g. "../../etc/passwd") coming from document metadata. When root_path is unset,
-        # file paths are treated as absolute by design and no containment check is applied; callers that
-        # process untrusted metadata should configure root_path (see component docstrings).
-        if root_path:
-            resolved_file_path = resolved_file_path.resolve()
-            resolved_root = Path(root_path).resolve()
-            if not resolved_file_path.is_relative_to(resolved_root):
-                raise ValueError(
-                    f"Document with ID '{doc.id}' has a file path '{file_path}' that escapes the "
-                    f"configured root '{root_path}'. Resolved path: '{resolved_file_path}'."
-                )
-
-        if not resolved_file_path.is_file():
-            raise ValueError(
-                f"Document with ID '{doc.id}' has an invalid file path '{resolved_file_path}'. "
-                f"Please ensure that the documents you are trying to convert have valid file paths."
-            )
-
-        mime_type = doc.meta.get("mime_type") or mimetypes.guess_type(resolved_file_path)[0]
-        if mime_type not in IMAGE_MIME_TYPES:
-            raise ValueError(
-                f"Document with file path '{resolved_file_path}' has an unsupported MIME type '{mime_type}'. "
-                f"Please ensure that the documents you are trying to convert are of the supported "
-                f"types: {', '.join(IMAGE_MIME_TYPES)}."
-            )
-
-        image_info: _ImageSourceInfo = {"path": resolved_file_path, "mime_type": mime_type}
-
-        # If mimetype is PDF we also need the page number to be able to convert the right page
-        if mime_type == "application/pdf":
-            page_number = doc.meta.get("page_number")
-            if page_number is None:
-                raise ValueError(
-                    f"Document with ID '{doc.id}' comes from the PDF file '{resolved_file_path}' but is missing "
-                    f"the 'page_number' key in its metadata. Please ensure that PDF documents you are trying to "
-                    f"convert have this key set."
-                )
-            image_info["page_number"] = page_number
-
-        images_source_info.append(image_info)
+        try:
+            images_source_info.append(_extract_single_image_source_info(doc, file_path_meta_field, root_path))
+        except _PathTraversalError:
+            # Never downgraded to a warning: swallowing it would hide an attempted traversal in a large batch.
+            raise
+        except ValueError as error:
+            if raise_on_failure:
+                raise
+            # The exception text is the only place the reason for the failure exists, so it is carried into the
+            # warning rather than replaced by a generic one.
+            logger.warning("Skipping document with ID {document_id}: {reason}", document_id=doc.id, reason=str(error))
+            images_source_info.append(None)
 
     return images_source_info
 

--- a/releasenotes/notes/document-to-image-partial-failures-c7b3af6f29c15a18.yaml
+++ b/releasenotes/notes/document-to-image-partial-failures-c7b3af6f29c15a18.yaml
@@ -1,0 +1,23 @@
+---
+upgrade:
+  - |
+    ``DocumentToImageContent.run()`` no longer raises ``ValueError`` when a document cannot be converted.
+    A document that is missing the file path metadata key, points at a file that does not exist, or has an
+    unsupported MIME type now produces ``None`` in its position in ``image_contents`` and a logged warning
+    naming the document and the reason. Code that relied on the exception to detect bad input should check
+    for ``None`` entries instead:
+
+    .. code:: python
+
+      image_contents = converter.run(documents=documents)["image_contents"]
+      failed = [doc for doc, content in zip(documents, image_contents) if content is None]
+
+    A file path that escapes the configured ``root_path`` still raises ``ValueError``, because a rejected
+    path traversal is a property of the input as a whole rather than of one document.
+fixes:
+  - |
+    Fixed ``DocumentToImageContent`` dropping an entire batch when one document in it could not be converted.
+    Validation failures were raised before any document was processed, which made the documented partial
+    success path of ``LLMDocumentContentExtractor`` (routing unconvertible documents to ``failed_documents``
+    while returning the rest) unreachable for any batch containing a single bad document. Failures are now
+    reported per document as ``None``, the same way an out-of-range PDF page already was.

--- a/test/components/converters/image/test_document_to_image_content.py
+++ b/test/components/converters/image/test_document_to_image_content.py
@@ -53,32 +53,56 @@ class TestDocumentToImageContent:
         results = converter.run(documents=[])
         assert results == {"image_contents": []}
 
-    def test_run_with_missing_file_path_metadata(self) -> None:
+    def test_run_with_missing_file_path_metadata(self, caplog) -> None:
         converter = DocumentToImageContent()
         # Document without file_path in metadata
         doc_no_path = Document(content="test", meta={})
         # Document with file_path but file doesn't exist
         doc_no_file = Document(content="test", meta={"file_path": "nonexistent.jpg"})
-        with pytest.raises(ValueError, match="is missing the 'file_path' key"):
-            _ = converter.run(documents=[doc_no_path, doc_no_file])
 
-    def test_run_with_non_image_documents(self) -> None:
+        results = converter.run(documents=[doc_no_path, doc_no_file])
+
+        assert results["image_contents"] == [None, None]
+        assert "is missing the 'file_path' key" in caplog.text
+        assert "has an invalid file path" in caplog.text
+
+    def test_run_with_non_image_documents(self, caplog) -> None:
         converter = DocumentToImageContent()
         docx_doc = Document(content="test", meta={"file_path": "test/test_files/docx/sample_docx.docx"})
-        with pytest.raises(ValueError, match="has an unsupported MIME type"):
-            _ = converter.run(documents=[docx_doc])
+
+        results = converter.run(documents=[docx_doc])
+
+        assert results["image_contents"] == [None]
+        assert "has an unsupported MIME type" in caplog.text
 
     def test_run_with_invalid_file_path(self, caplog) -> None:
         converter = DocumentToImageContent()
         pdf_doc = Document(content="test", meta={"file_path": "wrong_name.jpg"})
-        with pytest.raises(ValueError, match="has an invalid file path 'wrong_name.jpg'"):
-            _ = converter.run(documents=[pdf_doc])
+
+        results = converter.run(documents=[pdf_doc])
+
+        assert results["image_contents"] == [None]
+        assert "has an invalid file path 'wrong_name.jpg'" in caplog.text
 
     def test_run_with_pdf_missing_page_number(self, caplog) -> None:
         converter = DocumentToImageContent()
         pdf_doc = Document(content="test", meta={"file_path": "test/test_files/pdf/sample_pdf_1.pdf"})
-        with pytest.raises(ValueError, match="is missing the 'page_number' key"):
-            _ = converter.run(documents=[pdf_doc])
+
+        results = converter.run(documents=[pdf_doc])
+
+        assert results["image_contents"] == [None]
+        assert "is missing the 'page_number' key" in caplog.text
+
+    def test_run_still_raises_on_path_traversal(self) -> None:
+        # A path escaping root_path is an attempted traversal rather than one document's data being wrong,
+        # so it is not downgraded to a None entry where it could be missed in a large batch.
+        converter = DocumentToImageContent(root_path="test/test_files/images")
+        documents = [
+            Document(content="", meta={"file_path": "apple.jpg"}),
+            Document(content="", meta={"file_path": "../../../../../../etc/passwd"}),
+        ]
+        with pytest.raises(ValueError, match="escapes the configured root"):
+            _ = converter.run(documents=documents)
 
     def test_run_with_image_documents(self) -> None:
         converter = DocumentToImageContent(root_path="test/test_files/images")
@@ -97,15 +121,42 @@ class TestDocumentToImageContent:
             "page_number": 1,
         }
 
-    def test_run_with_mixed_document_types(self) -> None:
+    def test_run_with_mixed_document_types(self, caplog) -> None:
+        # One unconvertible document must not cost the batch the convertible ones: this is what makes the
+        # documented `failed_documents` path of LLMDocumentContentExtractor reachable.
         converter = DocumentToImageContent(root_path="test/test_files")
         documents = [
             Document(content="", meta={"file_path": "images/apple.jpg"}),
             Document(content="", meta={"file_path": "pdf/sample_pdf_1.pdf", "page_number": 1}),
             Document(content="text", meta={"file_path": "docx/sample_docx.docx"}),
         ]
-        with pytest.raises(ValueError, match="has an unsupported MIME type"):
-            _ = converter.run(documents=documents)
+
+        image_contents = converter.run(documents=documents)["image_contents"]
+
+        assert len(image_contents) == 3
+        assert image_contents[0] is not None
+        assert image_contents[1] is not None
+        assert image_contents[2] is None
+        assert "has an unsupported MIME type" in caplog.text
+        assert documents[2].id in caplog.text
+
+    def test_run_keeps_positions_when_a_document_in_the_middle_fails(self) -> None:
+        # The failing document sits between the two good ones, and the second good one is a PDF, which is
+        # converted through a separate pass keyed by position. Dropping the failure from the list instead of
+        # holding its place would silently hand the PDF's image to the document before it.
+        converter = DocumentToImageContent(root_path="test/test_files")
+        documents = [
+            Document(content="", meta={"file_path": "images/apple.jpg"}),
+            Document(content="text", meta={"file_path": "docx/sample_docx.docx"}),
+            Document(content="", meta={"file_path": "pdf/sample_pdf_1.pdf", "page_number": 1}),
+        ]
+
+        image_contents = converter.run(documents=documents)["image_contents"]
+
+        assert len(image_contents) == 3
+        assert image_contents[0].meta == {"file_path": "images/apple.jpg"}
+        assert image_contents[1] is None
+        assert image_contents[2].meta == {"file_path": "pdf/sample_pdf_1.pdf", "page_number": 1}
 
     @patch("haystack.components.converters.image.document_to_image._extract_image_sources_info")
     @patch("haystack.components.converters.image.document_to_image._batch_convert_pdf_pages_to_images")

--- a/test/components/converters/image/test_image_utils.py
+++ b/test/components/converters/image/test_image_utils.py
@@ -149,6 +149,39 @@ class TestExtractImageSourcesInfo:
         with pytest.raises(ValueError, match="missing the 'page_number' key"):
             _extract_image_sources_info(documents=[document], file_path_meta_field="file_path", root_path="")
 
+    def test_extract_image_source_info_reports_failures_per_document(self, test_files_path, caplog):
+        documents = [
+            Document(content="test", meta={"file_path": str(test_files_path / "images" / "haystack-logo.png")}),
+            Document(content="test", meta={"file_path": str(test_files_path / "docx" / "sample_docx.docx")}),
+            Document(content="test"),
+            Document(content="test", meta={"file_path": str(test_files_path / "images" / "apple.jpg")}),
+        ]
+
+        images_source_info = _extract_image_sources_info(
+            documents=documents, file_path_meta_field="file_path", root_path="", raise_on_failure=False
+        )
+
+        # One entry per input document, in order, so the caller can map a result back to the document it came from.
+        assert len(images_source_info) == len(documents)
+        assert images_source_info[0]["mime_type"] == "image/png"
+        assert images_source_info[1] is None
+        assert images_source_info[2] is None
+        assert images_source_info[3]["mime_type"] == "image/jpeg"
+
+        # The reason each document failed is only in the exception text, so it has to reach the warning.
+        assert "has an unsupported MIME type" in caplog.text
+        assert "is missing the 'file_path' key" in caplog.text
+
+    def test_extract_image_source_info_still_raises_traversal_when_not_raising_on_failure(self, test_files_path):
+        document = Document(content="test", meta={"file_path": "../../../../../../etc/passwd"})
+        with pytest.raises(ValueError, match="escapes the configured root"):
+            _extract_image_sources_info(
+                documents=[document],
+                file_path_meta_field="file_path",
+                root_path=str(test_files_path / "images"),
+                raise_on_failure=False,
+            )
+
     def test_extract_image_source_info_rejects_path_traversal(self, test_files_path):
         # Attacker-controlled document metadata attempts to escape the configured root.
         document = Document(content="test", meta={"file_path": "../../../../../../etc/passwd"})


### PR DESCRIPTION
### Related Issues

- fixes #12447

### Proposed Changes:

`DocumentToImageContent.run` declares its output as `list[ImageContent | None]`, and `LLMDocumentContentExtractor` is built around that `None`: it pairs the list with the input documents and routes the `None` ones into `failed_documents` with a `content_extraction_error`. That partial-success path was unreachable for any batch containing a single unconvertible document, because `_extract_image_sources_info` validated the whole list up front and raised `ValueError` on the first failure. Two convertible documents and one `.docx` produced no output at all.

The component already treats a neighbouring failure exactly the way the issue asks for: a PDF page that does not exist yields `None` in that position and a logged warning (`test_run_none_images`).

So this does not add a new mechanism. The warning that names the failed documents already sits at the end of `run`, and `image_contents` is already `[None] * len(documents)` indexed by position — the validation failures simply never reached it.

- `_extract_image_sources_info` takes `raise_on_failure: bool = True`, keeping today's contract by default, and returns one entry per input document. Its per-document body moved into `_extract_single_image_source_info` so the loop can catch a failure without the nesting.
- When `raise_on_failure=False`, a failure is logged as a warning **carrying the text that would have been the exception**, and that document's entry is `None`. The reason a document failed only exists in that message, and a bare `None` would throw it away.
- `DocumentToImageContent.run` passes `raise_on_failure=False` and skips `None` entries.

### How did you test it?

Full unit suite on Python 3.12 via `hatch run test:unit`. `pre-commit run --files <changed files>` clean.

Reverting only the two source files and re-running the touched test directory gives 2 failures and 17 errors, so the new expectations do depend on the change.

New tests:

- `test_run_with_mixed_document_types` — the issue's own reproduction, now asserting `[ImageContent, ImageContent, None]` instead of a raise.
- `test_run_keeps_positions_when_a_document_in_the_middle_fails` — see the reviewer note below.
- `test_run_still_raises_on_path_traversal` — see the reviewer note below.
- `test_extract_image_source_info_reports_failures_per_document` and `test_extract_image_source_info_still_raises_traversal_when_not_raising_on_failure` at the helper level.

Four existing tests that pinned the raising behaviour (`test_run_with_missing_file_path_metadata`, `test_run_with_non_image_documents`, `test_run_with_invalid_file_path`, `test_run_with_pdf_missing_page_number`) now assert the `None` entry and the warning text instead. The six `pytest.raises` cases in `test_image_utils.py` are untouched, because the helper's default is unchanged.

### Notes for the reviewer

**One deliberate difference from what the issue asks.** Of the five `raise` sites in the helper, four describe one document's data. The fifth does not:

```python
# When root_path is set, ensure the resolved path stays within it to block path-traversal
# payloads (e.g. "../../etc/passwd") coming from document metadata.
```

Turning that into a warning would mean an attempted traversal is reported as one line among the failures of a large batch and the run continues. It keeps raising, through a `_PathTraversalError(ValueError)` subclass so that existing callers and the two existing tests matching on `ValueError` are unaffected. If you would rather it were reported per document like the rest, say so and I will change it.

**Why the helper returns `None` placeholders rather than a shorter list.** `run` walks the result with `enumerate` and uses the index to reach into `documents` and `image_contents`, and the PDF branch carries that index through a separate conversion pass. Dropping failures instead of holding their place silently attaches images to the wrong documents. `LLMDocumentContentExtractor` then pairs the two lists with `zip(..., strict=True)`, so a shorter list would raise there instead. `test_run_keeps_positions_when_a_document_in_the_middle_fails` puts the bad document between a good image and a good PDF for exactly this.

**Overlap, named rather than left to be discovered.** @Whxuan0701 said on 2026-08-24 that they would like to take this issue. As far as I can see nothing has been opened since, and this branch was written today; I am not trying to get in front of anyone. If they have work in progress, or if the maintainers would rather the issue went to them, close this and I will have no objection at all.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

---

This PR was fully generated with an AI assistant. I have reviewed the changes
and run the relevant tests.
