### PR TITLE
fix(agents): replay write-write conflicts in call order after batching

### DIFF
--- a/haystack/components/agents/tool_calling.py
+++ b/haystack/components/agents/tool_calling.py
@@ -547,10 +547,12 @@ def _run_tool(
 
     # Group the calls into batches that honor read-after-write dependencies on State (see `_schedule_tool_calls`).
     batches = _schedule_tool_calls(tool_calls, resolved_tools)
+    io_list = [_state_io_for_call(tool, tc.arguments) for tc, tool in zip(tool_calls, resolved_tools, strict=True)]
 
     # Results are indexed by call position so the returned messages stay in call order, even though batches may
     # execute the calls in a different order.
     results: list[ChatMessage | None] = [None] * len(tool_calls)
+    raw_results: list[Any] = [None] * len(tool_calls)
     stream_index = 0
 
     # Resolved once, before any tool runs, so all per-call spans of this step become siblings under the same parent.
@@ -577,17 +579,42 @@ def _run_tool(
 
             # Merge results in call order within the batch so write-write merges stay deterministic.
             for idx in batch:
+                raw_result = futures[idx].result()
                 message = _finalize_tool_result(
-                    futures[idx].result(),
+                    raw_result,
                     tool_calls[idx],
                     resolved_tools[idx],
                     state,
                     raise_on_failure=raise_on_failure,
                 )
                 results[idx] = message
+                raw_results[idx] = raw_result
                 if streaming_callback is not None:
                     streaming_callback(_create_tool_result_streaming_chunk(message, tool_calls[idx], stream_index))
                     stream_index += 1
+
+    # Write-write replay: batching only orders read-after-write dependencies, but the per-batch merge can let an
+    # earlier-indexed writer that landed in a later batch (pushed there by an unrelated dependency) overwrite a
+    # later-indexed writer. For keys with multiple writers and no same-step reader, replay the outputs in original
+    # call order so the last writer in call order wins, as the _schedule_tool_calls contract states.
+    readers: _StateKeys = set()
+    for reads, _ in io_list:
+        if reads is _ALL_STATE_KEYS:
+            readers = _ALL_STATE_KEYS
+            break
+        readers |= reads
+    if readers is not _ALL_STATE_KEYS:
+        writers_by_key: dict[str, list[int]] = {}
+        for idx, (_, writes) in enumerate(io_list):
+            for key in writes:
+                writers_by_key.setdefault(key, []).append(idx)
+        for key, writer_indices in writers_by_key.items():
+            if key in readers or len(writer_indices) < 2:
+                continue
+            for idx in writer_indices:  # already in ascending call order
+                raw_result = raw_results[idx]
+                if isinstance(raw_result, dict):
+                    _merge_tool_outputs_into_state(resolved_tools[idx], raw_result, state)
 
     tool_messages = error_messages + [m for m in results if m is not None]
 
@@ -636,10 +663,12 @@ async def _run_tool_async(
 
     # Group the calls into batches that honor read-after-write dependencies on State (see `_schedule_tool_calls`).
     batches = _schedule_tool_calls(tool_calls, resolved_tools)
+    io_list = [_state_io_for_call(tool, tc.arguments) for tc, tool in zip(tool_calls, resolved_tools, strict=True)]
 
     # Results are indexed by call position so the returned messages stay in call order, even though batches may
     # execute the calls in a different order.
     results: list[ChatMessage | None] = [None] * len(tool_calls)
+    raw_results: list[Any] = [None] * len(tool_calls)
     stream_index = 0
 
     # `max_workers` + Semaphore bounds concurrency for both sync and async tool calls async tools are awaited directly,
@@ -675,11 +704,32 @@ async def _run_tool_async(
                 result, tool_calls[idx], resolved_tools[idx], state, raise_on_failure=raise_on_failure
             )
             results[idx] = message
+            raw_results[idx] = result
             if streaming_callback is not None:
                 await _invoke_streaming_callback(
                     streaming_callback, _create_tool_result_streaming_chunk(message, tool_calls[idx], stream_index)
                 )
                 stream_index += 1
+
+    # Write-write replay: mirror the sync path — see the comment in `_run_tool`.
+    readers: _StateKeys = set()
+    for reads, _ in io_list:
+        if reads is _ALL_STATE_KEYS:
+            readers = _ALL_STATE_KEYS
+            break
+        readers |= reads
+    if readers is not _ALL_STATE_KEYS:
+        writers_by_key: dict[str, list[int]] = {}
+        for idx, (_, writes) in enumerate(io_list):
+            for key in writes:
+                writers_by_key.setdefault(key, []).append(idx)
+        for key, writer_indices in writers_by_key.items():
+            if key in readers or len(writer_indices) < 2:
+                continue
+            for idx in writer_indices:  # already in ascending call order
+                raw_result = raw_results[idx]
+                if isinstance(raw_result, dict):
+                    _merge_tool_outputs_into_state(resolved_tools[idx], raw_result, state)
 
     tool_messages = error_messages + [m for m in results if m is not None]
 

--- a/releasenotes/notes/fix-agent-write-write-batch-order.yaml
+++ b/releasenotes/notes/fix-agent-write-write-batch-order.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed the write-write merge order in Agent tool-call scheduling: when an
+    unrelated read-after-write dependency pushed one of two writers into a later
+    batch, the earlier-indexed writer could overwrite a later-indexed one, so the
+    contended state key no longer reflected the LLM's call order. Conflicting
+    outputs are now replayed in call order after all batches resolve.

--- a/test/components/agents/test_tool_calling_write_write.py
+++ b/test/components/agents/test_tool_calling_write_write.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack.components.agents.state.state import State
+from haystack.components.agents.tool_calling import _run_tool, _run_tool_async
+from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.tools import Tool
+
+
+def _build_tools():
+    def tool_a_fn(dep):
+        return {"out": "A-value"}
+
+    def tool_b_fn():
+        return {"out": "B-value"}
+
+    def tool_c_fn():
+        return {"out": "dep-value"}
+
+    tool_a = Tool(
+        name="tool_a",
+        description="reads dep, writes shared",
+        parameters={"type": "object", "properties": {"dep": {"type": "string"}}, "required": ["dep"]},
+        function=tool_a_fn,
+        inputs_from_state={"dep": "dep"},
+        outputs_to_state={"shared": {"source": "out"}},
+    )
+    tool_b = Tool(
+        name="tool_b",
+        description="writes shared, no reads",
+        parameters={"type": "object", "properties": {}},
+        function=tool_b_fn,
+        outputs_to_state={"shared": {"source": "out"}},
+    )
+    tool_c = Tool(
+        name="tool_c",
+        description="writes dep",
+        parameters={"type": "object", "properties": {}},
+        function=tool_c_fn,
+        outputs_to_state={"dep": {"source": "out"}},
+    )
+    return [tool_a, tool_b, tool_c]
+
+
+def _build_message():
+    return ChatMessage.from_assistant(
+        tool_calls=[
+            ToolCall(tool_name="tool_a", arguments={}),
+            ToolCall(tool_name="tool_b", arguments={}),
+            ToolCall(tool_name="tool_c", arguments={}),
+        ]
+    )
+
+
+def test_write_write_winner_is_last_in_call_order_not_batch_order():
+    """tool_a lands in a later batch (it reads dep, written by tool_c), but tool_b — listed after tool_a and
+    independent of it — must still win the write-write race on 'shared' (issue #12621)."""
+    message = _build_message()
+    state = State(schema={"dep": {"type": str}, "shared": {"type": str}})
+    _run_tool(messages=[message], state=state, tools=_build_tools(), raise_on_failure=True)
+    assert state.get("shared") == "B-value"
+    # The read-after-write dependency must still be honored: tool_a read dep after tool_c wrote it.
+    assert state.get("dep") == "dep-value"
+
+
+async def test_write_write_winner_is_last_in_call_order_async():
+    message = _build_message()
+    state = State(schema={"dep": {"type": str}, "shared": {"type": str}})
+    await _run_tool_async(messages=[message], state=state, tools=_build_tools(), raise_on_failure=True)
+    assert state.get("shared") == "B-value"
+    assert state.get("dep") == "dep-value"


### PR DESCRIPTION
## Summary

`_schedule_tool_calls` batches a step's tool calls by read-after-write dependency on State keys, and `_run_tool` / `_run_tool_async` merge each batch's outputs into State as the batch finishes. The scheduler's contract states that a pure write-write overlap (no shared reads) keeps outputs merged in call order afterward — but that only holds when both writers land in the **same batch**.

When an unrelated dependency pushes one of the two writers into a later batch, the per-batch merge lets the earlier-indexed writer overwrite the later-indexed one: the contended key is decided by **batch order instead of call order**.

Reproduction from #12621 — `tool_a` (call 0, reads `dep`, writes `shared`), `tool_b` (call 1, writes `shared`), `tool_c` (call 2, writes `dep`) schedule as `[[1, 2], [0]]`, so `shared` ends up as `tool_a`'s value even though `tool_b` was requested after it and neither call reads the other's output.

## Fix

After all batches resolve, keys with **multiple writers and no same-step reader** are replayed in original call order, restoring the documented "last writer in call order wins" contract without serializing execution:

- read-after-write semantics are untouched (a reader still observes the writer that ran before it);
- keys read anywhere in the same step are excluded from the replay, so dependency-ordered writes keep their semantics;
- the scheduler itself is unchanged — this only fixes the merge side.

## Tests

New `test/components/agents/test_tool_calling_write_write.py` (sync + async):

- the #12621 scenario: `shared` ends as `B-value` (later call wins) while `dep` still reflects the read-after-write dependency;
- async variant of the same.

Full `test/components/agents/test_tool_calling.py` suite: 67 passed — existing scheduling, batching, and write-write behavior unchanged.

A release note is included under `releasenotes/notes/`.

Fixes #12621
