### PR TITLE
feat(tools): derive Tool description and parameters from its function

### DIFF
--- a/docs-website/docs/tools/tool.mdx
+++ b/docs-website/docs/tools/tool.mdx
@@ -27,8 +27,8 @@ The `Tool` class is used in Chat Generators and provides a consistent experience
 @dataclass
 class Tool:
     name: str
-    description: str
-    parameters: dict[str, Any]
+    description: str = _DERIVE_FROM_FUNCTION
+    parameters: dict[str, Any] = _DERIVE_FROM_FUNCTION
     function: Callable | None = None
     outputs_to_string: dict[str, Any] | None = None
     inputs_from_state: dict[str, str] | None = None
@@ -37,8 +37,8 @@ class Tool:
 ```
 
 - `name` is the name of the Tool.
-- `description` is a string describing what the Tool does.
-- `parameters` is a JSON schema describing the expected parameters.
+- `description` is a string describing what the Tool does. If you don’t pass it, it is taken from the docstring of `function` (or `async_function`). Pass an empty string to leave it deliberately empty.
+- `parameters` is a JSON schema describing the expected parameters. If you don’t pass it, it is generated from the signature of `function` (or `async_function`), which must have a type hint for every parameter.
 - `function` is invoked when the Tool is called. It must be a regular (sync) function.
 - `async_function` (optional) is a coroutine function awaited when the Tool is invoked in an async context. See [Async Tools](#async-tools) below.
 - `outputs_to_string` (optional) controls how parts of the tool’s output are converted into one or more strings (e.g. for LLM consumption).
@@ -57,10 +57,10 @@ There are three ways to create a `Tool`:
 
 - **`@tool` decorator** — recommended for most cases; infers name, description, and schema from the function.
 - **`create_tool_from_function`** — same as `@tool` but called as a function; useful when you can’t decorate directly.
-- **Manual initialization** — construct `Tool(...)` directly when you need full control over the JSON schema.
+- **Manual initialization** — construct `Tool(...)` directly when you need full control over the JSON schema, or when the Tool is built from configuration rather than from a decorated function.
 
 :::tip
-For most use cases, we recommend `@tool` or `create_tool_from_function`. Both automatically generate the `parameters` JSON schema from your function’s type hints and [`Annotated`](https://docs.python.org/3/library/typing.html#typing.Annotated) parameter descriptions, so you don’t need to write the schema by hand.
+For most use cases, we recommend `@tool` or `create_tool_from_function`. Both automatically generate the `parameters` JSON schema from your function’s type hints and [`Annotated`](https://docs.python.org/3/library/typing.html#typing.Annotated) parameter descriptions, so you don’t need to write the schema by hand. Constructing `Tool(...)` directly and omitting `description` or `parameters` generates them the same way, so you only have to write out the schema when you want one that differs from the function’s.
 :::
 
 ### @tool decorator
@@ -195,6 +195,28 @@ print(add_tool.invoke(a=15, b=10))
 
 25
 ```
+
+Omit `description` or `parameters` and they are derived from `function`, the same way `@tool` and `create_tool_from_function` derive them. This is useful when the `Tool` is assembled from configuration — from a YAML file, say — where the decorator and the helper are not available:
+
+```python
+add_tool = Tool(name="addition_tool", function=add)
+
+print(add_tool.tool_spec)
+```
+
+```
+{
+    ‘name’: ‘addition_tool’,
+    ‘description’: ‘’,
+    ‘parameters’: {
+        ‘type’: ‘object’,
+        ‘properties’: {‘a’: {‘type’: ‘integer’}, ‘b’: {‘type’: ‘integer’}},
+        ‘required’: [‘a’, ‘b’]
+    }
+}
+```
+
+The description is empty here because `add` has no docstring — give the function one, or pass `description` explicitly.
 
 ### Advanced Tool Configuration
 

--- a/haystack/tools/from_function.py
+++ b/haystack/tools/from_function.py
@@ -130,6 +130,48 @@ def create_tool_from_function(
     :raises SchemaGenerationError:
         If there is an error generating the JSON schema for the Tool.
     """
+    tool_description, schema = _description_and_parameters_from_function(
+        function=function, description=description, inputs_from_state=inputs_from_state
+    )
+
+    is_async = inspect.iscoroutinefunction(function)
+
+    return Tool(
+        name=name or function.__name__,
+        description=tool_description,
+        parameters=schema,
+        function=None if is_async else function,
+        async_function=function if is_async else None,
+        inputs_from_state=inputs_from_state,
+        outputs_to_state=outputs_to_state,
+        outputs_to_string=outputs_to_string,
+    )
+
+
+def _description_and_parameters_from_function(
+    function: Callable, description: str | None = None, inputs_from_state: dict[str, str] | None = None
+) -> tuple[str, dict[str, Any]]:
+    """
+    Derive a Tool description and JSON schema from a function.
+
+    `Tool.__post_init__` calls this for any of the two that was not passed explicitly, so that a Tool built directly
+    and one built by `create_tool_from_function` describe the same function the same way.
+
+    :param function:
+        The function to describe. Every parameter must carry a type hint.
+    :param description:
+        Used as-is when given, including an empty string. When `None`, the function's docstring is used.
+    :param inputs_from_state:
+        Optional dictionary mapping state keys to tool parameter names. Parameters filled from state are left out
+        of the schema, since the model does not provide them.
+    :returns:
+        The description and the JSON schema of the parameters.
+
+    :raises ValueError:
+        If any parameter of the function lacks a type hint.
+    :raises SchemaGenerationError:
+        If there is an error generating the JSON schema.
+    """
     tool_description = description if description is not None else (function.__doc__ or "")
 
     signature = inspect.signature(function)
@@ -179,18 +221,7 @@ def create_tool_from_function(
         if param_name in schema["properties"]:
             schema["properties"][param_name]["description"] = param_description
 
-    is_async = inspect.iscoroutinefunction(function)
-
-    return Tool(
-        name=name or function.__name__,
-        description=tool_description,
-        parameters=schema,
-        function=None if is_async else function,
-        async_function=function if is_async else None,
-        inputs_from_state=inputs_from_state,
-        outputs_to_state=outputs_to_state,
-        outputs_to_string=outputs_to_string,
-    )
+    return tool_description, schema
 
 
 @overload

--- a/haystack/tools/tool.py
+++ b/haystack/tools/tool.py
@@ -15,6 +15,12 @@ from haystack.core.serialization import generate_qualified_class_name
 from haystack.tools.errors import ToolInvocationError
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
 
+# Default for `description` and `parameters`, meaning "not given, derive it from the function". It is annotated
+# `Any` so that the two fields keep the types they actually have once `__post_init__` has run — `str` and
+# `dict[str, Any]`. Declaring them optional instead would push a `None` that cannot occur onto every reader of
+# `tool.description` and `tool.parameters`, here and in the integrations.
+_DERIVE_FROM_FUNCTION: Any = None
+
 
 @dataclass
 class Tool:
@@ -32,9 +38,11 @@ class Tool:
     :param name:
         Name of the Tool.
     :param description:
-        Description of the Tool.
+        Description of the Tool. If not provided, it is derived from the docstring of `function`
+        (or `async_function`). To intentionally leave the description empty, pass an empty string.
     :param parameters:
-        A JSON schema defining the parameters expected by the Tool.
+        A JSON schema defining the parameters expected by the Tool. If not provided, it is derived from the
+        signature of `function` (or `async_function`), which must carry a type hint for every parameter.
     :param function:
         The synchronous function invoked by `Tool.invoke`. Must be a regular function — coroutine functions should
         be passed to `async_function` instead. Either `function` or `async_function` (or both) must be set.
@@ -93,15 +101,18 @@ class Tool:
         ```
     :raises ValueError: If neither `function` nor `async_function` is provided, if `function` is a
         coroutine function, if `async_function` is not a coroutine function, if `parameters` is not a
-        valid JSON schema, or if the `outputs_to_state`, `outputs_to_string`, or `inputs_from_state`
+        valid JSON schema, if `parameters` has to be derived and a parameter of the function lacks a
+        type hint, or if the `outputs_to_state`, `outputs_to_string`, or `inputs_from_state`
         configurations are invalid.
     :raises TypeError: If any configuration value in `outputs_to_state`, `outputs_to_string`, or
         `inputs_from_state` has the wrong type.
+    :raises SchemaGenerationError: If `parameters` has to be derived and the JSON schema cannot be
+        generated from the function.
     """
 
     name: str
-    description: str
-    parameters: dict[str, Any]
+    description: str = _DERIVE_FROM_FUNCTION
+    parameters: dict[str, Any] = _DERIVE_FROM_FUNCTION
     function: Callable | None = None
     outputs_to_string: dict[str, Any] | None = None
     inputs_from_state: dict[str, str] | None = None
@@ -109,8 +120,10 @@ class Tool:
     async_function: Callable | None = None
 
     def __post_init__(self) -> None:  # noqa: C901, PLR0912
-        # At least one of function / async_function must be set.
-        if self.function is None and self.async_function is None:
+        # At least one of function / async_function must be set. `function` is the one introspected when both are,
+        # matching `_get_valid_inputs` below.
+        introspection_target = self.function if self.function is not None else self.async_function
+        if introspection_target is None:
             raise ValueError(f"Tool '{self.name}' requires at least one of `function` or `async_function` to be set.")
 
         # `function` must be a regular (sync) function. Coroutine functions belong on `async_function`.
@@ -127,6 +140,10 @@ class Tool:
                 f"`async_function` must be a coroutine function defined with `async def`. "
                 f"Got '{getattr(self.async_function, '__name__', repr(self.async_function))}'."
             )
+
+        # Derive whatever was not given from the function itself, before the schema is validated below.
+        if self.description is _DERIVE_FROM_FUNCTION or self.parameters is _DERIVE_FROM_FUNCTION:
+            self._derive_missing_from_function(introspection_target)
 
         # Check that the parameters define a valid JSON schema
         try:
@@ -210,6 +227,29 @@ class Tool:
                         f"inputs_from_state maps '{state_key}' to unknown parameter '{param_name}'. "
                         f"Valid parameters are: {valid_inputs}."
                     )
+
+    def _derive_missing_from_function(self, function: Callable) -> None:
+        """
+        Fill in `description` and `parameters` from the function when they were not passed.
+
+        The derivation is the one `create_tool_from_function` performs, called through a shared helper so that a Tool
+        built directly and a Tool built from a function describe that function the same way.
+
+        :param function: The function to describe — `function` when it is set, `async_function` otherwise.
+
+        :raises ValueError: If `parameters` has to be derived and a parameter of the function lacks a type hint.
+        :raises SchemaGenerationError: If the JSON schema cannot be generated from the function.
+        """
+        # Imported here rather than at module level because `from_function` imports this module.
+        from haystack.tools.from_function import _description_and_parameters_from_function
+
+        derived_description, derived_parameters = _description_and_parameters_from_function(
+            function=function, inputs_from_state=self.inputs_from_state
+        )
+        if self.description is _DERIVE_FROM_FUNCTION:
+            self.description = derived_description
+        if self.parameters is _DERIVE_FROM_FUNCTION:
+            self.parameters = derived_parameters
 
     def _get_valid_inputs(self) -> set[str]:
         """

--- a/releasenotes/notes/tool-derive-description-and-parameters-from-function-dfe9704b81d35ed2.yaml
+++ b/releasenotes/notes/tool-derive-description-and-parameters-from-function-dfe9704b81d35ed2.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    ``Tool`` now derives ``description`` and ``parameters`` from its own ``function`` (or ``async_function``)
+    when they are not passed, using the same logic as ``create_tool_from_function``. Building a tool from a
+    function no longer means hand-writing its JSON schema, which matters when a ``Tool`` is constructed from
+    configuration rather than through the ``create_tool_from_function`` helper or the ``@tool`` decorator.
+    Passing either field explicitly behaves exactly as before, and an explicit empty description stays empty.

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from typing import Any
+from typing import Annotated, Any, Literal
 
 import pytest
 
+from haystack.components.agents.state.state import State
 from haystack.dataclasses import TextContent
-from haystack.tools import Tool, _check_duplicate_tool_names
+from haystack.tools import Tool, _check_duplicate_tool_names, create_tool_from_function
 from haystack.tools.errors import ToolInvocationError
 from haystack.tools.tool import (
     _deserialize_outputs_to_state,
@@ -472,3 +473,123 @@ def test_check_duplicate_tool_names():
         Tool(name="weather2", description="Get weather report", parameters=parameters, function=get_weather_report),
     ]
     _check_duplicate_tool_names(tools)
+
+
+def documented_weather(
+    city: Annotated[str, "the city for which to get the weather"] = "Munich",
+    unit: Annotated[Literal["Celsius", "Fahrenheit"], "the unit for the temperature"] = "Celsius",
+) -> str:
+    """A simple function to get the current weather for a location."""
+    return f"Weather report for {city}: 20 {unit}, sunny"
+
+
+async def async_documented_weather(city: Annotated[str, "the city for which to get the weather"] = "Munich") -> str:
+    """An async function to get the current weather for a location."""
+    return f"Weather report for {city}: 20°C, sunny"
+
+
+def weather_with_state(city: str, state: State, api_key: str = "secret") -> str:
+    return f"Weather report for {city}: 20°C, sunny"
+
+
+def undocumented_weather(city: str) -> str:
+    return f"Weather report for {city}: 20°C, sunny"
+
+
+documented_weather_parameters = {
+    "type": "object",
+    "properties": {
+        "city": {"type": "string", "description": "the city for which to get the weather", "default": "Munich"},
+        "unit": {
+            "type": "string",
+            "enum": ["Celsius", "Fahrenheit"],
+            "description": "the unit for the temperature",
+            "default": "Celsius",
+        },
+    },
+}
+
+
+class TestToolDerivedFromFunction:
+    def test_description_and_parameters_are_derived(self):
+        tool = Tool(name="weather", function=documented_weather)
+
+        assert tool.description == "A simple function to get the current weather for a location."
+        assert tool.parameters == documented_weather_parameters
+
+    def test_derived_values_match_create_tool_from_function(self):
+        derived = Tool(name="documented_weather", function=documented_weather)
+        built = create_tool_from_function(documented_weather)
+
+        assert derived.description == built.description
+        assert derived.parameters == built.parameters
+
+    def test_only_the_missing_one_is_derived(self):
+        without_description = Tool(name="weather", parameters=parameters, function=documented_weather)
+        assert without_description.description == "A simple function to get the current weather for a location."
+        assert without_description.parameters == parameters
+
+        without_parameters = Tool(name="weather", description="Get weather report", function=documented_weather)
+        assert without_parameters.description == "Get weather report"
+        assert without_parameters.parameters == documented_weather_parameters
+
+    def test_explicit_empty_description_is_kept(self):
+        tool = Tool(name="weather", description="", parameters=parameters, function=documented_weather)
+
+        assert tool.description == ""
+
+    def test_missing_docstring_derives_an_empty_description(self):
+        tool = Tool(name="weather", function=undocumented_weather)
+
+        assert tool.description == ""
+
+    def test_derived_from_async_function(self):
+        tool = Tool(name="weather", async_function=async_documented_weather)
+
+        assert tool.description == "An async function to get the current weather for a location."
+        assert tool.parameters == {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "the city for which to get the weather", "default": "Munich"}
+            },
+        }
+
+    def test_function_is_preferred_over_async_function(self):
+        tool = Tool(name="weather", function=documented_weather, async_function=async_documented_weather)
+
+        assert tool.description == "A simple function to get the current weather for a location."
+        assert tool.parameters == documented_weather_parameters
+
+    def test_derived_parameters_skip_state_and_inputs_from_state(self):
+        tool = Tool(name="weather", function=weather_with_state, inputs_from_state={"key": "api_key"})
+
+        assert tool.parameters == {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+
+    def test_tool_spec_uses_the_derived_values(self):
+        tool = Tool(name="weather", function=documented_weather)
+
+        assert tool.tool_spec == {
+            "name": "weather",
+            "description": "A simple function to get the current weather for a location.",
+            "parameters": documented_weather_parameters,
+        }
+
+    def test_derived_tool_round_trips(self):
+        tool = Tool(name="weather", function=documented_weather)
+        data = tool.to_dict()
+
+        assert data["data"]["description"] == "A simple function to get the current weather for a location."
+        assert data["data"]["parameters"] == documented_weather_parameters
+
+        deserialized = Tool.from_dict(data)
+        assert deserialized.description == tool.description
+        assert deserialized.parameters == tool.parameters
+        assert deserialized.function is documented_weather
+
+    def test_derivation_requires_type_hints(self):
+        with pytest.raises(ValueError, match="parameter 'city' does not have a type hint"):
+            Tool(name="weather", function=lambda city: f"Weather report for {city}")
+
+    def test_missing_function_still_raises_before_derivation(self):
+        with pytest.raises(ValueError, match="requires at least one of `function` or `async_function`"):
+            Tool(name="weather")


### PR DESCRIPTION
### Related Issues

- fixes #9006

### Proposed Changes:

`Tool` requires `description` and `parameters` at construction. `parameters` is
a JSON schema, so building a tool from a function by hand means writing out

```python
{"type": "object", "properties": {"city": {"type": "string", "description": ...}}}
```

for a function whose signature already says all of it. Haystack derives exactly
that, correctly, in `create_tool_from_function` — but that helper *constructs*
the `Tool`, so the derivation is unreachable to anyone who has to build the
object themselves. That is the case in the issue: a tool instantiated from a
YAML/config mapping, where neither the helper nor the `@tool` decorator is in
the picture.

Both fields are now optional and derived from the tool's own `function` (or
`async_function`) when they are not passed:

```python
def get_weather(
    city: Annotated[str, "the city for which to get the weather"] = "Munich",
    unit: Annotated[Literal["Celsius", "Fahrenheit"], "the unit"] = "Celsius",
) -> str:
    """A simple function to get the current weather for a location."""
    ...

Tool(name="get_weather", function=get_weather)
# description: 'A simple function to get the current weather for a location.'
# parameters:  the same schema create_tool_from_function(get_weather) produces
```

The schema-and-docstring logic moved out of `create_tool_from_function` into
`_description_and_parameters_from_function`, which both paths now call — so a
`Tool` built directly and a `Tool` built from a function cannot describe the
same function differently, including as that logic changes.

Deliberately unchanged:

- **`name` stays required.** @anakin87 raised inferring it as an aside and
  neither maintainer asked for it; the issue is about the other two.
- **`description=""` still means an empty description**, not "derive it". Only
  an omitted field is derived, which is why the default is a sentinel and not
  the empty string.
- **Passing either field explicitly behaves exactly as before**, subclasses
  included: `ComponentTool`, `AgentTool` and `PipelineTool` all resolve both
  values before calling `super().__init__`, so nothing is derived for them.

Two notes on the shape, both places where I went against the obvious version:

- **The ordering problem raised in the issue does not arise.** `name`,
  `description` and `parameters` are the first three fields and everything
  after them already defaults, so the middle two can take defaults with no
  reordering and no `field()` tricks.
- **The fields keep their real types instead of becoming `Optional`.** The
  sketch in the issue used `Optional[str] = None`, and I tried that first: it
  type-checks, but `description` and `parameters` are never `None` once
  `__post_init__` has run, so declaring them optional pushes an impossible case
  onto every reader. `hatch run test:types` measured it — **18 errors across 8
  files**, `haystack/tools/searchable_toolset.py` among them, each one an `or
  {}` guarding a case that cannot happen, and the same would land on the
  integrations repo. The sentinel default annotated `Any` keeps `str` and
  `dict[str, Any]` true for every consumer and needs no `type: ignore`, no cast
  and no assertion — which is what `AGENTS.md` asks for. It is one line and it
  is commented where it sits.

### How did you test it?

`test/tools/test_tool.py`, class `TestToolDerivedFromFunction` — 12 tests:
both fields derived; only the missing one derived; derived values equal to
`create_tool_from_function`'s; explicit `""` kept; missing docstring giving
`""`; derivation from `async_function`; `function` preferred when both are set;
`State` and `inputs_from_state` parameters left out of the derived schema;
`tool_spec`; `to_dict`/`from_dict` round trip; a parameter without a type hint
raising; and no function at all still raising first.

- `hatch run test:unit` — **6359 passed, 10 skipped, 324 deselected, 0 failed**
  on `main` at `84b90b8`; **6371 passed, 10 skipped, 324 deselected, 0 failed**
  with this branch, which is the baseline plus the 12 new tests and nothing
  else moved.
- Reverting only `haystack/tools/tool.py` fails **11 of the 12** with
  `TypeError: Tool.__init__() missing 2 required positional arguments`. The
  twelfth is the `description=""` guard, which passes either way by
  construction.
- `hatch run test:types` — `Success: no issues found in 482 source files`.
- `pre-commit run --files …` — all hooks pass, `release-note-backticks` and
  `codespell` included.

### Notes for the reviewer

The interesting file is `haystack/tools/tool.py`. `from_function.py` is a pure
move in its own commit: `create_tool_from_function`'s body is unchanged, it
just lives in the new helper and the old function calls it.

`docs-website/docs/tools/tool.mdx` is in here because the page prints the
dataclass signature with both fields required and tells the reader to use
`@tool` *"so you don't need to write the schema by hand"* — sentences this
change makes wrong. I touched only those, plus one worked example whose output
I ran rather than typed. Happy to drop that file if you would rather write the
docs yourselves.

One open question I could not answer from the thread: @anakin87, you wrote in
March 2025 that you would like to work on this — if it is still yours, say so
and I will close this.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

---

This PR was fully generated with an AI assistant. I have reviewed the changes
and run the relevant tests.
