### PR TITLE
fix: round-trip serialization of Literal types with Enum values

### DIFF
--- a/haystack/utils/type_serialization.py
+++ b/haystack/utils/type_serialization.py
@@ -7,6 +7,7 @@ import builtins
 import importlib
 import inspect
 import typing
+from enum import Enum
 from threading import Lock
 from types import GenericAlias, ModuleType, NoneType, UnionType
 from typing import Any, Union, get_args
@@ -69,6 +70,19 @@ def _serialize_type_arg(arg: Any) -> str:
     return serialize_type(arg)
 
 
+def _serialize_literal_value(value: Any) -> str:
+    """
+    Serialize a single ``Literal`` value.
+
+    An Enum member is a valid ``Literal`` parameter (PEP 586), but its ``repr()`` ("<ChatRole.USER: 'user'>")
+    is not readable back, so it is rendered as the import path of its class plus the member name. Every other
+    value kind (str, bytes, int, bool, None) is rendered with ``repr()``.
+    """
+    if isinstance(value, Enum):
+        return f"{serialize_type(type(value))}.{value.name}"
+    return repr(value)
+
+
 def serialize_type(target: Any) -> str:
     """
     Serializes a type or an instance to its string representation, including the module name.
@@ -92,9 +106,9 @@ def serialize_type(target: Any) -> str:
         return "..."
 
     # Literal holds values (e.g. Literal["yes", "no"]), not types. Serialize each value with repr() so
-    # strings keep their quotes.
+    # strings keep their quotes; Enum members are serialized by import path (see _serialize_literal_value).
     if typing.get_origin(target) is typing.Literal:
-        return f"typing.Literal[{', '.join(repr(a) for a in get_args(target))}]"
+        return f"typing.Literal[{', '.join(_serialize_literal_value(a) for a in get_args(target))}]"
 
     args = get_args(target)
 
@@ -205,6 +219,50 @@ def _deserialize_type_arg(arg_str: str) -> Any:
     return deserialize_type(arg_str)
 
 
+def _deserialize_enum_member(path: str) -> Enum:
+    """
+    Resolve a dotted ``Literal`` value (e.g. "my_package.ChatRole.USER") to the Enum member it names.
+
+    The class part is resolved with ``deserialize_type``, so its module still has to pass the deserialization
+    allowlist, and only a member of an ``Enum`` subclass is accepted: no other attribute can be reached.
+    """
+    class_path, _, member_name = path.rpartition(".")
+    enum_class = deserialize_type(class_path)
+    if not (isinstance(enum_class, type) and issubclass(enum_class, Enum)):
+        raise DeserializationError(f"Could not deserialize Literal value '{path}': '{class_path}' is not an Enum")
+    try:
+        return enum_class[member_name]
+    except KeyError as e:
+        raise DeserializationError(
+            f"Could not deserialize Literal value '{path}': '{member_name}' is not a member of '{class_path}'"
+        ) from e
+
+
+def _deserialize_literal_values(args_str: str) -> tuple:
+    """
+    Parse the argument list of a serialized ``Literal`` into the values it holds.
+
+    The list is parsed with ``ast`` rather than split on commas, so quoting is respected and a comma inside a
+    string value does not split the arguments. Plain values are read with ``ast.literal_eval``, which is limited
+    to safe literals (str/int/bool/None/bytes); a dotted name is an Enum member and is resolved by import path.
+    """
+    try:
+        elements = ast.parse(f"({args_str},)", mode="eval").body.elts  # type: ignore[attr-defined]
+    except SyntaxError as e:
+        raise DeserializationError(f"Could not deserialize Literal arguments: {args_str}") from e
+
+    values = []
+    for element in elements:
+        if isinstance(element, ast.Attribute):
+            values.append(_deserialize_enum_member(ast.unparse(element)))
+            continue
+        try:
+            values.append(ast.literal_eval(element))
+        except ValueError as e:
+            raise DeserializationError(f"Could not deserialize Literal value: {ast.unparse(element)}") from e
+    return tuple(values)
+
+
 @mark_deserialization_internal
 def deserialize_type(type_str: str) -> Any:
     """
@@ -246,11 +304,11 @@ def deserialize_type(type_str: str) -> Any:
 
         main_type = deserialize_type(main_type_str)
 
-        # Parse literal args with ast.literal_eval, which safely handles
-        # str/int/bool/None/bytes and is quote-aware, so a comma inside a string value does not split the
-        # arguments.
+        # Parse literal args with _deserialize_literal_values, which safely handles
+        # str/int/bool/None/bytes plus Enum members, and is quote-aware, so a comma inside a string value
+        # does not split the arguments.
         if main_type is typing.Literal:
-            return typing.Literal[ast.literal_eval(f"({generics_str},)")]
+            return typing.Literal[_deserialize_literal_values(generics_str)]
 
         generic_args = [_deserialize_type_arg(arg) for arg in _parse_generic_args(generics_str)]
 

--- a/releasenotes/notes/fix-serialize-literal-enum-member-1b228cc319c3cd36.yaml
+++ b/releasenotes/notes/fix-serialize-literal-enum-member-1b228cc319c3cd36.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed ``serialize_type``/``deserialize_type`` for ``typing.Literal`` types whose values are Enum members
+    (a valid ``Literal`` parameter kind). Previously the members were serialized with ``repr()``, producing
+    text such as ``typing.Literal[<ChatRole.USER: 'user'>]``, which could not be read back: a pipeline using
+    such a type (for example in ``OutputAdapter``, ``ConditionalRouter`` or an ``Agent`` state schema) was
+    saved successfully but raised ``SyntaxError`` when loaded again. Enum members are now serialized by
+    import path and resolved back through the deserialization allowlist, so the type round-trips correctly.

--- a/test/utils/test_type_serialization.py
+++ b/test/utils/test_type_serialization.py
@@ -13,7 +13,7 @@ import pytest
 
 from haystack.core.errors import DeserializationError
 from haystack.core.serialization_security import _DENIED_BUILTIN_NAMES
-from haystack.dataclasses import Answer, ByteStream, ChatMessage, Document
+from haystack.dataclasses import Answer, ByteStream, ChatMessage, ChatRole, Document
 from haystack.utils.type_serialization import (
     _build_pep604_union_type,
     _is_union_type,
@@ -323,6 +323,48 @@ def test_output_type_round_trip_literal():
         Literal[b"bytes"],
         Optional[Literal["a", "b"]],
         Union[Literal["a"], int],
+    ]:
+        assert deserialize_type(serialize_type(type_)) == type_
+
+
+def test_output_type_serialization_literal_enum_member():
+    # Enum members are valid Literal parameters (PEP 586). repr() renders them as "<ChatRole.USER: 'user'>",
+    # which is not readable back, so they are serialized by import path instead.
+    assert serialize_type(Literal[ChatRole.USER]) == "typing.Literal[haystack.dataclasses.chat_message.ChatRole.USER]"
+    assert serialize_type(Literal[ChatRole.USER, ChatRole.ASSISTANT]) == (
+        "typing.Literal[haystack.dataclasses.chat_message.ChatRole.USER, "
+        "haystack.dataclasses.chat_message.ChatRole.ASSISTANT]"
+    )
+    # A Literal may mix enum members with plain values.
+    assert serialize_type(Literal[ChatRole.USER, "none"]) == (
+        "typing.Literal[haystack.dataclasses.chat_message.ChatRole.USER, 'none']"
+    )
+
+
+def test_output_type_deserialization_literal_enum_member():
+    assert deserialize_type("typing.Literal[haystack.dataclasses.chat_message.ChatRole.USER]") == Literal[ChatRole.USER]
+    assert (
+        deserialize_type("typing.Literal[haystack.dataclasses.chat_message.ChatRole.USER, 'none']")
+        == Literal[ChatRole.USER, "none"]
+    )
+
+
+def test_output_type_deserialization_literal_enum_member_errors():
+    # A dotted Literal value that does not resolve to an Enum member must be refused, not resolved.
+    with pytest.raises(DeserializationError):
+        deserialize_type("typing.Literal[haystack.dataclasses.chat_message.ChatRole.NOT_A_MEMBER]")
+    with pytest.raises(DeserializationError):
+        deserialize_type("typing.Literal[haystack.dataclasses.document.Document]")
+
+
+def test_output_type_round_trip_literal_enum_member():
+    for type_ in [
+        Literal[ChatRole.USER],
+        Literal[ChatRole.USER, ChatRole.ASSISTANT],
+        Literal[ChatRole.USER, "none"],
+        Optional[Literal[ChatRole.USER]],
+        List[Literal[ChatRole.USER, ChatRole.SYSTEM]],
+        Union[Literal[ChatRole.USER], int],
     ]:
         assert deserialize_type(serialize_type(type_)) == type_
 


### PR DESCRIPTION
### Related Issues

No open issue. This is the follow-up #12286 invited: it added `Literal` support and scoped Enum members out, noting they "can't be reconstructed from `repr()` alone and would need import-path handling".

### Proposed Changes:

PEP 586 allows Enum members as `Literal` parameters, but `serialize_type` renders every `Literal` value with `repr()`. For an Enum member that produces `typing.Literal[<ChatRole.USER: 'user'>]`, which is not valid Python. Serialization succeeds silently, and `deserialize_type` then raises a bare `SyntaxError` out of `ast.literal_eval`.

So a pipeline saves and cannot be loaded again. `OutputAdapter`, `ConditionalRouter`, `MetadataRouter`, `BranchJoiner`, `ListJoiner`, `LLMEvaluator` and the `Agent` state schema all round-trip their types through these two functions.

Enum members are now serialized by import path and resolved back through `deserialize_type`, so the existing module allowlist still applies and anything that is not an Enum member raises `DeserializationError` as before. Non-Enum `Literal` values still go through `repr()`, so their serialized form is unchanged. The argument list is parsed with `ast.parse` rather than split by hand, which keeps the existing quote-awareness.

### How did you test it?

Four unit tests in `test/utils/test_type_serialization.py` covering serialization, deserialization, the round trip and the rejection cases. All four fail on `main`.

- `hatch run test:unit test/utils/test_type_serialization.py`: 196 passed. The two remaining failures in that file are pre-existing on `main` under Python 3.14, where `typing.Union` and `types.UnionType` are unified; I confirmed they fail identically on unpatched source.
- Wider run over `test/utils/`, `test/core/`, `test/components/converters/test_output_adapter.py`, `test/components/routers/` and `test/components/joiners/`: 2651 passed, remaining failures pre-existing and environmental. `ruff check`, `ruff format --check` and `mypy` clean.
- Rejection path checked: a non-existent member, a non-Enum class, `os.path.sep`, `builtins.eval` and a bare undefined name all raise `DeserializationError`.

### Notes for the reviewer

This adds an attribute-resolution path into deserialization, which is security-sensitive. It resolves the class through `deserialize_type` rather than importing directly, so the allowlist is enforced exactly as before, and it accepts nothing but an Enum member of a resolved Enum class.

I could only execute against Python 3.14 locally, so I cannot claim the tests from execution on 3.10. `typing.Annotated` is deliberately untouched; that is #12338 and #12339.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes (no related issue)
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue