### PR TITLE
[HTTPXodus] migrate httpx to httpx2 (hard switch; closes #12593)

### DIFF
--- a/haystack/components/fetchers/link_content.py
+++ b/haystack/components/fetchers/link_content.py
@@ -10,7 +10,7 @@ from dataclasses import replace
 from fnmatch import fnmatch
 from typing import Any, cast
 
-import httpx
+import httpx2
 from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from haystack import component, logging
@@ -19,7 +19,7 @@ from haystack.lazy_imports import LazyImport
 from haystack.version import __version__
 
 # HTTP/2 support via lazy import
-with LazyImport("Run 'pip install httpx[http2]' to use HTTP/2 support") as h2_import:
+with LazyImport("Run 'pip install httpx2[http2]' to use HTTP/2 support") as h2_import:
     pass  # nothing to import as we simply set the http2 attribute, library handles the rest
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ def _merge_headers(*args: dict[str, str]) -> dict[str, str]:
     return {keymap[kl]: v for kl, v in merged.items()}
 
 
-def _text_content_handler(response: httpx.Response) -> ByteStream:
+def _text_content_handler(response: httpx2.Response) -> ByteStream:
     """
     Handles text content.
 
@@ -63,7 +63,7 @@ def _text_content_handler(response: httpx.Response) -> ByteStream:
     return ByteStream.from_string(response.text)
 
 
-def _binary_content_handler(response: httpx.Response) -> ByteStream:
+def _binary_content_handler(response: httpx2.Response) -> ByteStream:
     """
     Handles binary content.
 
@@ -132,8 +132,8 @@ class LinkContentFetcher:
         :param retry_attempts: The number of times to retry to fetch the URL's content.
         :param timeout: Timeout in seconds for the request.
         :param http2: Whether to enable HTTP/2 support for requests. Defaults to False.
-                     Requires the 'h2' package to be installed (via `pip install httpx[http2]`).
-        :param client_kwargs: Additional keyword arguments to pass to the httpx client.
+                     Requires the 'h2' package to be installed (via `pip install httpx2[http2]`).
+        :param client_kwargs: Additional keyword arguments to pass to the httpx2 client.
                      If `None`, default values are used.
         :param request_headers: Additional headers to send with every request. These take precedence over the
                      component's default headers but not over the rotating `User-Agent`.
@@ -150,12 +150,12 @@ class LinkContentFetcher:
         self.client_kwargs.setdefault("timeout", timeout)
         self.client_kwargs.setdefault("follow_redirects", True)
 
-        # httpx clients are built lazily in warm_up / warm_up_async (resource lifecycle)
-        self._client: httpx.Client | None = None
-        self._async_client: httpx.AsyncClient | None = None
+        # httpx2 clients are built lazily in warm_up / warm_up_async (resource lifecycle)
+        self._client: httpx2.Client | None = None
+        self._async_client: httpx2.AsyncClient | None = None
 
         # register default content handlers that extract data from the response
-        self.handlers: dict[str, Callable[[httpx.Response], ByteStream]] = defaultdict(lambda: _text_content_handler)
+        self.handlers: dict[str, Callable[[httpx2.Response], ByteStream]] = defaultdict(lambda: _text_content_handler)
         self.handlers["text/*"] = _text_content_handler
         self.handlers["text/html"] = _binary_content_handler
         self.handlers["application/json"] = _text_content_handler
@@ -164,7 +164,7 @@ class LinkContentFetcher:
         self.handlers["audio/*"] = _binary_content_handler
         self.handlers["video/*"] = _binary_content_handler
 
-    def _get_response(self, url: str) -> httpx.Response:
+    def _get_response(self, url: str) -> httpx2.Response:
         """
         Gets a response from a URL, rotating the user agent on every failed attempt.
 
@@ -172,7 +172,7 @@ class LinkContentFetcher:
         component would be advanced and reset by whichever fetches happen to be in flight at the same time.
 
         :param url: The URL to fetch.
-        :returns: The httpx Response object.
+        :returns: The httpx2 Response object.
         """
         user_agent_idx = 0
 
@@ -185,11 +185,11 @@ class LinkContentFetcher:
             reraise=True,
             stop=stop_after_attempt(self.retry_attempts + 1),
             wait=wait_exponential(multiplier=1, min=2, max=10),
-            retry=(retry_if_exception_type((httpx.HTTPStatusError, httpx.RequestError))),
+            retry=(retry_if_exception_type((httpx2.HTTPStatusError, httpx2.RequestError))),
             # This callback is invoked only after failed requests (exception raised)
             after=rotate_user_agent,
         )
-        def get_response(url: str) -> httpx.Response:
+        def get_response(url: str) -> httpx2.Response:
             assert self._client is not None  # mypy: client is built by warm_up before run
             response = self._client.get(url, headers=self._get_headers(self.user_agents[user_agent_idx]))
             response.raise_for_status()
@@ -199,7 +199,7 @@ class LinkContentFetcher:
 
     def _build_client_kwargs(self) -> dict[str, Any]:
         """
-        Build the keyword arguments used to construct the httpx clients.
+        Build the keyword arguments used to construct the httpx2 clients.
 
         Resolves optional HTTP/2 support, downgrading to HTTP/1.1 if the 'h2' package is not installed.
         """
@@ -213,7 +213,7 @@ class LinkContentFetcher:
             except ImportError:
                 logger.warning(
                     "HTTP/2 support requested but 'h2' package is not installed. "
-                    "Falling back to HTTP/1.1. Install with `pip install httpx[http2]` to enable HTTP/2 support."
+                    "Falling back to HTTP/1.1. Install with `pip install httpx2[http2]` to enable HTTP/2 support."
                 )
                 self.http2 = False  # Update the setting to match actual capability
 
@@ -221,21 +221,21 @@ class LinkContentFetcher:
 
     def warm_up(self) -> None:
         """
-        Initializes the synchronous httpx client.
+        Initializes the synchronous httpx2 client.
         """
         if self._client is None:
-            self._client = httpx.Client(**self._build_client_kwargs())
+            self._client = httpx2.Client(**self._build_client_kwargs())
 
     async def warm_up_async(self) -> None:  # noqa: RUF029
         """
-        Initializes the asynchronous httpx client on the serving event loop.
+        Initializes the asynchronous httpx2 client on the serving event loop.
         """
         if self._async_client is None:
-            self._async_client = httpx.AsyncClient(**self._build_client_kwargs())
+            self._async_client = httpx2.AsyncClient(**self._build_client_kwargs())
 
     def close(self) -> None:
         """
-        Releases the synchronous httpx client.
+        Releases the synchronous httpx2 client.
         """
         if self._client is not None:
             self._client.close()
@@ -243,7 +243,7 @@ class LinkContentFetcher:
 
     async def close_async(self) -> None:
         """
-        Releases the asynchronous httpx client.
+        Releases the asynchronous httpx2 client.
         """
         if self._async_client is not None:
             await self._async_client.aclose()
@@ -380,13 +380,13 @@ class LinkContentFetcher:
         return {"content_type": content_type, "url": url}, stream
 
     async def _fetch_async(
-        self, url: str, client: httpx.AsyncClient
+        self, url: str, client: httpx2.AsyncClient
     ) -> tuple[dict[str, str] | None, ByteStream | None]:
         """
         Asynchronously fetches content from a URL and returns it as a ByteStream.
 
         :param url: The URL to fetch content from.
-        :param client: The async httpx client to use for making requests.
+        :param client: The async httpx2 client to use for making requests.
         :returns: A tuple containing the ByteStream metadata dict and the corresponding ByteStream.
         """
         content_type: str = "text/html"
@@ -428,13 +428,13 @@ class LinkContentFetcher:
         else:
             return self._fetch(url)
 
-    async def _get_response_async(self, url: str, client: httpx.AsyncClient) -> httpx.Response:
+    async def _get_response_async(self, url: str, client: httpx2.AsyncClient) -> httpx2.Response:
         """
         Asynchronously gets a response from a URL with retry logic.
 
         :param url: The URL to fetch.
-        :param client: The async httpx client to use for making requests.
-        :returns: The httpx Response object.
+        :param client: The async httpx2 client to use for making requests.
+        :returns: The httpx2 Response object.
         """
         attempt = 0
         last_exception = None
@@ -447,7 +447,7 @@ class LinkContentFetcher:
                 response = await client.get(url, headers=self._get_headers(self.user_agents[user_agent_idx]))
                 response.raise_for_status()
                 return response
-            except (httpx.HTTPStatusError, httpx.RequestError) as e:
+            except (httpx2.HTTPStatusError, httpx2.RequestError) as e:
                 last_exception = e
                 attempt += 1
                 if attempt <= self.retry_attempts:
@@ -463,9 +463,9 @@ class LinkContentFetcher:
             raise last_exception
 
         # This should never happen, but just in case
-        raise httpx.RequestError("Failed to get response after retries", request=None)
+        raise httpx2.RequestError("Failed to get response after retries", request=None)
 
-    def _get_content_type(self, response: httpx.Response) -> str:
+    def _get_content_type(self, response: httpx2.Response) -> str:
         """
         Get the content type of the response.
 
@@ -475,7 +475,7 @@ class LinkContentFetcher:
         content_type = response.headers.get("Content-Type", "")
         return content_type.split(";")[0]
 
-    def _resolve_handler(self, content_type: str) -> Callable[[httpx.Response], ByteStream]:
+    def _resolve_handler(self, content_type: str) -> Callable[[httpx2.Response], ByteStream]:
         """
         Resolves the handler for the given content type.
 

--- a/haystack/core/pipeline/draw.py
+++ b/haystack/core/pipeline/draw.py
@@ -9,7 +9,7 @@ import random
 import zlib
 from typing import Any
 
-import httpx
+import httpx2
 import networkx
 
 from haystack import logging
@@ -178,7 +178,7 @@ _WEBP_SIGNATURE = b"WEBP"
 _SVG_PREFIXES = (b"<?xml", b"<svg")
 
 
-def _validate_image_response(resp: httpx.Response, params: dict[str, Any]) -> None:
+def _validate_image_response(resp: httpx2.Response, params: dict[str, Any]) -> None:
     """
     Validate that the Mermaid server response actually contains the expected image/SVG/PDF data.
 
@@ -312,7 +312,7 @@ def _to_mermaid_image(
 
     logger.debug("Rendering graph at {url}", url=url)
     try:
-        resp = httpx.get(url, timeout=timeout)
+        resp = httpx2.get(url, timeout=timeout)
         if resp.status_code >= 400:
             logger.warning(
                 "Failed to draw the pipeline: {server_url} returned status {status_code}",

--- a/haystack/utils/http_client.py
+++ b/haystack/utils/http_client.py
@@ -4,30 +4,30 @@
 
 from typing import Any, Literal, overload
 
-import httpx
+import httpx2
 
 
 @overload
 def init_http_client(
     http_client_kwargs: dict[str, Any] | None = ..., async_client: Literal[False] = ...
-) -> httpx.Client | None: ...
+) -> httpx2.Client | None: ...
 @overload
 def init_http_client(
     http_client_kwargs: dict[str, Any] | None = ..., async_client: Literal[True] = ...
-) -> httpx.AsyncClient | None: ...
+) -> httpx2.AsyncClient | None: ...
 def init_http_client(
     http_client_kwargs: dict[str, Any] | None = None, async_client: bool = False
-) -> httpx.Client | httpx.AsyncClient | None:
+) -> httpx2.Client | httpx2.AsyncClient | None:
     """
-    Initialize an httpx client based on the http_client_kwargs.
+    Initialize an httpx2 client based on the http_client_kwargs.
 
     :param http_client_kwargs:
-        The kwargs to pass to the httpx client.
+        The kwargs to pass to the httpx2 client.
     :param async_client:
         Whether to initialize an async client.
 
     :returns:
-        A httpx client or an async httpx client.
+        A httpx2 client or an async httpx2 client.
     """
     if not http_client_kwargs:
         return None
@@ -37,11 +37,11 @@ def init_http_client(
     # Create a copy to avoid modifying the original dict
     processed_kwargs = http_client_kwargs.copy()
 
-    # Handle limits parameter - convert dict to httpx.Limits object if needed
+    # Handle limits parameter - convert dict to httpx2.Limits object if needed
     if "limits" in processed_kwargs and isinstance(processed_kwargs["limits"], dict):
         limits_dict = processed_kwargs["limits"]
-        processed_kwargs["limits"] = httpx.Limits(**limits_dict)
+        processed_kwargs["limits"] = httpx2.Limits(**limits_dict)
 
     if async_client:
-        return httpx.AsyncClient(**processed_kwargs)
-    return httpx.Client(**processed_kwargs)
+        return httpx2.AsyncClient(**processed_kwargs)
+    return httpx2.Client(**processed_kwargs)

--- a/haystack/utils/requests_utils.py
+++ b/haystack/utils/requests_utils.py
@@ -5,7 +5,7 @@
 import logging
 from typing import Any
 
-import httpx
+import httpx2
 from tenacity import after_log, before_log, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 # NOTE: this uses the standard library logger (not `haystack.logging`) on purpose: tenacity's `before_log`/`after_log`
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 def request_with_retry(
     attempts: int = 3, status_codes_to_retry: list[int] | None = None, **kwargs: Any
-) -> httpx.Response:
+) -> httpx2.Response:
     """
     Executes an HTTP request with a configurable exponential backoff retry on failures.
 
@@ -53,9 +53,9 @@ def request_with_retry(
         List of HTTP status codes that will trigger a retry.
         When param is `None`, HTTP 408, 418, 429 and 503 will be retried.
     :param kwargs:
-        Optional arguments that `httpx.Client.request` accepts.
+        Optional arguments that `httpx2.Client.request` accepts.
     :returns:
-        The `httpx.Response` object.
+        The `httpx2.Response` object.
     """
 
     if status_codes_to_retry is None:
@@ -67,13 +67,13 @@ def request_with_retry(
     @retry(
         reraise=True,
         wait=wait_exponential(),
-        retry=retry_if_exception_type((httpx.HTTPError, TimeoutError)),
+        retry=retry_if_exception_type((httpx2.HTTPError, TimeoutError)),
         stop=stop_after_attempt(attempts),
         before=before_log(logger, logging.DEBUG),
         after=after_log(logger, logging.DEBUG),
     )
-    def run() -> httpx.Response:
-        with httpx.Client() as client:
+    def run() -> httpx2.Response:
+        with httpx2.Client() as client:
             res = client.request(**kwargs, timeout=timeout)
 
             if res.status_code in status_codes_to_retry:
@@ -91,7 +91,7 @@ def request_with_retry(
 
 async def async_request_with_retry(
     attempts: int = 3, status_codes_to_retry: list[int] | None = None, **kwargs: Any
-) -> httpx.Response:
+) -> httpx2.Response:
     """
     Executes an asynchronous HTTP request with a configurable exponential backoff retry on failures.
 
@@ -165,9 +165,9 @@ async def async_request_with_retry(
         List of HTTP status codes that will trigger a retry.
         When param is `None`, HTTP 408, 418, 429 and 503 will be retried.
     :param kwargs:
-        Optional arguments that `httpx.AsyncClient.request` accepts.
+        Optional arguments that `httpx2.AsyncClient.request` accepts.
     :returns:
-        The `httpx.Response` object.
+        The `httpx2.Response` object.
     """
 
     if status_codes_to_retry is None:
@@ -179,13 +179,13 @@ async def async_request_with_retry(
     @retry(
         reraise=True,
         wait=wait_exponential(),
-        retry=retry_if_exception_type((httpx.HTTPError, TimeoutError)),
+        retry=retry_if_exception_type((httpx2.HTTPError, TimeoutError)),
         stop=stop_after_attempt(attempts),
         before=before_log(logger, logging.DEBUG),
         after=after_log(logger, logging.DEBUG),
     )
-    async def run() -> httpx.Response:
-        async with httpx.AsyncClient() as client:
+    async def run() -> httpx2.Response:
+        async with httpx2.AsyncClient() as client:
             res = await client.request(**kwargs, timeout=timeout)
 
             if res.status_code in status_codes_to_retry:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
   "more-itertools",         # DocumentSplitter
   "networkx",               # Pipeline graphs
   "typing_extensions>=4.7", # Extended typing features (NotRequired, etc.)
-  "httpx",
+  "httpx2>=2.12.0",
   "numpy",
   "python-dateutil",
   "jsonschema",             # JsonSchemaValidator, Tool
@@ -123,7 +123,7 @@ dependencies = [
   "structlog",
 
   # needed in link content fetcher tests
-  "httpx[http2]",
+  "httpx2[http2]",
 
   # Azure Utils
   "azure-identity",

--- a/test/components/fetchers/test_link_content_fetcher.py
+++ b/test/components/fetchers/test_link_content_fetcher.py
@@ -5,7 +5,7 @@
 import threading
 from unittest.mock import AsyncMock, Mock, patch
 
-import httpx
+import httpx2
 import pytest
 from tenacity import wait_none
 
@@ -23,7 +23,7 @@ PDF_URL = "https://raw.githubusercontent.com/deepset-ai/haystack/b5987a6d8d0714e
 
 @pytest.fixture
 def mock_get_link_text_content():
-    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+    with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
         mock_response = Mock(status_code=200, text="Example test response", headers={"Content-Type": "text/plain"})
         mock_get.return_value = mock_response
         yield mock_get
@@ -31,7 +31,7 @@ def mock_get_link_text_content():
 
 @pytest.fixture
 def mock_get_link_content(test_files_path):
-    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+    with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
         with open(test_files_path / "pdf" / "sample_pdf_1.pdf", "rb") as f1:
             file_bytes = f1.read()
         mock_response = Mock(status_code=200, content=file_bytes, headers={"Content-Type": "application/pdf"})
@@ -83,7 +83,7 @@ class TestLinkContentFetcher:
     def test_run_text(self):
         """Test fetching text content"""
         correct_response = b"Example test response"
-        with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+        with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
             mock_response = Mock(status_code=200, text="Example test response", headers={"Content-Type": "text/plain"})
             mock_get.return_value = mock_response
             fetcher = LinkContentFetcher()
@@ -96,7 +96,7 @@ class TestLinkContentFetcher:
     def test_run_html(self):
         """Test fetching HTML content"""
         correct_response = b"<h1>Example test response</h1>"
-        with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+        with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
             mock_response = Mock(
                 status_code=200, content=b"<h1>Example test response</h1>", headers={"Content-Type": "text/html"}
             )
@@ -112,7 +112,7 @@ class TestLinkContentFetcher:
         """Test fetching binary content"""
         with open(test_files_path / "pdf" / "sample_pdf_1.pdf", "rb") as f1:
             file_bytes = f1.read()
-        with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+        with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
             mock_response = Mock(status_code=200, content=file_bytes, headers={"Content-Type": "application/pdf"})
             mock_get.return_value = mock_response
             fetcher = LinkContentFetcher()
@@ -127,11 +127,11 @@ class TestLinkContentFetcher:
         empty_byte_stream = b""
         fetcher = LinkContentFetcher(raise_on_failure=False, retry_attempts=0)
         mock_response = Mock(status_code=403)
-        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        mock_response.raise_for_status.side_effect = httpx2.HTTPStatusError(
             "403 Client Error", request=Mock(), response=mock_response
         )
 
-        with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+        with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
             mock_get.return_value = mock_response
             streams = fetcher.run(urls=["https://www.example.com"])["streams"]
 
@@ -150,24 +150,24 @@ class TestLinkContentFetcher:
         fetcher = LinkContentFetcher(raise_on_failure=True, retry_attempts=0)
 
         mock_response = Mock(status_code=403)
-        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        mock_response.raise_for_status.side_effect = httpx2.HTTPStatusError(
             "403 Client Error", request=Mock(), response=mock_response
         )
 
-        with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+        with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
             mock_get.return_value = mock_response
-            with pytest.raises(httpx.HTTPStatusError):
+            with pytest.raises(httpx2.HTTPStatusError):
                 fetcher.run(["https://non_existent_website_dot.com/"])
 
     def test_run_retries_once_when_retry_attempts_is_one(self):
         url = "https://www.example.com"
         successful_response = Mock(status_code=200, text="Success", headers={"Content-Type": "text/plain"})
 
-        with patch("haystack.components.fetchers.link_content.httpx.Client") as client_mock:
+        with patch("haystack.components.fetchers.link_content.httpx2.Client") as client_mock:
             client = client_mock.return_value
             client.headers = {}
             client.get.side_effect = [
-                httpx.RequestError("transient failure", request=httpx.Request("GET", url)),
+                httpx2.RequestError("transient failure", request=httpx2.Request("GET", url)),
                 successful_response,
             ]
 
@@ -180,7 +180,7 @@ class TestLinkContentFetcher:
 
     def test_request_headers_merging_and_ua_override(self):
         # Patch the Client class to control the instance created by LinkContentFetcher
-        with patch("haystack.components.fetchers.link_content.httpx.Client") as ClientMock:
+        with patch("haystack.components.fetchers.link_content.httpx2.Client") as ClientMock:
             client = ClientMock.return_value
             client.headers = {}  # base headers used in the merge
             mock_response = Mock(status_code=200, text="OK", headers={"Content-Type": "text/plain"})
@@ -223,12 +223,12 @@ class TestLinkContentFetcher:
                 attempts[url] = attempt + 1
             if attempt == 0:
                 # Every URL fails once, so every URL rotates once.
-                raise httpx.RequestError("simulated transient failure", request=httpx.Request("GET", url))
+                raise httpx2.RequestError("simulated transient failure", request=httpx2.Request("GET", url))
             with lock:
                 user_agent_on_success[url] = headers["User-Agent"]
             return Mock(status_code=200, text="OK", headers={"Content-Type": "text/plain"})
 
-        with patch("haystack.components.fetchers.link_content.httpx.Client") as ClientMock:
+        with patch("haystack.components.fetchers.link_content.httpx2.Client") as ClientMock:
             client = ClientMock.return_value
             client.headers = {}
             client.get.side_effect = fake_get
@@ -250,7 +250,7 @@ class TestComponentLifecycle:
     def test_sync_lifecycle(self):
         client_instance = Mock()
         with patch(
-            "haystack.components.fetchers.link_content.httpx.Client", return_value=client_instance
+            "haystack.components.fetchers.link_content.httpx2.Client", return_value=client_instance
         ) as ClientMock:
             fetcher = LinkContentFetcher()
 
@@ -264,7 +264,7 @@ class TestComponentLifecycle:
             assert fetcher._client is None
 
     def test_warm_up_is_idempotent(self):
-        with patch("haystack.components.fetchers.link_content.httpx.Client") as ClientMock:
+        with patch("haystack.components.fetchers.link_content.httpx2.Client") as ClientMock:
             fetcher = LinkContentFetcher()
             fetcher.warm_up()
             fetcher.warm_up()
@@ -275,7 +275,7 @@ class TestComponentLifecycle:
         async_client_instance = Mock()
         async_client_instance.aclose = AsyncMock()
         with patch(
-            "haystack.components.fetchers.link_content.httpx.AsyncClient", return_value=async_client_instance
+            "haystack.components.fetchers.link_content.httpx2.AsyncClient", return_value=async_client_instance
         ) as AsyncClientMock:
             fetcher = LinkContentFetcher()
 
@@ -290,7 +290,7 @@ class TestComponentLifecycle:
 
     @pytest.mark.asyncio
     async def test_warm_up_async_is_idempotent(self):
-        with patch("haystack.components.fetchers.link_content.httpx.AsyncClient") as AsyncClientMock:
+        with patch("haystack.components.fetchers.link_content.httpx2.AsyncClient") as AsyncClientMock:
             fetcher = LinkContentFetcher()
             await fetcher.warm_up_async()
             await fetcher.warm_up_async()
@@ -310,8 +310,8 @@ class TestComponentLifecycle:
         async_client_instance = Mock()
         async_client_instance.aclose = AsyncMock()
         with (
-            patch("haystack.components.fetchers.link_content.httpx.Client", return_value=client_instance),
-            patch("haystack.components.fetchers.link_content.httpx.AsyncClient", return_value=async_client_instance),
+            patch("haystack.components.fetchers.link_content.httpx2.Client", return_value=client_instance),
+            patch("haystack.components.fetchers.link_content.httpx2.AsyncClient", return_value=async_client_instance),
         ):
             fetcher = LinkContentFetcher()
             fetcher.warm_up()
@@ -327,7 +327,7 @@ class TestComponentLifecycle:
             client_instance.close.assert_called_once()
 
     def test_run_self_heals(self):
-        with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+        with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
             mock_response = Mock(status_code=200, text="ok", headers={"Content-Type": "text/plain"})
             mock_get.return_value = mock_response
             fetcher = LinkContentFetcher()
@@ -336,7 +336,7 @@ class TestComponentLifecycle:
 
     @pytest.mark.asyncio
     async def test_run_async_self_heals(self):
-        with patch("haystack.components.fetchers.link_content.httpx.AsyncClient.get") as mock_get:
+        with patch("haystack.components.fetchers.link_content.httpx2.AsyncClient.get") as mock_get:
             mock_response = Mock(status_code=200, text="ok", headers={"Content-Type": "text/plain"})
             mock_get.return_value = mock_response
             fetcher = LinkContentFetcher()
@@ -423,7 +423,7 @@ class TestLinkContentFetcherIntegration:
 class TestLinkContentFetcherAsync:
     async def test_run_async(self):
         """Test basic async fetching with a mocked response"""
-        with patch("haystack.components.fetchers.link_content.httpx.AsyncClient.get") as mock_get:
+        with patch("haystack.components.fetchers.link_content.httpx2.AsyncClient.get") as mock_get:
             mock_response = Mock(status_code=200, text="Example test response", headers={"Content-Type": "text/plain"})
             mock_get.return_value = mock_response
 
@@ -438,7 +438,7 @@ class TestLinkContentFetcherAsync:
 
     async def test_run_async_multiple(self):
         """Test async fetching of multiple URLs with mocked responses"""
-        with patch("haystack.components.fetchers.link_content.httpx.AsyncClient.get") as mock_get:
+        with patch("haystack.components.fetchers.link_content.httpx2.AsyncClient.get") as mock_get:
             mock_response = Mock(status_code=200, text="Example test response", headers={"Content-Type": "text/plain"})
             mock_get.return_value = mock_response
 
@@ -462,9 +462,9 @@ class TestLinkContentFetcherAsync:
 
     async def test_run_async_error_handling(self):
         """Test error handling for async fetching"""
-        with patch("haystack.components.fetchers.link_content.httpx.AsyncClient.get") as mock_get:
+        with patch("haystack.components.fetchers.link_content.httpx2.AsyncClient.get") as mock_get:
             mock_response = Mock(status_code=404)
-            mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            mock_response.raise_for_status.side_effect = httpx2.HTTPStatusError(
                 "404 Not Found", request=Mock(), response=mock_response
             )
             mock_get.return_value = mock_response
@@ -476,13 +476,13 @@ class TestLinkContentFetcherAsync:
 
             # With raise_on_failure=True
             fetcher = LinkContentFetcher(raise_on_failure=True, retry_attempts=0)
-            with pytest.raises(httpx.HTTPStatusError):
+            with pytest.raises(httpx2.HTTPStatusError):
                 await fetcher.run_async(urls=["https://www.example.com"])
 
     async def test_run_async_user_agent_rotation(self):
         """Test user agent rotation in async fetching"""
         with (
-            patch("haystack.components.fetchers.link_content.httpx.AsyncClient.get") as mock_get,
+            patch("haystack.components.fetchers.link_content.httpx2.AsyncClient.get") as mock_get,
             patch("asyncio.sleep") as mock_sleep,
         ):
             # Mock asyncio.sleep used by tenacity to keep this test fast
@@ -490,7 +490,7 @@ class TestLinkContentFetcherAsync:
 
             # First call raises an error to trigger user agent rotation
             first_response = Mock(status_code=403)
-            first_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            first_response.raise_for_status.side_effect = httpx2.HTTPStatusError(
                 "403 Forbidden", request=Mock(), response=first_response
             )
 
@@ -513,7 +513,7 @@ class TestLinkContentFetcherAsync:
 
     async def test_request_headers_merging_and_ua_override(self):
         # Patch the AsyncClient class to control the instance created by LinkContentFetcher
-        with patch("haystack.components.fetchers.link_content.httpx.AsyncClient") as AsyncClientMock:
+        with patch("haystack.components.fetchers.link_content.httpx2.AsyncClient") as AsyncClientMock:
             aclient = AsyncClientMock.return_value
             aclient.headers = {}  # base headers used in the merge
 
@@ -535,7 +535,7 @@ class TestLinkContentFetcherAsync:
 
     async def test_duplicated_request_headers_merging(self):
         # Patch the AsyncClient class to control the instance created by LinkContentFetcher
-        with patch("haystack.components.fetchers.link_content.httpx.AsyncClient") as AsyncClientMock:
+        with patch("haystack.components.fetchers.link_content.httpx2.AsyncClient") as AsyncClientMock:
             aclient = AsyncClientMock.return_value
             aclient.headers = {}  # base headers used in the merge
 

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
-import httpx
+import httpx2
 import pytest
 from openai import OpenAIError
 from openai.types.chat import (
@@ -1872,7 +1872,7 @@ class TestComponentLifecycle:
 
     def test_http_client_kwargs_are_used_for_requests(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
-        requests: list[httpx.Request] = []
+        requests: list[httpx2.Request] = []
         # trimmed capture of a real /chat/completions response
         completion = {
             "id": "chatcmpl-ECjrZ3klFGP0kTdMQgSCTPnNr0z87",
@@ -1883,13 +1883,13 @@ class TestComponentLifecycle:
             "usage": {"prompt_tokens": 17, "completion_tokens": 10, "total_tokens": 27},
         }
 
-        def handler(request: httpx.Request) -> httpx.Response:
+        def handler(request: httpx2.Request) -> httpx2.Response:
             requests.append(request)
-            return httpx.Response(200, json=completion)
+            return httpx2.Response(200, json=completion)
 
         generator = OpenAIChatGenerator(
             http_client_kwargs={
-                "transport": httpx.MockTransport(handler),
+                "transport": httpx2.MockTransport(handler),
                 "cookies": {"session": "abc"},
                 "follow_redirects": False,
             }

--- a/test/components/generators/chat/test_openai_async.py
+++ b/test/components/generators/chat/test_openai_async.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
+import httpx2
 import pytest
 from openai import AsyncOpenAI, AsyncStream, OpenAIError
 from openai.types.chat import (
@@ -113,7 +113,7 @@ class TestOpenAIChatGeneratorAsync:
 
     async def test_http_client_kwargs_are_used_for_requests(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
-        requests: list[httpx.Request] = []
+        requests: list[httpx2.Request] = []
         # trimmed capture of a real /chat/completions response
         completion = {
             "id": "chatcmpl-ECjrZ3klFGP0kTdMQgSCTPnNr0z87",
@@ -124,13 +124,13 @@ class TestOpenAIChatGeneratorAsync:
             "usage": {"prompt_tokens": 17, "completion_tokens": 10, "total_tokens": 27},
         }
 
-        async def handler(request: httpx.Request) -> httpx.Response:
+        async def handler(request: httpx2.Request) -> httpx2.Response:
             requests.append(request)
-            return httpx.Response(200, json=completion)
+            return httpx2.Response(200, json=completion)
 
         component = OpenAIChatGenerator(
             http_client_kwargs={
-                "transport": httpx.MockTransport(handler),
+                "transport": httpx2.MockTransport(handler),
                 "cookies": {"session": "abc"},
                 "follow_redirects": False,
             }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -39,7 +39,7 @@ for _pattern in (
     "*.test_*",  # `<subdir>.test_<name>` modules (pytest treats sub-packages this way)
     "test.*",  # modules inside the proper `test` package (with __init__.py)
     "pydantic",  # pydantic models used in base-serialization tests
-    "httpx",  # used in callable-serialization tests
+    "httpx2",  # used in callable-serialization tests
 ):
     allow_deserialization_module(_pattern)
 

--- a/test/core/pipeline/test_draw.py
+++ b/test/core/pipeline/test_draw.py
@@ -4,7 +4,7 @@
 
 from unittest.mock import MagicMock, patch
 
-import httpx
+import httpx2
 import pytest
 
 from haystack.core.errors import PipelineDrawingError
@@ -26,7 +26,7 @@ def test_to_mermaid_image():
     assert image_data
 
 
-@patch("haystack.core.pipeline.draw.httpx")
+@patch("haystack.core.pipeline.draw.httpx2")
 def test_to_mermaid_image_does_not_edit_graph(mock_httpx):
     pipe = Pipeline()
     pipe.add_component("comp1", AddFixedValue(add=3))
@@ -42,7 +42,7 @@ def test_to_mermaid_image_does_not_edit_graph(mock_httpx):
     assert expected_pipe == pipe.to_dict()
 
 
-@patch("haystack.core.pipeline.draw.httpx")
+@patch("haystack.core.pipeline.draw.httpx2")
 def test_to_mermaid_image_applies_timeout(mock_httpx):
     pipe = Pipeline()
     pipe.add_component("comp1", Double())
@@ -64,10 +64,10 @@ def test_to_mermaid_image_failing_request(tmp_path):
     pipe.connect("comp1", "comp2")
     pipe.connect("comp2", "comp1")
 
-    with patch("haystack.core.pipeline.draw.httpx.get") as mock_get:
+    with patch("haystack.core.pipeline.draw.httpx2.get") as mock_get:
 
         def raise_for_status(self):
-            raise httpx.HTTPError("error")
+            raise httpx2.HTTPError("error")
 
         mock_response = MagicMock()
         mock_response.status_code = 429
@@ -171,7 +171,7 @@ def test_to_mermaid_image_scale_without_dimensions():
         _to_mermaid_image(pipe.graph, params={"format": "img", "scale": 2})
 
 
-@patch("haystack.core.pipeline.draw.httpx.get")
+@patch("haystack.core.pipeline.draw.httpx2.get")
 def test_to_mermaid_image_server_error(mock_get):
     # Test server failure
     pipe = Pipeline()
@@ -180,7 +180,7 @@ def test_to_mermaid_image_server_error(mock_get):
     pipe.connect("comp1", "comp2")
 
     def raise_for_status(self):
-        raise httpx.HTTPError("error")
+        raise httpx2.HTTPError("error")
 
     mock_response = MagicMock()
     mock_response.status_code = 500
@@ -244,7 +244,7 @@ def test_validate_image_response_warns_on_spoofed_content_type_but_relies_on_bod
     assert "unexpected Content-Type" in caplog.text
 
 
-@patch("haystack.core.pipeline.draw.httpx.get")
+@patch("haystack.core.pipeline.draw.httpx2.get")
 def test_to_mermaid_image_rejects_non_image_response(mock_get):
     # End-to-end: a 200 response with non-image content must not be returned for writing to disk.
     pipe = Pipeline()

--- a/test/dataclasses/test_file_content.py
+++ b/test/dataclasses/test_file_content.py
@@ -8,7 +8,7 @@ import warnings
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-import httpx
+import httpx2
 import pytest
 
 from haystack.dataclasses.file_content import FileContent
@@ -118,7 +118,7 @@ def test_file_content_from_file_path_default_filename(test_files_path):
 
 
 def test_file_content_from_url(test_files_path):
-    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+    with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
         with open(test_files_path / "pdf" / "sample_pdf_3.pdf", "rb") as f:
             pdf_bytes = f.read()
         mock_response = Mock(status_code=200, content=pdf_bytes, headers={"Content-Type": "application/pdf"})
@@ -135,7 +135,7 @@ def test_file_content_from_url(test_files_path):
 
 
 def test_file_content_from_url_default_filename(test_files_path):
-    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+    with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
         with open(test_files_path / "pdf" / "sample_pdf_3.pdf", "rb") as f:
             pdf_bytes = f.read()
         mock_response = Mock(status_code=200, content=pdf_bytes, headers={"Content-Type": "application/pdf"})
@@ -147,10 +147,10 @@ def test_file_content_from_url_default_filename(test_files_path):
 
 
 def test_file_content_from_url_bad_request():
-    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
-        mock_get.side_effect = httpx.HTTPStatusError("403 Client Error", request=Mock(), response=Mock())
+    with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
+        mock_get.side_effect = httpx2.HTTPStatusError("403 Client Error", request=Mock(), response=Mock())
 
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(httpx2.HTTPStatusError):
             FileContent.from_url(url="https://non_existent_website_dot.com/file.pdf", retry_attempts=0, timeout=1)
 
 

--- a/test/dataclasses/test_image_content.py
+++ b/test/dataclasses/test_image_content.py
@@ -7,7 +7,7 @@ import logging
 import warnings
 from unittest.mock import Mock, patch
 
-import httpx
+import httpx2
 import pytest
 from PIL import Image
 
@@ -171,7 +171,7 @@ def test_image_content_from_file_path_non_existing(test_files_path, caplog):
 
 
 def test_image_content_from_url(test_files_path):
-    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+    with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
         with open(test_files_path / "images" / "apple.jpg", "rb") as image_file:
             image_bytes = image_file.read()
         mock_response = Mock(status_code=200, content=image_bytes, headers={"Content-Type": "image/jpeg"})
@@ -188,15 +188,15 @@ def test_image_content_from_url(test_files_path):
 
 
 def test_image_content_from_url_bad_request():
-    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
-        mock_get.side_effect = httpx.HTTPStatusError("403 Client Error", request=Mock(), response=Mock())
+    with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
+        mock_get.side_effect = httpx2.HTTPStatusError("403 Client Error", request=Mock(), response=Mock())
 
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(httpx2.HTTPStatusError):
             ImageContent.from_url(url="https://non_existent_website_dot.com/image.jpg", retry_attempts=0, timeout=1)
 
 
 def test_image_content_from_url_wrong_mime_type_text():
-    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+    with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
         mock_response = Mock(status_code=200, text="a text", headers={"Content-Type": "text/plain"})
         mock_get.return_value = mock_response
 
@@ -207,7 +207,7 @@ def test_image_content_from_url_wrong_mime_type_text():
 
 
 def test_image_content_from_url_wrong_mime_type_pdf(test_files_path):
-    with patch("haystack.components.fetchers.link_content.httpx.Client.get") as mock_get:
+    with patch("haystack.components.fetchers.link_content.httpx2.Client.get") as mock_get:
         with open(test_files_path / "pdf" / "sample_pdf_1.pdf", "rb") as pdf_file:
             pdf_bytes = pdf_file.read()
         mock_response = Mock(status_code=200, content=pdf_bytes, headers={"Content-Type": "application/pdf"})

--- a/test/utils/test_callable_serialization.py
+++ b/test/utils/test_callable_serialization.py
@@ -4,7 +4,7 @@
 
 import inspect
 
-import httpx
+import httpx2
 import pytest
 
 from haystack.components.generators.utils import print_streaming_chunk
@@ -54,8 +54,8 @@ def test_callable_serialization_non_local():
     assert result == "haystack.components.generators.utils.print_streaming_chunk"
 
     # check serialization of another library's callable
-    result = serialize_callable(httpx.get)
-    assert result == "httpx.get"
+    result = serialize_callable(httpx2.get)
+    assert result == "httpx2.get"
 
 
 def test_fully_qualified_import_deserialization():
@@ -94,9 +94,9 @@ def test_callable_deserialization():
 
 
 def test_callable_deserialization_non_local():
-    result = serialize_callable(httpx.get)
+    result = serialize_callable(httpx2.get)
     fn = deserialize_callable(result)
-    assert fn is httpx.get
+    assert fn is httpx2.get
 
 
 def test_classmethod_serialization_deserialization():

--- a/test/utils/test_http_client.py
+++ b/test/utils/test_http_client.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import httpx
+import httpx2
 import pytest
 
 from haystack.utils.http_client import init_http_client
@@ -17,7 +17,7 @@ def test_init_http_client():
     client_kwargs = {"base_url": "https://example.com"}
     http_client = init_http_client(http_client_kwargs=client_kwargs)
     assert http_client is not None
-    assert isinstance(http_client, httpx.Client)
+    assert isinstance(http_client, httpx2.Client)
     assert http_client.base_url == "https://example.com"
 
 
@@ -29,7 +29,7 @@ def test_init_http_client_async():
     # test async client is initialized with http_client_kwargs
     http_async_client = init_http_client(http_client_kwargs={"base_url": "https://example.com"}, async_client=True)
     assert http_async_client is not None
-    assert isinstance(http_async_client, httpx.AsyncClient)
+    assert isinstance(http_async_client, httpx2.AsyncClient)
     assert http_async_client.base_url == "https://example.com"
 
 
@@ -46,12 +46,12 @@ def test_http_client_kwargs_with_invalid_params():
 
 
 def test_init_http_client_with_dict_limits():
-    """Test that dict limits are converted to httpx.Limits objects without AttributeError."""
+    """Test that dict limits are converted to httpx2.Limits objects without AttributeError."""
     http_client_kwargs = {"limits": {"max_connections": 100, "max_keepalive_connections": 20}}
 
     # This should not raise AttributeError: 'dict' object has no attribute 'max_connections'
     client = init_http_client(http_client_kwargs=http_client_kwargs, async_client=False)
     assert client is not None
-    assert isinstance(client, httpx.Client)
+    assert isinstance(client, httpx2.Client)
 
     client.close()

--- a/test/utils/test_requests_utils.py
+++ b/test/utils/test_requests_utils.py
@@ -4,7 +4,7 @@
 
 from unittest.mock import MagicMock, patch
 
-import httpx
+import httpx2
 import pytest
 
 from haystack.utils.requests_utils import async_request_with_retry, request_with_retry
@@ -12,7 +12,7 @@ from haystack.utils.requests_utils import async_request_with_retry, request_with
 
 @pytest.fixture
 def mock_httpx_response():
-    response = MagicMock(spec=httpx.Response)
+    response = MagicMock(spec=httpx2.Response)
     response.status_code = 200
     response.raise_for_status.return_value = None
     return response
@@ -21,7 +21,7 @@ def mock_httpx_response():
 class TestRequestWithRetry:
     def test_request_with_retry_success(self, mock_httpx_response):
         """Test that request_with_retry works with default parameters"""
-        with patch("httpx.Client.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.Client.request", return_value=mock_httpx_response) as mock_request:
             response = request_with_retry(method="GET", url="https://example.com")
 
             assert response == mock_httpx_response
@@ -29,7 +29,7 @@ class TestRequestWithRetry:
 
     def test_request_with_retry_custom_attempts(self, mock_httpx_response):
         """Test that request_with_retry respects custom attempts parameter"""
-        with patch("httpx.Client.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.Client.request", return_value=mock_httpx_response) as mock_request:
             response = request_with_retry(method="GET", url="https://example.com", attempts=5)
 
             assert response == mock_httpx_response
@@ -37,7 +37,7 @@ class TestRequestWithRetry:
 
     def test_request_with_retry_custom_status_codes(self, mock_httpx_response):
         """Test that request_with_retry respects custom status_codes_to_retry parameter"""
-        with patch("httpx.Client.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.Client.request", return_value=mock_httpx_response) as mock_request:
             response = request_with_retry(method="GET", url="https://example.com", status_codes_to_retry=[500, 502])
 
             assert response == mock_httpx_response
@@ -45,7 +45,7 @@ class TestRequestWithRetry:
 
     def test_request_with_retry_custom_timeout(self, mock_httpx_response):
         """Test that request_with_retry respects custom timeout parameter"""
-        with patch("httpx.Client.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.Client.request", return_value=mock_httpx_response) as mock_request:
             response = request_with_retry(method="GET", url="https://example.com", timeout=30)
 
             assert response == mock_httpx_response
@@ -54,7 +54,7 @@ class TestRequestWithRetry:
     def test_request_with_retry_with_headers(self, mock_httpx_response):
         """Test that request_with_retry passes headers correctly"""
         headers = {"Authorization": "Bearer token123"}
-        with patch("httpx.Client.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.Client.request", return_value=mock_httpx_response) as mock_request:
             response = request_with_retry(method="GET", url="https://example.com", headers=headers)
 
             assert response == mock_httpx_response
@@ -63,7 +63,7 @@ class TestRequestWithRetry:
     def test_request_with_retry_with_json(self, mock_httpx_response):
         """Test that request_with_retry passes JSON data correctly"""
         json_data = {"key": "value"}
-        with patch("httpx.Client.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.Client.request", return_value=mock_httpx_response) as mock_request:
             response = request_with_retry(method="POST", url="https://example.com", json=json_data)
 
             assert response == mock_httpx_response
@@ -75,12 +75,12 @@ class TestRequestWithRetry:
             # Mock time.sleep used by tenacity to keep this test fast
             mock_sleep.return_value = None
 
-            success_response = httpx.Response(status_code=200, request=httpx.Request("GET", "https://example.com"))
+            success_response = httpx2.Response(status_code=200, request=httpx2.Request("GET", "https://example.com"))
 
-            with patch("httpx.Client.request") as mock_request:
+            with patch("httpx2.Client.request") as mock_request:
                 # First call raises an error, second call succeeds
                 mock_request.side_effect = [
-                    httpx.RequestError("Server error", request=httpx.Request("GET", "https://example.com")),
+                    httpx2.RequestError("Server error", request=httpx2.Request("GET", "https://example.com")),
                     success_response,
                 ]
 
@@ -96,20 +96,20 @@ class TestRequestWithRetry:
             # Mock time.sleep used by tenacity to keep this test fast
             mock_sleep.return_value = None
 
-            error_response = httpx.Response(status_code=503, request=httpx.Request("GET", "https://example.com"))
+            error_response = httpx2.Response(status_code=503, request=httpx2.Request("GET", "https://example.com"))
 
             def raise_for_status():
                 if error_response.status_code in [503]:
-                    raise httpx.HTTPStatusError(
+                    raise httpx2.HTTPStatusError(
                         "Service Unavailable", request=error_response.request, response=error_response
                     )
 
             error_response.raise_for_status = raise_for_status  # type: ignore[method-assign]
 
-            success_response = httpx.Response(status_code=200, request=httpx.Request("GET", "https://example.com"))
+            success_response = httpx2.Response(status_code=200, request=httpx2.Request("GET", "https://example.com"))
             success_response.raise_for_status = lambda: None  # type: ignore[method-assign, assignment, return-value]
 
-            with patch("httpx.Client.request") as mock_request:
+            with patch("httpx2.Client.request") as mock_request:
                 # First call returns error status code, second call succeeds
                 mock_request.side_effect = [error_response, success_response]
 
@@ -129,12 +129,12 @@ class TestRequestWithRetry:
         retry silently fell back to the default of 10 seconds.
         """
         with patch("time.sleep", return_value=None):
-            success_response = httpx.Response(status_code=200, request=httpx.Request("GET", "https://example.com"))
+            success_response = httpx2.Response(status_code=200, request=httpx2.Request("GET", "https://example.com"))
 
-            with patch("httpx.Client.request") as mock_request:
+            with patch("httpx2.Client.request") as mock_request:
                 # First attempt fails with a retryable error, second attempt succeeds.
                 mock_request.side_effect = [
-                    httpx.RequestError("boom", request=httpx.Request("GET", "https://example.com")),
+                    httpx2.RequestError("boom", request=httpx2.Request("GET", "https://example.com")),
                     success_response,
                 ]
 
@@ -150,7 +150,7 @@ class TestAsyncRequestWithRetry:
     @pytest.mark.asyncio
     async def test_async_request_with_retry_success(self, mock_httpx_response):
         """Test that async_request_with_retry works with default parameters"""
-        with patch("httpx.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
             response = await async_request_with_retry(method="GET", url="https://example.com")
 
             assert response == mock_httpx_response
@@ -159,7 +159,7 @@ class TestAsyncRequestWithRetry:
     @pytest.mark.asyncio
     async def test_async_request_with_retry_custom_attempts(self, mock_httpx_response):
         """Test that async_request_with_retry respects custom attempts parameter"""
-        with patch("httpx.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
             response = await async_request_with_retry(method="GET", url="https://example.com", attempts=5)
 
             assert response == mock_httpx_response
@@ -168,7 +168,7 @@ class TestAsyncRequestWithRetry:
     @pytest.mark.asyncio
     async def test_async_request_with_retry_custom_status_codes(self, mock_httpx_response):
         """Test that async_request_with_retry respects custom status_codes_to_retry parameter"""
-        with patch("httpx.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
             response = await async_request_with_retry(
                 method="GET", url="https://example.com", status_codes_to_retry=[500, 502]
             )
@@ -179,7 +179,7 @@ class TestAsyncRequestWithRetry:
     @pytest.mark.asyncio
     async def test_async_request_with_retry_custom_timeout(self, mock_httpx_response):
         """Test that async_request_with_retry respects custom timeout parameter"""
-        with patch("httpx.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
             response = await async_request_with_retry(method="GET", url="https://example.com", timeout=30)
 
             assert response == mock_httpx_response
@@ -189,7 +189,7 @@ class TestAsyncRequestWithRetry:
     async def test_async_request_with_retry_with_headers(self, mock_httpx_response):
         """Test that async_request_with_retry passes headers correctly"""
         headers = {"Authorization": "Bearer token123"}
-        with patch("httpx.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
             response = await async_request_with_retry(method="GET", url="https://example.com", headers=headers)
 
             assert response == mock_httpx_response
@@ -199,7 +199,7 @@ class TestAsyncRequestWithRetry:
     async def test_async_request_with_retry_with_json(self, mock_httpx_response):
         """Test that async_request_with_retry passes JSON data correctly"""
         json_data = {"key": "value"}
-        with patch("httpx.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
+        with patch("httpx2.AsyncClient.request", return_value=mock_httpx_response) as mock_request:
             response = await async_request_with_retry(method="POST", url="https://example.com", json=json_data)
 
             assert response == mock_httpx_response
@@ -212,12 +212,12 @@ class TestAsyncRequestWithRetry:
             # Mock asyncio.sleep used by tenacity to keep this test fast
             mock_sleep.return_value = None
 
-            success_response = httpx.Response(status_code=200, request=httpx.Request("GET", "https://example.com"))
+            success_response = httpx2.Response(status_code=200, request=httpx2.Request("GET", "https://example.com"))
 
-            with patch("httpx.AsyncClient.request") as mock_request:
+            with patch("httpx2.AsyncClient.request") as mock_request:
                 # First call raises an error, second call succeeds
                 mock_request.side_effect = [
-                    httpx.RequestError("Server error", request=httpx.Request("GET", "https://example.com")),
+                    httpx2.RequestError("Server error", request=httpx2.Request("GET", "https://example.com")),
                     success_response,
                 ]
 
@@ -234,20 +234,20 @@ class TestAsyncRequestWithRetry:
             # Mock asyncio.sleep used by tenacity to keep this test fast
             mock_sleep.return_value = None
 
-            error_response = httpx.Response(status_code=503, request=httpx.Request("GET", "https://example.com"))
+            error_response = httpx2.Response(status_code=503, request=httpx2.Request("GET", "https://example.com"))
 
             def raise_for_status():
                 if error_response.status_code in [503]:
-                    raise httpx.HTTPStatusError(
+                    raise httpx2.HTTPStatusError(
                         "Service Unavailable", request=error_response.request, response=error_response
                     )
 
             error_response.raise_for_status = raise_for_status  # type: ignore[method-assign]
 
-            success_response = httpx.Response(status_code=200, request=httpx.Request("GET", "https://example.com"))
+            success_response = httpx2.Response(status_code=200, request=httpx2.Request("GET", "https://example.com"))
             success_response.raise_for_status = lambda: None  # type: ignore[method-assign, assignment, return-value]
 
-            with patch("httpx.AsyncClient.request") as mock_request:
+            with patch("httpx2.AsyncClient.request") as mock_request:
                 # First call returns error status code, second call succeeds
                 mock_request.side_effect = [error_response, success_response]
 
@@ -268,12 +268,12 @@ class TestAsyncRequestWithRetry:
         retry silently fell back to the default of 10 seconds.
         """
         with patch("asyncio.sleep", return_value=None):
-            success_response = httpx.Response(status_code=200, request=httpx.Request("GET", "https://example.com"))
+            success_response = httpx2.Response(status_code=200, request=httpx2.Request("GET", "https://example.com"))
 
-            with patch("httpx.AsyncClient.request") as mock_request:
+            with patch("httpx2.AsyncClient.request") as mock_request:
                 # First attempt fails with a retryable error, second attempt succeeds.
                 mock_request.side_effect = [
-                    httpx.RequestError("boom", request=httpx.Request("GET", "https://example.com")),
+                    httpx2.RequestError("boom", request=httpx2.Request("GET", "https://example.com")),
                     success_response,
                 ]
 


### PR DESCRIPTION
Closes #12593

> 🏷️ *Part of [HTTPXodus](https://github.com/ProgrammerPlus1998/httpxodus) — a community effort to help major Python projects plan their path off the stalled `httpx` stable line onto [`httpx2`](https://github.com/pydantic/httpx2), the actively maintained fork by Pydantic Services.*

## What this PR does

**Hard switch** from `httpx` to `httpx2`:
- Direct `import httpx2` in `haystack/utils/http_client.py`, `haystack/utils/requests_utils.py`, `haystack/core/pipeline/draw.py`, `haystack/components/fetchers/link_content.py` — no dual-import shim, no fallback
- All `httpx.X` references → `httpx2.X` (clients, `Limits`, `Response`, `HTTPError`, patch targets in tests)
- `pyproject.toml`: `httpx` → `httpx2>=2.12.0`; the `http2` extra now pulls `httpx2[http2]`
- `test/conftest.py`: the deserialization allowlist entry `"httpx"` → `"httpx2"` (haystack's `serialization_security` allowlists modules for callable deserialization; the callable-serialization tests round-trip `httpx2.get`)

`requires-python = ">=3.10"` already matches httpx2's floor, so no version boundary.

## Test results

- Converted-area tests (`test_http_client`, `test_requests_utils`, `test_draw`, `test_link_content_fetcher`, `test_image_content`, `test_file_content`, `test_callable_serialization`): **119 passed, 4 skipped** with httpx2 2.12.0 in an isolated env
- 7 errors in `TestLinkContentFetcher*Integration` setup are a local `flaky` plugin version mismatch (integration class, unrelated to the migration)
- The allowlist change was verified with a control run: the test fails with `httpx2.get` before the conftest fix and passes after

## Notes for reviewer

- ⚠️ **TLS behavior change**: `httpx2` verifies TLS against the **OS trust store** (via `truststore`) instead of the bundled `certifi`. Deployments that relied on certifi's CA bundle (minimal containers, corporate proxies) may need `SSL_CERT_FILE` / `SSL_CERT_DIR` after the switch. Worth a line in the changelog.
- The OpenAI-embedder/generator docstrings that reference httpx documentation describe the OpenAI SDK's own HTTP client and are intentionally left unchanged.
- Previous revision of this PR branch had an incorrect history; it has been rebuilt cleanly on top of current `main` as a single commit.

Happy to revise per review — and equally happy to close this PR if the maintainers would rather wait for `httpx` 1.0 stable. 🙏
