### PR TITLE
docs: add docs page for AmazonBedrockTokenCounter

### DIFF
--- a/docs-website/docs/token-counters.mdx
+++ b/docs-website/docs/token-counters.mdx
@@ -18,8 +18,9 @@ Haystack provides the `TokenCounter` protocol and three built-in implementations
 | [`OpenAITokenCounter`](token-counters/openaitokencounter.mdx) | Calls OpenAI's input token counting API | OpenAI API key | Exact, model-specific counts including images, files, and tools |
 | [`AnthropicTokenCounter`](token-counters/anthropictokencounter.mdx) | Calls Anthropic's token counting API | `anthropic-haystack` package and an Anthropic API key | Exact, model-specific counts for Claude models |
 | [`GoogleGenAITokenCounter`](token-counters/googlegenaitokencounter.mdx) | Calls Google's token counting API | `google-genai-haystack` package and Google credentials | Exact, model-specific counts for Gemini models |
+| [`AmazonBedrockTokenCounter`](token-counters/amazonbedrocktokencounter.mdx) | Calls Amazon Bedrock's `CountTokens` API | `amazon-bedrock-haystack` package and AWS credentials | Exact, model-specific counts for Bedrock-hosted models |
 
-All counters include message roles, text, tool calls, tool results, and optional tool schemas. The local counters account for images and files using configurable flat rates, including images and files nested in tool results. `OpenAITokenCounter`, `AnthropicTokenCounter`, and `GoogleGenAITokenCounter` send supported non-text content to the provider for a model-specific count.
+All counters include message roles, text, tool calls, tool results, and optional tool schemas. The local counters account for images and files using configurable flat rates, including images and files nested in tool results. `OpenAITokenCounter`, `AnthropicTokenCounter`, `GoogleGenAITokenCounter`, and `AmazonBedrockTokenCounter` send supported non-text content to the provider for a model-specific count.
 
 See the [Token Counters API reference](/reference/token-counters-api) for all constructor parameters and methods.
 
@@ -60,6 +61,7 @@ See the documentation for the counter you use to understand how it counts non-te
 - [`OpenAITokenCounter`](token-counters/openaitokencounter.mdx)
 - [`AnthropicTokenCounter`](token-counters/anthropictokencounter.mdx)
 - [`GoogleGenAITokenCounter`](token-counters/googlegenaitokencounter.mdx)
+- [`AmazonBedrockTokenCounter`](token-counters/amazonbedrocktokencounter.mdx)
 
 ## Creating a custom token counter
 

--- a/docs-website/docs/token-counters/amazonbedrocktokencounter.mdx
+++ b/docs-website/docs/token-counters/amazonbedrocktokencounter.mdx
@@ -1,0 +1,90 @@
+---
+title: "AmazonBedrockTokenCounter"
+id: amazonbedrocktokencounter
+slug: "/amazonbedrocktokencounter"
+description: "Count message and tool tokens exactly for Bedrock-hosted models with Amazon Bedrock's CountTokens API."
+---
+
+# AmazonBedrockTokenCounter
+
+`AmazonBedrockTokenCounter` uses Amazon Bedrock's `CountTokens` API to count the input tokens of `ChatMessage` objects and optional tool schemas for a specific Bedrock model. The API returns an exact count without generating a response, so it does not incur generation costs.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Import path** | `haystack_integrations.token_counters.amazon_bedrock.AmazonBedrockTokenCounter` |
+| **Mandatory init variables** | `model`: The Bedrock model ID or ARN to count for |
+| **API reference** | [Amazon Bedrock](/reference/integrations-amazon-bedrock) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/amazon_bedrock |
+| **Package name** | `amazon-bedrock-haystack` |
+
+</div>
+
+Because it calls a remote API, it needs AWS credentials and adds network latency to every count. Use it when you need exact, model-specific counts for models hosted on Bedrock. For local estimates, use [`ApproximateTokenCounter`](approximatetokencounter.mdx) or [`TiktokenCounter`](tiktokencounter.mdx).
+
+The counter converts messages and tools to the Bedrock `Converse` format in the same way [`AmazonBedrockChatGenerator`](../pipeline-components/generators/amazonbedrockchatgenerator.mdx) does, so the count matches what an equivalent `Converse` request consumes.
+
+## Installation
+
+Install the `amazon-bedrock-haystack` package:
+
+```bash
+pip install amazon-bedrock-haystack
+```
+
+## Usage
+
+Token counts are model-specific, so pass the model you intend to generate with. The model must support the `CountTokens` API:
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.token_counters.amazon_bedrock import (
+    AmazonBedrockTokenCounter,
+)
+
+messages = [
+    ChatMessage.from_system("You are a helpful assistant."),
+    ChatMessage.from_user("Explain retrieval-augmented generation."),
+]
+
+counter = AmazonBedrockTokenCounter(model="anthropic.claude-sonnet-4-20250514-v1:0")
+token_count = counter.count(messages)
+print(token_count)
+```
+
+The counter authenticates like the other Amazon Bedrock components. By default, it reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` from the environment. You can also pass them as Haystack [Secret](../concepts/secret-management.mdx) arguments and configure the underlying Boto3 client with `boto3_config`:
+
+```python
+from haystack.utils import Secret
+
+counter = AmazonBedrockTokenCounter(
+    model="anthropic.claude-sonnet-4-20250514-v1:0",
+    aws_region_name=Secret.from_token("us-west-2"),
+    boto3_config={"read_timeout": 30},
+)
+```
+
+To include the context consumed by tool schemas, pass the tools to `count()`:
+
+```python
+token_count = counter.count(messages, tools=[search_tool])
+```
+
+The counter creates its Bedrock client on the first call to `count()`. To create it during application startup instead, call `warm_up()` explicitly. Call `close()` when you are done with the counter to release the client's resources:
+
+```python
+counter.warm_up()
+...
+counter.close()
+```
+
+## Whole conversations only
+
+Bedrock validates the input of `CountTokens` the same way it validates a `Converse` request: the conversation must begin with a user message, and each tool result must follow the tool call that produced it. The counter therefore measures complete conversations, and raises `AmazonBedrockInferenceError` for fragments such as a single tool result message.
+
+Because of this, do not pass the counter to [`CompactionHook`](../pipeline-components/agents-1/compaction/compaction-hook.mdx) or a compactor. They count groups of messages and lone tool results, which Bedrock rejects. Use a local counter such as [`ApproximateTokenCounter`](approximatetokencounter.mdx) for compaction, and use `AmazonBedrockTokenCounter` to size a full request before you send it.
+
+## Non-text content
+
+The counter sends images and files to Bedrock in the same format as [`AmazonBedrockChatGenerator`](../pipeline-components/generators/amazonbedrockchatgenerator.mdx), so Bedrock counts them as part of the request instead of applying a flat estimate. It supports the same content types as the generator: JPEG, PNG, GIF, and WebP images, PDF and other document formats, and video files. Unsupported MIME types raise an error rather than being estimated.

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -784,6 +784,7 @@ export default {
         'token-counters/openaitokencounter',
         'token-counters/anthropictokencounter',
         'token-counters/googlegenaitokencounter',
+        'token-counters/amazonbedrocktokencounter',
       ],
     },
     {

--- a/docs-website/versioned_docs/version-3.1/token-counters.mdx
+++ b/docs-website/versioned_docs/version-3.1/token-counters.mdx
@@ -18,8 +18,9 @@ Haystack provides the `TokenCounter` protocol and three built-in implementations
 | [`OpenAITokenCounter`](token-counters/openaitokencounter.mdx) | Calls OpenAI's input token counting API | OpenAI API key | Exact, model-specific counts including images, files, and tools |
 | [`AnthropicTokenCounter`](token-counters/anthropictokencounter.mdx) | Calls Anthropic's token counting API | `anthropic-haystack` package and an Anthropic API key | Exact, model-specific counts for Claude models |
 | [`GoogleGenAITokenCounter`](token-counters/googlegenaitokencounter.mdx) | Calls Google's token counting API | `google-genai-haystack` package and Google credentials | Exact, model-specific counts for Gemini models |
+| [`AmazonBedrockTokenCounter`](token-counters/amazonbedrocktokencounter.mdx) | Calls Amazon Bedrock's `CountTokens` API | `amazon-bedrock-haystack` package and AWS credentials | Exact, model-specific counts for Bedrock-hosted models |
 
-All counters include message roles, text, tool calls, tool results, and optional tool schemas. The local counters account for images and files using configurable flat rates, including images and files nested in tool results. `OpenAITokenCounter`, `AnthropicTokenCounter`, and `GoogleGenAITokenCounter` send supported non-text content to the provider for a model-specific count.
+All counters include message roles, text, tool calls, tool results, and optional tool schemas. The local counters account for images and files using configurable flat rates, including images and files nested in tool results. `OpenAITokenCounter`, `AnthropicTokenCounter`, `GoogleGenAITokenCounter`, and `AmazonBedrockTokenCounter` send supported non-text content to the provider for a model-specific count.
 
 See the [Token Counters API reference](/reference/token-counters-api) for all constructor parameters and methods.
 
@@ -60,6 +61,7 @@ See the documentation for the counter you use to understand how it counts non-te
 - [`OpenAITokenCounter`](token-counters/openaitokencounter.mdx)
 - [`AnthropicTokenCounter`](token-counters/anthropictokencounter.mdx)
 - [`GoogleGenAITokenCounter`](token-counters/googlegenaitokencounter.mdx)
+- [`AmazonBedrockTokenCounter`](token-counters/amazonbedrocktokencounter.mdx)
 
 ## Creating a custom token counter
 

--- a/docs-website/versioned_docs/version-3.1/token-counters/amazonbedrocktokencounter.mdx
+++ b/docs-website/versioned_docs/version-3.1/token-counters/amazonbedrocktokencounter.mdx
@@ -1,0 +1,90 @@
+---
+title: "AmazonBedrockTokenCounter"
+id: amazonbedrocktokencounter
+slug: "/amazonbedrocktokencounter"
+description: "Count message and tool tokens exactly for Bedrock-hosted models with Amazon Bedrock's CountTokens API."
+---
+
+# AmazonBedrockTokenCounter
+
+`AmazonBedrockTokenCounter` uses Amazon Bedrock's `CountTokens` API to count the input tokens of `ChatMessage` objects and optional tool schemas for a specific Bedrock model. The API returns an exact count without generating a response, so it does not incur generation costs.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **Import path** | `haystack_integrations.token_counters.amazon_bedrock.AmazonBedrockTokenCounter` |
+| **Mandatory init variables** | `model`: The Bedrock model ID or ARN to count for |
+| **API reference** | [Amazon Bedrock](/reference/integrations-amazon-bedrock) |
+| **GitHub link** | https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/amazon_bedrock |
+| **Package name** | `amazon-bedrock-haystack` |
+
+</div>
+
+Because it calls a remote API, it needs AWS credentials and adds network latency to every count. Use it when you need exact, model-specific counts for models hosted on Bedrock. For local estimates, use [`ApproximateTokenCounter`](approximatetokencounter.mdx) or [`TiktokenCounter`](tiktokencounter.mdx).
+
+The counter converts messages and tools to the Bedrock `Converse` format in the same way [`AmazonBedrockChatGenerator`](../pipeline-components/generators/amazonbedrockchatgenerator.mdx) does, so the count matches what an equivalent `Converse` request consumes.
+
+## Installation
+
+Install the `amazon-bedrock-haystack` package:
+
+```bash
+pip install amazon-bedrock-haystack
+```
+
+## Usage
+
+Token counts are model-specific, so pass the model you intend to generate with. The model must support the `CountTokens` API:
+
+```python
+from haystack.dataclasses import ChatMessage
+from haystack_integrations.token_counters.amazon_bedrock import (
+    AmazonBedrockTokenCounter,
+)
+
+messages = [
+    ChatMessage.from_system("You are a helpful assistant."),
+    ChatMessage.from_user("Explain retrieval-augmented generation."),
+]
+
+counter = AmazonBedrockTokenCounter(model="anthropic.claude-sonnet-4-20250514-v1:0")
+token_count = counter.count(messages)
+print(token_count)
+```
+
+The counter authenticates like the other Amazon Bedrock components. By default, it reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` from the environment. You can also pass them as Haystack [Secret](../concepts/secret-management.mdx) arguments and configure the underlying Boto3 client with `boto3_config`:
+
+```python
+from haystack.utils import Secret
+
+counter = AmazonBedrockTokenCounter(
+    model="anthropic.claude-sonnet-4-20250514-v1:0",
+    aws_region_name=Secret.from_token("us-west-2"),
+    boto3_config={"read_timeout": 30},
+)
+```
+
+To include the context consumed by tool schemas, pass the tools to `count()`:
+
+```python
+token_count = counter.count(messages, tools=[search_tool])
+```
+
+The counter creates its Bedrock client on the first call to `count()`. To create it during application startup instead, call `warm_up()` explicitly. Call `close()` when you are done with the counter to release the client's resources:
+
+```python
+counter.warm_up()
+...
+counter.close()
+```
+
+## Whole conversations only
+
+Bedrock validates the input of `CountTokens` the same way it validates a `Converse` request: the conversation must begin with a user message, and each tool result must follow the tool call that produced it. The counter therefore measures complete conversations, and raises `AmazonBedrockInferenceError` for fragments such as a single tool result message.
+
+Because of this, do not pass the counter to [`CompactionHook`](../pipeline-components/agents-1/compaction/compaction-hook.mdx) or a compactor. They count groups of messages and lone tool results, which Bedrock rejects. Use a local counter such as [`ApproximateTokenCounter`](approximatetokencounter.mdx) for compaction, and use `AmazonBedrockTokenCounter` to size a full request before you send it.
+
+## Non-text content
+
+The counter sends images and files to Bedrock in the same format as [`AmazonBedrockChatGenerator`](../pipeline-components/generators/amazonbedrockchatgenerator.mdx), so Bedrock counts them as part of the request instead of applying a flat estimate. It supports the same content types as the generator: JPEG, PNG, GIF, and WebP images, PDF and other document formats, and video files. Unsupported MIME types raise an error rather than being estimated.

--- a/docs-website/versioned_sidebars/version-3.1-sidebars.json
+++ b/docs-website/versioned_sidebars/version-3.1-sidebars.json
@@ -777,7 +777,8 @@
         "token-counters/tiktokencounter",
         "token-counters/openaitokencounter",
         "token-counters/anthropictokencounter",
-        "token-counters/googlegenaitokencounter"
+        "token-counters/googlegenaitokencounter",
+        "token-counters/amazonbedrocktokencounter"
       ]
     },
     {


### PR DESCRIPTION
### Related Issues

Documents `AmazonBedrockTokenCounter`, proposed in deepset-ai/haystack-core-integrations#3865

### Proposed Changes:

- Add an `AmazonBedrockTokenCounter` docs page
- Add a "Whole conversations only" section: Bedrock's `CountTokens` validates input like `Converse` (must start with a user message, tool results must follow their tool calls), so the counter cannot size message fragments. It therefore advises against using it with `CompactionHook` or the compactors, which count message groups and lone tool results, and points to `ApproximateTokenCounter` for that.
- Add the counter to the comparison table and register the page in `sidebars.js`.
- Mirror everything into `versioned_docs/version-3.1` and `versioned_sidebars/version-3.1-sidebars.json`

### How did you test it?

- Ran the integration test when reviewing the integration PR

### Notes for the reviewer

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [ ] I have updated the related issue with new insights and changes. — n/a, no related issue in this repo
- [ ] I have added unit tests and updated the docstrings. — n/a, docs-only change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [ ] I have documented my code. — n/a, docs-only change
- [ ] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes). — n/a, docs-only change
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
