### PR TITLE
fix: preserve string outputs when ConditionalRouter output_type is a Union including str.

### DIFF
--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -22,6 +22,20 @@ from haystack.utils.type_serialization import _is_union_type
 logger = logging.getLogger(__name__)
 
 
+def _output_type_accepts_str(output_type: Any) -> bool:
+    """
+    Returns True if `str` is a valid value for `output_type`.
+
+    Either `output_type` is `str` itself, or `output_type` is a Union (e.g. `str | None`,
+    `Optional[str]`) that includes `str` as a member.
+    """
+    if output_type is str:
+        return True
+    if _is_union_type(get_origin(output_type)):
+        return str in get_args(output_type)
+    return False
+
+
 class NoRouteSelectedException(Exception):
     """Exception raised when no route is selected in ConditionalRouter."""
 
@@ -463,7 +477,7 @@ class ConditionalRouter:
                         # "42" -> 42, "None" -> None) is returned unchanged instead of being coerced to
                         # another type, which would violate the declared output_type.
                         with contextlib.suppress(Exception):
-                            if not self._unsafe and output_type is not str:
+                            if not self._unsafe and not _output_type_accepts_str(output_type):
                                 output_value = ast.literal_eval(output_value)
 
                     # Validate output type if needed

--- a/test/components/routers/test_conditional_router.py
+++ b/test/components/routers/test_conditional_router.py
@@ -398,6 +398,27 @@ class TestRouter:
         assert result["reply"] == [1, 2, 3]
         assert isinstance(result["reply"], list)
 
+    def test_optional_str_output_type_preserved_over_literal_eval(self):
+        # PR #12322 fixed literal_eval-preservation for output_type=str specifically. This regression
+        # test covers the gap that fix left open: a Union that includes str (e.g. `str | None`, the
+        # normal way to mark an optional string output) still hit `output_type is not str` == True,
+        # so "42" was silently coerced to the int 42 instead of being preserved as a string.
+        routes: list[Route] = [
+            {"condition": "{{ True }}", "output": "{{ reply }}", "output_name": "reply", "output_type": str | None}
+        ]
+        result = ConditionalRouter(routes).run(reply="42")
+        assert result["reply"] == "42"
+        assert isinstance(result["reply"], str)
+
+        router = ConditionalRouter(routes, validate_output_type=True)
+        result = router.run(reply="42")
+        assert result["reply"] == "42"
+        assert isinstance(result["reply"], str)
+
+        result = ConditionalRouter(routes).run(reply="1,000")
+        assert result["reply"] == "1,000"
+        assert isinstance(result["reply"], str)
+
     def test_sede_with_custom_filter(self):
         routes: list[Route] = [
             {


### PR DESCRIPTION
Fixes #12617

What does this PR do?

`ConditionalRouter.run()` only skipped `ast.literal_eval` coercion when `output_type` was exactly `str` (fixed for that specific case in #12322). This PR generalizes the check to also cover any Union type that includes `str` as a member (e.g. `str | None`, `Optional[str]`), which is a very normal way to declare an optional string output.

**Root cause**
```python
if not self._unsafe and output_type is not str:
    output_value = ast.literal_eval(output_value)
```
`output_type is not str` evaluates to `True` for any Union, even one that includes `str`, so the literal_eval coercion ran and could silently turn a valid string like `"42"` into the int `42`.

**Fix**
Added `_output_type_accepts_str()`, which returns `True` if `output_type` is `str` itself, or a Union that includes `str`. Used this instead of the direct `is not str` check.

**How did you test it?**
Added `test_optional_str_output_type_preserved_over_literal_eval`, covering:
- `str | None` output_type preserves a plain numeric-looking string
- Works correctly with `validate_output_type=True` (previously raised a spurious `ValueError`)
- Structured literals (e.g. `"1,000"`) are still preserved as strings, matching existing `str`-only behavior

Ran the full test file locally: `hatch run test:unit -- test/components/routers/test_conditional_router.py -v` → 46 passed, 0 failed.
`hatch run fmt-check` and `hatch run ruff check` both pass clean.