### PR TITLE
fix: embed documents that share an id separately in OpenAIDocumentEmbedder

### DIFF
--- a/haystack/components/embedders/openai_document_embedder.py
+++ b/haystack/components/embedders/openai_document_embedder.py
@@ -224,33 +224,35 @@ class OpenAIDocumentEmbedder:
         """
         return default_from_dict(cls, data)
 
-    def _prepare_texts_to_embed(self, documents: list[Document]) -> dict[str, str]:
+    def _prepare_texts_to_embed(self, documents: list[Document]) -> list[tuple[str, str]]:
         """
         Prepare the texts to embed by concatenating the Document text with the metadata fields to embed.
+
+        Returns one `(document id, text)` pair per input document, in input order. Documents are not keyed by
+        id, so documents sharing an id each keep their own text.
         """
-        texts_to_embed = {}
+        texts_to_embed = []
         for doc in documents:
             meta_values_to_embed = [
                 str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key] is not None
             ]
 
-            texts_to_embed[doc.id] = (
-                self.prefix + self.embedding_separator.join(meta_values_to_embed + [doc.content or ""]) + self.suffix
-            )
+            text = self.prefix + self.embedding_separator.join(meta_values_to_embed + [doc.content or ""]) + self.suffix
+            texts_to_embed.append((doc.id, text))
 
         return texts_to_embed
 
     def _embed_batch(
-        self, texts_to_embed: dict[str, str], batch_size: int
-    ) -> tuple[dict[str, list[float]], dict[str, Any]]:
+        self, texts_to_embed: list[tuple[str, str]], batch_size: int
+    ) -> tuple[list[list[float] | None], dict[str, Any]]:
         """
         Embed a list of texts in batches.
         """
 
-        doc_ids_to_embeddings: dict[str, list[float]] = {}
+        all_embeddings: list[list[float] | None] = []
         meta: dict[str, Any] = {}
         for batch in tqdm(
-            batched(texts_to_embed.items(), batch_size), disable=not self.progress_bar, desc="Calculating embeddings"
+            batched(texts_to_embed, batch_size), disable=not self.progress_bar, desc="Calculating embeddings"
         ):
             args: dict[str, Any] = {"model": self.model, "input": [b[1] for b in batch], "encoding_format": "float"}
 
@@ -267,10 +269,10 @@ class OpenAIDocumentEmbedder:
                 logger.exception(msg, ids=ids, exc=exc)
                 if self.raise_on_failure:
                     raise exc
+                all_embeddings.extend([None] * len(batch))
                 continue
 
-            embeddings = [el.embedding for el in response.data]
-            doc_ids_to_embeddings.update(dict(zip((b[0] for b in batch), embeddings, strict=True)))
+            all_embeddings.extend(el.embedding for el in response.data)
 
             if "model" not in meta:
                 meta["model"] = response.model
@@ -280,19 +282,19 @@ class OpenAIDocumentEmbedder:
                 meta["usage"]["prompt_tokens"] += response.usage.prompt_tokens
                 meta["usage"]["total_tokens"] += response.usage.total_tokens
 
-        return doc_ids_to_embeddings, meta
+        return all_embeddings, meta
 
     async def _embed_batch_async(
-        self, texts_to_embed: dict[str, str], batch_size: int
-    ) -> tuple[dict[str, list[float]], dict[str, Any]]:
+        self, texts_to_embed: list[tuple[str, str]], batch_size: int
+    ) -> tuple[list[list[float] | None], dict[str, Any]]:
         """
         Embed a list of texts in batches asynchronously.
         """
 
-        doc_ids_to_embeddings: dict[str, list[float]] = {}
+        all_embeddings: list[list[float] | None] = []
         meta: dict[str, Any] = {}
 
-        batches = list(batched(texts_to_embed.items(), batch_size))
+        batches = list(batched(texts_to_embed, batch_size))
         if self.progress_bar:
             batches = async_tqdm(batches, desc="Calculating embeddings")
 
@@ -312,10 +314,10 @@ class OpenAIDocumentEmbedder:
                 logger.exception(msg, ids=ids, exc=exc)
                 if self.raise_on_failure:
                     raise exc
+                all_embeddings.extend([None] * len(batch))
                 continue
 
-            embeddings = [el.embedding for el in response.data]
-            doc_ids_to_embeddings.update(dict(zip((b[0] for b in batch), embeddings, strict=True)))
+            all_embeddings.extend(el.embedding for el in response.data)
 
             if "model" not in meta:
                 meta["model"] = response.model
@@ -325,7 +327,7 @@ class OpenAIDocumentEmbedder:
                 meta["usage"]["prompt_tokens"] += response.usage.prompt_tokens
                 meta["usage"]["total_tokens"] += response.usage.total_tokens
 
-        return doc_ids_to_embeddings, meta
+        return all_embeddings, meta
 
     @component.output_types(documents=list[Document], meta=dict[str, Any])
     def run(self, documents: list[Document]) -> dict[str, Any]:
@@ -350,14 +352,12 @@ class OpenAIDocumentEmbedder:
 
         texts_to_embed = self._prepare_texts_to_embed(documents=documents)
 
-        doc_ids_to_embeddings, meta = self._embed_batch(texts_to_embed=texts_to_embed, batch_size=self.batch_size)
+        all_embeddings, meta = self._embed_batch(texts_to_embed=texts_to_embed, batch_size=self.batch_size)
 
-        new_documents = []
-        for doc in documents:
-            if doc.id in doc_ids_to_embeddings:
-                new_documents.append(replace(doc, embedding=doc_ids_to_embeddings[doc.id]))
-            else:
-                new_documents.append(replace(doc))
+        new_documents = [
+            replace(doc, embedding=embedding) if embedding is not None else replace(doc)
+            for doc, embedding in zip(documents, all_embeddings, strict=True)
+        ]
 
         return {"documents": new_documents, "meta": meta}
 
@@ -384,15 +384,11 @@ class OpenAIDocumentEmbedder:
 
         texts_to_embed = self._prepare_texts_to_embed(documents=documents)
 
-        doc_ids_to_embeddings, meta = await self._embed_batch_async(
-            texts_to_embed=texts_to_embed, batch_size=self.batch_size
-        )
+        all_embeddings, meta = await self._embed_batch_async(texts_to_embed=texts_to_embed, batch_size=self.batch_size)
 
-        new_documents = []
-        for doc in documents:
-            if doc.id in doc_ids_to_embeddings:
-                new_documents.append(replace(doc, embedding=doc_ids_to_embeddings[doc.id]))
-            else:
-                new_documents.append(replace(doc))
+        new_documents = [
+            replace(doc, embedding=embedding) if embedding is not None else replace(doc)
+            for doc, embedding in zip(documents, all_embeddings, strict=True)
+        ]
 
         return {"documents": new_documents, "meta": meta}

--- a/releasenotes/notes/openai-document-embedder-duplicate-ids-4f31604f6c5a7d4c.yaml
+++ b/releasenotes/notes/openai-document-embedder-duplicate-ids-4f31604f6c5a7d4c.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed ``OpenAIDocumentEmbedder`` (and ``AzureOpenAIDocumentEmbedder``, which inherits from it) silently
+    dropping one of two documents that share an ``id``. Texts were collected in a dictionary keyed by document
+    id, so the second document's text overwrote the first, only one embedding was requested, and both documents
+    were returned carrying it. Texts are now kept in input order, so each document is embedded and receives its
+    own embedding.

--- a/test/components/embedders/test_azure_document_embedder.py
+++ b/test/components/embedders/test_azure_document_embedder.py
@@ -218,7 +218,7 @@ class TestAzureOpenAIDocumentEmbedder:
         embedder.warm_up()
         assert embedder.client is not None
 
-        fake_texts_to_embed = {"1": "text1", "2": "text2"}
+        fake_texts_to_embed = [("1", "text1"), ("2", "text2")]
 
         with patch.object(
             embedder.client.embeddings,
@@ -239,7 +239,7 @@ class TestAzureOpenAIDocumentEmbedder:
         )
         embedder.warm_up()
         assert embedder.client is not None
-        fake_texts_to_embed = {"1": "text1", "2": "text2"}
+        fake_texts_to_embed = [("1", "text1"), ("2", "text2")]
         with patch.object(
             embedder.client.embeddings,
             "create",

--- a/test/components/embedders/test_openai_document_embedder.py
+++ b/test/components/embedders/test_openai_document_embedder.py
@@ -15,6 +15,15 @@ from haystack.components.embedders.openai_document_embedder import OpenAIDocumen
 from haystack.utils.auth import Secret
 
 
+def one_embedding_per_input(**kwargs):
+    """Mimic the embeddings API, which returns exactly one embedding per input text."""
+    response = Mock()
+    response.data = [Mock(embedding=[float(i)]) for i in range(len(kwargs["input"]))]
+    response.model = "text-embedding-ada-002"
+    response.usage = {"prompt_tokens": 10, "total_tokens": 10}
+    return response
+
+
 class TestOpenAIDocumentEmbedder:
     def test_init_default(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
@@ -167,13 +176,13 @@ class TestOpenAIDocumentEmbedder:
 
         prepared_texts = embedder._prepare_texts_to_embed(documents)
 
-        assert prepared_texts == {
-            "0": "meta_value 0 | document number 0:\ncontent",
-            "1": "meta_value 1 | document number 1:\ncontent",
-            "2": "meta_value 2 | document number 2:\ncontent",
-            "3": "meta_value 3 | document number 3:\ncontent",
-            "4": "meta_value 4 | document number 4:\ncontent",
-        }
+        assert prepared_texts == [
+            ("0", "meta_value 0 | document number 0:\ncontent"),
+            ("1", "meta_value 1 | document number 1:\ncontent"),
+            ("2", "meta_value 2 | document number 2:\ncontent"),
+            ("3", "meta_value 3 | document number 3:\ncontent"),
+            ("4", "meta_value 4 | document number 4:\ncontent"),
+        ]
 
     def test_prepare_texts_to_embed_w_suffix(self):
         documents = [Document(id=f"{i}", content=f"document number {i}") for i in range(5)]
@@ -184,13 +193,13 @@ class TestOpenAIDocumentEmbedder:
 
         prepared_texts = embedder._prepare_texts_to_embed(documents)
 
-        assert prepared_texts == {
-            "0": "my_prefix document number 0 my_suffix",
-            "1": "my_prefix document number 1 my_suffix",
-            "2": "my_prefix document number 2 my_suffix",
-            "3": "my_prefix document number 3 my_suffix",
-            "4": "my_prefix document number 4 my_suffix",
-        }
+        assert prepared_texts == [
+            ("0", "my_prefix document number 0 my_suffix"),
+            ("1", "my_prefix document number 1 my_suffix"),
+            ("2", "my_prefix document number 2 my_suffix"),
+            ("3", "my_prefix document number 3 my_suffix"),
+            ("4", "my_prefix document number 4 my_suffix"),
+        ]
 
     def test_run_wrong_input_format(self):
         embedder = OpenAIDocumentEmbedder(api_key=Secret.from_token("fake-api-key"))
@@ -218,7 +227,7 @@ class TestOpenAIDocumentEmbedder:
         embedder = OpenAIDocumentEmbedder(api_key=Secret.from_token("fake_api_key"))
         embedder.warm_up()
         assert embedder.client is not None
-        fake_texts_to_embed = {"1": "text1", "2": "text2"}
+        fake_texts_to_embed = [("1", "text1"), ("2", "text2")]
         with patch.object(
             embedder.client.embeddings,
             "create",
@@ -259,11 +268,56 @@ class TestOpenAIDocumentEmbedder:
         assert result["documents"][0].embedding is None
         assert result["documents"][1].embedding == [0.4, 0.5, 0.6]
 
+    def test_run_documents_sharing_an_id_are_embedded_separately(self):
+        embedder = OpenAIDocumentEmbedder(api_key=Secret.from_token("fake_api_key"))
+        embedder.warm_up()
+        assert embedder.client is not None
+
+        documents = [
+            Document(id="A", content="first text"),
+            Document(id="B", content="second text"),
+            Document(id="A", content="third text, same id as the first"),
+        ]
+
+        with patch.object(embedder.client.embeddings, "create", side_effect=one_embedding_per_input) as mock_create:
+            result = embedder.run(documents=documents)
+
+        assert mock_create.call_args.kwargs["input"] == [
+            "first text",
+            "second text",
+            "third text, same id as the first",
+        ]
+        assert [doc.embedding for doc in result["documents"]] == [[0.0], [1.0], [2.0]]
+
+    @pytest.mark.asyncio
+    async def test_run_async_documents_sharing_an_id_are_embedded_separately(self):
+        embedder = OpenAIDocumentEmbedder(api_key=Secret.from_token("fake_api_key"))
+        await embedder.warm_up_async()
+        assert embedder.async_client is not None
+
+        documents = [
+            Document(id="A", content="first text"),
+            Document(id="B", content="second text"),
+            Document(id="A", content="third text, same id as the first"),
+        ]
+
+        with patch.object(
+            embedder.async_client.embeddings, "create", new=AsyncMock(side_effect=one_embedding_per_input)
+        ) as mock_create:
+            result = await embedder.run_async(documents=documents)
+
+        assert mock_create.call_args.kwargs["input"] == [
+            "first text",
+            "second text",
+            "third text, same id as the first",
+        ]
+        assert [doc.embedding for doc in result["documents"]] == [[0.0], [1.0], [2.0]]
+
     def test_embed_batch_raises_exception_on_failure(self):
         embedder = OpenAIDocumentEmbedder(api_key=Secret.from_token("fake_api_key"), raise_on_failure=True)
         embedder.warm_up()
         assert embedder.client is not None
-        fake_texts_to_embed = {"1": "text1", "2": "text2"}
+        fake_texts_to_embed = [("1", "text1"), ("2", "text2")]
         with patch.object(
             embedder.client.embeddings,
             "create",


### PR DESCRIPTION
### Related Issues

- fixes #12566

### Proposed Changes:

`_prepare_texts_to_embed` collected the prepared texts into a dict keyed by `doc.id`, and `_embed_batch` keyed the resulting embeddings the same way. When two input documents share an `id`, the second document's text overwrote the first in that dict, so only one embedding was ever requested. `run` then looked the embedding up by `doc.id` and handed the same vector to both documents. The first document's text was never embedded, and nothing warned about it.

The texts are now kept in input order as `(document id, text)` pairs, and the embeddings are zipped back onto the documents positionally, which is what `MockDocumentEmbedder` already does. Two details worth noting:

- `_embed_batch` already iterated `(id, text)` tuples via `.items()`, so its body is unchanged and the document ids are still available for the `APIError` log line.
- A batch that fails with `raise_on_failure=False` now contributes one `None` per document instead of simply being absent, so the positional alignment holds and those documents still come back without an embedding, as before.

`AzureOpenAIDocumentEmbedder` subclasses `OpenAIDocumentEmbedder` without overriding either method, so it inherits the fix.

The three changed methods are private, and `run`/`run_async` keep their signatures and return shapes.

### How did you test it?

Two regression tests, one for `run` and one for `run_async`, embedding three documents where the first and third share an `id`. They assert that all three texts reach the API and that each returned document gets its own embedding. The mock returns one embedding per input text, mirroring the real endpoint, so on the unpatched code the tests fail on the assertion itself:

```
E       AssertionError: assert ['third text,...'second text'] == ['first text'...as the first']
E         At index 0 diff: 'third text, same id as the first' != 'first text'
E         Right contains one more item: 'third text, same id as the first'
```

Commands run locally:

```
hatch run test:unit test/components/embedders/   ->  105 passed, 6 deselected
hatch run test:types                             ->  Success: no issues found in 482 source files
hatch run fmt                                    ->  All checks passed!
pre-commit run --files <changed files>           ->  all hooks passed
```

The existing tests that asserted the dict shape of `_prepare_texts_to_embed`, and the `_embed_batch` fixtures in both the OpenAI and Azure test modules, were updated to the new `(id, text)` pair shape.

### Notes for the reviewer

The alternative was to keep the dict and de-duplicate documents by id up front, but that changes what `run` returns for duplicate input and would still need a positional path for the output, so ordering the texts seemed like the smaller change.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
