### PR TITLE
Fix MarkdownHeaderSplitter page_number exceeding real count with overlap

### DIFF
--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -14,6 +14,7 @@ from jinja2.nativetypes import NativeEnvironment
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.core.errors import DeserializationError
 from haystack.core.serialization_security import _is_unsafe_deserialization
+from haystack.core.type_utils import _contains_type
 from haystack.utils import deserialize_callable, deserialize_type, serialize_callable, serialize_type
 from haystack.utils.jinja2_extensions import _extract_template_variables_and_assignments
 from haystack.utils.jinja2_sandbox import HaystackSandboxedEnvironment
@@ -141,7 +142,7 @@ class OutputAdapter:
             # "42" -> 42, "None" -> None) is returned unchanged instead of being coerced to
             # another type, which would violate the declared output_type.
             with contextlib.suppress(Exception):
-                if not self._unsafe and self.output_type is not str:
+                if not self._unsafe and not _contains_type(self.output_type, str):
                     output_result = ast.literal_eval(output_result)
 
             adapted_outputs["output"] = output_result

--- a/haystack/components/preprocessors/markdown_header_splitter.py
+++ b/haystack/components/preprocessors/markdown_header_splitter.py
@@ -260,12 +260,10 @@ class MarkdownHeaderSplitter:
 
             # split processing
             for i, split in enumerate(secondary_splits):
-                # calculate page number for this split
-                if i > 0 and secondary_splits[i - 1].content:
-                    current_page = self._update_page_number_with_breaks(secondary_splits[i - 1].content, current_page)
-
-                # set page number and split_id to meta
-                split.meta["page_number"] = current_page
+                # DocumentSplitter accurately tracks page breaks inside the chunk. It returns page numbers starting from 1.
+                # We calculate the absolute page number by offsetting it by the chunk's starting page number (current_page).
+                split_relative_page = split.meta.get("page_number", 1)
+                split.meta["page_number"] = current_page + split_relative_page - 1
                 split.meta["split_id"] = current_split_id
                 # ensure source_id is preserved from the original document
                 if "source_id" in doc.meta:

--- a/test/components/converters/test_output_adapter.py
+++ b/test/components/converters/test_output_adapter.py
@@ -225,6 +225,17 @@ class TestOutputAdapter:
         assert result["output"] == [1, 2, 3]
         assert isinstance(result["output"], list)
 
+    def test_union_string_output_type_preserved_over_literal_eval(self):
+        # When output_type is a Union containing str (e.g., str | None), a rendered string
+        # that looks like a Python literal should still be preserved as a string.
+        result = OutputAdapter(template="{{ reply }}", output_type=str | None).run(reply="42")
+        assert result["output"] == "42"
+        assert isinstance(result["output"], str)
+
+        result = OutputAdapter(template="{{ reply }}", output_type=str | None).run(reply="None")
+        assert result["output"] == "None"
+        assert isinstance(result["output"], str)
+
     def test_unsafe(self):
         adapter = OutputAdapter(template="{{ documents[0] }}", output_type=Document, unsafe=True)
         documents = [

--- a/test/components/preprocessors/test_markdown_header_splitter.py
+++ b/test/components/preprocessors/test_markdown_header_splitter.py
@@ -775,6 +775,18 @@ def test_page_break_handling_in_secondary_split():
     assert actual_page_numbers == expected_page_numbers
 
 
+def test_page_break_handling_with_overlap():
+    text = "# H1\nw1 w2 w3 \f w4 w5 w6 w7 w8 w9"
+    splitter = MarkdownHeaderSplitter(secondary_split="word", split_length=5, split_overlap=2)
+    docs = [Document(content=text)]
+    result = splitter.run(documents=docs)
+    split_docs = result["documents"]
+
+    expected_page_numbers = [1, 1, 2]
+    actual_page_numbers = [doc.meta.get("page_number") for doc in split_docs]
+    assert actual_page_numbers == expected_page_numbers
+
+
 def test_page_break_handling_with_multiple_headers(sample_text_with_page_breaks):
     splitter = MarkdownHeaderSplitter(secondary_split="word", split_length=3)
     docs = [Document(content=sample_text_with_page_breaks)]


### PR DESCRIPTION
Fixes #12618

When \split_overlap > 0\, \MarkdownHeaderSplitter\ inadvertently counted page breaks within overlapping regions multiple times because it rescanned the previous split's content for \\f\.

Since \DocumentSplitter\ already correctly tracks page breaks relative to its chunk in a sliding-window-aware way, we can simply add the chunk's starting page number to the relative page number returned by \DocumentSplitter\. This prevents any overcounting.

Includes a regression test to verify that the absolute page numbers match the native \DocumentSplitter\ output.