### PR TITLE
fix: isolate InMemoryDocumentStore filter_documents meta when stripping embeddings

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -10,6 +10,7 @@ import uuid
 from collections import Counter
 from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Literal
@@ -455,7 +456,8 @@ class InMemoryDocumentStore:
             docs = list(self.storage.values())
 
         if not self.return_embedding:
-            docs = [replace(doc, embedding=None) for doc in docs]
+            # deepcopy meta so returned docs do not alias store mutables via replace()
+            docs = [replace(doc, embedding=None, meta=deepcopy(doc.meta)) for doc in docs]
 
         return docs
 

--- a/releasenotes/notes/inmemory-filter-documents-meta-isolation-2f9b9f1268f190cb.yaml
+++ b/releasenotes/notes/inmemory-filter-documents-meta-isolation-2f9b9f1268f190cb.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed ``InMemoryDocumentStore.filter_documents`` so that when ``return_embedding=False``,
+    returned Documents no longer share ``meta`` (including nested mutables) with the stored
+    Documents. ``dataclasses.replace`` was used to strip embeddings, which is a shallow copy;
+    mutating ``doc.meta`` on a returned Document could therefore corrupt the store. Meta is now
+    deep-copied when constructing the returned Document.

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -396,6 +396,26 @@ class TestMemoryDocumentStore(
         filtered_docs = docstore.filter_documents()
         assert all(doc.embedding is None for doc in filtered_docs)
 
+    def test_filter_documents_return_embedding_false_isolates_meta(self):
+        # When return_embedding=False, filter_documents uses dataclasses.replace to strip
+        # embeddings. Without copying meta, the returned Document aliases the stored meta
+        # (including nested mutables), so mutating the returned doc corrupts the store.
+        docstore = InMemoryDocumentStore(return_embedding=False)
+        docstore.write_documents(
+            [Document(content="hello", embedding=[0.1, 0.2], meta={"label": "keep", "tags": ["a"]})]
+        )
+
+        returned = docstore.filter_documents()[0]
+        assert returned.embedding is None
+
+        returned.meta["label"] = "mutated"
+        returned.meta["tags"].append("extra")
+
+        stored = list(docstore.storage.values())[0]
+        assert stored.meta["label"] == "keep"
+        assert stored.meta["tags"] == ["a"]
+        assert returned.meta is not stored.meta
+
     def test_embedding_retrieval_override_return_embedding(self):
         docstore = InMemoryDocumentStore(embedding_similarity_function="cosine", return_embedding=False)
         docs = [


### PR DESCRIPTION
### Related Issues

- fixes #12653

### Proposed Changes:

When `InMemoryDocumentStore(return_embedding=False)` runs `filter_documents`, it strips embeddings with:

```python
docs = [replace(doc, embedding=None) for doc in docs]
```

`dataclasses.replace` is a shallow copy: the returned Document is a new instance, but it still shares the stored `meta` dict (and nested mutables). Mutating `returned.meta` therefore corrupts the store.

**Fix (smallest correct change):** pass `meta=deepcopy(doc.meta)` into `replace(...)`, matching the project pattern of deep-copying nested meta (e.g. ChatPromptBuilder message copies).

### How did you test it?

- Added `test_filter_documents_return_embedding_false_isolates_meta`
- **Proved FAIL on unmodified upstream/main** (shared meta object; mutating tags/label corrupts `storage`)
- **Proved PASS with this patch** (meta isolated; store unchanged)
- Ran related unit tests: `filter_documents` / `return_embedding` slice → 14 passed
- Minimal repro before/after also confirms isolation

### Notes for the reviewer

- Scope is intentionally limited to the `return_embedding=False` `replace()` path (the misleading partial copy). When `return_embedding=True`, `filter_documents` still returns live storage references (pre-existing behavior / performance tradeoff).
- CODEOWNERS: `@deepset-ai/open-source-engineering`
- Recent committers on `document_store.py`: @davidsbatista @julian-risch @bogdankostic @sjrl

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I have documented my code.
- [x] I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- [x] I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

### AI disclaimer

This PR was fully AI-generated (Cursor / Grok). The bug was re-verified on current `upstream/main` before patching; the new unit test was proven to fail without the patch and pass with it.