### PR TITLE
fix: fix `CompactionHook` mis-counting context size when measuring a conversation with no assistant messages

### DIFF
--- a/haystack/hooks/compaction/hooks.py
+++ b/haystack/hooks/compaction/hooks.py
@@ -237,12 +237,12 @@ class CompactionHook:
         # If the original value was 0, leave it unchanged so later steps keep recounting the full request locally.
         if original_context_tokens != 0:
             # Re-estimate the provider-accounted context through the last assistant message, including overhead. If we
-            # added the trailing tool results, a second registered hook could double count them.
-            state.set(
-                "context_tokens",
-                self.token_counter.count(messages=compacted[: _last_assistant_index(messages=compacted) + 1])
-                + estimated_overhead,
-            )
+            # added the trailing tool results, a second registered hook could double count them. With no assistant
+            # message the whole compacted conversation is accounted for, which is what `_estimated_context_tokens`
+            # expects when it returns the count unchanged.
+            last_assistant_index = _last_assistant_index(messages=compacted)
+            accounted = compacted if last_assistant_index < 0 else compacted[: last_assistant_index + 1]
+            state.set("context_tokens", self.token_counter.count(messages=accounted) + estimated_overhead)
         logger.debug(
             "Compacted the Agent's conversation at step {step} from {before} to {after} messages, targeting {target} "
             "tokens.",

--- a/haystack/hooks/compaction/hooks.py
+++ b/haystack/hooks/compaction/hooks.py
@@ -15,13 +15,39 @@ from haystack.core.serialization import (
 )
 from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction.types import Compactor
-from haystack.hooks.compaction.utils import _estimated_context_tokens, _last_assistant_index
+from haystack.hooks.compaction.utils import _last_assistant_index
 from haystack.token_counters import ApproximateTokenCounter, TokenCounter
 from haystack.tools import ToolsType
 from haystack.utils.deserialization import deserialize_component_inplace
 from haystack.utils.experimental import _experimental
 
 logger = logging.getLogger(__name__)
+
+
+def _estimated_context_tokens(
+    messages: list[ChatMessage], context_tokens: int, token_counter: TokenCounter, tools: ToolsType | None = None
+) -> int:
+    """
+    Estimate the size of the whole conversation.
+
+    :param messages: The conversation, oldest to newest.
+    :param context_tokens: The `context_tokens` state key, anchored on the provider's own token counting. It accounts
+        for the conversation through the last assistant message, or for the whole conversation when there is none.
+    :param token_counter: The counter to measure the unaccounted messages with.
+    :param tools: Tools whose schemas are sent alongside the messages. These are counted when provider usage is absent.
+    :returns: The estimated total token count.
+    """
+    # Nothing sent yet, or a generator that reports no usage, so count everything.
+    if context_tokens == 0:
+        return token_counter.count(messages=messages, tools=tools)
+    # `context_tokens` accounts for the conversation through the last assistant message, so only the tool result
+    # messages after it still need estimating. If there is no assistant message, `context_tokens` accounts for the
+    # whole conversation, so nothing more needs counting.
+    last_assistant_index = _last_assistant_index(messages=messages)
+    if last_assistant_index < 0:
+        return context_tokens
+    tool_result_messages = messages[last_assistant_index + 1 :]
+    return context_tokens + token_counter.count(messages=tool_result_messages)
 
 
 @_experimental
@@ -167,6 +193,8 @@ class CompactionHook:
         :returns: The target token amount the messages should be compacted to and the estimated non-message overhead,
             or None when the conversation is not yet large enough to compact.
         """
+        # Estimate the total context size, including the provider's own count of the conversation through the last
+        # assistant message and the tool schemas.
         estimated = _estimated_context_tokens(
             messages=messages, context_tokens=context_tokens, token_counter=self.token_counter, tools=tools
         )
@@ -237,9 +265,8 @@ class CompactionHook:
         # If the original value was 0, leave it unchanged so later steps keep recounting the full request locally.
         if original_context_tokens != 0:
             # Re-estimate the provider-accounted context through the last assistant message, including overhead. If we
-            # added the trailing tool results, a second registered hook could double count them. With no assistant
-            # message the whole compacted conversation is accounted for, which is what `_estimated_context_tokens`
-            # expects when it returns the count unchanged.
+            # added the trailing tool results, a second registered hook could double count them. If there is no
+            # assistant message, count everything.
             last_assistant_index = _last_assistant_index(messages=compacted)
             accounted = compacted if last_assistant_index < 0 else compacted[: last_assistant_index + 1]
             state.set("context_tokens", self.token_counter.count(messages=accounted) + estimated_overhead)

--- a/haystack/hooks/compaction/utils.py
+++ b/haystack/hooks/compaction/utils.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from haystack.dataclasses import ChatMessage, ChatRole
-from haystack.token_counters import TokenCounter
-from haystack.tools import ToolsType
 
 # Meta key marking a message that a compactor produced. Its value records which strategy ran.
 _COMPACTION_META_KEY = "context_compaction"
@@ -131,29 +129,3 @@ def _historical_turn_groups(messages: list[ChatMessage], system_end: int, task_i
         list(range(start, end))
         for start, end in _historical_turn_spans(messages=messages, start=system_end, end=historical_end)
     ]
-
-
-def _estimated_context_tokens(
-    messages: list[ChatMessage], context_tokens: int, token_counter: TokenCounter, tools: ToolsType | None = None
-) -> int:
-    """
-    Estimate the size of the whole conversation.
-
-    :param messages: The conversation, oldest to newest.
-    :param context_tokens: The `context_tokens` state key, anchored on the provider's own token counting. It accounts
-        for the conversation through the last assistant message, or for the whole conversation when there is none.
-    :param token_counter: The counter to measure the unaccounted messages with.
-    :param tools: Tools whose schemas are sent alongside the messages. These are counted when provider usage is absent.
-    :returns: The estimated total token count.
-    """
-    # Nothing sent yet, or a generator that reports no usage, so count everything.
-    if context_tokens == 0:
-        return token_counter.count(messages=messages, tools=tools)
-    # `context_tokens` accounts for the conversation through the last assistant message, so only the tool result
-    # messages after it still need estimating. With no assistant message it accounts for the whole conversation, so
-    # counting the messages on top of it would double count them.
-    last_assistant_index = _last_assistant_index(messages=messages)
-    if last_assistant_index < 0:
-        return context_tokens
-    tool_result_messages = messages[last_assistant_index + 1 :]
-    return context_tokens + token_counter.count(messages=tool_result_messages)

--- a/haystack/hooks/compaction/utils.py
+++ b/haystack/hooks/compaction/utils.py
@@ -140,7 +140,8 @@ def _estimated_context_tokens(
     Estimate the size of the whole conversation.
 
     :param messages: The conversation, oldest to newest.
-    :param context_tokens: The `context_tokens` state key which is computed using the provider's own token counting.
+    :param context_tokens: The `context_tokens` state key, anchored on the provider's own token counting. It accounts
+        for the conversation through the last assistant message, or for the whole conversation when there is none.
     :param token_counter: The counter to measure the unaccounted messages with.
     :param tools: Tools whose schemas are sent alongside the messages. These are counted when provider usage is absent.
     :returns: The estimated total token count.
@@ -148,6 +149,11 @@ def _estimated_context_tokens(
     # Nothing sent yet, or a generator that reports no usage, so count everything.
     if context_tokens == 0:
         return token_counter.count(messages=messages, tools=tools)
-    # Only need to estimate the tool result messages after the last assistant message
-    tool_result_messages = messages[_last_assistant_index(messages=messages) + 1 :]
+    # `context_tokens` accounts for the conversation through the last assistant message, so only the tool result
+    # messages after it still need estimating. With no assistant message it accounts for the whole conversation, so
+    # counting the messages on top of it would double count them.
+    last_assistant_index = _last_assistant_index(messages=messages)
+    if last_assistant_index < 0:
+        return context_tokens
+    tool_result_messages = messages[last_assistant_index + 1 :]
     return context_tokens + token_counter.count(messages=tool_result_messages)

--- a/releasenotes/notes/fix-CompactionHook-token-over-count-when-no-assistant-message-is-present-f0b4c1c24f4b8709.yaml
+++ b/releasenotes/notes/fix-CompactionHook-token-over-count-when-no-assistant-message-is-present-f0b4c1c24f4b8709.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed ``CompactionHook`` mis-estimating the context size when compaction leaves a conversation with no assistant
+    message, for example when a compactor summarizes every Agent step away. The hook now records the whole compacted
+    conversation as accounted for, and the estimate reads that count back unchanged, so a second compaction hook
+    running right after sees the true size instead of counting the conversation twice.

--- a/test/hooks/compaction/test_hooks.py
+++ b/test/hooks/compaction/test_hooks.py
@@ -237,6 +237,25 @@ class TestCompactionHook:
         assert state.data["token_usage"] == {"prompt_tokens": 12}
         assert state.data["tool_call_counts"] == {"fetch": 2}
 
+    def test_re_estimates_context_tokens_when_compaction_leaves_no_assistant_message(self):
+        # A compactor can summarize every step away, leaving only system and user messages. The written back count then
+        # accounts for the whole conversation, so a second hook running right after reads it back unchanged instead of
+        # losing the surviving messages.
+        counter = FakeCounter()
+        compacted = [ChatMessage.from_system("rules"), ChatMessage.from_user("a summary of the work so far")]
+        messages = fresh_conversation_with_two_steps()
+        original_context_tokens = 800
+        estimated_overhead = _estimated_context_tokens(
+            messages=messages, context_tokens=original_context_tokens, token_counter=counter
+        ) - counter.count(messages=messages)
+        state = make_state(messages=messages, context_tokens=original_context_tokens)
+
+        _hook(_RecordingCompactor(result=compacted), token_counter=counter).run(state=state)
+
+        written = counter.count(messages=compacted) + estimated_overhead
+        assert state.data["context_tokens"] == written
+        assert _estimated_context_tokens(messages=compacted, context_tokens=written, token_counter=counter) == written
+
     def test_preserves_the_no_usage_sentinel_after_compaction(self):
         compacted = [ChatMessage.from_assistant("kept")]
         state = make_state([ChatMessage.from_user("x" * 4000)], context_tokens=0)

--- a/test/hooks/compaction/test_hooks.py
+++ b/test/hooks/compaction/test_hooks.py
@@ -11,7 +11,8 @@ from haystack.components.agents import Agent
 from haystack.components.generators.chat import MockChatGenerator
 from haystack.dataclasses import ChatMessage
 from haystack.hooks.compaction import CompactionHook, Compactor, SlidingWindowCompactor, ToolResultPruningCompactor
-from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _estimated_context_tokens, _last_assistant_index
+from haystack.hooks.compaction.hooks import _estimated_context_tokens
+from haystack.hooks.compaction.utils import _COMPACTION_META_KEY, _last_assistant_index
 from haystack.hooks.invocation import _run_hooks, _run_hooks_async
 from haystack.token_counters import TokenCounter
 from haystack.tools import tool
@@ -32,6 +33,12 @@ WINDOW = 1000
 # `_record_context_tokens` sums the prompt and completion tokens, so every reply reports a context of 800 tokens - 80%
 # of the window, which is over any `compact_at` these tests use.
 USAGE_META = {"usage": {"prompt_tokens": 700, "completion_tokens": 100}}
+
+
+@tool
+def lookup(query: str) -> str:
+    """Look up information relevant to a query."""
+    return query
 
 
 @tool
@@ -104,6 +111,70 @@ def _assert_every_tool_result_is_answered(messages: list[ChatMessage]) -> None:
             offered_call_ids.add(call.id)
         for result in message.tool_call_results:
             assert result.origin.id in offered_call_ids, f"orphaned tool result: {result.origin}"
+
+
+class TestEstimatedContextTokens:
+    def test_counts_only_what_the_generator_has_not_seen(self):
+        counter = FakeCounter()
+        # The reported count covers everything through the assistant reply; only the tool result came after.
+        messages = [
+            ChatMessage.from_user(text="start"),
+            ChatMessage.from_assistant(text="reply"),
+            tool_result(result="R" * 400),
+        ]
+        delta = counter.count(messages=messages[2:])
+        assert _estimated_context_tokens(messages=messages, context_tokens=5000, token_counter=counter) == 5000 + delta
+        assert delta > 0
+
+    def test_equals_the_reported_count_when_nothing_followed(self):
+        messages = [ChatMessage.from_user(text="start"), ChatMessage.from_assistant(text="reply")]
+        assert _estimated_context_tokens(messages=messages, context_tokens=5000, token_counter=FakeCounter()) == 5000
+
+    def test_falls_back_to_counting_everything_without_reported_usage(self):
+        counter = FakeCounter()
+        messages = [
+            ChatMessage.from_user(text="start"),
+            ChatMessage.from_assistant(text="reply"),
+            tool_result(result="R" * 400),
+        ]
+        assert _estimated_context_tokens(
+            messages=messages, context_tokens=0, token_counter=counter, tools=[lookup]
+        ) == counter.count(messages=messages, tools=[lookup])
+
+    def test_the_written_back_value_does_not_double_count(self):
+        # After compacting, the hook writes back the count through the last assistant message. Feeding that straight
+        # back in must reproduce the size of the whole conversation, not overshoot it. Counting the two parts separately
+        # loses the separator between them, so allow a couple of tokens of slack.
+        counter = FakeCounter()
+        messages = [
+            ChatMessage.from_user(text="start"),
+            ChatMessage.from_assistant(text="reply"),
+            tool_result(result="R" * 400),
+        ]
+        written = counter.count(messages=messages[: _last_assistant_index(messages=messages) + 1])
+        assert _estimated_context_tokens(
+            messages=messages, context_tokens=written, token_counter=counter
+        ) == pytest.approx(counter.count(messages=messages), abs=2)
+
+    @pytest.mark.parametrize(
+        "messages",
+        [
+            pytest.param([ChatMessage.from_user(text="hi"), tool_result(result="R" * 400)], id="after-user"),
+            pytest.param([ChatMessage.from_system(text="rules"), tool_result(result="R" * 400)], id="after-system"),
+        ],
+    )
+    def test_returns_the_reported_count_without_an_assistant_message(self, messages):
+        # The reported count covers the whole conversation when no assistant message splits it, so nothing is added.
+        assert _estimated_context_tokens(messages=messages, context_tokens=1000, token_counter=FakeCounter()) == 1000
+
+    def test_the_written_back_value_does_not_under_count_without_an_assistant_message(self):
+        # After compacting to a conversation with no assistant message, the hook writes back the count of the whole
+        # conversation. Feeding that straight back in must reproduce it rather than drop the messages.
+        counter = FakeCounter()
+        messages = [ChatMessage.from_system(text="rules"), ChatMessage.from_user(text="a summary of the work so far")]
+        written = counter.count(messages=messages)
+        assert _estimated_context_tokens(messages=messages, context_tokens=written, token_counter=counter) == written
+        assert written > 0
 
 
 class TestCompactionHookConfiguration:

--- a/test/hooks/compaction/test_utils.py
+++ b/test/hooks/compaction/test_utils.py
@@ -224,3 +224,23 @@ class TestEstimatedContextTokens:
         assert _estimated_context_tokens(
             messages=messages, context_tokens=written, token_counter=counter
         ) == pytest.approx(counter.count(messages=messages), abs=2)
+
+    @pytest.mark.parametrize(
+        "messages",
+        [
+            pytest.param([ChatMessage.from_user(text="hi"), tool_result(result="R" * 400)], id="after-user"),
+            pytest.param([ChatMessage.from_system(text="rules"), tool_result(result="R" * 400)], id="after-system"),
+        ],
+    )
+    def test_returns_the_reported_count_without_an_assistant_message(self, messages):
+        # The reported count covers the whole conversation when no assistant message splits it, so nothing is added.
+        assert _estimated_context_tokens(messages=messages, context_tokens=1000, token_counter=FakeCounter()) == 1000
+
+    def test_the_written_back_value_does_not_under_count_without_an_assistant_message(self):
+        # After compacting to a conversation with no assistant message, the hook writes back the count of the whole
+        # conversation. Feeding that straight back in must reproduce it rather than drop the messages.
+        counter = FakeCounter()
+        messages = [ChatMessage.from_system(text="rules"), ChatMessage.from_user(text="a summary of the work so far")]
+        written = counter.count(messages=messages)
+        assert _estimated_context_tokens(messages=messages, context_tokens=written, token_counter=counter) == written
+        assert written > 0

--- a/test/hooks/compaction/test_utils.py
+++ b/test/hooks/compaction/test_utils.py
@@ -9,22 +9,14 @@ from haystack.hooks.compaction.utils import (
     _COMPACTION_META_KEY,
     _agent_step_spans,
     _current_agent_step_groups,
-    _estimated_context_tokens,
     _historical_turn_groups,
     _historical_turn_spans,
     _is_compaction_message,
     _last_assistant_index,
 )
-from haystack.tools import tool
-from test.hooks.compaction.helpers import FakeCounter, tool_call, tool_result
+from test.hooks.compaction.helpers import tool_call, tool_result
 
 pytestmark = pytest.mark.filterwarnings("ignore::haystack.utils.experimental.ExperimentalWarning")
-
-
-@tool
-def lookup(query: str) -> str:
-    """Look up information relevant to a query."""
-    return query
 
 
 class TestLastAssistantIndex:
@@ -180,67 +172,3 @@ class TestCurrentAgentStepGroups:
     def test_missing_task_anchor(self):
         messages = [ChatMessage.from_system("rules"), ChatMessage.from_assistant("step")]
         assert _current_agent_step_groups(messages=messages, system_end=1, task_index=None) == [[1]]
-
-
-class TestEstimatedContextTokens:
-    def test_counts_only_what_the_generator_has_not_seen(self):
-        counter = FakeCounter()
-        # The reported count covers everything through the assistant reply; only the tool result came after.
-        messages = [
-            ChatMessage.from_user(text="start"),
-            ChatMessage.from_assistant(text="reply"),
-            tool_result(result="R" * 400),
-        ]
-        delta = counter.count(messages=messages[2:])
-        assert _estimated_context_tokens(messages=messages, context_tokens=5000, token_counter=counter) == 5000 + delta
-        assert delta > 0
-
-    def test_equals_the_reported_count_when_nothing_followed(self):
-        messages = [ChatMessage.from_user(text="start"), ChatMessage.from_assistant(text="reply")]
-        assert _estimated_context_tokens(messages=messages, context_tokens=5000, token_counter=FakeCounter()) == 5000
-
-    def test_falls_back_to_counting_everything_without_reported_usage(self):
-        counter = FakeCounter()
-        messages = [
-            ChatMessage.from_user(text="start"),
-            ChatMessage.from_assistant(text="reply"),
-            tool_result(result="R" * 400),
-        ]
-        assert _estimated_context_tokens(
-            messages=messages, context_tokens=0, token_counter=counter, tools=[lookup]
-        ) == counter.count(messages=messages, tools=[lookup])
-
-    def test_the_written_back_value_does_not_double_count(self):
-        # After compacting, the hook writes back the count through the last assistant message. Feeding that straight
-        # back in must reproduce the size of the whole conversation, not overshoot it. Counting the two parts separately
-        # loses the separator between them, so allow a couple of tokens of slack.
-        counter = FakeCounter()
-        messages = [
-            ChatMessage.from_user(text="start"),
-            ChatMessage.from_assistant(text="reply"),
-            tool_result(result="R" * 400),
-        ]
-        written = counter.count(messages=messages[: _last_assistant_index(messages=messages) + 1])
-        assert _estimated_context_tokens(
-            messages=messages, context_tokens=written, token_counter=counter
-        ) == pytest.approx(counter.count(messages=messages), abs=2)
-
-    @pytest.mark.parametrize(
-        "messages",
-        [
-            pytest.param([ChatMessage.from_user(text="hi"), tool_result(result="R" * 400)], id="after-user"),
-            pytest.param([ChatMessage.from_system(text="rules"), tool_result(result="R" * 400)], id="after-system"),
-        ],
-    )
-    def test_returns_the_reported_count_without_an_assistant_message(self, messages):
-        # The reported count covers the whole conversation when no assistant message splits it, so nothing is added.
-        assert _estimated_context_tokens(messages=messages, context_tokens=1000, token_counter=FakeCounter()) == 1000
-
-    def test_the_written_back_value_does_not_under_count_without_an_assistant_message(self):
-        # After compacting to a conversation with no assistant message, the hook writes back the count of the whole
-        # conversation. Feeding that straight back in must reproduce it rather than drop the messages.
-        counter = FakeCounter()
-        messages = [ChatMessage.from_system(text="rules"), ChatMessage.from_user(text="a summary of the work so far")]
-        written = counter.count(messages=messages)
-        assert _estimated_context_tokens(messages=messages, context_tokens=written, token_counter=counter) == written
-        assert written > 0


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/12580

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fixed ``CompactionHook`` mis-estimating the context size when compaction leaves a conversation with no assistant message, for example when a compactor summarizes every Agent step away. The hook now records the whole compacted conversation as accounted for, and the estimate reads that count back unchanged, so a second compaction hook running right after sees the true size instead of counting the conversation twice.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

I also noticed the util function `_estimated_context_tokens` is only used by `CompactionHook` so I moved it to be in the same file so the implementation details are closer together. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
