### PR TITLE
fix: avoid overlap-only trailing chunks in DocumentSplitter token mode

### DIFF
--- a/docs-website/docs/pipeline-components/preprocessors/documentsplitter.mdx
+++ b/docs-website/docs/pipeline-components/preprocessors/documentsplitter.mdx
@@ -31,8 +31,6 @@ description: "`DocumentSplitter` divides a list of text documents into a list of
 - `split_overlap` is an integer indicating the number of overlapping words, sentences, or passages between chunks.
 - `split_threshold` is an integer indicating the minimum number of words, sentences, or passages that the document fragment should have. If the fragment is below the threshold, it will be attached to the previous one.
 
-When `split_by="token"`, splitting stops as soon as a chunk reaches the end of the document. No additional chunks containing only overlap from that final chunk are emitted. Documents that fit within `split_length` tokens produce a single chunk, even when `split_overlap` is set.
-
 A field `"source_id"` is added to each document's `meta` data to keep track of the original document that was split. Another meta field `"page_number"` is added to each document to keep track of the page it belonged to in the original document. Other metadata are copied from the original document.
 
 The DocumentSplitter is compatible with the following DocumentStores:

--- a/docs-website/docs/pipeline-components/preprocessors/documentsplitter.mdx
+++ b/docs-website/docs/pipeline-components/preprocessors/documentsplitter.mdx
@@ -26,10 +26,12 @@ description: "`DocumentSplitter` divides a list of text documents into a list of
 
 `DocumentSplitter` expects a list of documents as input and returns a list of documents with split texts. It splits each input document by `split_by` after `split_length` units with an overlap of `split_overlap` units. These additional parameters can be set when the component is initialized:
 
-- `split_by` can be `"word"`, `"sentence"`, `"passage"` (paragraph), `"page"`, `"line"`, `"period"` or `"function"`.
+- `split_by` can be `"word"`, `"sentence"`, `"passage"` (paragraph), `"page"`, `"line"`, `"period"`, `"token"` or `"function"`.
 - `split_length` is an integer indicating the chunk size, which is the number of words, sentences, or passages.
 - `split_overlap` is an integer indicating the number of overlapping words, sentences, or passages between chunks.
 - `split_threshold` is an integer indicating the minimum number of words, sentences, or passages that the document fragment should have. If the fragment is below the threshold, it will be attached to the previous one.
+
+When `split_by="token"`, splitting stops as soon as a chunk reaches the end of the document. No additional chunks containing only overlap from that final chunk are emitted. Documents that fit within `split_length` tokens produce a single chunk, even when `split_overlap` is set.
 
 A field `"source_id"` is added to each document's `meta` data to keep track of the original document that was split. Another meta field `"page_number"` is added to each document to keep track of the page it belonged to in the original document. Other metadata are copied from the original document.
 

--- a/haystack/components/preprocessors/document_splitter.py
+++ b/haystack/components/preprocessors/document_splitter.py
@@ -268,6 +268,7 @@ class DocumentSplitter:
 
         Encodes the full document text to tokens, slices into chunks of `split_length` tokens
         with `split_overlap` overlap, then decodes each chunk back to a string.
+        Stops once a chunk reaches the end of the document, avoiding overlap-only trailing chunks.
         """
         tokens = self._tiktoken_tokenizer.encode(doc.content)  # type: ignore[union-attr, arg-type]
         if not tokens:
@@ -301,6 +302,9 @@ class DocumentSplitter:
                 text_splits.append(full_text[chunk_start:chunk_end])
                 splits_pages.append(cur_page)
                 splits_start_idxs.append(chunk_start)
+
+            if i + chunk_token_count == len(tokens):
+                break
 
             non_overlap_end = offsets[min(i + step, len(tokens))]
             cur_page += full_text[prev_end:non_overlap_end].count("\f")

--- a/releasenotes/notes/document-splitter-token-overlap-tail-4ec84073d732609c.yaml
+++ b/releasenotes/notes/document-splitter-token-overlap-tail-4ec84073d732609c.yaml
@@ -1,8 +1,6 @@
 ---
 fixes:
   - |
-    Fix ``DocumentSplitter`` with ``split_by="token"`` emitting trailing chunks
-    that contain only overlap from an earlier chunk. Splitting now stops as soon
-    as a chunk reaches the end of the document, including when the whole document
-    fits in one chunk. This reduces the chunk count for affected inputs while
-    preserving document content and overlap between chunks with new content.
+    Fix ``DocumentSplitter`` with ``split_by="token"`` generating redundant
+    trailing chunks containing only overlap. The splitter now stops creating
+    chunks after reaching the end of the document.

--- a/releasenotes/notes/document-splitter-token-overlap-tail-4ec84073d732609c.yaml
+++ b/releasenotes/notes/document-splitter-token-overlap-tail-4ec84073d732609c.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix ``DocumentSplitter`` with ``split_by="token"`` emitting trailing chunks
+    that contain only overlap from an earlier chunk. Splitting now stops as soon
+    as a chunk reaches the end of the document, including when the whole document
+    fits in one chunk. This reduces the chunk count for affected inputs while
+    preserving document content and overlap between chunks with new content.

--- a/test/components/preprocessors/test_document_splitter.py
+++ b/test/components/preprocessors/test_document_splitter.py
@@ -1012,16 +1012,21 @@ class TestSplittingByToken:
     @pytest.mark.parametrize(
         "split_length,split_overlap,split_threshold,content,expected_splits",
         [
-            (3, 1, 0, "t1 t2 t3 t4", ["t1 t2 t3", " t3 t4"]),
-            (3, 1, 3, "t1 t2 t3 t4", ["t1 t2 t3 t4"]),
-            (10, 0, 5, "t1 t2", ["t1 t2"]),
-            (3, 2, 2, "t1 t2 t3", ["t1 t2 t3"]),
-            (3, 1, 0, "t1 t2 t3", ["t1 t2 t3"]),
-            (5, 4, 0, "t1 t2 t3", ["t1 t2 t3"]),
-            (3, 2, 0, "t1 t2 t3 t4", ["t1 t2 t3", " t2 t3 t4"]),
-            (4, 2, 0, "t1 t2 t3 t4 t5", ["t1 t2 t3 t4", " t3 t4 t5"]),
-            (4, 2, 4, "t1 t2 t3 t4 t5", ["t1 t2 t3 t4 t5"]),
-            (3, 0, 0, "t1 t2 t3 t4", ["t1 t2 t3", " t4"]),
+            pytest.param(
+                3, 1, 0, "t1 t2 t3 t4", ["t1 t2 t3", " t3 t4"], id="four-tokens-create-two-overlapping-chunks"
+            ),
+            pytest.param(3, 1, 3, "t1 t2 t3 t4", ["t1 t2 t3 t4"], id="final-chunk-below-threshold-is-merged"),
+            pytest.param(10, 0, 5, "t1 t2", ["t1 t2"], id="short-document-without-overlap-creates-one-chunk"),
+            pytest.param(3, 1, 0, "t1 t2 t3", ["t1 t2 t3"], id="exact-fit-does-not-create-overlap-only-chunk"),
+            pytest.param(5, 4, 0, "t1 t2 t3", ["t1 t2 t3"], id="short-document-with-overlap-creates-one-chunk"),
+            pytest.param(
+                3,
+                2,
+                0,
+                "t1 t2 t3 t4",
+                ["t1 t2 t3", " t2 t3 t4"],
+                id="partial-final-chunk-does-not-create-overlap-only-chunks",
+            ),
         ],
     )
     def test_split_by_token_mock(
@@ -1056,24 +1061,6 @@ class TestSplittingByToken:
 @pytest.mark.integration
 class TestSplittingByTokenIntegration:
     """Integration tests for split_by="token" mode requiring real tiktoken."""
-
-    @pytest.mark.parametrize(
-        "split_length,split_overlap,expected_ends", [(8, 4, [8, 10]), (10, 9, [10]), (12, 10, [10])]
-    )
-    def test_no_overlap_only_tail(self, split_length, split_overlap, expected_ends):
-        splitter = DocumentSplitter(split_by="token", split_length=split_length, split_overlap=split_overlap)
-        text = "one two three four five six seven eight nine ten"
-        docs = splitter.run(documents=[Document(content=text)])["documents"]
-
-        assert splitter._tiktoken_tokenizer is not None
-        _, offsets = splitter._tiktoken_tokenizer.decode_with_offsets(splitter._tiktoken_tokenizer.encode(text))
-        offsets.append(len(text))
-        actual_ends = []
-        for doc in docs:
-            assert doc.content is not None
-            actual_ends.append(doc.meta["split_idx_start"] + len(doc.content))
-        assert actual_ends == [offsets[end] for end in expected_ends]
-        assert text == merge_documents(docs)
 
     def test_basic_chunking(self):
         splitter = DocumentSplitter(split_by="token", split_length=5, split_overlap=0)

--- a/test/components/preprocessors/test_document_splitter.py
+++ b/test/components/preprocessors/test_document_splitter.py
@@ -1015,7 +1015,13 @@ class TestSplittingByToken:
             (3, 1, 0, "t1 t2 t3 t4", ["t1 t2 t3", " t3 t4"]),
             (3, 1, 3, "t1 t2 t3 t4", ["t1 t2 t3 t4"]),
             (10, 0, 5, "t1 t2", ["t1 t2"]),
-            (3, 2, 2, "t1 t2 t3", ["t1 t2 t3", " t2 t3"]),
+            (3, 2, 2, "t1 t2 t3", ["t1 t2 t3"]),
+            (3, 1, 0, "t1 t2 t3", ["t1 t2 t3"]),
+            (5, 4, 0, "t1 t2 t3", ["t1 t2 t3"]),
+            (3, 2, 0, "t1 t2 t3 t4", ["t1 t2 t3", " t2 t3 t4"]),
+            (4, 2, 0, "t1 t2 t3 t4 t5", ["t1 t2 t3 t4", " t3 t4 t5"]),
+            (4, 2, 4, "t1 t2 t3 t4 t5", ["t1 t2 t3 t4 t5"]),
+            (3, 0, 0, "t1 t2 t3 t4", ["t1 t2 t3", " t4"]),
         ],
     )
     def test_split_by_token_mock(
@@ -1050,6 +1056,24 @@ class TestSplittingByToken:
 @pytest.mark.integration
 class TestSplittingByTokenIntegration:
     """Integration tests for split_by="token" mode requiring real tiktoken."""
+
+    @pytest.mark.parametrize(
+        "split_length,split_overlap,expected_ends", [(8, 4, [8, 10]), (10, 9, [10]), (12, 10, [10])]
+    )
+    def test_no_overlap_only_tail(self, split_length, split_overlap, expected_ends):
+        splitter = DocumentSplitter(split_by="token", split_length=split_length, split_overlap=split_overlap)
+        text = "one two three four five six seven eight nine ten"
+        docs = splitter.run(documents=[Document(content=text)])["documents"]
+
+        assert splitter._tiktoken_tokenizer is not None
+        _, offsets = splitter._tiktoken_tokenizer.decode_with_offsets(splitter._tiktoken_tokenizer.encode(text))
+        offsets.append(len(text))
+        actual_ends = []
+        for doc in docs:
+            assert doc.content is not None
+            actual_ends.append(doc.meta["split_idx_start"] + len(doc.content))
+        assert actual_ends == [offsets[end] for end in expected_ends]
+        assert text == merge_documents(docs)
 
     def test_basic_chunking(self):
         splitter = DocumentSplitter(split_by="token", split_length=5, split_overlap=0)


### PR DESCRIPTION
### Related Issues

Follow-up to the token mode introduced by #12529 (which closed #12528). No separate bug report has been filed.

### Proposed Changes:

With ten tokens, `split_length=8` and `split_overlap=4`, token mode emits chunks covering tokens [0, 8), [4, 10), and [8, 10). The last chunk adds no content. Inputs already fitting within one chunk can likewise produce redundant suffix chunks.

Stop when the current chunk reaches the end of the token sequence, after any threshold merge. Keep the existing overlap and metadata handling for retained chunks. Add regression cases for exact-fit and shorter inputs, high overlap, partial final chunks, threshold merging, and zero overlap, plus documentation and a release note.

One existing mocked expectation accepted a redundant suffix for `split_length=3`, `split_overlap=2`, and `split_threshold=2`. It now expects one chunk.

### How did you test it?

- Before the fix: five unit cases and all three new real-tokenizer cases failed on the extra chunks.
- `hatch run test:unit test/components/preprocessors/test_document_splitter.py --no-cov`: **77 passed**.
- `hatch run test:integration test/components/preprocessors/test_document_splitter.py -k TestSplittingByTokenIntegration --no-cov`: **10 passed**, including Unicode reconstruction, page tracking, overlap metadata, and pipeline integration.
- `hatch run test:types haystack/components/preprocessors/document_splitter.py test/components/preprocessors/test_document_splitter.py`: passed.
- Pre-commit checks on the four changed files and `git diff --check`: passed.

Validated on Windows with Python 3.12.4 and Hatch 1.18.0. The full repository suite and documentation website build were not run.

### Notes for the reviewer

Affected inputs produce fewer chunks. No retrieval-quality or latency improvement is claimed.

**AI disclosure:** this patch and its tests were prepared with Codex. This PR is a draft pending the author's manual review and understanding of the generated content.

### Checklist

- [x] The author has personally reviewed the contribution guidelines and code of conduct.
- [x] The author has personally reviewed and understood all AI-generated content.
- [x] Unit tests, relevant docstrings, and documentation are updated.
- [x] The title uses a conventional commit type.
- [x] A release note is included.
- [x] Relevant local pre-commit checks pass.
