### PR TITLE
fix: clear stale metadata_extraction_* keys on successful empty-JSON retry

### DIFF
--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -375,11 +375,11 @@ class LLMMetadataExtractor:
                 failed_documents.append(replace(document, meta=new_meta))
                 continue
 
+            # Remove metadata_extraction_error and metadata_extraction_response if present from previous runs
+            new_meta.pop("metadata_extraction_error", None)
+            new_meta.pop("metadata_extraction_response", None)
             for key in parsed_metadata:
                 new_meta[key] = parsed_metadata[key]
-                # Remove metadata_extraction_error and metadata_extraction_response if present from previous runs
-                new_meta.pop("metadata_extraction_error", None)
-                new_meta.pop("metadata_extraction_response", None)
             successful_documents.append(replace(document, meta=new_meta))
         return successful_documents, failed_documents
 

--- a/releasenotes/notes/Fix-LLMMetadataExtractor-retaining-stale-failure-metadata-after-a-successful-empty-JSON-retry-a495dfbcbda5d483.yaml
+++ b/releasenotes/notes/Fix-LLMMetadataExtractor-retaining-stale-failure-metadata-after-a-successful-empty-JSON-retry-a495dfbcbda5d483.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed ``LLMMetadataExtractor`` so that a successful retry no longer retains
+    ``metadata_extraction_error`` and ``metadata_extraction_response`` from a
+    previous failed attempt when the retry parses an empty JSON object (``{}``).

--- a/test/components/extractors/test_llm_metadata_extractor.py
+++ b/test/components/extractors/test_llm_metadata_extractor.py
@@ -356,6 +356,41 @@ class TestLLMMetadataExtractor:
         # Ensure no attempt was made to call the LLM
         mock_chat_generator.run_async.assert_not_called()
 
+    def test_run_clears_error_meta_on_empty_json_retry(self):
+        extractor = LLMMetadataExtractor(
+            prompt="Extract {{ document.content }}", chat_generator=MockChatGenerator(responses=["not json", "{}"])
+        )
+
+        first = extractor.run(documents=[Document(content="a")])
+        assert len(first["failed_documents"]) == 1
+        failed_doc = first["failed_documents"][0]
+        assert "metadata_extraction_error" in failed_doc.meta
+        assert "metadata_extraction_response" in failed_doc.meta
+
+        second = extractor.run(documents=[failed_doc])
+        assert len(second["documents"]) == 1
+        retried_doc = second["documents"][0]
+        assert "metadata_extraction_error" not in retried_doc.meta
+        assert "metadata_extraction_response" not in retried_doc.meta
+
+    @pytest.mark.asyncio
+    async def test_run_async_clears_error_meta_on_empty_json_retry(self):
+        extractor = LLMMetadataExtractor(
+            prompt="Extract {{ document.content }}", chat_generator=MockChatGenerator(responses=["not json", "{}"])
+        )
+
+        first = await extractor.run_async(documents=[Document(content="a")])
+        assert len(first["failed_documents"]) == 1
+        failed_doc = first["failed_documents"][0]
+        assert "metadata_extraction_error" in failed_doc.meta
+        assert "metadata_extraction_response" in failed_doc.meta
+
+        second = await extractor.run_async(documents=[failed_doc])
+        assert len(second["documents"]) == 1
+        retried_doc = second["documents"][0]
+        assert "metadata_extraction_error" not in retried_doc.meta
+        assert "metadata_extraction_response" not in retried_doc.meta
+
     @pytest.mark.asyncio
     async def test_run_async_respects_max_workers(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")


### PR DESCRIPTION
Fixes #12532

**Bug**
`LLMMetadataExtractor._process_results` cleared `metadata_extraction_error` and `metadata_extraction_response` inside the loop over parsed metadata keys. When a retry successfully parsed an empty JSON object (`{}`), that loop never executed, so the stale failure metadata from the previous run remained in `document.meta`.

**Fix**
Move the two `pop` calls before the metadata-key loop, so any successful retry (empty or not) removes the leftover failure metadata before applying the new metadata.

**Verification**
- Added regression tests for both `run()` and `run_async()` that fail before the fix and pass after.
- `hatch run test:unit test/components/extractors/test_llm_metadata_extractor.py` passes (29 passed, 2 deselected).
- `hatch run fmt` passes.
- Added release note.