### PR TITLE
fix: leave empty-string tool results in context instead of offloading them

### DIFF
--- a/haystack/hooks/tool_result_offloading/hooks.py
+++ b/haystack/hooks/tool_result_offloading/hooks.py
@@ -269,12 +269,15 @@ class ToolResultOffloadHook:
         if policy is None:
             return message
 
+        # Both shapes an empty result can take - an empty string and an empty sequence - are left in context: there is
+        # nothing to write and a pointer would cost more context than the result it replaces.
+        if not result.result:
+            return message
+
         # A plain string result is handled as a single text block, so everything below has one shape to work with.
         content_blocks: list[TextContent | ImageContent | FileContent] = (
             [TextContent(text=result.result)] if isinstance(result.result, str) else list(result.result)
         )
-        if not content_blocks:
-            return message
 
         # Check whether the store can store binary content before offloading an image or file result. A text-only store
         # leaves the result in context and logs a warning.

--- a/releasenotes/notes/tool-result-offload-empty-string-c94aebcf11fbbe39.yaml
+++ b/releasenotes/notes/tool-result-offload-empty-string-c94aebcf11fbbe39.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed ``ToolResultOffloadHook`` offloading a tool result that is an empty string. An empty string result was
+    written to the store as a zero-byte entry and replaced in the conversation by a pointer with a dangling
+    ``Preview:``. Empty results are now left in context for both shapes a result can take, an empty string and an
+    empty sequence, matching the hook's documented behavior.

--- a/test/hooks/tool_result_offloading/test_hooks.py
+++ b/test/hooks/tool_result_offloading/test_hooks.py
@@ -189,14 +189,15 @@ class TestToolResultOffloadHookBehavior:
         assert over_state.data["messages"][0].tool_call_result.result.startswith("Tool result offloaded")
         assert under_state.data["messages"][0].tool_call_result.result == [image]
 
-    def test_empty_result_is_not_offloaded(self, tmp_path):
+    @pytest.mark.parametrize("empty_result", ["", []], ids=["empty_string", "empty_list"])
+    def test_empty_result_is_not_offloaded(self, tmp_path, empty_result):
         hook = ToolResultOffloadHook(
             store=FileSystemToolResultStore(root=tmp_path), offload_strategies={"*": AlwaysOffload()}
         )
-        message = ChatMessage.from_tool(tool_result=[], origin=ToolCall(tool_name="a", arguments={}, id="1"))
+        message = ChatMessage.from_tool(tool_result=empty_result, origin=ToolCall(tool_name="a", arguments={}, id="1"))
         state = _state_with_messages([message])
         hook.run(state)
-        assert state.data["messages"][0].tool_call_result.result == []
+        assert state.data["messages"][0].tool_call_result.result == empty_result
         assert not list(Path(tmp_path).iterdir())
 
     def test_id_less_parallel_calls_do_not_collide(self, tmp_path):


### PR DESCRIPTION
### Related Issues

- fixes #12583

### Proposed Changes:

`ToolResultOffloadHook._maybe_offload` documents that a tool result is left in context *"when the result is empty"*, but the emptiness guard ran **after** a `str` result had already been wrapped into a single-element list:

```python
content_blocks = [TextContent(text=result.result)] if isinstance(result.result, str) else list(result.result)
if not content_blocks:
    return message
```

`ToolCallResultContentT` is `str | Sequence[TextContent | ImageContent | FileContent]`, so an empty result has two shapes — and only one of them reached the guard:

| `result.result` | `content_blocks` | outcome |
| --- | --- | --- |
| `[]` | `[]` | left in context ✅ |
| `""` | `[TextContent("")]` | offloaded ❌ |

The empty-string case was written to the store as a zero-byte entry and replaced in the conversation by a pointer ending in a dangling `Preview: ` — no ellipsis is emitted, because `len("") > preview_chars` is false and the slice itself is empty:

```
Tool result offloaded to text (0 characters) at '<store>/0_a_1.txt'. Preview:
```

That entry is never read again, so the run pays a store write and hands the model a pointer to nothing.

This is reachable from a normal Agent run, not only from a hand-built message: a tool returning `""` passes through `_result_to_string`, which returns strings as-is, into `ChatMessage.from_tool`, which stores the value verbatim — so `result.result` keeps its `str` shape all the way to the hook.

The fix tests the raw result before the wrapping, so both empty shapes take the same path:

```python
if not result.result:
    return message
```

The `if not content_blocks` check is dropped as unreachable: past the new guard the result is truthy, and both arms of the union are truthy only when they yield at least one block.

No API change, and no behavior change for non-empty results.

### How did you test it?

Extended the existing `test_empty_result_is_not_offloaded` into a parametrized test over `""` and `[]`, asserting both that the result is unchanged in state and that nothing was written to the store.

Checked against the pre-fix code so the new case is a real regression test — it reproduces the reported symptom exactly:

```
FAILED test/hooks/tool_result_offloading/test_hooks.py::TestToolResultOffloadHookBehavior::test_empty_result_is_not_offloaded[empty_string]
E   assert "Tool result ...t'. Preview: " == ''
E     + Tool result offloaded to text (0 characters) at '.../1_a_1.txt'. Preview:
1 failed, 1 passed
```

With the change, `test/hooks/tool_result_offloading/` passes in full (37 passed), as do `ruff format --check`, `ruff check`, and `mypy` on the package.

### Notes for the reviewer

One adjacent shape is deliberately left alone: a non-empty list whose blocks are all empty text (`[TextContent(text="")]`) still offloads, and still produces the dangling `Preview: `. Covering it would need `all(isinstance(b, TextContent) and not b.text for b in content_blocks)`, which reads further from the docstring's "the result is empty" than the raw-value check does. Happy to widen it if you would rather the symptom be gone in every shape.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
