### PR TITLE
Raise a clear error when type routers reuse reserved output names

### DIFF
--- a/haystack/components/routers/document_type_router.py
+++ b/haystack/components/routers/document_type_router.py
@@ -68,7 +68,7 @@ class DocumentTypeRouter:
 
         :param mime_types:
             A list of MIME types or regex patterns to classify the input documents.
-            (for example: `["text/plain", "audio/x-wav", "image/jpeg"]`).
+            (for example: `["text/plain", "audio/x-wav", "image/jpeg"]`). `"unclassified"` is reserved.
         :param mime_type_meta_field:
             Optional name of the metadata field that holds the MIME type.
         :param file_path_meta_field:
@@ -79,11 +79,17 @@ class DocumentTypeRouter:
             `mimetypes` module. Useful when working with uncommon or custom file types.
             For example: `{"application/vnd.custom-type": ".custom"}`.
 
-        :raises ValueError: If `mime_types` is empty or if both `mime_type_meta_field` and `file_path_meta_field` are
-            not provided.
+        :raises ValueError: If `mime_types` is empty, uses the reserved name `"unclassified"`, or if both
+            `mime_type_meta_field` and `file_path_meta_field` are not provided.
         """
         if not mime_types:
             raise ValueError("The list of mime types cannot be empty.")
+
+        if "unclassified" in mime_types:
+            raise ValueError(
+                "'unclassified' is a reserved output name in DocumentTypeRouter for documents "
+                "whose MIME type does not match any rule. Rename the MIME type to something else."
+            )
 
         if mime_type_meta_field is None and file_path_meta_field is None:
             raise ValueError(

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -68,6 +68,7 @@ class FileTypeRouter:
         :param mime_types:
             A list of MIME types or regex patterns to classify the input files or byte streams.
             (for example: `["text/plain", "audio/x-wav", "image/jpeg"]`).
+            `"unclassified"` and `"failed"` are reserved output names and cannot be used here.
 
         :param additional_mimetypes:
             A dictionary containing the MIME type to add to the mimetypes package to prevent unsupported or non-native
@@ -77,9 +78,22 @@ class FileTypeRouter:
         :param raise_on_failure:
             If True, raises FileNotFoundError when a file path doesn't exist.
             If False (default), only emits a warning when a file path doesn't exist.
+        :raises ValueError:
+            If `mime_types` is empty, contains an invalid regex, or uses the reserved names
+            `"unclassified"` or `"failed"`.
         """
         if not mime_types:
             raise ValueError("The list of mime types cannot be empty.")
+
+        reserved = {"unclassified", "failed"}
+        collisions = reserved.intersection(mime_types)
+        if collisions:
+            names = ", ".join(repr(name) for name in sorted(collisions))
+            raise ValueError(
+                f"MIME type(s) {names} are reserved output names in FileTypeRouter "
+                "('unclassified' for unmatched sources, 'failed' for unreadable files). "
+                "Rename the MIME type to something else."
+            )
 
         if additional_mimetypes:
             for mime, ext in additional_mimetypes.items():

--- a/releasenotes/notes/validate-type-router-reserved-output-7c4a91e2b8d1f0a3.yaml
+++ b/releasenotes/notes/validate-type-router-reserved-output-7c4a91e2b8d1f0a3.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    ``FileTypeRouter`` and ``DocumentTypeRouter`` now raise a clear ``ValueError``
+    when a MIME type uses a reserved output name (``unclassified``, or ``failed``
+    on ``FileTypeRouter``), instead of failing with an internal duplicate-keyword
+    ``TypeError`` during output registration.

--- a/test/components/routers/test_document_type_router.py
+++ b/test/components/routers/test_document_type_router.py
@@ -35,6 +35,18 @@ class TestDocumentTypeRouter:
         ):
             DocumentTypeRouter(mime_types=["text/plain"])
 
+    def test_init_rejects_reserved_output_name(self):
+        with pytest.raises(ValueError, match="'unclassified'.*reserved"):
+            DocumentTypeRouter(mime_types=["unclassified", "text/plain"], mime_type_meta_field="mime_type")
+
+    def test_from_dict_rejects_reserved_output_name(self):
+        data = component_to_dict(
+            DocumentTypeRouter(mime_types=["text/plain"], mime_type_meta_field="mime_type"), "router"
+        )
+        data["init_parameters"]["mime_types"] = ["unclassified", "text/plain"]
+        with pytest.raises(ValueError, match="'unclassified'.*reserved"):
+            component_from_dict(DocumentTypeRouter, data, "router")
+
     def test_init_with_invalid_regex(self):
         with pytest.raises(ValueError, match="Invalid regex pattern"):
             DocumentTypeRouter(mime_type_meta_field="mime_type", mime_types=["[Invalid-Regex"])

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -45,6 +45,17 @@ class TestFileTypeRouter:
         with pytest.raises(ValueError):
             FileTypeRouter(mime_types=[])
 
+    @pytest.mark.parametrize("reserved", ["unclassified", "failed"])
+    def test_init_rejects_reserved_output_name(self, reserved: str):
+        with pytest.raises(ValueError, match=f"'{reserved}'.*reserved"):
+            FileTypeRouter(mime_types=[reserved, "text/plain"])
+
+    def test_from_dict_rejects_reserved_output_name(self):
+        data = FileTypeRouter(mime_types=["text/plain"]).to_dict()
+        data["init_parameters"]["mime_types"] = ["unclassified", "text/plain"]
+        with pytest.raises(ValueError, match="'unclassified'.*reserved"):
+            FileTypeRouter.from_dict(data)
+
     def test_to_dict(self):
         router = FileTypeRouter(
             mime_types=["text/plain", "audio/x-wav", "image/jpeg"],

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -46,7 +46,7 @@ class TestFileTypeRouter:
             FileTypeRouter(mime_types=[])
 
     @pytest.mark.parametrize("reserved", ["unclassified", "failed"])
-    def test_init_rejects_reserved_output_name(self, reserved: str):
+    def test_init_rejects_reserved_output_name(self, reserved: str) -> None:
         with pytest.raises(ValueError, match=f"'{reserved}'.*reserved"):
             FileTypeRouter(mime_types=[reserved, "text/plain"])
 


### PR DESCRIPTION
## Summary
- Sibling of #12614. `FileTypeRouter` and `DocumentTypeRouter` splat `mime_types` into `set_output_types` next to reserved outputs (`unclassified`, and `failed` on `FileTypeRouter`).
- A MIME type with one of those names raised `TypeError: got multiple values for keyword argument ...` from the framework internals.
- Guard in `__init__` and raise `ValueError` naming the reserved output. `MetadataRouter` is left to #12614.

## Test plan
- [x] `FileTypeRouter(mime_types=["unclassified", ...])` and `["failed", ...]` raise `ValueError`
- [x] `DocumentTypeRouter(mime_types=["unclassified", ...])` raises `ValueError`
- [x] `from_dict` hits the same check

Fixes #12622
