### PR TITLE
fix: preserve OpenAI developer chat role

### DIFF
--- a/docs-website/docs/concepts/data-classes/chatmessage.mdx
+++ b/docs-website/docs/concepts/data-classes/chatmessage.mdx
@@ -9,7 +9,8 @@ description: "`ChatMessage` is the central abstraction to represent a message fo
 
 `ChatMessage` is the central abstraction to represent a message for a LLM. It contains role, metadata and several types of content, including text, images, tool calls, tool call results, and reasoning content.
 
-To create a `ChatMessage` instance, use `from_user`, `from_system`, `from_assistant`, and `from_tool` class methods.
+To create a `ChatMessage` instance, use `from_user`, `from_system`, `from_developer`, `from_assistant`, and
+`from_tool` class methods.
 
 The [content](#types-of-content) of the `ChatMessage` can then be inspected using the `text`, `texts`, `image`, `images`, `file`, `files`, `tool_call`, `tool_calls`, `tool_call_result`, `tool_call_results`, `reasoning`, and `reasonings` properties.
 
@@ -372,7 +373,8 @@ There are some breaking changes involved, so we recommend reviewing this guide t
 
 You can no longer directly initialize `ChatMessage` using `role`, `content`, and `meta`.
 
-- Use the following class methods instead: `from_assistant`, `from_user`, `from_system`, and `from_tool`.
+- Use the following class methods instead: `from_assistant`, `from_user`, `from_system`, `from_developer`, and
+  `from_tool`.
 - Replace the `content` parameter with `text`.
 
 ```python

--- a/haystack/components/builders/chat_prompt_builder.py
+++ b/haystack/components/builders/chat_prompt_builder.py
@@ -172,7 +172,11 @@ class ChatPromptBuilder:
         if template and not variables:
             if isinstance(template, list):
                 for message in template:
-                    if message.is_from(ChatRole.USER) or message.is_from(ChatRole.SYSTEM):
+                    if (
+                        message.is_from(ChatRole.USER)
+                        or message.is_from(ChatRole.SYSTEM)
+                        or message.is_from(ChatRole.DEVELOPER)
+                    ):
                         # infer variables from template
                         if message.text is None:
                             raise ValueError(NO_TEXT_ERROR_MESSAGE.format(role=message.role.value, message=message))
@@ -259,7 +263,11 @@ class ChatPromptBuilder:
         processed_messages = []
         if isinstance(template, list):
             for message in template:
-                if message.is_from(ChatRole.USER) or message.is_from(ChatRole.SYSTEM):
+                if (
+                    message.is_from(ChatRole.USER)
+                    or message.is_from(ChatRole.SYSTEM)
+                    or message.is_from(ChatRole.DEVELOPER)
+                ):
                     self._validate_variables(set(template_variables_combined.keys()))
                     if message.text is None:
                         raise ValueError(NO_TEXT_ERROR_MESSAGE.format(role=message.role.value, message=message))

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -27,6 +27,9 @@ class ChatRole(str, Enum):
     #: The system role. A message from the system contains only text.
     SYSTEM = "system"
 
+    #: The developer role. A message from the developer contains only text.
+    DEVELOPER = "developer"
+
     #: The assistant role. A message from the assistant can contain text and Tool calls. It can also store metadata.
     ASSISTANT = "assistant"
 
@@ -285,7 +288,8 @@ class ChatMessage:
     """
     Represents a message in a LLM chat conversation.
 
-    Use the `from_assistant`, `from_user`, `from_system`, and `from_tool` class methods to create a ChatMessage.
+    Use the `from_assistant`, `from_user`, `from_system`, `from_developer`, and `from_tool` class methods to create a
+    ChatMessage.
     """
 
     _role: ChatRole
@@ -477,6 +481,18 @@ class ChatMessage:
         :returns: A new ChatMessage instance.
         """
         return cls(_role=ChatRole.SYSTEM, _content=[TextContent(text=text)], _meta=meta or {}, _name=name)
+
+    @classmethod
+    def from_developer(cls, text: str, meta: dict[str, Any] | None = None, name: str | None = None) -> "ChatMessage":
+        """
+        Create a message from the developer.
+
+        :param text: The text content of the message.
+        :param meta: Additional metadata associated with the message.
+        :param name: An optional name for the participant. This field is only supported by OpenAI.
+        :returns: A new ChatMessage instance.
+        """
+        return cls(_role=ChatRole.DEVELOPER, _content=[TextContent(text=text)], _meta=meta or {}, _name=name)
 
     @classmethod
     def from_assistant(
@@ -828,8 +844,10 @@ class ChatMessage:
 
         if role == "user":
             return cls.from_user(text=content, name=name)
-        if role in ["system", "developer"]:
+        if role == "system":
             return cls.from_system(text=content, name=name)
+        if role == "developer":
+            return cls.from_developer(text=content, name=name)
 
         if isinstance(content, list):
             if not all("text" in el for el in content):

--- a/haystack/utils/jinja2_chat_extension.py
+++ b/haystack/utils/jinja2_chat_extension.py
@@ -365,13 +365,16 @@ class ChatMessageExtension(Extension):
                 )
             return ChatMessage.from_user(meta=meta, name=name, content_parts=valid_parts)
 
-        if role == "system":
+        if role in ["system", "developer"]:
+            role_name = role.capitalize()
             if not isinstance(parts[0], TextContent):
-                raise ValueError("System message must contain a text part.")
+                raise ValueError(f"{role_name} message must contain a text part.")
             text = parts[0].text
             if len(parts) > 1:
-                raise ValueError("System message must contain only one text part.")
-            return ChatMessage.from_system(meta=meta, name=name, text=text)
+                raise ValueError(f"{role_name} message must contain only one text part.")
+            if role == "system":
+                return ChatMessage.from_system(meta=meta, name=name, text=text)
+            return ChatMessage.from_developer(meta=meta, name=name, text=text)
 
         if role == "assistant":
             texts = [part.text for part in parts if isinstance(part, TextContent)]

--- a/releasenotes/notes/preserve-openai-developer-role-12604.yaml
+++ b/releasenotes/notes/preserve-openai-developer-role-12604.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Preserve the OpenAI ``developer`` role when converting between OpenAI chat
+    dictionaries and ``ChatMessage`` objects.

--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -68,6 +68,16 @@ class TestChatPromptBuilder:
         assert set(outputs.keys()) == {"prompt"}
         assert outputs["prompt"].type == list[ChatMessage]
 
+    def test_developer_message_variables_are_inferred_and_rendered(self):
+        builder = ChatPromptBuilder(template=[ChatMessage.from_developer("Answer in {{ language }}")])
+
+        inputs = builder.__haystack_input__._sockets_dict  # type: ignore[attr-defined]
+        assert "language" in inputs
+
+        result = builder.run(language="English")
+
+        assert result["prompt"] == [ChatMessage.from_developer("Answer in English")]
+
     def test_init_with_required_variables(self):
         builder = ChatPromptBuilder(
             template=[ChatMessage.from_user("This is a {{ variable }}")], required_variables=["variable"]

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -842,6 +842,10 @@ class TestToOpenaiDictFormat:
         message = ChatMessage.from_system("You are good assistant")
         assert message.to_openai_dict_format() == {"role": "system", "content": "You are good assistant"}
 
+    def test_to_openai_dict_format_developer_message(self):
+        message = ChatMessage.from_developer("You are a developer")
+        assert message.to_openai_dict_format() == {"role": "developer", "content": "You are a developer"}
+
     def test_to_openai_dict_format_user_message(self):
         message = ChatMessage.from_user("I have a question")
         assert message.to_openai_dict_format() == {"role": "user", "content": "I have a question"}
@@ -1036,6 +1040,20 @@ class TestFromOpenaiDictFormat:
         message = ChatMessage.from_openai_dict_format(openai_msg)
         assert message.role.value == "system"
         assert message.text == "You are a helpful assistant"
+
+    def test_from_openai_dict_format_developer_message(self):
+        openai_msg = {"role": "developer", "content": "You are a developer"}
+        message = ChatMessage.from_openai_dict_format(openai_msg)
+        assert message.role == ChatRole.DEVELOPER
+        assert message.text == "You are a developer"
+        assert message.to_openai_dict_format()["role"] == "developer"
+
+    def test_from_openai_dict_format_developer_and_system_are_distinct(self):
+        system_message = ChatMessage.from_openai_dict_format({"role": "system", "content": "x"})
+        developer_message = ChatMessage.from_openai_dict_format({"role": "developer", "content": "x"})
+        assert system_message.role == ChatRole.SYSTEM
+        assert developer_message.role == ChatRole.DEVELOPER
+        assert system_message.role != developer_message.role
 
     def test_from_openai_dict_format_assistant_message_with_content(self):
         openai_msg = {"role": "assistant", "content": "I can help with that"}

--- a/test/tools/test_parameters_schema_utils.py
+++ b/test/tools/test_parameters_schema_utils.py
@@ -245,7 +245,7 @@ FILE_CONTENT_SCHEMA = {
 
 CHAT_ROLE_SCHEMA = {
     "description": "Enumeration representing the roles within a chat.",
-    "enum": ["user", "system", "assistant", "tool"],
+    "enum": ["user", "system", "developer", "assistant", "tool"],
     "type": "string",
 }
 

--- a/test/utils/test_jinja2_chat_extension.py
+++ b/test/utils/test_jinja2_chat_extension.py
@@ -553,6 +553,16 @@ But my favorite subject is Small Language Models.
         with pytest.raises(ValueError):
             jinja_env.from_string(template).render(image=image)
 
+    def test_developer_message(self, jinja_env):
+        template = """
+        {% message role="developer" %}
+        You are a developer.
+        {% endmessage %}
+        """
+        rendered = jinja_env.from_string(template).render()
+        output = json.loads(rendered.strip())
+        assert output == {"role": "developer", "content": [{"text": "You are a developer."}], "meta": {}, "name": None}
+
     def test_invalid_assistant_message_raises_error(self, jinja_env, base64_image_string):
         template = """
         {% message role="assistant" %}


### PR DESCRIPTION
### Related Issues

- Fixes #12604

### Proposed Changes

- Add ChatRole.DEVELOPER and ChatMessage.from_developer().
- Preserve OpenAI's developer role in from_openai_dict_format() and to_openai_dict_format() round-trips.
- Support developer messages in the Jinja chat extension and ChatPromptBuilder variable rendering.
- Update the ChatMessage documentation and parameter schema expectations.
- Add regression tests for OpenAI conversion, Jinja message construction, PromptBuilder rendering, and role schemas.

### How did you test it?

- hatch run test:unit test/dataclasses/test_chat_message.py test/utils/test_jinja2_chat_extension.py test/components/builders/test_chat_prompt_builder.py test/tools/test_parameters_schema_utils.py
  - 237 passed, 1 deselected
- hatch run fmt-check passed.
- hatch run test:types passed with no issues in 484 source files.
- hatch -e test run pre-commit run --files <changed files> passed all hooks.
- The full unit suite ran with 6,348 passed, 8 skipped, and 25 failures related to existing Python 3.14/dependency compatibility issues. The affected tests for this change pass.

### Notes for the reviewer

The OpenAI validator already accepted the developer role, but deserialization collapsed it into system. This change makes the internal role model faithful to the OpenAI wire format while preserving existing behavior for all other roles.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [ ] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title and added ! in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the contributors guidelines.
- [x] I have run pre-commit hooks and fixed any issue.