### PR TITLE
docs: add docs page for GoogleGenAITokenCounter

### DIFF
--- a/docs-website/docs/token-counters.mdx
+++ b/docs-website/docs/token-counters.mdx
@@ -17,8 +17,9 @@ Haystack provides the `TokenCounter` protocol and three built-in implementations
 | [`TiktokenCounter`](token-counters/tiktokencounter.mdx) | Uses OpenAI's `tiktoken` byte-pair encoder | `tiktoken` | More accurate estimates for OpenAI models |
 | [`OpenAITokenCounter`](token-counters/openaitokencounter.mdx) | Calls OpenAI's input token counting API | OpenAI API key | Exact, model-specific counts including images, files, and tools |
 | [`AnthropicTokenCounter`](token-counters/anthropictokencounter.mdx) | Calls Anthropic's token counting API | `anthropic-haystack` package and an Anthropic API key | Exact, model-specific counts for Claude models |
+| [`GoogleGenAITokenCounter`](token-counters/googlegenaitokencounter.mdx) | Calls Google's token counting API | `google-genai-haystack` package and Google credentials | Exact, model-specific counts for Gemini models |
 
-All counters include message roles, text, tool calls, tool results, and optional tool schemas. The local counters account for images and files using configurable flat rates, including images and files nested in tool results. `OpenAITokenCounter` and `AnthropicTokenCounter` send supported non-text content to the provider for a model-specific count.
+All counters include message roles, text, tool calls, tool results, and optional tool schemas. The local counters account for images and files using configurable flat rates, including images and files nested in tool results. `OpenAITokenCounter`, `AnthropicTokenCounter`, and `GoogleGenAITokenCounter` send supported non-text content to the provider for a model-specific count.
 
 See the [Token Counters API reference](/reference/token-counters-api) for all constructor parameters and methods.
 
@@ -58,6 +59,7 @@ See the documentation for the counter you use to understand how it counts non-te
 - [`TiktokenCounter`](token-counters/tiktokencounter.mdx)
 - [`OpenAITokenCounter`](token-counters/openaitokencounter.mdx)
 - [`AnthropicTokenCounter`](token-counters/anthropictokencounter.mdx)
+- [`GoogleGenAITokenCounter`](token-counters/googlegenaitokencounter.mdx)
 
 ## Creating a custom token counter
 

--- a/docs-website/docs/token-counters/googlegenaitokencounter.mdx
+++ b/docs-website/docs/token-counters/googlegenaitokencounter.mdx
@@ -1,0 +1,122 @@
+---
+title: "GoogleGenAITokenCounter"
+id: googlegenaitokencounter
+slug: "/googlegenaitokencounter"
+description: "Count message and tool tokens exactly for Gemini models with Google's token counting API."
+---
+
+# GoogleGenAITokenCounter
+
+`GoogleGenAITokenCounter` uses the `countTokens` endpoint of the Google Gen AI SDK to count the input tokens of `ChatMessage` objects and optional tool schemas for a specific Gemini model. The endpoint returns a count without generating a response, so it does not incur generation costs.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Import path** | `haystack_integrations.token_counters.google_genai.GoogleGenAITokenCounter` |
+| **Mandatory init variables** | `model`: The Gemini model to count for |
+| **API reference** | [Google GenAI](/reference/integrations-google-genai) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_genai |
+| **Package name** | `google-genai-haystack` |
+
+</div>
+
+Because it calls a remote API, it needs Google credentials and adds network latency to every count. Use it when you need model-specific counts for Gemini models. For local estimates, use [`ApproximateTokenCounter`](approximatetokencounter.mdx) or [`TiktokenCounter`](tiktokencounter.mdx).
+
+The counter assembles the request exactly as [`GoogleGenAIChatGenerator`](../pipeline-components/generators/googlegenaichatgenerator.mdx) does: a leading system message becomes the system instruction, and the remaining messages become the request contents.
+
+## Installation
+
+Install the `google-genai-haystack` package:
+
+```bash
+pip install google-genai-haystack
+```
+
+## Usage
+
+Token counts are model-specific, so pass the model you intend to generate with:
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.token_counters.google_genai import GoogleGenAITokenCounter
+
+messages = [
+    ChatMessage.from_system("You are a helpful assistant."),
+    ChatMessage.from_user("Explain retrieval-augmented generation."),
+]
+
+counter = GoogleGenAITokenCounter(model="gemini-2.5-flash")
+token_count = counter.count(messages)
+print(token_count)
+```
+
+By default, the counter uses the Gemini Developer API and reads the API key from the `GOOGLE_API_KEY` or `GEMINI_API_KEY` environment variable. You can also pass a Haystack [Secret](../concepts/secret-management.mdx) explicitly, and set the `timeout` and `max_retries` of the underlying Google Gen AI client:
+
+```python
+from haystack.utils import Secret
+
+counter = GoogleGenAITokenCounter(
+    model="gemini-2.5-flash",
+    api_key=Secret.from_env_var("MY_GOOGLE_API_KEY"),
+    timeout=30.0,
+    max_retries=3,
+)
+```
+
+To count with Vertex AI instead, set `api="vertex"` and pass your Google Cloud project and location. With Application Default Credentials, no API key is needed:
+
+```python
+counter = GoogleGenAITokenCounter(
+    model="gemini-2.5-flash",
+    api="vertex",
+    vertex_ai_project="my-project",
+    vertex_ai_location="us-central1",
+)
+```
+
+To include the context consumed by tool schemas, pass the tools to `count()`:
+
+```python
+token_count = counter.count(messages, tools=[search_tool])
+```
+
+The counter creates its API client on the first call to `count()`. To create it during application startup instead, call `warm_up()` explicitly. Call `close()` when you are done with the counter to release the client's HTTP resources:
+
+```python
+counter.warm_up()
+...
+counter.close()
+```
+
+## Gemini Developer API versus Vertex AI
+
+The Google Gen AI SDK only accepts a system instruction and tool schemas on `countTokens` when the client targets Vertex AI. This affects what the counter can measure on each backend:
+
+| Input | Gemini Developer API (`api="gemini"`) | Vertex AI (`api="vertex"`) |
+| --- | --- | --- |
+| User, assistant, and tool messages | Exact count | Exact count |
+| Leading system message | Measured as a user turn, which is a close approximation | Measured as the system instruction, exact count |
+| Tool schemas | Not supported, `count()` raises a `ValueError` | Exact count |
+
+If you need exact counts for system prompts or need to include tool schemas, target Vertex AI. On the Gemini Developer API, count only the messages.
+
+## Non-text content
+
+Gemini counts images and files as part of the request, so the counter measures them instead of applying a flat estimate. It supports the same content types as [`GoogleGenAIChatGenerator`](../pipeline-components/generators/googlegenaichatgenerator.mdx): images must be in user messages and have a MIME type of PNG, JPEG, WebP, HEIC, or HEIF. Files must also be in user messages and have a MIME type set. Unsupported image MIME types raise an error rather than being estimated.
+
+## Use with compaction
+
+Pass the counter to [`CompactionHook`](../pipeline-components/agents-1/compaction/compaction-hook.mdx) to size an Agent's conversation with the same tokenizer Gemini uses:
+
+```python
+from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
+
+compaction_hook = CompactionHook(
+    compactor=SlidingWindowCompactor(),
+    context_window=1_000_000,
+    token_counter=GoogleGenAITokenCounter(model="gemini-2.5-flash"),
+)
+```
+
+Keep in mind that the hook counts messages on every Agent step, so each compaction check costs an API round trip. When no provider usage is available yet, for example on the first Agent step, the hook also passes the Agent's tools to the counter. If your Agent has tools, use `api="vertex"` so that call does not raise an error.

--- a/docs-website/docs/token-counters/googlegenaitokencounter.mdx
+++ b/docs-website/docs/token-counters/googlegenaitokencounter.mdx
@@ -23,8 +23,6 @@ description: "Count message and tool tokens exactly for Gemini models with Googl
 
 Because it calls a remote API, it needs Google credentials and adds network latency to every count. Use it when you need model-specific counts for Gemini models. For local estimates, use [`ApproximateTokenCounter`](approximatetokencounter.mdx) or [`TiktokenCounter`](tiktokencounter.mdx).
 
-The counter assembles the request exactly as [`GoogleGenAIChatGenerator`](../pipeline-components/generators/googlegenaichatgenerator.mdx) does: a leading system message becomes the system instruction, and the remaining messages become the request contents.
-
 ## Installation
 
 Install the `google-genai-haystack` package:
@@ -51,20 +49,7 @@ token_count = counter.count(messages)
 print(token_count)
 ```
 
-By default, the counter uses the Gemini Developer API and reads the API key from the `GOOGLE_API_KEY` or `GEMINI_API_KEY` environment variable. You can also pass a Haystack [Secret](../concepts/secret-management.mdx) explicitly, and set the `timeout` and `max_retries` of the underlying Google Gen AI client:
-
-```python
-from haystack.utils import Secret
-
-counter = GoogleGenAITokenCounter(
-    model="gemini-2.5-flash",
-    api_key=Secret.from_env_var("MY_GOOGLE_API_KEY"),
-    timeout=30.0,
-    max_retries=3,
-)
-```
-
-To count with Vertex AI instead, set `api="vertex"` and pass your Google Cloud project and location. With Application Default Credentials, no API key is needed:
+By default, the counter uses the Gemini Developer API and reads the API key from the `GOOGLE_API_KEY` or `GEMINI_API_KEY` environment variable. You can also pass a Haystack [Secret](../concepts/secret-management.mdx) explicitly, set the `timeout` and `max_retries` of the underlying client, or target Vertex AI with `api="vertex"`:
 
 ```python
 counter = GoogleGenAITokenCounter(
@@ -91,19 +76,11 @@ counter.close()
 
 ## Gemini Developer API versus Vertex AI
 
-The Google Gen AI SDK only accepts a system instruction and tool schemas on `countTokens` when the client targets Vertex AI. This affects what the counter can measure on each backend:
-
-| Input | Gemini Developer API (`api="gemini"`) | Vertex AI (`api="vertex"`) |
-| --- | --- | --- |
-| User, assistant, and tool messages | Exact count | Exact count |
-| Leading system message | Measured as a user turn, which is a close approximation | Measured as the system instruction, exact count |
-| Tool schemas | Not supported, `count()` raises a `ValueError` | Exact count |
-
-If you need exact counts for system prompts or need to include tool schemas, target Vertex AI. On the Gemini Developer API, count only the messages.
+The Google Gen AI SDK only accepts a system instruction and tool schemas on `countTokens` when the client targets Vertex AI. On the Gemini Developer API, a leading system message is measured as a user turn, which is a close approximation rather than the exact count, and passing tools raises a `ValueError`. If you need exact counts for system prompts or tool schemas, use `api="vertex"`.
 
 ## Non-text content
 
-Gemini counts images and files as part of the request, so the counter measures them instead of applying a flat estimate. It supports the same content types as [`GoogleGenAIChatGenerator`](../pipeline-components/generators/googlegenaichatgenerator.mdx): images must be in user messages and have a MIME type of PNG, JPEG, WebP, HEIC, or HEIF. Files must also be in user messages and have a MIME type set. Unsupported image MIME types raise an error rather than being estimated.
+Gemini counts images and files as part of the request, so the counter measures them instead of applying a flat estimate. It supports the same content types as [`GoogleGenAIChatGenerator`](../pipeline-components/generators/googlegenaichatgenerator.mdx): PNG, JPEG, WebP, HEIC, and HEIF images, and files with a MIME type set, both in user messages only. Other image MIME types raise an error rather than being estimated.
 
 ## Use with compaction
 
@@ -115,8 +92,8 @@ from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
 compaction_hook = CompactionHook(
     compactor=SlidingWindowCompactor(),
     context_window=1_000_000,
-    token_counter=GoogleGenAITokenCounter(model="gemini-2.5-flash"),
+    token_counter=GoogleGenAITokenCounter(model="gemini-2.5-flash", api="vertex"),
 )
 ```
 
-Keep in mind that the hook counts messages on every Agent step, so each compaction check costs an API round trip. When no provider usage is available yet, for example on the first Agent step, the hook also passes the Agent's tools to the counter. If your Agent has tools, use `api="vertex"` so that call does not raise an error.
+Keep in mind that the hook counts messages on every Agent step, so each compaction check costs an API round trip. The hook also passes the Agent's tools to the counter, so use `api="vertex"` when the Agent has tools.

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -783,6 +783,7 @@ export default {
         'token-counters/tiktokencounter',
         'token-counters/openaitokencounter',
         'token-counters/anthropictokencounter',
+        'token-counters/googlegenaitokencounter',
       ],
     },
     {

--- a/docs-website/versioned_docs/version-3.1/token-counters.mdx
+++ b/docs-website/versioned_docs/version-3.1/token-counters.mdx
@@ -17,8 +17,9 @@ Haystack provides the `TokenCounter` protocol and three built-in implementations
 | [`TiktokenCounter`](token-counters/tiktokencounter.mdx) | Uses OpenAI's `tiktoken` byte-pair encoder | `tiktoken` | More accurate estimates for OpenAI models |
 | [`OpenAITokenCounter`](token-counters/openaitokencounter.mdx) | Calls OpenAI's input token counting API | OpenAI API key | Exact, model-specific counts including images, files, and tools |
 | [`AnthropicTokenCounter`](token-counters/anthropictokencounter.mdx) | Calls Anthropic's token counting API | `anthropic-haystack` package and an Anthropic API key | Exact, model-specific counts for Claude models |
+| [`GoogleGenAITokenCounter`](token-counters/googlegenaitokencounter.mdx) | Calls Google's token counting API | `google-genai-haystack` package and Google credentials | Exact, model-specific counts for Gemini models |
 
-All counters include message roles, text, tool calls, tool results, and optional tool schemas. The local counters account for images and files using configurable flat rates, including images and files nested in tool results. `OpenAITokenCounter` and `AnthropicTokenCounter` send supported non-text content to the provider for a model-specific count.
+All counters include message roles, text, tool calls, tool results, and optional tool schemas. The local counters account for images and files using configurable flat rates, including images and files nested in tool results. `OpenAITokenCounter`, `AnthropicTokenCounter`, and `GoogleGenAITokenCounter` send supported non-text content to the provider for a model-specific count.
 
 See the [Token Counters API reference](/reference/token-counters-api) for all constructor parameters and methods.
 
@@ -58,6 +59,7 @@ See the documentation for the counter you use to understand how it counts non-te
 - [`TiktokenCounter`](token-counters/tiktokencounter.mdx)
 - [`OpenAITokenCounter`](token-counters/openaitokencounter.mdx)
 - [`AnthropicTokenCounter`](token-counters/anthropictokencounter.mdx)
+- [`GoogleGenAITokenCounter`](token-counters/googlegenaitokencounter.mdx)
 
 ## Creating a custom token counter
 

--- a/docs-website/versioned_docs/version-3.1/token-counters/googlegenaitokencounter.mdx
+++ b/docs-website/versioned_docs/version-3.1/token-counters/googlegenaitokencounter.mdx
@@ -1,0 +1,122 @@
+---
+title: "GoogleGenAITokenCounter"
+id: googlegenaitokencounter
+slug: "/googlegenaitokencounter"
+description: "Count message and tool tokens exactly for Gemini models with Google's token counting API."
+---
+
+# GoogleGenAITokenCounter
+
+`GoogleGenAITokenCounter` uses the `countTokens` endpoint of the Google Gen AI SDK to count the input tokens of `ChatMessage` objects and optional tool schemas for a specific Gemini model. The endpoint returns a count without generating a response, so it does not incur generation costs.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Import path** | `haystack_integrations.token_counters.google_genai.GoogleGenAITokenCounter` |
+| **Mandatory init variables** | `model`: The Gemini model to count for |
+| **API reference** | [Google GenAI](/reference/integrations-google-genai) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/google_genai |
+| **Package name** | `google-genai-haystack` |
+
+</div>
+
+Because it calls a remote API, it needs Google credentials and adds network latency to every count. Use it when you need model-specific counts for Gemini models. For local estimates, use [`ApproximateTokenCounter`](approximatetokencounter.mdx) or [`TiktokenCounter`](tiktokencounter.mdx).
+
+The counter assembles the request exactly as [`GoogleGenAIChatGenerator`](../pipeline-components/generators/googlegenaichatgenerator.mdx) does: a leading system message becomes the system instruction, and the remaining messages become the request contents.
+
+## Installation
+
+Install the `google-genai-haystack` package:
+
+```bash
+pip install google-genai-haystack
+```
+
+## Usage
+
+Token counts are model-specific, so pass the model you intend to generate with:
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.token_counters.google_genai import GoogleGenAITokenCounter
+
+messages = [
+    ChatMessage.from_system("You are a helpful assistant."),
+    ChatMessage.from_user("Explain retrieval-augmented generation."),
+]
+
+counter = GoogleGenAITokenCounter(model="gemini-2.5-flash")
+token_count = counter.count(messages)
+print(token_count)
+```
+
+By default, the counter uses the Gemini Developer API and reads the API key from the `GOOGLE_API_KEY` or `GEMINI_API_KEY` environment variable. You can also pass a Haystack [Secret](../concepts/secret-management.mdx) explicitly, and set the `timeout` and `max_retries` of the underlying Google Gen AI client:
+
+```python
+from haystack.utils import Secret
+
+counter = GoogleGenAITokenCounter(
+    model="gemini-2.5-flash",
+    api_key=Secret.from_env_var("MY_GOOGLE_API_KEY"),
+    timeout=30.0,
+    max_retries=3,
+)
+```
+
+To count with Vertex AI instead, set `api="vertex"` and pass your Google Cloud project and location. With Application Default Credentials, no API key is needed:
+
+```python
+counter = GoogleGenAITokenCounter(
+    model="gemini-2.5-flash",
+    api="vertex",
+    vertex_ai_project="my-project",
+    vertex_ai_location="us-central1",
+)
+```
+
+To include the context consumed by tool schemas, pass the tools to `count()`:
+
+```python
+token_count = counter.count(messages, tools=[search_tool])
+```
+
+The counter creates its API client on the first call to `count()`. To create it during application startup instead, call `warm_up()` explicitly. Call `close()` when you are done with the counter to release the client's HTTP resources:
+
+```python
+counter.warm_up()
+...
+counter.close()
+```
+
+## Gemini Developer API versus Vertex AI
+
+The Google Gen AI SDK only accepts a system instruction and tool schemas on `countTokens` when the client targets Vertex AI. This affects what the counter can measure on each backend:
+
+| Input | Gemini Developer API (`api="gemini"`) | Vertex AI (`api="vertex"`) |
+| --- | --- | --- |
+| User, assistant, and tool messages | Exact count | Exact count |
+| Leading system message | Measured as a user turn, which is a close approximation | Measured as the system instruction, exact count |
+| Tool schemas | Not supported, `count()` raises a `ValueError` | Exact count |
+
+If you need exact counts for system prompts or need to include tool schemas, target Vertex AI. On the Gemini Developer API, count only the messages.
+
+## Non-text content
+
+Gemini counts images and files as part of the request, so the counter measures them instead of applying a flat estimate. It supports the same content types as [`GoogleGenAIChatGenerator`](../pipeline-components/generators/googlegenaichatgenerator.mdx): images must be in user messages and have a MIME type of PNG, JPEG, WebP, HEIC, or HEIF. Files must also be in user messages and have a MIME type set. Unsupported image MIME types raise an error rather than being estimated.
+
+## Use with compaction
+
+Pass the counter to [`CompactionHook`](../pipeline-components/agents-1/compaction/compaction-hook.mdx) to size an Agent's conversation with the same tokenizer Gemini uses:
+
+```python
+from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
+
+compaction_hook = CompactionHook(
+    compactor=SlidingWindowCompactor(),
+    context_window=1_000_000,
+    token_counter=GoogleGenAITokenCounter(model="gemini-2.5-flash"),
+)
+```
+
+Keep in mind that the hook counts messages on every Agent step, so each compaction check costs an API round trip. When no provider usage is available yet, for example on the first Agent step, the hook also passes the Agent's tools to the counter. If your Agent has tools, use `api="vertex"` so that call does not raise an error.

--- a/docs-website/versioned_docs/version-3.1/token-counters/googlegenaitokencounter.mdx
+++ b/docs-website/versioned_docs/version-3.1/token-counters/googlegenaitokencounter.mdx
@@ -23,8 +23,6 @@ description: "Count message and tool tokens exactly for Gemini models with Googl
 
 Because it calls a remote API, it needs Google credentials and adds network latency to every count. Use it when you need model-specific counts for Gemini models. For local estimates, use [`ApproximateTokenCounter`](approximatetokencounter.mdx) or [`TiktokenCounter`](tiktokencounter.mdx).
 
-The counter assembles the request exactly as [`GoogleGenAIChatGenerator`](../pipeline-components/generators/googlegenaichatgenerator.mdx) does: a leading system message becomes the system instruction, and the remaining messages become the request contents.
-
 ## Installation
 
 Install the `google-genai-haystack` package:
@@ -51,20 +49,7 @@ token_count = counter.count(messages)
 print(token_count)
 ```
 
-By default, the counter uses the Gemini Developer API and reads the API key from the `GOOGLE_API_KEY` or `GEMINI_API_KEY` environment variable. You can also pass a Haystack [Secret](../concepts/secret-management.mdx) explicitly, and set the `timeout` and `max_retries` of the underlying Google Gen AI client:
-
-```python
-from haystack.utils import Secret
-
-counter = GoogleGenAITokenCounter(
-    model="gemini-2.5-flash",
-    api_key=Secret.from_env_var("MY_GOOGLE_API_KEY"),
-    timeout=30.0,
-    max_retries=3,
-)
-```
-
-To count with Vertex AI instead, set `api="vertex"` and pass your Google Cloud project and location. With Application Default Credentials, no API key is needed:
+By default, the counter uses the Gemini Developer API and reads the API key from the `GOOGLE_API_KEY` or `GEMINI_API_KEY` environment variable. You can also pass a Haystack [Secret](../concepts/secret-management.mdx) explicitly, set the `timeout` and `max_retries` of the underlying client, or target Vertex AI with `api="vertex"`:
 
 ```python
 counter = GoogleGenAITokenCounter(
@@ -91,19 +76,11 @@ counter.close()
 
 ## Gemini Developer API versus Vertex AI
 
-The Google Gen AI SDK only accepts a system instruction and tool schemas on `countTokens` when the client targets Vertex AI. This affects what the counter can measure on each backend:
-
-| Input | Gemini Developer API (`api="gemini"`) | Vertex AI (`api="vertex"`) |
-| --- | --- | --- |
-| User, assistant, and tool messages | Exact count | Exact count |
-| Leading system message | Measured as a user turn, which is a close approximation | Measured as the system instruction, exact count |
-| Tool schemas | Not supported, `count()` raises a `ValueError` | Exact count |
-
-If you need exact counts for system prompts or need to include tool schemas, target Vertex AI. On the Gemini Developer API, count only the messages.
+The Google Gen AI SDK only accepts a system instruction and tool schemas on `countTokens` when the client targets Vertex AI. On the Gemini Developer API, a leading system message is measured as a user turn, which is a close approximation rather than the exact count, and passing tools raises a `ValueError`. If you need exact counts for system prompts or tool schemas, use `api="vertex"`.
 
 ## Non-text content
 
-Gemini counts images and files as part of the request, so the counter measures them instead of applying a flat estimate. It supports the same content types as [`GoogleGenAIChatGenerator`](../pipeline-components/generators/googlegenaichatgenerator.mdx): images must be in user messages and have a MIME type of PNG, JPEG, WebP, HEIC, or HEIF. Files must also be in user messages and have a MIME type set. Unsupported image MIME types raise an error rather than being estimated.
+Gemini counts images and files as part of the request, so the counter measures them instead of applying a flat estimate. It supports the same content types as [`GoogleGenAIChatGenerator`](../pipeline-components/generators/googlegenaichatgenerator.mdx): PNG, JPEG, WebP, HEIC, and HEIF images, and files with a MIME type set, both in user messages only. Other image MIME types raise an error rather than being estimated.
 
 ## Use with compaction
 
@@ -115,8 +92,8 @@ from haystack.hooks.compaction import CompactionHook, SlidingWindowCompactor
 compaction_hook = CompactionHook(
     compactor=SlidingWindowCompactor(),
     context_window=1_000_000,
-    token_counter=GoogleGenAITokenCounter(model="gemini-2.5-flash"),
+    token_counter=GoogleGenAITokenCounter(model="gemini-2.5-flash", api="vertex"),
 )
 ```
 
-Keep in mind that the hook counts messages on every Agent step, so each compaction check costs an API round trip. When no provider usage is available yet, for example on the first Agent step, the hook also passes the Agent's tools to the counter. If your Agent has tools, use `api="vertex"` so that call does not raise an error.
+Keep in mind that the hook counts messages on every Agent step, so each compaction check costs an API round trip. The hook also passes the Agent's tools to the counter, so use `api="vertex"` when the Agent has tools.

--- a/docs-website/versioned_sidebars/version-3.1-sidebars.json
+++ b/docs-website/versioned_sidebars/version-3.1-sidebars.json
@@ -776,7 +776,8 @@
         "token-counters/approximatetokencounter",
         "token-counters/tiktokencounter",
         "token-counters/openaitokencounter",
-        "token-counters/anthropictokencounter"
+        "token-counters/anthropictokencounter",
+        "token-counters/googlegenaitokencounter"
       ]
     },
     {


### PR DESCRIPTION
### Related Issues

- None. Documents `GoogleGenAITokenCounter`, added in deepset-ai/haystack-core-integrations#3868 and released in `google-genai-haystack` 4.9.0.

### Proposed Changes:

- Add a `GoogleGenAITokenCounter` docs page under Token Counters, mirroring the structure of the `AnthropicTokenCounter` page
- Add a section explaining the backend differences: on the Gemini Developer API a leading system message is approximated as a user turn and tool schemas raise a `ValueError`; on Vertex AI both are counted exactly.
- Add the counter to the comparison table and the images/files list on the Token Counters overview page.
- Register the page in `sidebars.js`.
- Mirror all of the above into `versioned_docs/version-3.1` and `versioned_sidebars/version-3.1-sidebars.json`

### How did you test it?

### Notes for the reviewer

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes. — n/a, no related issue
- [ ] I have added unit tests and updated the docstrings. — n/a, docs-only change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [ ] I have documented my code. — n/a, docs-only change
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes). — n/a, docs-only change
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
