### PR TITLE
fix: reject pipeline snapshot component mismatches

### DIFF
--- a/haystack/core/pipeline/breakpoint.py
+++ b/haystack/core/pipeline/breakpoint.py
@@ -73,6 +73,16 @@ def _validate_pipeline_snapshot_against_pipeline(pipeline_snapshot: PipelineSnap
             f"are not part of the current pipeline."
         )
 
+    # A snapshot must describe the complete pipeline it resumes. If the current pipeline contains components that
+    # were not present when the snapshot was created, they would never be added to the resume queue and could be
+    # silently skipped.
+    missing_ordered_components = valid_components - set(pipeline_snapshot.ordered_component_names)
+    if missing_ordered_components:
+        raise PipelineInvalidPipelineSnapshotError(
+            f"Invalid pipeline snapshot: components {missing_ordered_components} in the current pipeline are not "
+            f"present in 'ordered_component_names'."
+        )
+
     # Check if the original_input_data is valid components in the pipeline
     serialized_input_data = pipeline_snapshot.original_input_data["serialized_data"]
     invalid_input_data = set(serialized_input_data.keys()) - valid_components

--- a/releasenotes/notes/reject-pipeline-snapshot-component-mismatch-12672.yaml
+++ b/releasenotes/notes/reject-pipeline-snapshot-component-mismatch-12672.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Pipeline snapshot resumption now rejects snapshots whose component set differs from the current pipeline.
+    This prevents newly added components from being silently skipped during a resumed run, while preserving the
+    existing validation for components removed since the snapshot was created.

--- a/test/core/pipeline/test_breakpoint.py
+++ b/test/core/pipeline/test_breakpoint.py
@@ -224,6 +224,20 @@ class TestResumeFromPipelineSnapshot:
         result = pipeline.run(data={}, pipeline_snapshot=snapshot, break_point=Breakpoint(component_name="comp1"))
         assert result["comp3"]["result"] == "test_processed_processed_processed"
 
+    def test_resume_rejects_pipeline_with_added_component(self):
+        pipeline = _three_component_pipeline()
+
+        with pytest.raises(BreakpointException) as exc_info:
+            pipeline.run(data={"comp1": {"input_value": "test"}}, break_point=Breakpoint(component_name="comp2"))
+        snapshot = exc_info.value.pipeline_snapshot
+        assert snapshot is not None
+
+        pipeline.add_component("comp4", _AppendingComponent())
+        pipeline.connect("comp3", "comp4")
+
+        with pytest.raises(PipelineInvalidPipelineSnapshotError, match="not present in 'ordered_component_names'"):
+            pipeline.run(data={}, pipeline_snapshot=snapshot)
+
     def test_break_point_matching_pipeline_snapshot_break_point_raises(self):
         pipeline = _three_component_pipeline()
 


### PR DESCRIPTION
### Related Issues

- fixes #12672

### Proposed Changes

Pipeline snapshot validation previously rejected snapshots when a component had been removed from the current pipeline, but accepted snapshots when the current pipeline had added components. Because resume scheduling uses the snapshot's `ordered_component_names`, newly added components could be silently skipped and the run could return incomplete output.

This change makes the validation symmetric: resuming now fails closed when the current pipeline contains components missing from the snapshot. The existing removed-component validation remains unchanged.

### How did you test it?

- Added `test_resume_rejects_pipeline_with_added_component` covering a snapshot resumed after adding a downstream component.
- `uv run --with pytest pytest -q test/core/pipeline/test_breakpoint.py` — 40 passed.
- Ruff check and format checks passed for the changed Python files.
- `git diff --check` passed.

### Notes for the reviewer

The added-component test reproduces the reported behavior on the unmodified code: resume returned `{}` without running the newly added component. The fix rejects the mismatched snapshot before scheduling begins.

### Checklist

- I have read the contributors guidelines and code of conduct.
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings where needed.
- I have used a conventional commit title.
- I have documented the behavior change in a release note.
