### PR TITLE
fix: allow FilterRetriever to clear default filters

### DIFF
--- a/haystack/components/retrievers/filter_retriever.py
+++ b/haystack/components/retrievers/filter_retriever.py
@@ -86,7 +86,8 @@ class FilterRetriever:
         :returns:
             A list of retrieved documents.
         """
-        return {"documents": self.document_store.filter_documents(filters=filters or self.filters)}
+        resolved_filters = filters if filters is not None else self.filters
+        return {"documents": self.document_store.filter_documents(filters=resolved_filters)}
 
     @component.output_types(documents=list[Document])
     async def run_async(self, filters: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -100,7 +101,10 @@ class FilterRetriever:
             A list of retrieved documents.
         """
         # 'ignore' since filter_documents_async is not defined in the Protocol but exists in the implementations
-        out_documents = await self.document_store.filter_documents_async(filters=filters or self.filters)  # type: ignore[attr-defined]
+        resolved_filters = filters if filters is not None else self.filters
+        out_documents = await self.document_store.filter_documents_async(  # type: ignore[attr-defined]
+            filters=resolved_filters
+        )
         return {"documents": out_documents}
 
     def close(self) -> None:

--- a/releasenotes/notes/filter-retriever-empty-filter-override-7dc8aaa4385680d8.yaml
+++ b/releasenotes/notes/filter-retriever-empty-filter-override-7dc8aaa4385680d8.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Fixed ``FilterRetriever`` so that an empty runtime ``filters`` dictionary clears filters provided at initialization
+    during synchronous and asynchronous execution.

--- a/test/components/retrievers/test_filter_retriever.py
+++ b/test/components/retrievers/test_filter_retriever.py
@@ -122,6 +122,14 @@ class TestFilterRetriever:
         assert len(result["documents"]) == 2
         assert TestFilterRetriever._documents_equal(result["documents"], sample_docs["de_docs"])
 
+    def test_retriever_init_filter_run_empty_filter_override(self, sample_document_store, sample_docs):
+        retriever = FilterRetriever(sample_document_store, filters={"field": "lang", "operator": "==", "value": "en"})
+        result = retriever.run(filters={})
+
+        assert "documents" in result
+        assert len(result["documents"]) == 5
+        assert TestFilterRetriever._documents_equal(result["documents"], sample_docs["all_docs"])
+
     @pytest.mark.integration
     def test_run_with_pipeline(self, sample_document_store, sample_docs):
         retriever = FilterRetriever(sample_document_store, filters={"field": "lang", "operator": "==", "value": "de"})
@@ -145,6 +153,14 @@ class TestFilterRetriever:
         results_docs = result["retriever"]["documents"]
         assert results_docs
         assert TestFilterRetriever._documents_equal(results_docs, sample_docs["en_docs"])
+
+        result: dict[str, Any] = pipeline.run(data={"retriever": {"filters": {}}})
+
+        assert result
+        assert "retriever" in result
+        results_docs = result["retriever"]["documents"]
+        assert results_docs
+        assert TestFilterRetriever._documents_equal(results_docs, sample_docs["all_docs"])
 
     def test_close(self):
         closable_document_store = Mock(spec=["close"])

--- a/test/components/retrievers/test_filter_retriever_async.py
+++ b/test/components/retrievers/test_filter_retriever_async.py
@@ -72,6 +72,15 @@ class TestFilterRetrieverAsync:
         assert TestFilterRetrieverAsync._documents_equal(result["documents"], sample_docs["de_docs"])
 
     @pytest.mark.asyncio
+    async def test_retriever_init_filter_run_empty_filter_override(self, sample_document_store, sample_docs):
+        retriever = FilterRetriever(sample_document_store, filters={"field": "lang", "operator": "==", "value": "en"})
+        result = await retriever.run_async(filters={})
+
+        assert "documents" in result
+        assert len(result["documents"]) == 5
+        assert TestFilterRetrieverAsync._documents_equal(result["documents"], sample_docs["all_docs"])
+
+    @pytest.mark.asyncio
     @pytest.mark.integration
     async def test_run_with_pipeline(self, sample_document_store, sample_docs):
         retriever = FilterRetriever(sample_document_store, filters={"field": "lang", "operator": "==", "value": "de"})
@@ -95,6 +104,14 @@ class TestFilterRetrieverAsync:
         results_docs = result["retriever"]["documents"]
         assert results_docs
         assert TestFilterRetrieverAsync._documents_equal(results_docs, sample_docs["en_docs"])
+
+        result: dict[str, Any] = await pipeline.run_async(data={"retriever": {"filters": {}}})
+
+        assert result
+        assert "retriever" in result
+        results_docs = result["retriever"]["documents"]
+        assert results_docs
+        assert TestFilterRetrieverAsync._documents_equal(results_docs, sample_docs["all_docs"])
 
     @pytest.mark.asyncio
     async def test_close_async(self):


### PR DESCRIPTION
### Related Issues

None.

### Proposed Changes

FilterRetriever previously used a truthiness fallback, so an explicit empty runtime filter dictionary reused filters supplied at initialization. The runtime value now overrides constructor filters whenever it is provided, including an empty dictionary.

Added synchronous and asynchronous regression tests for direct calls plus Pipeline.run and Pipeline.run_async.

### How did you test it?

- Targeted FilterRetriever tests: 18 passed.
- Full test/components/retrievers suite: 216 passed, 11 skipped (pre-existing integration skips).
- Formatting and lint: hatch run fmt.
- Type checking: hatch run test:types.

### Notes for the reviewer

The implementation matches MultiRetriever, which already distinguishes an omitted filter from an explicit empty filter.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- [x] I have read the contributors guidelines and code of conduct.
- [x] I have added regression tests.
- [x] The title uses the conventional fix: prefix.
- [x] I have added a release note file.
- [x] I have run the relevant quality checks.