### PR TITLE
fix: preserve mixed text and tool calls in OpenAI streams

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -567,11 +567,12 @@ class OpenAIChatGenerator:
         chunks: list[StreamingChunk] = []
         for chunk in chat_completion:
             assert len(chunk.choices) <= 1, "Streaming responses should have at most one choice."
-            chunk_delta = _convert_chat_completion_chunk_to_streaming_chunk(
+            chunk_deltas = _convert_chat_completion_chunk_to_streaming_chunks(
                 chunk=chunk, previous_chunks=chunks, component_info=component_info
             )
-            chunks.append(chunk_delta)
-            callback(chunk_delta)
+            for chunk_delta in chunk_deltas:
+                chunks.append(chunk_delta)
+                callback(chunk_delta)
         return [_convert_streaming_chunks_to_chat_message(chunks=chunks)]
 
     async def _handle_async_stream_response(
@@ -582,11 +583,12 @@ class OpenAIChatGenerator:
         try:
             async for chunk in chat_completion:
                 assert len(chunk.choices) <= 1, "Streaming responses should have at most one choice."
-                chunk_delta = _convert_chat_completion_chunk_to_streaming_chunk(
+                chunk_deltas = _convert_chat_completion_chunk_to_streaming_chunks(
                     chunk=chunk, previous_chunks=chunks, component_info=component_info
                 )
-                chunks.append(chunk_delta)
-                await _invoke_streaming_callback(callback, chunk_delta)
+                for chunk_delta in chunk_deltas:
+                    chunks.append(chunk_delta)
+                    await _invoke_streaming_callback(callback, chunk_delta)
 
         except asyncio.CancelledError:
             await asyncio.shield(chat_completion.close())
@@ -692,11 +694,11 @@ def _convert_chat_completion_to_chat_message(
     return ChatMessage.from_assistant(text=text, tool_calls=tool_calls, meta=meta)
 
 
-def _convert_chat_completion_chunk_to_streaming_chunk(
+def _convert_chat_completion_chunk_to_streaming_chunks(
     chunk: ChatCompletionChunk, previous_chunks: list[StreamingChunk], component_info: ComponentInfo | None = None
-) -> StreamingChunk:
+) -> list[StreamingChunk]:
     """
-    Converts the streaming response chunk from the OpenAI API to a StreamingChunk.
+    Converts an OpenAI response chunk to separate text and tool-call StreamingChunks.
 
     :param chunk: The chunk returned by the OpenAI API.
     :param previous_chunks: A list of previously received StreamingChunks.
@@ -704,7 +706,7 @@ def _convert_chat_completion_chunk_to_streaming_chunk(
         generated the chunk, such as the component name and type.
 
     :returns:
-        A StreamingChunk object representing the content of the chunk from the OpenAI API.
+        StreamingChunk objects representing the content of the chunk from the OpenAI API.
     """
     finish_reason_mapping: dict[str, FinishReason] = {
         "stop": "stop",
@@ -716,18 +718,20 @@ def _convert_chat_completion_chunk_to_streaming_chunk(
     # On very first chunk so len(previous_chunks) == 0, the Choices field only provides role info (e.g. "assistant")
     # Choices is empty if include_usage is set to True where the usage information is returned.
     if len(chunk.choices) == 0:
-        return StreamingChunk(
-            content="",
-            component_info=component_info,
-            # Index is None since it's only set to an int when a content block is present
-            index=None,
-            finish_reason=None,
-            meta={
-                "model": chunk.model,
-                "received_at": datetime.now().isoformat(),
-                "usage": _serialize_object(chunk.usage),
-            },
-        )
+        return [
+            StreamingChunk(
+                content="",
+                component_info=component_info,
+                # Index is None since it's only set to an int when a content block is present
+                index=None,
+                finish_reason=None,
+                meta={
+                    "model": chunk.model,
+                    "received_at": datetime.now().isoformat(),
+                    "usage": _serialize_object(chunk.usage),
+                },
+            )
+        ]
 
     choice: ChunkChoice = chunk.choices[0]
 
@@ -744,23 +748,36 @@ def _convert_chat_completion_chunk_to_streaming_chunk(
                     arguments=function.arguments if function and function.arguments else None,
                 )
             )
-        return StreamingChunk(
-            content=choice.delta.content or "",
-            component_info=component_info,
-            # We adopt the first tool_calls_deltas.index as the overall index of the chunk.
-            index=tool_calls_deltas[0].index,
-            tool_calls=tool_calls_deltas,
-            start=tool_calls_deltas[0].tool_name is not None,
-            finish_reason=finish_reason_mapping.get(choice.finish_reason) if choice.finish_reason else None,
-            meta={
-                "model": chunk.model,
-                "index": choice.index,
-                "tool_calls": choice.delta.tool_calls,
-                "finish_reason": choice.finish_reason,
-                "received_at": datetime.now().isoformat(),
-                "usage": _serialize_object(chunk.usage),
-            },
-        )
+        text_chunks = []
+        if choice.delta.content:
+            # A StreamingChunk carries only one content type. Keep terminal metadata on the tool chunk.
+            text_choice = choice.model_copy(
+                update={"delta": choice.delta.model_copy(update={"tool_calls": None}), "finish_reason": None}
+            )
+            text_chunk = chunk.model_copy(update={"choices": [text_choice], "usage": None})
+            text_chunks = _convert_chat_completion_chunk_to_streaming_chunks(
+                text_chunk, previous_chunks, component_info
+            )
+        return [
+            *text_chunks,
+            StreamingChunk(
+                content="",
+                component_info=component_info,
+                # We adopt the first tool_calls_deltas.index as the overall index of the chunk.
+                index=tool_calls_deltas[0].index,
+                tool_calls=tool_calls_deltas,
+                start=tool_calls_deltas[0].tool_name is not None,
+                finish_reason=finish_reason_mapping.get(choice.finish_reason) if choice.finish_reason else None,
+                meta={
+                    "model": chunk.model,
+                    "index": choice.index,
+                    "tool_calls": choice.delta.tool_calls,
+                    "finish_reason": choice.finish_reason,
+                    "received_at": datetime.now().isoformat(),
+                    "usage": _serialize_object(chunk.usage),
+                },
+            ),
+        ]
 
     # On very first chunk the choice field only provides role info (e.g. "assistant") so we set index to None
     # We set all chunks missing the content field to index of None. E.g. can happen if chunk only contains finish
@@ -768,9 +785,7 @@ def _convert_chat_completion_chunk_to_streaming_chunk(
     if choice.delta and (choice.delta.content is None or choice.delta.role is not None):
         resolved_index = None
     else:
-        # We set the index to be 0 since if text content is being streamed then no tool calls are being streamed
-        # NOTE: We may need to revisit this if OpenAI allows planning/thinking content before tool calls like
-        #       Anthropic Claude
+        # Text content uses index 0; tool-call chunks retain the provider's tool-call indexes.
         resolved_index = 0
 
     # Initialize meta dictionary
@@ -793,13 +808,15 @@ def _convert_chat_completion_chunk_to_streaming_chunk(
     if choice.delta and choice.delta.content:
         content = choice.delta.content
 
-    return StreamingChunk(
-        content=content,
-        component_info=component_info,
-        index=resolved_index,
-        # The first chunk is always a start message chunk that only contains role information, so if we reach here
-        # and previous_chunks is length 1 then this is the start of text content.
-        start=len(previous_chunks) == 1,
-        finish_reason=finish_reason_mapping.get(choice.finish_reason) if choice.finish_reason else None,
-        meta=meta,
-    )
+    return [
+        StreamingChunk(
+            content=content,
+            component_info=component_info,
+            index=resolved_index,
+            # The first chunk is always a start message chunk that only contains role information, so if we reach here
+            # and previous_chunks is length 1 then this is the start of text content.
+            start=len(previous_chunks) == 1,
+            finish_reason=finish_reason_mapping.get(choice.finish_reason) if choice.finish_reason else None,
+            meta=meta,
+        )
+    ]

--- a/releasenotes/notes/fix-mixed-openai-streaming-deltas-901fad8f7dab6dfc.yaml
+++ b/releasenotes/notes/fix-mixed-openai-streaming-deltas-901fad8f7dab6dfc.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix streaming failures in ``OpenAIChatGenerator`` and ``AzureOpenAIChatGenerator``
+    when a provider delta contains both text and tool calls. Emit separate text and
+    tool-call chunks while preserving the complete reply, terminal metadata and usage.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -36,7 +36,7 @@ from haystack import component
 from haystack.components.generators.chat.openai import (
     OpenAIChatGenerator,
     _check_finish_reason,
-    _convert_chat_completion_chunk_to_streaming_chunk,
+    _convert_chat_completion_chunk_to_streaming_chunks,
     _make_schema_strict,
 )
 from haystack.components.generators.utils import print_streaming_chunk
@@ -1904,13 +1904,98 @@ class TestComponentLifecycle:
 
 
 class TestChatCompletionChunkConversion:
-    def test_convert_chat_completion_chunk_to_streaming_chunk(
+    @pytest.mark.parametrize("use_async,async_callback", [(False, False), (True, False), (True, True)])
+    async def test_stream_mixed_text_and_tool_call_deltas(self, use_async: bool, async_callback: bool) -> None:
+        chunks = [
+            ChatCompletionChunk(
+                id="mixed",
+                created=1,
+                model="test-model",
+                object="chat.completion.chunk",
+                choices=[chat_completion_chunk.Choice(index=0, delta=ChoiceDelta(role="assistant"))],
+            ),
+            ChatCompletionChunk(
+                id="mixed",
+                created=1,
+                model="test-model",
+                object="chat.completion.chunk",
+                choices=[
+                    chat_completion_chunk.Choice(
+                        index=0,
+                        delta=ChoiceDelta(
+                            content="Checking ",
+                            tool_calls=[
+                                ChoiceDeltaToolCall(
+                                    index=0,
+                                    id="call_weather",
+                                    type="function",
+                                    function=ChoiceDeltaToolCallFunction(name="weather", arguments='{"city":'),
+                                )
+                            ],
+                        ),
+                    )
+                ],
+            ),
+            ChatCompletionChunk(
+                id="mixed",
+                created=1,
+                model="test-model",
+                object="chat.completion.chunk",
+                choices=[
+                    chat_completion_chunk.Choice(
+                        index=0,
+                        finish_reason="tool_calls",
+                        delta=ChoiceDelta(
+                            content="the weather.",
+                            tool_calls=[
+                                ChoiceDeltaToolCall(index=0, function=ChoiceDeltaToolCallFunction(arguments='"Paris"}'))
+                            ],
+                        ),
+                    )
+                ],
+                usage=CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            ),
+        ]
+        payload = "".join(f"data: {chunk.model_dump_json()}\n\n" for chunk in chunks) + "data: [DONE]\n\n"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert json.loads(request.content)["stream"] is True
+            return httpx.Response(200, text=payload, headers={"content-type": "text/event-stream"})
+
+        received: list[StreamingChunk] = []
+
+        async def callback(chunk: StreamingChunk) -> None:
+            received.append(chunk)
+
+        generator = OpenAIChatGenerator(
+            api_key=Secret.from_token("test-key"),
+            http_client_kwargs={"transport": httpx.MockTransport(handler)},
+            streaming_callback=callback if async_callback else received.append,
+        )
+        try:
+            messages = [ChatMessage.from_user("What is the weather in Paris?")]
+            result = await generator.run_async(messages) if use_async else generator.run(messages)
+        finally:
+            generator.close()
+            await generator.close_async()
+
+        reply = result["replies"][0]
+        assert reply.text == "Checking the weather."
+        assert reply.tool_calls == [ToolCall(id="call_weather", tool_name="weather", arguments={"city": "Paris"})]
+        assert reply.meta["finish_reason"] == "tool_calls"
+        assert reply.meta["usage"]["total_tokens"] == 15
+        assert [chunk.content for chunk in received] == ["", "Checking ", "", "the weather.", ""]
+        assert [bool(chunk.tool_calls) for chunk in received] == [False, False, True, False, True]
+        assert [chunk.finish_reason for chunk in received] == [None, None, None, None, "tool_calls"]
+        assert sum((chunk.meta.get("usage") or {}).get("total_tokens", 0) for chunk in received) == 15
+
+    def test_convert_chat_completion_chunk_to_streaming_chunks(
         self, chat_completion_chunks: MagicMock, streaming_chunks: Any
     ) -> None:
 
         previous_chunks: list[StreamingChunk] = []
         for openai_chunk, haystack_chunk in zip(chat_completion_chunks, streaming_chunks, strict=True):
-            stream_chunk = _convert_chat_completion_chunk_to_streaming_chunk(
+            [stream_chunk] = _convert_chat_completion_chunk_to_streaming_chunks(
                 chunk=openai_chunk, previous_chunks=previous_chunks
             )
             assert stream_chunk == haystack_chunk
@@ -1934,7 +2019,7 @@ class TestChatCompletionChunkConversion:
             model="gpt-5-mini",
             object="chat.completion.chunk",
         )
-        result = _convert_chat_completion_chunk_to_streaming_chunk(chunk=chunk, previous_chunks=[])
+        [result] = _convert_chat_completion_chunk_to_streaming_chunks(chunk=chunk, previous_chunks=[])
         assert result.content == ""
         assert result.start is False
         assert result.tool_calls == [ToolCallDelta(index=0)]
@@ -1949,7 +2034,7 @@ class TestChatCompletionChunkConversion:
         This should not happen, but some OpenAI-compatible providers sometimes return a delta set to None.
         """
 
-        result = _convert_chat_completion_chunk_to_streaming_chunk(
+        [result] = _convert_chat_completion_chunk_to_streaming_chunks(
             chunk=chat_completion_chunk_delta_none, previous_chunks=[]
         )
 
@@ -2016,7 +2101,7 @@ class TestChatCompletionChunkConversion:
                 prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0),
             ),
         )
-        result = _convert_chat_completion_chunk_to_streaming_chunk(chunk=usage_chunk, previous_chunks=[])
+        [result] = _convert_chat_completion_chunk_to_streaming_chunks(chunk=usage_chunk, previous_chunks=[])
         assert result.content == ""
         assert result.start is False
         assert result.tool_calls is None


### PR DESCRIPTION
### Related Issues

Fixes #12610.

### Proposed Changes:

When an OpenAI-compatible streaming delta contains both text and tool calls, the converter creates a `StreamingChunk` with both fields. Its single-content-type validation raises `ValueError`, aborting the generation.

Let the internal converter return separate text and tool-call chunks, and deliver all of them through the sync and async streaming paths. The text comes first, while the finish reason and usage stay on the tool chunk so callbacks receive terminal metadata only once. Provider chunks are copied when extracting text; tool names, IDs and argument fragments remain intact. The inherited Azure path uses the same fix.

### How did you test it?

- Three new regressions fail on unmodified main and pass with the fix: sync generation, async generation with a sync callback, and async generation with an async callback.
- Tests use the real OpenAI SDK through `httpx.MockTransport`, feeding SSE with mixed text/tool deltas and checking callback order, assembled text/tool arguments, finish reason and non-duplicated token usage.
- 101 related OpenAI sync/async and Azure unit tests pass; 20 integration tests are deselected.
- Focused Mypy, Ruff and pre-commit checks pass.

### Notes for the reviewer

The reproduction uses synthetic SDK-valid SSE, not live provider traffic. No public generator signature or `StreamingChunk` validation rule is changed. Includes a release note.

Completed with AI assistance.