### PR TITLE
fix: CompactionHook token over-count when no assistant message is present

### DIFF
--- a/haystack/hooks/compaction/utils.py
+++ b/haystack/hooks/compaction/utils.py
@@ -148,6 +148,11 @@ def _estimated_context_tokens(
     # Nothing sent yet, or a generator that reports no usage, so count everything.
     if context_tokens == 0:
         return token_counter.count(messages=messages, tools=tools)
-    # Only need to estimate the tool result messages after the last assistant message
-    tool_result_messages = messages[_last_assistant_index(messages=messages) + 1 :]
+    # Only need to estimate the tool result messages after the last assistant message.
+    # If there is no assistant message yet, the provider's reported count already covers
+    # everything that was sent, so we must not add the full message list on top of it.
+    last_assistant_index = _last_assistant_index(messages=messages)
+    if last_assistant_index < 0:
+        return context_tokens
+    tool_result_messages = messages[last_assistant_index + 1 :]
     return context_tokens + token_counter.count(messages=tool_result_messages)

--- a/releasenotes/notes/fix-CompactionHook-token-over-count-when-no-assistant-message-is-present-f0b4c1c24f4b8709.yaml
+++ b/releasenotes/notes/fix-CompactionHook-token-over-count-when-no-assistant-message-is-present-f0b4c1c24f4b8709.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed `_estimated_context_tokens` in the compaction hook over-counting tokens
+    when the conversation contained no assistant message. Previously, when
+    `context_tokens > 0` and `_last_assistant_index` returned `-1`, the entire
+    message list was counted on top of the reported usage. Now the reported
+    count is returned unchanged in that case.

--- a/test/hooks/compaction/test_utils.py
+++ b/test/hooks/compaction/test_utils.py
@@ -224,3 +224,37 @@ class TestEstimatedContextTokens:
         assert _estimated_context_tokens(
             messages=messages, context_tokens=written, token_counter=counter
         ) == pytest.approx(counter.count(messages=messages), abs=2)
+
+    def test_no_assistant_message_does_not_over_count(self):
+        counter = FakeCounter()
+
+        # Empty conversation: nothing to add.
+        assert _estimated_context_tokens(messages=[], context_tokens=0, token_counter=counter) == 0
+
+        # No assistant message yet, so reported usage already covers everything.
+        user_only = [ChatMessage.from_user(text="hi")]
+        assert _estimated_context_tokens(messages=user_only, context_tokens=0, token_counter=counter) == counter.count(
+            messages=user_only
+        )
+
+        user_assistant = [ChatMessage.from_user(text="hi"), ChatMessage.from_assistant(text="hello")]
+        assert _estimated_context_tokens(
+            messages=user_assistant, context_tokens=0, token_counter=counter
+        ) == counter.count(messages=user_assistant)
+
+        # Tool result after an assistant message is counted, earlier messages are not.
+        with_assistant = [
+            ChatMessage.from_user(text="hi"),
+            ChatMessage.from_assistant(text="hello"),
+            tool_result(result="R" * 400),
+        ]
+        assert _estimated_context_tokens(
+            messages=with_assistant, context_tokens=1000, token_counter=counter
+        ) == 1000 + counter.count(messages=[with_assistant[-1]])
+
+        # Tool result with no preceding assistant message must not double-count.
+        user_tool = [ChatMessage.from_user(text="hi"), tool_result(result="R" * 400)]
+        assert _estimated_context_tokens(messages=user_tool, context_tokens=1000, token_counter=counter) == 1000
+
+        system_tool = [ChatMessage.from_system(text="rules"), tool_result(result="R" * 400)]
+        assert _estimated_context_tokens(messages=system_tool, context_tokens=1000, token_counter=counter) == 1000


### PR DESCRIPTION
Fixes #12580\n\nWhen `context_tokens > 0` but the conversation has no assistant message, `_estimated_context_tokens` was counting the entire message list on top of the provider's reported usage. This change short-circuits and returns `context_tokens` when there is no assistant message, matching the behavior described in the issue.\n\nChanges:\n- Updated `_estimated_context_tokens` in `haystack/hooks/compaction/utils.py`.\n- Added regression tests in `test/hooks/compaction/test_utils.py`.\n- Added release note.