### PR TITLE
fix: allow OpenAI generators to clear default tools

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -522,7 +522,8 @@ class OpenAIChatGenerator:
         # adapt ChatMessage(s) to the format expected by the OpenAI API
         openai_formatted_messages = [message.to_openai_dict_format() for message in messages]
 
-        flattened_tools = flatten_tools_or_toolsets(tools or self.tools)
+        resolved_tools = tools if tools is not None else self.tools
+        flattened_tools = flatten_tools_or_toolsets(resolved_tools)
         tools_strict = tools_strict if tools_strict is not None else self.tools_strict
         _check_duplicate_tool_names(flattened_tools)
 

--- a/haystack/components/generators/chat/openai_responses.py
+++ b/haystack/components/generators/chat/openai_responses.py
@@ -550,7 +550,7 @@ class OpenAIResponsesChatGenerator:
         for message in messages:
             openai_formatted_messages.extend(_convert_chat_message_to_responses_api_format(message))
 
-        tools = tools or self.tools
+        tools = tools if tools is not None else self.tools
         tools_strict = tools_strict if tools_strict is not None else self.tools_strict
 
         openai_tools = {}

--- a/releasenotes/notes/openai-empty-runtime-tools-override-8944f214ccc5043b.yaml
+++ b/releasenotes/notes/openai-empty-runtime-tools-override-8944f214ccc5043b.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Fixed ``OpenAIChatGenerator`` and ``OpenAIResponsesChatGenerator`` so that an empty runtime ``tools`` list
+    overrides tools configured at initialization.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -502,6 +502,13 @@ class TestOpenAIChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
+    def test_run_with_empty_tools_override(self, tools: list[Tool], openai_mock_chat_completion: MagicMock) -> None:
+
+        component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"), tools=tools[:1])
+        component.run([ChatMessage.from_user("What's the capital of France?")], tools=[])
+
+        assert "tools" not in openai_mock_chat_completion.call_args.kwargs
+
     def test_run_with_generation_kwargs(
         self, chat_messages: list[ChatMessage], openai_mock_chat_completion: MagicMock
     ) -> None:

--- a/test/components/generators/chat/test_openai_responses.py
+++ b/test/components/generators/chat/test_openai_responses.py
@@ -596,6 +596,13 @@ class TestRun:
         assert len(response["replies"]) == 1
         assert isinstance(response["replies"][0], ChatMessage)
 
+    def test_run_with_empty_tools_override(self, tools: list[Tool], openai_mock_responses: MagicMock) -> None:
+
+        component = OpenAIResponsesChatGenerator(api_key=Secret.from_token("test-api-key"), tools=tools[:1])
+        component.run([ChatMessage.from_user("What's the capital of France?")], tools=[])
+
+        assert "tools" not in openai_mock_responses.call_args.kwargs
+
     def test_run_with_generation_kwargs(self, openai_mock_responses: MagicMock) -> None:
 
         component = OpenAIResponsesChatGenerator(


### PR DESCRIPTION
### Related Issues

None.

### Proposed Changes

`OpenAIChatGenerator` and `OpenAIResponsesChatGenerator` previously used a truthiness fallback when resolving runtime tools. As a result, explicitly passing `tools=[]` reused tools configured at initialization and still sent them to the OpenAI SDK.

Runtime tools now override initialization tools whenever provided, including an empty list. This preserves initialized tools when the runtime argument is omitted (`None`).

Added regression tests that call both public `run()` methods and inspect the final SDK request kwargs to ensure no initialized tools are sent.

### How did you test it?

- Targeted regressions: 2 passed.
- OpenAI chat and Responses generator tests, including async chat/Responses coverage: 110 passed, 32 skipped (API-key integration tests).
- `hatch run fmt`: passed.
- `hatch run test:types`: passed with no issues in 484 source files.

### Notes for the reviewer

The change follows the existing runtime-override semantics used by other components and keeps the `ToolsType` empty-sequence behavior intact.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

### Checklist

- [x] I have read the contributors guidelines and code of conduct.
- [x] I have added regression tests.
- [x] The title uses the conventional `fix:` prefix.
- [x] I have added a release note file.
- [x] I have run the relevant quality checks.