### PR TITLE
fix: avoid duplicate text from contained sentence window chunks

### DIFF
--- a/docs-website/docs/pipeline-components/retrievers/sentencewindowretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/sentencewindowretriever.mdx
@@ -33,6 +33,8 @@ Once we have the relevant sentences, we can retrieve neighboring sentences to pr
 
 This component is meant to be used with other Retrievers, such as the `InMemoryEmbeddingRetriever`. These Retrievers find relevant sentences by comparing a query against indexed sentences using a similarity metric. Then, the `SentenceWindowRetriever` component retrieves neighboring sentences around the relevant ones by leveraging metadata stored in the `Document` object.
 
+When all neighboring chunks include `split_idx_start` metadata, overlapping text appears only once in each context window, including when one chunk is fully contained in another. Without this metadata, the component concatenates the chunk contents as they are.
+
 ## Usage
 
 ### On its own

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -145,8 +145,8 @@ class SentenceWindowRetriever:
             # append the non-overlapping part to the merged text
             merged_text += doc.content[start - int(doc.meta["split_idx_start"]) :]
 
-            # update the last end index
-            last_idx_end = int(doc.meta["split_idx_start"]) + len(doc.content)
+            # A contained chunk must not move the covered end backwards.
+            last_idx_end = max(last_idx_end, int(doc.meta["split_idx_start"]) + len(doc.content))
 
         return merged_text
 

--- a/releasenotes/notes/fix-contained-sentence-window-chunks-066fb6b3be6a1e0f.yaml
+++ b/releasenotes/notes/fix-contained-sentence-window-chunks-066fb6b3be6a1e0f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Prevent ``SentenceWindowRetriever`` from duplicating overlapping text when a
+    context window contains a chunk fully contained within an earlier chunk.

--- a/test/components/retrievers/test_sentence_window_retriever.py
+++ b/test/components/retrievers/test_sentence_window_retriever.py
@@ -62,6 +62,38 @@ class TestSentenceWindowRetriever:
         expected = "This is a text with some words. There is a second sentence. And there is also a third sentence"
         assert merged_text == expected
 
+    @pytest.mark.parametrize(
+        "spans",
+        [
+            [(0, 6), (2, 4), (4, 8)],
+            [(0, 6), (0, 3), (4, 8)],
+            [(0, 6), (2, 2), (4, 8)],
+            [(0, 6), (2, 4), (3, 5), (4, 8)],
+        ],
+    )
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_merge_documents_with_contained_chunks(self, spans: list[tuple[int, int]], reverse: bool) -> None:
+        text = "abcdefgh"
+        docs = [Document(content=text[start:end], meta={"split_idx_start": start}) for start, end in spans]
+        if reverse:
+            docs.reverse()
+
+        assert SentenceWindowRetriever.merge_documents_text(docs) == text
+
+    def test_run_with_contained_chunks(self, in_memory_doc_store: InMemoryDocumentStore) -> None:
+        text = "The bird sings."
+        splitter = DocumentSplitter(
+            split_by="function", splitting_function=lambda content: [content[:8], content[4:6], content[6:]]
+        )
+        docs = splitter.run(documents=[Document(content=text)])["documents"]
+        in_memory_doc_store.write_documents(docs)
+        retriever = SentenceWindowRetriever(document_store=in_memory_doc_store, window_size=1)
+
+        result = retriever.run(retrieved_documents=[docs[1]])
+
+        assert result["context_windows"] == [text]
+        assert result["context_documents"] == docs
+
     def test_to_dict(self, in_memory_doc_store):
         window_retriever = SentenceWindowRetriever(in_memory_doc_store)
         data = window_retriever.to_dict()

--- a/test/components/retrievers/test_sentence_window_retriever_async.py
+++ b/test/components/retrievers/test_sentence_window_retriever_async.py
@@ -12,9 +12,25 @@ from haystack import Document, Pipeline
 from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.retrievers import InMemoryBM25Retriever
 from haystack.components.retrievers.sentence_window_retriever import SentenceWindowRetriever
+from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 
 class TestSentenceWindowRetrieverAsync:
+    @pytest.mark.asyncio
+    async def test_run_async_with_contained_chunks(self, in_memory_doc_store: InMemoryDocumentStore) -> None:
+        text = "The bird sings."
+        splitter = DocumentSplitter(
+            split_by="function", splitting_function=lambda content: [content[:8], content[4:6], content[6:]]
+        )
+        docs = splitter.run(documents=[Document(content=text)])["documents"]
+        in_memory_doc_store.write_documents(docs)
+        retriever = SentenceWindowRetriever(document_store=in_memory_doc_store, window_size=1)
+
+        result = await retriever.run_async(retrieved_documents=[docs[1]])
+
+        assert result["context_windows"] == [text]
+        assert result["context_documents"] == docs
+
     @pytest.mark.asyncio
     async def test_document_without_split_id(self, in_memory_doc_store):
         docs = [


### PR DESCRIPTION
### Related Issues

No existing issue or open pull request found for contained chunks moving the covered text boundary backwards. Related context: #8557 introduced overlap-aware context merging.

### Proposed Changes:

`SentenceWindowRetriever` can repeat text in a RAG context window when a chunk is fully contained in an earlier chunk. For example, a custom `DocumentSplitter` returning `The bird`, `bi`, and `rd sings.` from `The bird sings.` generates valid offsets of 0, 4, and 6. Both retrieval paths currently return `The birdrd sings.`.

Keep the furthest covered end offset when processing a contained chunk, so later chunks only append text not already included. The retrieved document list, ordering, metadata fallback, and public interfaces stay unchanged. Add a release note and clarify overlap handling in the component documentation.

Minimal reproduction against the base revision:

```python
from haystack import Document
from haystack.components.preprocessors import DocumentSplitter
from haystack.components.retrievers import SentenceWindowRetriever

text = "The bird sings."
splitter = DocumentSplitter(
    split_by="function",
    splitting_function=lambda content: [content[:8], content[4:6], content[6:]],
)
documents = splitter.run(documents=[Document(content=text)])["documents"]
assert SentenceWindowRetriever.merge_documents_text(documents) == text
```

### How did you test it?

- Ten new regression cases cover contained chunks, equal start offsets, empty chunks, consecutive contained chunks, reversed input order, and sync/async retrieval using actual `DocumentSplitter` output and `InMemoryDocumentStore`.
- Against unchanged base `01b43d4ee19895b87f4b734d1a7d1800c885cf3f`, nine cases fail and the control case passes.
- `hatch run test:unit test/components/retrievers/test_sentence_window_retriever.py test/components/retrievers/test_sentence_window_retriever_async.py --no-cov -q`: 41 passed.
- `hatch run test:integration test/components/retrievers/test_sentence_window_retriever.py test/components/retrievers/test_sentence_window_retriever_async.py -q`: all four existing pipeline integration tests passed.
- `hatch run test:types`: no issues in 484 source files.
- `hatch run fmt-check haystack/components/retrievers/sentence_window_retriever.py test/components/retrievers/test_sentence_window_retriever.py test/components/retrievers/test_sentence_window_retriever_async.py docs-website/docs/pipeline-components/retrievers/sentencewindowretriever.mdx`: passed.
- `hatch run pre-commit run --files` with all five changed files: passed.

### Notes for the reviewer

This PR was fully generated with AI coding assistants. The implementation received an independent agent review and was verified with the regression tests and local checks listed above. No human code review is claimed. No provider credentials or external model calls are used by these tests.

### Checklist

- [x] Read the contributor guidelines and code of conduct.
- [x] Included new reproduction details above; no existing issue for this case was found.
- [x] Added unit tests and documented the behavior.
- [x] Used a conventional commit title.
- [x] Added a release note file.
- [x] Ran pre-commit hooks and fixed reported issues.
