### PR TITLE
fix: preserve nested pipeline errors in Pipeline.run_async

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -582,6 +582,18 @@ class Pipeline(PipelineBase):
                 # For sync-only components, _run_component_async dispatches to a thread via asyncio.to_thread,
                 # which copies the current contextvars context — preserving e.g. the active tracing span.
                 outputs = await _execute_component_async(instance, **component_inputs_copy)
+            except BreakpointException as error:
+                # Re-raise BreakpointException to preserve the original exception context, matching
+                # the sync _run_component: a breakpoint triggered by a nested component (e.g. an Agent)
+                # must bubble up to the main pipeline instead of being wrapped.
+                raise error
+
+            # A component that internally uses Pipeline._run_component_async could raise a PipelineRuntimeError
+            # carrying additional context (e.g. an agent snapshot); re-raise it instead of wrapping it in
+            # another PipelineRuntimeError, matching the sync _run_component.
+            except PipelineRuntimeError as runtime_error:
+                raise runtime_error
+
             except Exception as error:
                 raise PipelineRuntimeError.from_exception(component_name, instance.__class__, error) from error
 

--- a/releasenotes/notes/run-component-async-preserve-pipeline-errors-74569fb943007982.yaml
+++ b/releasenotes/notes/run-component-async-preserve-pipeline-errors-74569fb943007982.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    ``Pipeline.run_async`` now lets a ``BreakpointException`` or ``PipelineRuntimeError`` raised by a
+    nested component propagate unchanged, instead of wrapping it in another ``PipelineRuntimeError``.
+    This matches the synchronous ``Pipeline.run`` and preserves the original error context (for example an
+    agent snapshot) when a component internally runs a pipeline.

--- a/test/core/pipeline/test_async_pipeline.py
+++ b/test/core/pipeline/test_async_pipeline.py
@@ -550,3 +550,62 @@ async def test_run_async_raises_when_multi_element_list_is_unwrapped_at_runtime(
 
     with pytest.raises(PipelineRuntimeError, match="Cannot unwrap a list of 3 items"):
         await pipe.run_async({})
+
+
+@pytest.mark.asyncio
+async def test_run_async_does_not_double_wrap_a_nested_pipeline_runtime_error():
+    """
+    A component that internally runs a pipeline and lets a PipelineRuntimeError escape (e.g. an Agent
+    carrying a snapshot) should have that error propagate unchanged, not wrapped in another
+    PipelineRuntimeError. This matches the synchronous _run_component.
+    """
+    from haystack.core.errors import PipelineRuntimeError
+
+    inner_error = PipelineRuntimeError(component_name="inner", component_type=None, message="inner failure")
+
+    @component
+    class NestedPipelineComponent:
+        @component.output_types(value=str)
+        def run(self, text: str) -> dict[str, str]:  # pragma: no cover - async path is under test
+            raise inner_error
+
+        @component.output_types(value=str)
+        async def run_async(self, text: str) -> dict[str, str]:
+            raise inner_error
+
+    pp = Pipeline()
+    pp.add_component("nested", NestedPipelineComponent())
+
+    with pytest.raises(PipelineRuntimeError) as exc_info:
+        await pp.run_async({"nested": {"text": "x"}})
+
+    assert exc_info.value is inner_error
+    assert not isinstance(exc_info.value.__cause__, PipelineRuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_run_async_lets_a_nested_breakpoint_exception_bubble_up():
+    """A BreakpointException raised by a nested component must reach the caller as-is, not wrapped."""
+    from haystack.core.errors import BreakpointException
+    from haystack.dataclasses.breakpoints import Breakpoint
+
+    break_point = Breakpoint(component_name="inner", visit_count=0)
+    breakpoint_error = BreakpointException.from_triggered_breakpoint(break_point)
+
+    @component
+    class BreakpointingComponent:
+        @component.output_types(value=str)
+        def run(self, text: str) -> dict[str, str]:  # pragma: no cover - async path is under test
+            raise breakpoint_error
+
+        @component.output_types(value=str)
+        async def run_async(self, text: str) -> dict[str, str]:
+            raise breakpoint_error
+
+    pp = Pipeline()
+    pp.add_component("bp", BreakpointingComponent())
+
+    with pytest.raises(BreakpointException) as exc_info:
+        await pp.run_async({"bp": {"text": "x"}})
+
+    assert exc_info.value is breakpoint_error


### PR DESCRIPTION
### Related Issues

- No issue. Sync/async parity in the pipeline engine.

### Proposed Changes:

`Pipeline._run_component` (sync) wraps the component call in:

```python
try:
    component_output = instance.run(**inputs_copy)
except BreakpointException as error:
    raise error
except PipelineRuntimeError as runtime_error:
    raise runtime_error
except Exception as error:
    raise PipelineRuntimeError.from_exception(component_name, instance.__class__, error) from error
```

The two special-case re-raises exist (per the inline comments) so that a nested component — e.g. an
`Agent` that internally runs a pipeline — can bubble a `BreakpointException`, or a
`PipelineRuntimeError` carrying an agent snapshot, up to the main pipeline unchanged.

`_run_component_async` only had the bare `except Exception`, so both of those were caught and
re-wrapped in another `PipelineRuntimeError`, burying the original context. This copies the two
`except` clauses over.

### How did you test it?

`hatch run test:unit` on `test_async_pipeline.py`, `test_pipeline.py`, `test_breakpoint.py`: 83 passed.

Two new async regression tests in `test_async_pipeline.py`:

- `test_run_async_does_not_double_wrap_a_nested_pipeline_runtime_error` — a component whose
  `run_async` raises a `PipelineRuntimeError`; the caught error must be that same object, and its
  `__cause__` must not be a `PipelineRuntimeError`.
- `test_run_async_lets_a_nested_breakpoint_exception_bubble_up` — a component whose `run_async` raises
  a `BreakpointException`; the caller must see a `BreakpointException`, not a `PipelineRuntimeError`.

Both fail on `main` (double-wrapped) and pass with the change.

`hatch run fmt-check` and `hatch run test:types` (source + test file) clean. Release note added.

### Notes for the reviewer

Reachable today only through a custom component that runs a `Pipeline` internally and lets its error
escape; no shipped component does this from `run()`/`run_async()`. The change is purely defensive
parity with the sync path.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title.
- [x] I have documented my code.
- [x] I have added a release note file.
- [x] I have run pre-commit hooks and fixed any issue.

This PR was generated with an AI assistant. I have reviewed the changes and run the tests locally.
