### PR TITLE
fix(hooks): skip offload for empty-string tool results

### DIFF
--- a/haystack/hooks/tool_result_offloading/hooks.py
+++ b/haystack/hooks/tool_result_offloading/hooks.py
@@ -269,12 +269,15 @@ class ToolResultOffloadHook:
         if policy is None:
             return message
 
+        # Empty results ("" or []) stay in context — check before wrapping a string into TextContent,
+        # otherwise "" becomes a one-element list and slips past the emptiness guard.
+        if not result.result:
+            return message
+
         # A plain string result is handled as a single text block, so everything below has one shape to work with.
         content_blocks: list[TextContent | ImageContent | FileContent] = (
             [TextContent(text=result.result)] if isinstance(result.result, str) else list(result.result)
         )
-        if not content_blocks:
-            return message
 
         # Check whether the store can store binary content before offloading an image or file result. A text-only store
         # leaves the result in context and logs a warning.

--- a/releasenotes/notes/fix-empty-string-tool-result-offload-12583.yaml
+++ b/releasenotes/notes/fix-empty-string-tool-result-offload-12583.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    ``ToolResultOffloadHook`` no longer offloads empty-string tool results. Empty
+    strings are now treated like empty lists and left in context, matching the
+    documented "when the result is empty" behavior and avoiding zero-byte store
+    files with a dangling ``Preview:`` pointer.

--- a/test/hooks/tool_result_offloading/test_hooks.py
+++ b/test/hooks/tool_result_offloading/test_hooks.py
@@ -189,14 +189,15 @@ class TestToolResultOffloadHookBehavior:
         assert over_state.data["messages"][0].tool_call_result.result.startswith("Tool result offloaded")
         assert under_state.data["messages"][0].tool_call_result.result == [image]
 
-    def test_empty_result_is_not_offloaded(self, tmp_path):
+    @pytest.mark.parametrize("empty_result", ["", []], ids=["empty_string", "empty_list"])
+    def test_empty_result_is_not_offloaded(self, tmp_path, empty_result):
         hook = ToolResultOffloadHook(
             store=FileSystemToolResultStore(root=tmp_path), offload_strategies={"*": AlwaysOffload()}
         )
-        message = ChatMessage.from_tool(tool_result=[], origin=ToolCall(tool_name="a", arguments={}, id="1"))
+        message = ChatMessage.from_tool(tool_result=empty_result, origin=ToolCall(tool_name="a", arguments={}, id="1"))
         state = _state_with_messages([message])
         hook.run(state)
-        assert state.data["messages"][0].tool_call_result.result == []
+        assert state.data["messages"][0].tool_call_result.result == empty_result
         assert not list(Path(tmp_path).iterdir())
 
     def test_id_less_parallel_calls_do_not_collide(self, tmp_path):


### PR DESCRIPTION
### Related Issues

- fixes #12583

### Proposed Changes:

`_maybe_offload` wrapped string results into `[TextContent(...)]` before the emptiness check, so `result=""` became a one-element list and was offloaded as a zero-byte file with a dangling `Preview:` pointer. Empty lists already returned early. Check `if not result.result` before wrapping so `""` and `[]` are both left in context.

### How did you test it?

```bash
pytest test/hooks/tool_result_offloading/test_hooks.py -k empty_result_is_not_offloaded -q
```

2 passed (`empty_string`, `empty_list`).

### Notes for the reviewer

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- I have read the contributors guidelines and the code of conduct.
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the conventional commit types for my PR title.
- I have documented my code.
- I have added a release note file.
- I have run focused tests for this change.

Made with [Cursor](https://cursor.com)