### PR TITLE
docs: fix two docstrings that reference names the code does not have

### DIFF
--- a/haystack/components/builders/chat_prompt_builder.py
+++ b/haystack/components/builders/chat_prompt_builder.py
@@ -234,7 +234,7 @@ class ChatPromptBuilder:
         :returns: A dictionary with the following keys:
             - `prompt`: The updated list of `ChatMessage` objects after rendering the templates.
         :raises ValueError:
-            If `chat_messages` is empty or contains elements that are not instances of `ChatMessage`.
+            If `template` is empty or contains elements that are not instances of `ChatMessage`.
         """
         kwargs = kwargs or {}
         template_variables = template_variables or {}

--- a/haystack/core/pipeline/draw.py
+++ b/haystack/core/pipeline/draw.py
@@ -259,7 +259,7 @@ def _to_mermaid_image(
     :param server_url:
         Base URL of the Mermaid server (default: 'https://mermaid.ink').
     :param params:
-        Dictionary of customization parameters. See `validate_mermaid_params` for valid keys.
+        Dictionary of customization parameters. See `_validate_mermaid_params` for valid keys.
     :param timeout:
         Timeout in seconds for the request to the Mermaid server.
     :param super_component_mapping:


### PR DESCRIPTION
Third haystack docs PR after #12204 and #12295 (both merged). Two docstrings point readers at names
that do not exist in the code. Docstrings only, no behavior change.

## What's wrong

| Location | Docstring said | Reality |
|---|---|---|
| `haystack/core/pipeline/draw.py:262` | "See `validate_mermaid_params` for valid keys." | The function is **`_validate_mermaid_params`** — defined at `:109`, called at `:279`. There is no public name without the underscore, so the pointer leads nowhere. |
| `haystack/components/builders/chat_prompt_builder.py:237` | ":raises ValueError: If `chat_messages` is empty or contains elements that are not instances of `ChatMessage`." | `run()` takes **`template`**; `chat_messages` is not a parameter of `run` or of `__init__`. The two `ValueError` sites (`:247` `if not template`, `:253` the `isinstance` check over `template`) both test `template`. |

Both are the same class: prose naming a symbol the reader cannot resolve. I checked the description
against the code that actually raises rather than renaming to the nearest-looking parameter — the
`:247`/`:253` conditions are what fixed the wording.

## Checked for siblings

- `grep -rn "validate_mermaid_params"` now returns only `_validate_mermaid_params`; no other file
  repeats the bad pointer, and `haystack/core/super_component/` has no mirrored copy of that
  docstring.
- `chat_messages` appears nowhere else in `haystack/components/builders/` except the unrelated
  private helper `_render_chat_messages_from_str_template`.

## Validation

```
$ hatch run fmt
All checks passed!
558 files left unchanged

$ hatch run test:unit -k "chat_prompt_builder or draw or mermaid"
97 passed, 6622 deselected in 21.21s
```

`hatch run test:types` reports 20 errors in 10 files, but those are **pre-existing** — I verified by
stashing this diff and re-running, which gives the identical `Found 20 errors in 10 files`. None are
in the two files touched here, and this change is docstring text only.

`git diff --stat`: 2 files, +2/-2. Commit prefix is `docs:`, so `release_notes.yml` exempts it from
the release-note check.

## How this was found

An AST pass that flags backticked snake_case identifiers in docstring prose which are neither a
parameter of that function nor any symbol anywhere in the repo. Getting it quiet took two rounds of
narrowing, which is worth stating so the two hits above are not mistaken for a broad sweep:

1. A module-local symbol table produced 84 hits in haystack — nearly all legitimate cross-module
   references (`deserialize_callable` appears in 23 files, `raw_result` in 7). Widening to a
   repo-wide symbol table cut it to 29.
2. Lines shaped ``- `key`: description`` enumerate keys of a passthrough dict — `generation_kwargs`
   listing `max_completion_tokens`, `presence_penalty`, and friends. Those name an upstream API's
   fields, not the function's parameters. Excluding them cut it to 17.

Of the remaining 17 I am sending only these 2. The rest are legitimate on inspection: placeholder
names in illustrative examples (`my_filter`, `my_field`, `value_0`), and prompt-template field names
in `hooks/compaction/summarization.py`. Naming them here so it is clear they were reviewed rather
than missed.

---

🤖 Written with [Claude Code](https://claude.com/claude-code). Both sites were read in context, and
the corrected wording was taken from the code that raises rather than guessed from the parameter list.
