### PR TITLE
ci: stop installing ffmpeg in Test Python snippets in docs workflow

### DIFF
--- a/.github/workflows/docs-website-test-docs-snippets.yml
+++ b/.github/workflows/docs-website-test-docs-snippets.yml
@@ -40,9 +40,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install system dependencies
-        run: sudo apt-get install -y ffmpeg
-
       - name: Install Hatch
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
### Related Issues

Failing Test Python snippets in docs workflow: https://github.com/deepset-ai/haystack/actions/runs/33587283909/job/100153053704

This workflow tests the execution of a number of code snippets in docstrings.

It tries to install ffmpeg with `sudo apt-get install -y ffmpeg` but fails.

While looking into this, I realized that ffmpeg was needed to test snippets for Whisper components, which no longer live in Haystack but in Core Integrations.

### Proposed Changes:
- stop installing ffmpeg in Test Python snippets in docs workflow

### How did you test it?
Ran the script locally.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
