### PR TITLE
fix(evaluators): raise ValueError on empty input instead of ZeroDivisionError

### DIFF
--- a/haystack/components/evaluators/answer_exact_match.py
+++ b/haystack/components/evaluators/answer_exact_match.py
@@ -53,6 +53,9 @@ class AnswerExactMatchEvaluator:
             - `score` - A number from 0.0 to 1.0 that represents the proportion of questions where any predicted
                          answer matched one of the ground truth answers.
         """
+        if len(ground_truth_answers) == 0 or len(predicted_answers) == 0:
+            raise ValueError("ground_truth_answers and predicted_answers must be provided.")
+
         if not len(ground_truth_answers) == len(predicted_answers):
             raise ValueError("The length of ground_truth_answers and predicted_answers must be the same.")
 

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -108,6 +108,10 @@ class DocumentMAPEvaluator:
             - `individual_scores` - A list of numbers from 0.0 to 1.0 that represents how high retrieved documents
                 are ranked.
         """
+        if len(ground_truth_documents) == 0 or len(retrieved_documents) == 0:
+            msg = "ground_truth_documents and retrieved_documents must be provided."
+            raise ValueError(msg)
+
         if len(ground_truth_documents) != len(retrieved_documents):
             msg = "The length of ground_truth_documents and retrieved_documents must be the same."
             raise ValueError(msg)

--- a/haystack/components/evaluators/document_mrr.py
+++ b/haystack/components/evaluators/document_mrr.py
@@ -106,6 +106,10 @@ class DocumentMRREvaluator:
             - `individual_scores` - A list of numbers from 0.0 to 1.0 that represents how high the first retrieved
                 document is ranked.
         """
+        if len(ground_truth_documents) == 0 or len(retrieved_documents) == 0:
+            msg = "ground_truth_documents and retrieved_documents must be provided."
+            raise ValueError(msg)
+
         if len(ground_truth_documents) != len(retrieved_documents):
             msg = "The length of ground_truth_documents and retrieved_documents must be the same."
             raise ValueError(msg)

--- a/haystack/components/evaluators/document_recall.py
+++ b/haystack/components/evaluators/document_recall.py
@@ -172,6 +172,10 @@ class DocumentRecallEvaluator:
             - `individual_scores` - A list of numbers from 0.0 to 1.0 that represents the proportion of matching
                 documents retrieved. If the mode is `single_hit`, the individual scores are 0 or 1.
         """
+        if len(ground_truth_documents) == 0 or len(retrieved_documents) == 0:
+            msg = "ground_truth_documents and retrieved_documents must be provided."
+            raise ValueError(msg)
+
         if len(ground_truth_documents) != len(retrieved_documents):
             msg = "The length of ground_truth_documents and retrieved_documents must be the same."
             raise ValueError(msg)

--- a/releasenotes/notes/fix-document-evaluators-empty-input-a9f223006a04a830.yaml
+++ b/releasenotes/notes/fix-document-evaluators-empty-input-a9f223006a04a830.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    Fixed ``DocumentMAPEvaluator``, ``DocumentMRREvaluator``, ``DocumentRecallEvaluator``, and
+    ``AnswerExactMatchEvaluator`` raising ``ZeroDivisionError`` instead of a clear ``ValueError``
+    when ``run`` was called with empty input lists. They now raise the same error as
+    ``DocumentNDCGEvaluator`` does in this situation.

--- a/test/components/evaluators/test_answer_exact_match.py
+++ b/test/components/evaluators/test_answer_exact_match.py
@@ -63,6 +63,24 @@ def test_run_with_complex_data():
     assert result == {"individual_scores": [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1], "score": 0.3333333333333333}
 
 
+def test_run_no_predicted_and_no_ground_truth():
+    evaluator = AnswerExactMatchEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(ground_truth_answers=[], predicted_answers=[])
+
+
+def test_run_no_ground_truth():
+    evaluator = AnswerExactMatchEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(ground_truth_answers=[], predicted_answers=["Berlin"])
+
+
+def test_run_no_predicted():
+    evaluator = AnswerExactMatchEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(ground_truth_answers=["Berlin"], predicted_answers=[])
+
+
 def test_run_with_different_lengths():
     evaluator = AnswerExactMatchEvaluator()
 

--- a/test/components/evaluators/test_document_map.py
+++ b/test/components/evaluators/test_document_map.py
@@ -158,6 +158,24 @@ def test_run_with_complex_data():
     }
 
 
+def test_run_no_retrieved_and_no_ground_truth():
+    evaluator = DocumentMAPEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(ground_truth_documents=[], retrieved_documents=[])
+
+
+def test_run_no_ground_truth():
+    evaluator = DocumentMAPEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(ground_truth_documents=[], retrieved_documents=[[Document(content="Berlin")]])
+
+
+def test_run_no_retrieved():
+    evaluator = DocumentMAPEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(ground_truth_documents=[[Document(content="Berlin")]], retrieved_documents=[])
+
+
 def test_run_with_different_lengths():
     with pytest.raises(ValueError):
         evaluator = DocumentMAPEvaluator()

--- a/test/components/evaluators/test_document_mrr.py
+++ b/test/components/evaluators/test_document_mrr.py
@@ -136,6 +136,24 @@ def test_run_with_complex_data():
     }
 
 
+def test_run_no_retrieved_and_no_ground_truth():
+    evaluator = DocumentMRREvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(ground_truth_documents=[], retrieved_documents=[])
+
+
+def test_run_no_ground_truth():
+    evaluator = DocumentMRREvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(ground_truth_documents=[], retrieved_documents=[[Document(content="Berlin")]])
+
+
+def test_run_no_retrieved():
+    evaluator = DocumentMRREvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(ground_truth_documents=[[Document(content="Berlin")]], retrieved_documents=[])
+
+
 def test_run_with_different_lengths():
     with pytest.raises(ValueError):
         evaluator = DocumentMRREvaluator()

--- a/test/components/evaluators/test_document_recall.py
+++ b/test/components/evaluators/test_document_recall.py
@@ -124,6 +124,18 @@ class TestDocumentRecallEvaluatorSingleHit:
         assert all(isinstance(individual_score, float) for individual_score in result["individual_scores"])
         assert result == {"individual_scores": [1, 1, 1, 1, 0, 1], "score": 0.8333333333333334}
 
+    def test_run_no_retrieved_and_no_ground_truth(self, evaluator):
+        with pytest.raises(ValueError):
+            evaluator.run(ground_truth_documents=[], retrieved_documents=[])
+
+    def test_run_no_ground_truth(self, evaluator):
+        with pytest.raises(ValueError):
+            evaluator.run(ground_truth_documents=[], retrieved_documents=[[Document(content="Berlin")]])
+
+    def test_run_no_retrieved(self, evaluator):
+        with pytest.raises(ValueError):
+            evaluator.run(ground_truth_documents=[[Document(content="Berlin")]], retrieved_documents=[])
+
     def test_run_with_different_lengths(self, evaluator):
         with pytest.raises(ValueError):
             evaluator.run(
@@ -253,6 +265,18 @@ class TestDocumentRecallEvaluatorMultiHit:
         )
         assert all(isinstance(individual_score, float) for individual_score in result["individual_scores"])
         assert result == {"individual_scores": [1.0, 1.0, 0.5, 1.0, 0.75, 1.0], "score": 0.875}
+
+    def test_run_no_retrieved_and_no_ground_truth(self, evaluator):
+        with pytest.raises(ValueError):
+            evaluator.run(ground_truth_documents=[], retrieved_documents=[])
+
+    def test_run_no_ground_truth(self, evaluator):
+        with pytest.raises(ValueError):
+            evaluator.run(ground_truth_documents=[], retrieved_documents=[[Document(content="Berlin")]])
+
+    def test_run_no_retrieved(self, evaluator):
+        with pytest.raises(ValueError):
+            evaluator.run(ground_truth_documents=[[Document(content="Berlin")]], retrieved_documents=[])
 
     def test_run_with_different_lengths(self, evaluator):
         with pytest.raises(ValueError):


### PR DESCRIPTION
fixes #12543

`DocumentMAPEvaluator`, `DocumentMRREvaluator`, `DocumentRecallEvaluator`, and `AnswerExactMatchEvaluator` crash with `ZeroDivisionError` when called with empty input lists. `DocumentNDCGEvaluator` allready handles this correctly with early `ValueError`.

added same guard to all four evaluators for consistancy — early `ValueError` in `run()` when either input list is empty.

added 3 tests per evaluator (12 total) to verify ValueError on empty input. existing evaluator tests still pass.