### PR TITLE
fix(routers): recognize str in Union output_type before literal_eval

### DIFF
--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -458,12 +458,12 @@ class ConditionalRouter:
                         # we try to evaluate it and would fail.
                         # This must be done cause the output could be different literal structures.
                         # This doesn't support any user types.
-                        # When the declared output_type is str we skip literal evaluation so that a
-                        # rendered string that happens to be a valid Python literal (e.g. "1,000" -> (1, 0),
-                        # "42" -> 42, "None" -> None) is returned unchanged instead of being coerced to
-                        # another type, which would violate the declared output_type.
+                        # When the declared output_type is str, or a Union that includes str (e.g. str | None),
+                        # we skip literal evaluation so that a rendered string that happens to be a valid Python
+                        # literal (e.g. "1,000" -> (1, 0), "42" -> 42, "None" -> None) is returned unchanged
+                        # instead of being coerced to another type, which would violate the declared output_type.
                         with contextlib.suppress(Exception):
-                            if not self._unsafe and output_type is not str:
+                            if not self._unsafe and not self._output_type_includes_str(output_type):
                                 output_value = ast.literal_eval(output_value)
 
                     # Validate output type if needed
@@ -568,6 +568,17 @@ class ConditionalRouter:
             return True
         except TemplateSyntaxError:
             return False
+
+    @staticmethod
+    def _output_type_includes_str(output_type: Any) -> bool:
+        """
+        Checks whether `output_type` is `str` itself, or a Union that includes `str` (e.g. `str | None`).
+        """
+        if output_type is str:
+            return True
+        if _is_union_type(output_type):
+            return str in get_args(output_type)
+        return False
 
     def _output_matches_type(self, value: Any, expected_type: type) -> bool:  # noqa: PLR0911
         """

--- a/releasenotes/notes/conditional-router-union-str-coercion-e7d09e2a41240baa.yaml
+++ b/releasenotes/notes/conditional-router-union-str-coercion-e7d09e2a41240baa.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed `ConditionalRouter` silently coercing string output to another type when `output_type` is a
+    Union that includes `str` (for example `str | None`). The literal-evaluation skip previously only
+    checked for the exact `str` type, so a rendered value like `"42"` declared with `output_type=str | None`
+    was coerced to the integer `42` instead of being returned as the string `"42"`.

--- a/test/components/routers/test_conditional_router.py
+++ b/test/components/routers/test_conditional_router.py
@@ -398,6 +398,37 @@ class TestRouter:
         assert result["reply"] == [1, 2, 3]
         assert isinstance(result["reply"], list)
 
+    def test_union_str_output_type_preserved_over_literal_eval(self):
+        # A Union output_type that includes str (e.g. str | None, a normal way to declare an optional
+        # string output) must be treated like a plain str output_type: a rendered string that happens to be
+        # a valid Python literal must not be silently coerced to another type.
+        routes: list[Route] = [
+            {
+                "condition": "{{ True }}",
+                "output": "{{ reply }}",
+                "output_name": "reply",
+                # A PEP 604 union is not a `type`, but `conditional_router.py` has an explicit branch for
+                # union output types, so `Route.output_type` is narrower than the real contract.
+                "output_type": str | None,  # type: ignore[typeddict-item]
+            }
+        ]
+        result = ConditionalRouter(routes, validate_output_type=True).run(reply="42")
+        assert result["reply"] == "42"
+        assert isinstance(result["reply"], str)
+
+        # Non-str Union members must still reconstruct structured literals from the rendered string.
+        routes = [
+            {
+                "condition": "{{ True }}",
+                "output": "{{ reply }}",
+                "output_name": "reply",
+                "output_type": list | None,  # type: ignore[typeddict-item]
+            }
+        ]
+        result = ConditionalRouter(routes, validate_output_type=True).run(reply="[1, 2, 3]")
+        assert result["reply"] == [1, 2, 3]
+        assert isinstance(result["reply"], list)
+
     def test_sede_with_custom_filter(self):
         routes: list[Route] = [
             {


### PR DESCRIPTION
### Related Issues

Fixes #12617.

### Proposed Changes

`ConditionalRouter.run()` only skipped `ast.literal_eval` coercion when `output_type` was exactly `str`, so a Union that includes `str` (e.g. `str | None`, `Optional[str]`) still went through literal evaluation. A rendered value like `"42"` declared with `output_type=str | None` was silently coerced to the integer `42` instead of being returned as the string `"42"` — even though `str | None` is a very normal way to declare an optional string output.

Added `ConditionalRouter._output_type_includes_str()`, which returns `True` when `output_type` is `str` itself, or a Union (`typing.Union` or PEP 604 `X | Y`) that includes `str` among its members, using the `_is_union_type` helper already used elsewhere in this file. `run()` now calls this instead of the direct `output_type is not str` check.

Non-str output types (including non-str Union members) are unaffected and continue to reconstruct structured literals from the rendered string as before.

### How did you test it?

- Added `test_union_str_output_type_preserved_over_literal_eval`, confirmed it fails on current `main` with `ValueError: Route 'reply' type doesn't match expected type` (reproducing the issue), and passes with the fix.
- Ran the full `test/components/routers/test_conditional_router.py` suite: 46 passed.
- Ran `hatch run fmt` (Ruff format + lint): all checks passed.
- Ran `hatch run test:types` (mypy): success, no issues found in 484 source files.
- Ran `git diff --check`.

### Notes for the reviewer

This generalizes the fix from #12322, which handled the exact `output_type=str` case for `ConditionalRouter` and `OutputAdapter`. `OutputAdapter.run()` has the identical `output_type is not str` pattern and is likely affected by the same Union gap, but I've kept this PR scoped to the issue as reported (`ConditionalRouter`) — happy to open a follow-up for `OutputAdapter` if that's wanted.