### PR TITLE
fix: validate reserved MetadataRouter output name

### DIFF
--- a/haystack/components/routers/metadata_router.py
+++ b/haystack/components/routers/metadata_router.py
@@ -63,7 +63,7 @@ class MetadataRouter:
         Initializes the MetadataRouter component.
 
         :param rules: A dictionary defining how to route documents or byte streams to output connections based on their
-            metadata. Keys are output connection names, and values are dictionaries of
+            metadata. Keys are output connection names (`"unmatched"` is reserved), and values are dictionaries of
             [filtering expressions](https://docs.haystack.deepset.ai/docs/metadata-filtering) in Haystack.
             For example:
             ```python
@@ -102,7 +102,12 @@ class MetadataRouter:
         :param strict_datetime_comparison:
             If `True`, timezone-naive and timezone-aware datetimes never match each other.
             If `False` (the default), the timezone from the aware datetime is copied to the naive one before comparing.
+        :raises ValueError:
+            If `rules` contains the reserved output name `"unmatched"` or an invalid filter.
         """
+        if "unmatched" in rules:
+            raise ValueError("The rule name 'unmatched' is reserved for documents that do not match any rule.")
+
         self.rules = rules
         self.output_type = output_type
         self.strict_datetime_comparison = strict_datetime_comparison

--- a/releasenotes/notes/validate-metadata-router-reserved-output-8e900a9eebb8cf72.yaml
+++ b/releasenotes/notes/validate-metadata-router-reserved-output-8e900a9eebb8cf72.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    ``MetadataRouter`` now raises a clear ``ValueError`` when a rule uses the
+    reserved output name ``unmatched``, instead of failing with an internal
+    duplicate-keyword ``TypeError`` during output registration.

--- a/test/components/routers/test_metadata_router.py
+++ b/test/components/routers/test_metadata_router.py
@@ -11,6 +11,21 @@ from haystack.dataclasses import ByteStream, Document
 
 
 class TestMetadataRouter:
+    @pytest.mark.parametrize("output_type", [list[Document], list[ByteStream]])
+    def test_init_rejects_reserved_output_name(self, output_type: type) -> None:
+        with pytest.raises(ValueError, match="'unmatched'.*reserved"):
+            MetadataRouter(
+                rules={"unmatched": {"field": "meta.language", "operator": "==", "value": "en"}},
+                output_type=output_type,
+            )
+
+    def test_from_dict_rejects_reserved_output_name(self) -> None:
+        data = MetadataRouter(rules={"english": {"field": "meta.language", "operator": "==", "value": "en"}}).to_dict()
+        rules = data["init_parameters"]["rules"]
+        rules["unmatched"] = rules.pop("english")
+        with pytest.raises(ValueError, match="'unmatched'.*reserved"):
+            MetadataRouter.from_dict(data)
+
     def test_run(self):
         rules = {
             "edge_1": {


### PR DESCRIPTION
### Related Issues

Fixes #12614.

### Proposed Changes:

`MetadataRouter(rules={"unmatched": ...})` currently fails inside output registration with an opaque duplicate-keyword `TypeError`. Validate the reserved output name at construction and raise a `ValueError` that explains its purpose. Valid routing and the default unmatched output retain their existing behavior.

The constructor docstring documents the reserved name and error. Includes a release note.

### How did you test it?

- The two new constructor regression cases fail on unmodified main, for both Document and ByteStream output types.
- 16 MetadataRouter tests pass, including the new deserialization regression and existing pipeline, routing and serialization cases.
- Focused Mypy, Ruff and pre-commit checks pass.

### Notes for the reviewer

Completed with AI assistance.