### PR TITLE
docs: correct DocumentCleaner remove_substrings parameter name

### DIFF
--- a/docs-website/docs/pipeline-components/preprocessors/documentcleaner.mdx
+++ b/docs-website/docs/pipeline-components/preprocessors/documentcleaner.mdx
@@ -37,7 +37,7 @@ Use `DocumentCleaner` to make text documents more readable. It removes extra whi
 `remove_extra_whitespaces` and `remove_empty_lines` work best on plain-text content. If your converter returns Markdown, such as [`AzureDocumentIntelligenceConverter`](../converters/azuredocumentintelligenceconverter.mdx), [`MarkItDownConverter`](../converters/markitdownconverter.mdx), [`MistralOCRDocumentConverter`](../converters/mistralocrdocumentconverter.mdx), or [`PaddleOCRVLDocumentConverter`](../converters/paddleocrvldocumentconverter.mdx), disable those options to preserve headings, tables, lists, and image tags.
 :::
 
-In addition, you can specify a list of strings that should be removed from all documents as part of the cleaning with the parameter `remove_substring`. You can also specify a regular expression with the parameter `remove_regex` and any matches will be removed.
+In addition, you can specify a list of strings that should be removed from all documents as part of the cleaning with the parameter `remove_substrings`. You can also specify a regular expression with the parameter `remove_regex` and any matches will be removed.
 
 The cleaning steps are executed in the following order:
 

--- a/docs-website/versioned_docs/version-3.1/pipeline-components/preprocessors/documentcleaner.mdx
+++ b/docs-website/versioned_docs/version-3.1/pipeline-components/preprocessors/documentcleaner.mdx
@@ -36,7 +36,7 @@ Use `DocumentCleaner` to make text documents more readable. It removes extra whi
 `remove_extra_whitespaces` and `remove_empty_lines` work best on plain-text content. If your converter returns Markdown, such as [`AzureDocumentIntelligenceConverter`](../converters/azuredocumentintelligenceconverter.mdx), [`MarkItDownConverter`](../converters/markitdownconverter.mdx), [`MistralOCRDocumentConverter`](../converters/mistralocrdocumentconverter.mdx), or [`PaddleOCRVLDocumentConverter`](../converters/paddleocrvldocumentconverter.mdx), disable those options to preserve headings, tables, lists, and image tags.
 :::
 
-In addition, you can specify a list of strings that should be removed from all documents as part of the cleaning with the parameter `remove_substring`. You can also specify a regular expression with the parameter `remove_regex` and any matches will be removed.
+In addition, you can specify a list of strings that should be removed from all documents as part of the cleaning with the parameter `remove_substrings`. You can also specify a regular expression with the parameter `remove_regex` and any matches will be removed.
 
 The cleaning steps are executed in the following order:
 


### PR DESCRIPTION
### Related Issues
None found.

### Proposed Changes
Correct `remove_substring` to `remove_substrings` in the DocumentCleaner
overview for the next version and version 3.1. This matches the constructor
signature and the existing Python and YAML examples. No runtime changes.

### How did you test it?
- Verified the parameter against DocumentCleaner.__init__.
- Compiled both modified MDX documents with @mdx-js/mdx.
- Ran git diff --check.

Python tests, the full documentation build, and the full pre-commit suite
were not run.

### Notes for the reviewer
This documentation change was generated with an AI assistant.
No generated API reference files were modified.