### PR TITLE
fix: leave empty tool results in context instead of offloading them

### DIFF
--- a/haystack/hooks/tool_result_offloading/hooks.py
+++ b/haystack/hooks/tool_result_offloading/hooks.py
@@ -243,8 +243,8 @@ class ToolResultOffloadHook:
 
         A message is left as-is when it is not a tool result, when the result is an error (including `before_tool`
         human-in-the-loop rejections), when it was already offloaded (e.g. another offload hook under `after_tool`
-        handled it), when no policy applies, when the result is empty, when the result carries image or file content
-        that `store` cannot store, or when the policy declines to offload.
+        handled it), when no policy applies, when the result is empty (no content, or nothing but empty text), when
+        the result carries image or file content that `store` cannot store, or when the policy declines to offload.
 
         Otherwise the result is written to `store` and the message is rebuilt with a pointer in place of the full
         result, preserving its origin and error flag and marking it offloaded. Each part of the result goes to its own
@@ -273,7 +273,9 @@ class ToolResultOffloadHook:
         content_blocks: list[TextContent | ImageContent | FileContent] = (
             [TextContent(text=result.result)] if isinstance(result.result, str) else list(result.result)
         )
-        if not content_blocks:
+        # A result made up of nothing but empty text has nothing worth storing, so it stays in context. `all` also
+        # covers a result with no content blocks at all.
+        if all(isinstance(content_block, TextContent) and not content_block.text for content_block in content_blocks):
             return message
 
         # Check whether the store can store binary content before offloading an image or file result. A text-only store

--- a/releasenotes/notes/empty-tool-result-not-offloaded-2424585b455c6772.yaml
+++ b/releasenotes/notes/empty-tool-result-not-offloaded-2424585b455c6772.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed ``ToolResultOffloadHook`` offloading empty tool results. An empty string, or a result made up of nothing
+    but empty text blocks, was written to the ``ToolResultStore`` as a zero-byte entry and replaced in the
+    conversation by a pointer ending in a dangling ``Preview:`` - growing the context the hook exists to shrink, and
+    inviting the model to read back an empty file. Such results are now left in context, as empty-list results
+    already were.

--- a/test/hooks/tool_result_offloading/test_hooks.py
+++ b/test/hooks/tool_result_offloading/test_hooks.py
@@ -189,15 +189,32 @@ class TestToolResultOffloadHookBehavior:
         assert over_state.data["messages"][0].tool_call_result.result.startswith("Tool result offloaded")
         assert under_state.data["messages"][0].tool_call_result.result == [image]
 
-    def test_empty_result_is_not_offloaded(self, tmp_path):
+    @pytest.mark.parametrize(
+        "empty_result",
+        ["", [], [TextContent(text="")], [TextContent(text=""), TextContent(text="")]],
+        ids=["empty_string", "empty_list", "single_empty_text_block", "several_empty_text_blocks"],
+    )
+    def test_empty_result_is_not_offloaded(self, tmp_path, empty_result):
         hook = ToolResultOffloadHook(
             store=FileSystemToolResultStore(root=tmp_path), offload_strategies={"*": AlwaysOffload()}
         )
-        message = ChatMessage.from_tool(tool_result=[], origin=ToolCall(tool_name="a", arguments={}, id="1"))
+        message = ChatMessage.from_tool(tool_result=empty_result, origin=ToolCall(tool_name="a", arguments={}, id="1"))
         state = _state_with_messages([message])
         hook.run(state)
-        assert state.data["messages"][0].tool_call_result.result == []
+        assert state.data["messages"][0].tool_call_result.result == empty_result
         assert not list(Path(tmp_path).iterdir())
+
+    def test_empty_text_alongside_image_is_offloaded(self, tmp_path):
+        hook = ToolResultOffloadHook(
+            store=FileSystemToolResultStore(root=tmp_path), offload_strategies={"*": AlwaysOffload()}
+        )
+        image = ImageContent(base64_image=base64.b64encode(b"PNGDATA").decode(), mime_type="image/png")
+        message = ChatMessage.from_tool(
+            tool_result=[TextContent(text=""), image], origin=ToolCall(tool_name="a", arguments={}, id="1")
+        )
+        state = _state_with_messages([message])
+        hook.run(state)
+        assert state.data["messages"][0].tool_call_result.result.startswith("Tool result offloaded")
 
     def test_id_less_parallel_calls_do_not_collide(self, tmp_path):
         store = FileSystemToolResultStore(root=tmp_path)


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/12583

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Fixed ``ToolResultOffloadHook`` offloading empty tool results. An empty string, or a result made up of nothing but empty text blocks, was written to the ``ToolResultStore`` as a zero-byte entry and replaced in the conversation by a pointer ending in a dangling ``Preview:`` - growing the context the hook exists to shrink, and inviting the model to read back an empty file. Such results are now left in context, as empty-list results already were.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

New tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
