### PR TITLE
fix: honour max_workers in the multi-retrievers' run_async

### DIFF
--- a/haystack/components/retrievers/multi_query_embedding_retriever.py
+++ b/haystack/components/retrievers/multi_query_embedding_retriever.py
@@ -170,7 +170,14 @@ class MultiQueryEmbeddingRetriever:
 
         await self.warm_up_async()
 
-        tasks = [asyncio.create_task(self._run_one_async(query, retriever_kwargs)) for query in queries]
+        # Bound concurrency to max_workers, mirroring the ThreadPoolExecutor in the sync `run`.
+        semaphore = asyncio.Semaphore(max(1, self.max_workers))
+
+        async def _bounded_run_one(query: str) -> list[Document] | None:
+            async with semaphore:
+                return await self._run_one_async(query, retriever_kwargs)
+
+        tasks = [asyncio.create_task(_bounded_run_one(query)) for query in queries]
         results = await _gather_tasks_with_cancel(tasks)
         docs: list[Document] = [doc for result in results if result for doc in result]
         docs = _deduplicate_documents(docs)

--- a/haystack/components/retrievers/multi_query_text_retriever.py
+++ b/haystack/components/retrievers/multi_query_text_retriever.py
@@ -148,7 +148,14 @@ class MultiQueryTextRetriever:
 
         await self.warm_up_async()
 
-        tasks = [asyncio.create_task(self._run_one_async(query, retriever_kwargs)) for query in queries]
+        # Bound concurrency to max_workers, mirroring the ThreadPoolExecutor in the sync `run`.
+        semaphore = asyncio.Semaphore(max(1, self.max_workers))
+
+        async def _bounded_run_one(query: str) -> list[Document] | None:
+            async with semaphore:
+                return await self._run_one_async(query, retriever_kwargs)
+
+        tasks = [asyncio.create_task(_bounded_run_one(query)) for query in queries]
         results = await _gather_tasks_with_cancel(tasks)
         docs: list[Document] = [doc for result in results if result for doc in result]
         docs = _deduplicate_documents(docs)

--- a/haystack/components/retrievers/multi_retriever.py
+++ b/haystack/components/retrievers/multi_retriever.py
@@ -313,12 +313,16 @@ class MultiRetriever:
         if resolved_filters is not None:
             run_kwargs["filters"] = resolved_filters
 
+        # Bound concurrency to max_workers, mirroring the ThreadPoolExecutor in the sync `run`.
+        semaphore = asyncio.Semaphore(max(1, self.max_workers))
+
         async def _run_one(name: str, retriever: TextRetriever) -> list[Document]:
-            try:
-                result = await _execute_component_async(retriever, **run_kwargs)
-                return result.get("documents", [])
-            except Exception as e:
-                raise RuntimeError(f"Retriever '{name}' failed: {e}") from e
+            async with semaphore:
+                try:
+                    result = await _execute_component_async(retriever, **run_kwargs)
+                    return result.get("documents", [])
+                except Exception as e:
+                    raise RuntimeError(f"Retriever '{name}' failed: {e}") from e
 
         tasks = [asyncio.create_task(_run_one(name, retriever)) for name, retriever in retrievers_to_run.items()]
         document_lists = await _gather_tasks_with_cancel(tasks)

--- a/releasenotes/notes/multi-retrievers-bound-async-concurrency-419ea994ae8c9f6d.yaml
+++ b/releasenotes/notes/multi-retrievers-bound-async-concurrency-419ea994ae8c9f6d.yaml
@@ -1,9 +1,9 @@
 ---
 fixes:
   - |
-    `MultiQueryTextRetriever`, `MultiQueryEmbeddingRetriever` and `MultiRetriever` now honour `max_workers`
-    in their `run_async` methods. Previously only the synchronous `run` bounded fan-out (via a
-    `ThreadPoolExecutor`); `run_async` launched every sub-query / sub-retriever call at once, ignoring
-    `max_workers` and risking rate limits or connection exhaustion against the underlying retriever or
-    embedder. `run_async` now bounds concurrency with an `asyncio.Semaphore`, matching the behaviour of the
-    LLM extractors.
+    ``MultiQueryTextRetriever``, ``MultiQueryEmbeddingRetriever`` and ``MultiRetriever`` now honour
+    ``max_workers`` in their ``run_async`` methods. Previously only the synchronous ``run`` bounded fan-out
+    (via a ``ThreadPoolExecutor``); ``run_async`` launched every sub-query / sub-retriever call at once,
+    ignoring ``max_workers`` and risking rate limits or connection exhaustion against the underlying
+    retriever or embedder. ``run_async`` now bounds concurrency with an ``asyncio.Semaphore``, matching the
+    behaviour of the LLM extractors.

--- a/releasenotes/notes/multi-retrievers-bound-async-concurrency-419ea994ae8c9f6d.yaml
+++ b/releasenotes/notes/multi-retrievers-bound-async-concurrency-419ea994ae8c9f6d.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    `MultiQueryTextRetriever`, `MultiQueryEmbeddingRetriever` and `MultiRetriever` now honour `max_workers`
+    in their `run_async` methods. Previously only the synchronous `run` bounded fan-out (via a
+    `ThreadPoolExecutor`); `run_async` launched every sub-query / sub-retriever call at once, ignoring
+    `max_workers` and risking rate limits or connection exhaustion against the underlying retriever or
+    embedder. `run_async` now bounds concurrency with an `asyncio.Semaphore`, matching the behaviour of the
+    LLM extractors.

--- a/test/components/retrievers/test_multi_query_embedding_retriever_async.py
+++ b/test/components/retrievers/test_multi_query_embedding_retriever_async.py
@@ -171,6 +171,32 @@ class TestMultiQueryEmbeddingRetrieverAsync:
 
         assert slow_cancelled is True
 
+    @pytest.mark.asyncio
+    async def test_run_async_bounds_concurrency_to_max_workers(self):
+        state = {"current": 0, "peak": 0}
+
+        @component
+        class TrackingRetriever:
+            @component.output_types(documents=list[Document])
+            def run(self, query_embedding: list[float], **kwargs: Any) -> dict[str, list[Document]]:
+                return {"documents": []}
+
+            @component.output_types(documents=list[Document])
+            async def run_async(self, query_embedding: list[float], **kwargs: Any) -> dict[str, list[Document]]:
+                state["current"] += 1
+                state["peak"] = max(state["peak"], state["current"])
+                await asyncio.sleep(0.02)
+                state["current"] -= 1
+                return {"documents": []}
+
+        multi_retriever = MultiQueryEmbeddingRetriever(
+            retriever=TrackingRetriever(), query_embedder=MockTextEmbedder(), max_workers=2
+        )
+        await multi_retriever.run_async(queries=[f"q{i}" for i in range(8)])
+
+        assert state["peak"] <= 2
+        assert state["peak"] > 1  # the queries do overlap; they are not serialized
+
     @pytest.fixture
     def document_store_with_categorized_docs(self):
         documents = [

--- a/test/components/retrievers/test_multi_query_text_retriever_async.py
+++ b/test/components/retrievers/test_multi_query_text_retriever_async.py
@@ -149,6 +149,30 @@ class TestMultiQueryTextRetrieverAsync:
         assert slow_cancelled is True
 
     @pytest.mark.asyncio
+    async def test_run_async_bounds_concurrency_to_max_workers(self):
+        state = {"current": 0, "peak": 0}
+
+        @component
+        class TrackingRetriever:
+            @component.output_types(documents=list[Document])
+            def run(self, query: str, **kwargs: Any) -> dict[str, list[Document]]:
+                return {"documents": []}
+
+            @component.output_types(documents=list[Document])
+            async def run_async(self, query: str, **kwargs: Any) -> dict[str, list[Document]]:
+                state["current"] += 1
+                state["peak"] = max(state["peak"], state["current"])
+                await asyncio.sleep(0.02)
+                state["current"] -= 1
+                return {"documents": []}
+
+        multi_retriever = MultiQueryTextRetriever(retriever=TrackingRetriever(), max_workers=2)
+        await multi_retriever.run_async(queries=[f"q{i}" for i in range(8)])
+
+        assert state["peak"] <= 2
+        assert state["peak"] > 1  # the queries do overlap; they are not serialized
+
+    @pytest.mark.asyncio
     @pytest.mark.integration
     async def test_run_async_with_filters(self, document_store_with_docs):
         in_memory_retriever = InMemoryBM25Retriever(document_store=document_store_with_docs)

--- a/test/components/retrievers/test_multi_retriever.py
+++ b/test/components/retrievers/test_multi_retriever.py
@@ -600,6 +600,30 @@ class TestMultiRetrieverAsync:
         assert len(result["documents"]) == 1
         assert result["documents"][0].id == "async1"
 
+    @pytest.mark.asyncio
+    async def test_run_async_bounds_concurrency_to_max_workers(self):
+        state = {"current": 0, "peak": 0}
+
+        @component
+        class TrackingRetriever:
+            @component.output_types(documents=list[Document])
+            def run(self, query: str, filters: dict[str, Any] | None = None, top_k: int | None = None):
+                return {"documents": []}
+
+            @component.output_types(documents=list[Document])
+            async def run_async(self, query: str, filters: dict[str, Any] | None = None, top_k: int | None = None):
+                state["current"] += 1
+                state["peak"] = max(state["peak"], state["current"])
+                await asyncio.sleep(0.02)
+                state["current"] -= 1
+                return {"documents": []}
+
+        retriever = MultiRetriever(retrievers={f"r{i}": TrackingRetriever() for i in range(8)}, max_workers=2)
+        await retriever.run_async(query="energy")
+
+        assert state["peak"] <= 2
+        assert state["peak"] > 1  # the retrievers do overlap; they are not serialized
+
     @pytest.mark.skipif(os.environ.get("OPENAI_API_KEY", "") == "", reason="OPENAI_API_KEY is not set")
     @pytest.mark.integration
     @pytest.mark.asyncio


### PR DESCRIPTION
### Related Issues

- No issue. Sync/async parity defect.

### Proposed Changes:

`MultiQueryTextRetriever`, `MultiQueryEmbeddingRetriever` and `MultiRetriever` each parallelise a
fan-out: the multi-query retrievers run one retrieval per query, `MultiRetriever` runs each configured
retriever. The synchronous `run` bounds this with `ThreadPoolExecutor(max_workers=self.max_workers)`.

`run_async` did **not**: it created a task per query / per retriever and awaited them all together
(`_gather_tasks_with_cancel`), so `max_workers` was silently ignored and every underlying
retriever/embedder call fired at once. Worst case is `MultiQueryEmbeddingRetriever`, which makes an
embedding **API call per expanded query** — 50 expanded queries meant 50 concurrent embedding requests
regardless of `max_workers=3`, a rate-limit and connection-pool hazard.

Each `run_async` now wraps its unit of work in `async with asyncio.Semaphore(max(1, self.max_workers))`.
This is the same pattern `LLMDocumentContentExtractor` and `LLMMetadataExtractor` already use to enforce
`max_workers` on their async paths (`sem = asyncio.Semaphore(max(1, self.max_workers))`). `_gather_tasks_with_cancel`
still drains siblings when one task fails.

`MultiRetriever` is `@_experimental`; the other two are stable.

### How did you test it?

`hatch run test:unit` on the three retrievers' test files: 53 passed.

Added `test_run_async_bounds_concurrency_to_max_workers` to each async suite — a retriever whose
`run_async` records the peak number of concurrently in-flight calls; with `max_workers=2` and 8 units of
work the peak must be `<= 2` (and `> 1`, so the fix doesn't accidentally serialise). All three fail on
`main` (peak = 8), pass with the fix.

`hatch run fmt-check` and `hatch run test:types` on the three files are clean. Release note added.

### Notes for the reviewer

The multi-query retrievers are edited identically. In `MultiRetriever` the semaphore wraps the existing
`try/except` inside `_run_one` so the `RuntimeError("Retriever '{name}' failed")` wrapping is unchanged.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file.
- [x] I have run pre-commit hooks and fixed any issue.

This PR was generated with an AI assistant. I have reviewed the changes and run the tests locally.
