### PR TITLE
fix: page_number for form feeds inside a RecursiveDocumentSplitter chunk

### DIFF
--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -421,7 +421,8 @@ class RecursiveDocumentSplitter:
             )
 
     def _run_one(self, doc: Document) -> list[Document]:
-        chunks = self._chunk_text(doc.content)  # type: ignore # the caller already check for a non-empty doc.content
+        text = doc.content or ""  # the caller already check for a non-empty doc.content
+        chunks = self._chunk_text(text)
         chunks = chunks[:-1] if len(chunks[-1]) == 0 else chunks  # remove last empty chunk if it exists
 
         # apply the overlap once, on the fully chunked list, so that chunks produced
@@ -430,7 +431,6 @@ class RecursiveDocumentSplitter:
             chunks = self._apply_overlap(chunks)
 
         current_position = 0
-        current_page = 1
 
         new_docs: list[Document] = []
 
@@ -447,17 +447,12 @@ class RecursiveDocumentSplitter:
             if split_nr > 0 and self.split_overlap > 0:
                 self._add_overlap_info(current_position, new_doc, new_docs)
 
-            # count page breaks in the chunk
-            current_page += chunk.count("\f")
-
-            # if there are consecutive page breaks at the end with no more text, adjust the page number
-            # e.g: "text\f\f\f" -> 3 page breaks, but current_page should be 1
-            consecutive_page_breaks = len(chunk) - len(chunk.rstrip("\f"))
-
-            if consecutive_page_breaks > 0:
-                new_doc.meta["page_number"] = current_page - consecutive_page_breaks
-            else:
-                new_doc.meta["page_number"] = current_page
+            # A chunk belongs to the page its first character of text is on, so only page breaks *before*
+            # that character count. Leading page breaks are part of the chunk and do advance it, while
+            # breaks inside or at the end of the chunk belong to later chunks.
+            # e.g: "text\f\f\f" -> 3 page breaks, but page_number is still 1
+            leading_page_breaks = len(chunk) - len(chunk.lstrip("\f"))
+            new_doc.meta["page_number"] = 1 + text.count("\f", 0, current_position + leading_page_breaks)
 
             # keep the new chunk doc and update the current position
             new_docs.append(new_doc)

--- a/releasenotes/notes/recursive-splitter-page-number-inside-chunk-32775c51be8f5db2.yaml
+++ b/releasenotes/notes/recursive-splitter-page-number-inside-chunk-32775c51be8f5db2.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed ``RecursiveDocumentSplitter`` assigning a chunk the ``page_number`` of the page it ends on
+    rather than the page its text starts on. Page breaks were counted before the page number was
+    assigned, and the existing correction only applied when the form feed was the chunk's very last
+    character, so any separator other than ``"\f"`` left the chunk one or more pages ahead.
+    ``page_number`` is now derived from the chunk's start offset in the original document.

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -213,7 +213,8 @@ def test_run_split_by_word_count_page_breaks_split_unit_char():
     assert doc_chunks[1].meta["split_idx_start"] == text.index(doc_chunks[1].content)
 
     assert doc_chunks[2].content == "another page. \f "
-    assert doc_chunks[2].meta["page_number"] == 3
+    # "another" is still on page 2; the page break only starts the page the next chunk is on
+    assert doc_chunks[2].meta["page_number"] == 2
     assert doc_chunks[2].meta["split_id"] == 2
     assert doc_chunks[2].meta["split_idx_start"] == text.index(doc_chunks[2].content)
 
@@ -226,6 +227,18 @@ def test_run_split_by_word_count_page_breaks_split_unit_char():
     assert doc_chunks[4].meta["page_number"] == 3
     assert doc_chunks[4].meta["split_id"] == 4
     assert doc_chunks[4].meta["split_idx_start"] == text.index(doc_chunks[4].content)
+
+
+def test_run_page_break_inside_chunk_keeps_page_number_of_chunk_start() -> None:
+    splitter = RecursiveDocumentSplitter(split_length=4, split_overlap=0, separators=[" "], split_unit="word")
+    text = "aa bb\fcc dd ee ff\fgg hh"
+
+    doc_chunks = splitter.run([Document(content=text)])["documents"]
+
+    assert [chunk.content for chunk in doc_chunks] == ["aa bb\fcc dd ee ", "ff\fgg hh"]
+    # "aa" is on page 1 and "ff" is on page 2, so a page break that falls inside a chunk must not
+    # move that chunk onto a later page
+    assert [chunk.meta["page_number"] for chunk in doc_chunks] == [1, 2]
 
 
 def test_run_split_by_page_break_count_page_breaks() -> None:
@@ -563,7 +576,8 @@ def test_run_split_by_word_count_page_breaks_word_unit():
     assert doc_chunks[1].meta["split_idx_start"] == text.index(doc_chunks[1].content)
 
     assert doc_chunks[2].content == "on another page. \f "
-    assert doc_chunks[2].meta["page_number"] == 3
+    # "on another page." is still on page 2; the page break only starts the page the next chunk is on
+    assert doc_chunks[2].meta["page_number"] == 2
     assert doc_chunks[2].meta["split_id"] == 2
     assert doc_chunks[2].meta["split_idx_start"] == text.index(doc_chunks[2].content)
 


### PR DESCRIPTION
### Related Issues

None — found comparing how the splitters compute `page_number`.

### Proposed Changes:

`RecursiveDocumentSplitter` counted every `\f` in a chunk *before* assigning its `page_number`, so a chunk got the page it **ends** on, not the page its text **starts** on.

A correction exists, but it only strips form feeds that are the chunk's very last characters (`chunk.rstrip("\f")`). With any separator other than `"\f"` the break is followed by the separator, so it never fires — `"another page. \f "` ends with a space.

`page_number` now comes from the chunk's start offset, already tracked for `split_idx_start`. Leading form feeds still advance the chunk's page, so that is unchanged.

`"aa bb\fcc dd ee ff\fgg hh"`, `split_length=4`, `separators=[" "]`, `split_unit="word"`:

| chunk | before | after |
|---|---|---|
| `"aa bb\fcc dd ee "` | 2 | 1 |
| `"ff\fgg hh"` | 3 | 2 |

`DocumentSplitter` returns 1 and 2 for this text.

### How did you test it?

New unit test for a break inside a chunk. `hatch run test:unit test`: 6360 passed before, 6361 after, no failures either side. `fmt` and `test:types` clean on the changed files.

Two existing assertions changed from 3 to 2, both on the chunk starting `"another page."` — that text is on page 2. The other four page assertions in each test are unchanged.

### Notes for the reviewer

This PR was generated with an AI assistant (Claude Code, claude-opus-5). I reviewed the changes and ran the relevant tests.
