### PR TITLE
fix: DocumentJoiner weights bind to Variadic arrival order, not connect order

### DIFF
--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -106,7 +106,10 @@ class DocumentJoiner:
             Assign importance to each list of documents to influence how they're joined.
             This parameter is ignored for
             `concatenate` or `distribution_based_rank_fusion` join modes.
-            Weight for each list of documents must match the number of inputs.
+            Weights are applied in `Pipeline.connect()` / sender order (not component
+            execution or arrival order). The length must match the number of connected
+            senders; missing senders (for example a skipped ConditionalRouter branch)
+            are treated as empty lists.
         :param top_k:
             The maximum number of documents to return. Must be `None` or greater than 0.
         :param sort_by_score:

--- a/haystack/components/joiners/list_joiner.py
+++ b/haystack/components/joiners/list_joiner.py
@@ -16,7 +16,7 @@ class ListJoiner:
     A component that joins multiple lists into a single flat list.
 
     The ListJoiner receives multiple lists of the same type and concatenates them into a single flat list.
-    The output order respects the pipeline's execution sequence, with earlier inputs being added first.
+    The output order follows Pipeline.connect() / sender order for Variadic inputs.
 
     Usage example:
     ```python

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -593,10 +593,11 @@ class PipelineBase:  # noqa: PLW1641
         'component_name.connections_name'.
 
         If multiple senders are connected to the same list-typed receiver socket, the socket is
-        promoted to a lazy variadic socket so it can accept all incoming values. With the synchronous
-        `run`, the resulting list is ordered alphabetically by sender component name, not by the order in
-        which `connect()` was called. With the asynchronous run path (`run_async`), no ordering is
-        guaranteed, since components in different branches may run in parallel.
+        promoted to a lazy variadic socket so it can accept all incoming values. For those
+        auto-promoted sockets, sync `run` still delivers values in alphabetical sender-name order
+        (async arrival order is not guaranteed). Explicit `Variadic[...]` inputs (for example
+        DocumentJoiner) are instead aligned to `connect()` / sender order, and missing list-typed
+        senders are padded with `[]` so positional weights stay stable.
 
         :param sender:
             The component that delivers the value. This can be either just a component name or can be
@@ -1357,12 +1358,11 @@ class PipelineBase:  # noqa: PLW1641
                     consumed_inputs[socket_name] = [socket_inputs_values[0]]
                 elif socket.is_lazy_variadic:
                     if socket.wrap_input_in_list:
-                        # We use all inputs provided to the socket on a lazy variadic socket.
-                        # So keep it wrapped in a list.
-                        consumed_inputs[socket_name] = socket_inputs_values
+                        # Explicit Variadic[...] (e.g. DocumentJoiner): align to connect()/sender
+                        # order so positional weights are stable across sync and async runs.
+                        consumed_inputs[socket_name] = _order_lazy_variadic_socket_values(socket, socket_inputs)
                     else:
-                        # We flatten one-level of lists for lazy variadic sockets that don't wrap inputs in lists.
-                        # This way the incoming inputs match the expected type of the socket.
+                        # Auto-promoted list sockets: preserve historical execution/arrival order.
                         consumed_inputs[socket_name] = list(itertools.chain.from_iterable(socket_inputs_values))
                 else:
                     # For a normal socket we only care about the first input provided to the socket.
@@ -1941,6 +1941,41 @@ def _validate_component_output_keys(
             component_type=component_type,
             extra_keys=extra_keys,
         )
+
+
+def _order_lazy_variadic_socket_values(socket: InputSocket, socket_inputs: list[dict[str, Any]]) -> list[Any]:
+    """
+    Order Variadic socket values by ``connect()`` / ``socket.senders`` order.
+
+    User-provided values (``sender is None``) are kept first. Pipeline sender values follow
+    ``socket.senders``. Missing senders or ``_NoOutputProduced`` entries are padded with ``[]`` when
+    the socket type is a list type (e.g. DocumentJoiner's ``Variadic[list[Document]]``), so positional
+    weights stay aligned. Non-list Variadic sockets omit missing senders.
+    """
+    by_sender: dict[str, Any] = {}
+    user_values: list[Any] = []
+    for sock in socket_inputs:
+        if isinstance(sock["value"], _NoOutputProduced):
+            continue
+        sender = sock["sender"]
+        if sender is None:
+            user_values.append(sock["value"])
+        else:
+            by_sender[sender] = sock["value"]
+
+    pad_missing = _safe_get_origin(socket.type) is list
+    ordered: list[Any] = list(user_values)
+    for sender in socket.senders:
+        if sender in by_sender:
+            ordered.append(by_sender[sender])
+        elif pad_missing:
+            ordered.append([])
+
+    known_senders = set(socket.senders)
+    for sender, value in by_sender.items():
+        if sender not in known_senders:
+            ordered.append(value)
+    return ordered
 
 
 def _write_to_lazy_variadic_socket(

--- a/releasenotes/notes/document-joiner-weights-connect-order-3953528139b5278f.yaml
+++ b/releasenotes/notes/document-joiner-weights-connect-order-3953528139b5278f.yaml
@@ -1,0 +1,11 @@
+﻿---
+fixes:
+  - |
+    Fix ``DocumentJoiner`` positional ``weights`` binding to Variadic arrival/execution
+    order instead of ``Pipeline.connect()`` / sender order. Sync runs previously applied
+    weights in alphabetical component-name order; ``run_async`` used nondeterministic
+    completion order — so the same graph and weights could produce different hybrid
+    scores. Variadic inputs are now aligned to connect/sender order. Missing senders
+    (for example a skipped ``ConditionalRouter`` branch) are padded with empty lists
+    for list-typed Variadic sockets, avoiding ``zip(..., strict=True)`` crashes when
+    ``len(document_lists) < len(weights)``.

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -7,8 +7,9 @@ import re
 
 import pytest
 
-from haystack import Document
+from haystack import Document, Pipeline, component
 from haystack.components.joiners.document_joiner import DocumentJoiner, JoinMode
+from haystack.components.routers import ConditionalRouter
 
 
 class TestDocumentJoiner:
@@ -355,3 +356,89 @@ class TestDocumentJoiner:
         documents_2 = [Document(content="d", score=0.2)]
         output = joiner.run([documents_1, documents_2])
         assert output["documents"] == documents_1 + documents_2
+
+
+@component
+class _EmitDocuments:
+    """Test helper that emits a fixed document list."""
+
+    def __init__(self, documents: list[Document]) -> None:
+        self._documents = documents
+
+    @component.output_types(documents=list[Document])
+    def run(self) -> dict[str, list[Document]]:
+        return {"documents": self._documents}
+
+
+@component
+class _EmitDocumentsFromChoice:
+    """Test helper that emits documents tagged by a routed choice string."""
+
+    @component.output_types(documents=list[Document])
+    def run(self, choice: str) -> dict[str, list[Document]]:
+        return {"documents": [Document(content=f"from-{choice}", score=1.0)]}
+
+
+class TestDocumentJoinerPipelineWeightsOrder:
+    def test_merge_weights_follow_connect_order_not_alphabetical_component_names(self):
+        """
+        Positional weights must bind to connect()/sender order.
+
+        Component names are chosen so alphabetical execution order (dense < sparse)
+        differs from connect order (sparse then dense). Without a fix, sync run applies
+        weights in alphabetical arrival order and corrupts hybrid scores.
+        """
+        pipeline = Pipeline()
+        pipeline.add_component("dense", _EmitDocuments([Document(content="shared", score=10.0)]))
+        pipeline.add_component("sparse", _EmitDocuments([Document(content="shared", score=1.0)]))
+        pipeline.add_component("joiner", DocumentJoiner(join_mode="merge", weights=[0.9, 0.1], sort_by_score=False))
+        pipeline.connect("sparse", "joiner")
+        pipeline.connect("dense", "joiner")
+
+        result = pipeline.run({})
+        fused = result["joiner"]["documents"][0]
+        # connect order: sparse@1.0 * 0.9 + dense@10.0 * 0.1 == 1.9
+        # alphabetical arrival would yield dense@10.0 * 0.9 + sparse@1.0 * 0.1 == 9.1
+        assert fused.score == pytest.approx(1.9)
+
+    def test_rrf_weights_follow_connect_order_not_alphabetical_component_names(self):
+        pipeline = Pipeline()
+        pipeline.add_component("dense", _EmitDocuments([Document(content="only-dense"), Document(content="shared")]))
+        pipeline.add_component("sparse", _EmitDocuments([Document(content="only-sparse"), Document(content="shared")]))
+        pipeline.add_component(
+            "joiner", DocumentJoiner(join_mode="reciprocal_rank_fusion", weights=[0.9, 0.1], sort_by_score=True)
+        )
+        pipeline.connect("sparse", "joiner")
+        pipeline.connect("dense", "joiner")
+
+        result = pipeline.run({})
+        contents = [doc.content for doc in result["joiner"]["documents"]]
+        # Heavy weight on sparse (first connect) should rank only-sparse above only-dense.
+        assert contents.index("only-sparse") < contents.index("only-dense")
+
+    def test_merge_weights_tolerate_skipped_conditional_router_branch(self):
+        """
+        When a ConditionalRouter branch skips a sender, DocumentJoiner used to raise
+        zip(..., strict=True) because len(document_lists) < len(weights). Missing
+        senders must be padded as empty lists so weights stay aligned.
+        """
+        routes = [
+            {"condition": "{{choice == 'a'}}", "output": "{{choice}}", "output_name": "a", "output_type": str},
+            {"condition": "{{choice == 'b'}}", "output": "{{choice}}", "output_name": "b", "output_type": str},
+        ]
+        pipeline = Pipeline()
+        pipeline.add_component("router", ConditionalRouter(routes))
+        pipeline.add_component("branch_a", _EmitDocumentsFromChoice())
+        pipeline.add_component("branch_b", _EmitDocumentsFromChoice())
+        pipeline.add_component("joiner", DocumentJoiner(join_mode="merge", weights=[0.7, 0.3], sort_by_score=False))
+        pipeline.connect("router.a", "branch_a.choice")
+        pipeline.connect("router.b", "branch_b.choice")
+        pipeline.connect("branch_a", "joiner")
+        pipeline.connect("branch_b", "joiner")
+
+        result = pipeline.run({"router": {"choice": "a"}})
+        docs = result["joiner"]["documents"]
+        assert len(docs) == 1
+        assert docs[0].content == "from-a"
+        # Only branch_a contributed; weight 0.7 applies to its score 1.0
+        assert docs[0].score == pytest.approx(0.7)


### PR DESCRIPTION
### Related Issues

- fixes #12646

### Proposed Changes:

`DocumentJoiner` positional `weights` were zipped onto the Variadic `documents` list in **arrival/execution order**, not `Pipeline.connect()` / sender order:

- sync `run`: independent senders execute in alphabetical component-name order → weights silently bind to the wrong lists when names and connect order disagree
- `run_async`: completion order is nondeterministic → same graph + weights can yield different hybrid scores

Additionally, when a `ConditionalRouter` branch skips a sender, `len(document_lists) < len(weights)` and `zip(..., strict=True)` crashes.

**Fix (minimal):** for explicit `Variadic[...]` sockets (`wrap_input_in_list=True`, e.g. DocumentJoiner), `_consume_component_inputs` now:

1. orders values by `InputSocket.senders` (connect order)
2. pads missing / `_NoOutputProduced` list-typed senders with `[]`

Auto-promoted list sockets keep historical alphabetical/arrival ordering (see existing auto-variadic tests / #10979).

### How did you test it?

- Added `TestDocumentJoinerPipelineWeightsOrder` with three cases:
  - merge weights follow connect order (not alphabetical names)
  - RRF weights follow connect order
  - skipped ConditionalRouter branch no longer zip-crashes; missing sender padded
- Confirmed all three **fail on unmodified upstream/main** without this patch (`assert 9.1 == 1.9`, wrong RRF ranking, `zip() argument 2 is longer than argument 1`)
- Confirmed all three **pass with the patch**
- Ran `hatch run test:unit test/components/joiners/` → 102 passed
- Re-checked auto-variadic pipeline tests that encode alphabetical order → still pass

### Notes for the reviewer

- Behavior change is scoped to **explicit** `Variadic` inputs; auto-variadic list joining is unchanged
- Docs: `DocumentJoiner.weights`, `Pipeline.connect`, and `ListJoiner` (explicit Variadic) mention connect/sender order
- Recent committers on touched files: @linhongyu510 @manjunathbhaskar @anakin87 @sjrl @rautaditya2606 @bogdankostic

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I added unit tests and updated docstrings / release notes.
- [x] I used a [conventional commit](https://www.conventionalcommits.org/) type in the PR title / commit.
- [x] I documented my changes in a [reno note](https://github.com/deepset-ai/haystack/tree/main/releasenotes/notes).

### AI disclaimer

This PR was produced with AI assistance (Cursor / Grok). The bug was re-verified on current `upstream/main` before patching; tests were proven to fail without the patch and pass with it.