### PR TITLE
fix: LLMMetadataExtractor treats an extracted 'error' key as a failure

### DIFF
--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -28,6 +28,10 @@ from haystack.utils.misc import _parse_dict_from_json
 logger = logging.getLogger(__name__)
 
 
+class _MetadataExtractionError(Exception):
+    """Raised when the LLM response cannot be parsed into the expected metadata keys."""
+
+
 @component
 class LLMMetadataExtractor:
     """
@@ -278,7 +282,7 @@ class LLMMetadataExtractor:
             )
             if self.raise_on_failure:
                 raise e
-            return {"error": "Response is not valid JSON or missing keys. Error: " + str(e)}
+            raise _MetadataExtractionError("Response is not valid JSON or missing keys. Error: " + str(e)) from e
 
         return parsed_metadata
 
@@ -368,9 +372,10 @@ class LLMMetadataExtractor:
                 failed_documents.append(replace(document, meta=new_meta))
                 continue
 
-            parsed_metadata = self._extract_metadata(result["replies"][0].text)
-            if "error" in parsed_metadata:
-                new_meta["metadata_extraction_error"] = parsed_metadata["error"]
+            try:
+                parsed_metadata = self._extract_metadata(result["replies"][0].text)
+            except _MetadataExtractionError as e:
+                new_meta["metadata_extraction_error"] = str(e)
                 new_meta["metadata_extraction_response"] = result["replies"][0]
                 failed_documents.append(replace(document, meta=new_meta))
                 continue

--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -28,10 +28,6 @@ from haystack.utils.misc import _parse_dict_from_json
 logger = logging.getLogger(__name__)
 
 
-class _MetadataExtractionError(Exception):
-    """Raised when the LLM response cannot be parsed into the expected metadata keys."""
-
-
 @component
 class LLMMetadataExtractor:
     """
@@ -272,20 +268,6 @@ class LLMMetadataExtractor:
         deserialize_chatgenerator_inplace(data["init_parameters"], key="chat_generator")
         return default_from_dict(cls, data)
 
-    def _extract_metadata(self, llm_answer: str) -> dict[str, Any]:
-        try:
-            parsed_metadata = _parse_dict_from_json(llm_answer, expected_keys=self.expected_keys, raise_on_failure=True)
-        except (ValueError, json.JSONDecodeError) as e:
-            logger.warning(
-                "Response from the LLM is not valid JSON or missing expected keys. Received output: {response}",
-                response=llm_answer,
-            )
-            if self.raise_on_failure:
-                raise e
-            raise _MetadataExtractionError("Response is not valid JSON or missing keys. Error: " + str(e)) from e
-
-        return parsed_metadata
-
     def _prepare_prompts(
         self, documents: list[Document], expanded_range: list[int] | None = None
     ) -> list[ChatMessage | None]:
@@ -372,16 +354,24 @@ class LLMMetadataExtractor:
                 failed_documents.append(replace(document, meta=new_meta))
                 continue
 
+            reply = result["replies"][0]
             try:
-                parsed_metadata = self._extract_metadata(result["replies"][0].text)
-            except _MetadataExtractionError as e:
-                new_meta["metadata_extraction_error"] = str(e)
-                new_meta["metadata_extraction_response"] = result["replies"][0]
+                parsed_metadata = _parse_dict_from_json(
+                    reply.text, expected_keys=self.expected_keys, raise_on_failure=True
+                )
+            except (ValueError, json.JSONDecodeError) as e:
+                logger.warning(
+                    "Response from the LLM is not valid JSON or missing expected keys. Received output: {response}",
+                    response=reply.text,
+                )
+                if self.raise_on_failure:
+                    raise
+                new_meta["metadata_extraction_error"] = "Response is not valid JSON or missing keys. Error: " + str(e)
+                new_meta["metadata_extraction_response"] = reply
                 failed_documents.append(replace(document, meta=new_meta))
                 continue
 
-            for key in parsed_metadata:
-                new_meta[key] = parsed_metadata[key]
+            new_meta.update(parsed_metadata)
             # Remove metadata_extraction_error and metadata_extraction_response if present from previous runs.
             new_meta.pop("metadata_extraction_error", None)
             new_meta.pop("metadata_extraction_response", None)

--- a/releasenotes/notes/llm-metadata-extractor-error-key-collision-9f2c1a4b7d.yaml
+++ b/releasenotes/notes/llm-metadata-extractor-error-key-collision-9f2c1a4b7d.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    ``LLMMetadataExtractor`` no longer fails a document when the LLM's JSON output
+    legitimately contains an ``error`` key (for example when ``"error"`` is one of the
+    declared ``expected_keys``). Parse failures are now signaled by an internal
+    exception instead of a sentinel ``"error"`` key in the returned dict, so a
+    successful extraction that extracts an ``error`` field lands in ``documents``
+    with the extracted metadata.

--- a/releasenotes/notes/llm-metadata-extractor-error-key-collision-9f2c1a4b7d.yaml
+++ b/releasenotes/notes/llm-metadata-extractor-error-key-collision-9f2c1a4b7d.yaml
@@ -1,9 +1,6 @@
 ---
 fixes:
   - |
-    ``LLMMetadataExtractor`` no longer fails a document when the LLM's JSON output
-    legitimately contains an ``error`` key (for example when ``"error"`` is one of the
-    declared ``expected_keys``). Parse failures are now signaled by an internal
-    exception instead of a sentinel ``"error"`` key in the returned dict, so a
-    successful extraction that extracts an ``error`` field lands in ``documents``
-    with the extracted metadata.
+    Fixed ``LLMMetadataExtractor`` incorrectly treating an extracted ``error``
+    metadata field as an extraction failure. ``error`` can now be used in
+    ``expected_keys`` like any other metadata key.

--- a/test/components/extractors/test_llm_metadata_extractor.py
+++ b/test/components/extractors/test_llm_metadata_extractor.py
@@ -10,7 +10,6 @@ import pytest
 
 from haystack import Document, Pipeline
 from haystack.components.extractors import LLMMetadataExtractor
-from haystack.components.extractors.llm_metadata_extractor import _MetadataExtractionError
 from haystack.components.generators.chat import MockChatGenerator, OpenAIChatGenerator
 from haystack.components.writers import DocumentWriter
 from haystack.dataclasses import ChatMessage
@@ -144,29 +143,6 @@ class TestLLMMetadataExtractor:
         assert extractor.prompt == "some prompt that was used with the LLM {{document.content}}"
         assert isinstance(extractor._chat_generator, OpenAIChatGenerator)
         assert extractor._chat_generator.to_dict() == chat_generator.to_dict()
-
-    def test_extract_metadata(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
-        extractor = LLMMetadataExtractor(prompt="prompt {{document.content}}", chat_generator=OpenAIChatGenerator())
-        result = extractor._extract_metadata(llm_answer='{"output": "valid json"}')
-        assert result == {"output": "valid json"}
-
-    def test_extract_metadata_invalid_json(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
-        extractor = LLMMetadataExtractor(
-            prompt="prompt {{document.content}}", chat_generator=OpenAIChatGenerator(), raise_on_failure=True
-        )
-        with pytest.raises(ValueError):
-            extractor._extract_metadata(llm_answer='{"output: "valid json"}')
-
-    def test_extract_metadata_missing_key(self, monkeypatch, caplog):
-        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
-        extractor = LLMMetadataExtractor(
-            prompt="prompt {{document.content}}", chat_generator=OpenAIChatGenerator(), expected_keys=["key1"]
-        )
-        with pytest.raises(_MetadataExtractionError, match="Response is not valid JSON or missing keys"):
-            extractor._extract_metadata(llm_answer='{"output": "valid json"}')
-        assert "Response from the LLM is not valid JSON or missing expected keys" in caplog.text
 
     def test_prepare_prompts(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
@@ -312,6 +288,18 @@ class TestLLMMetadataExtractor:
         assert result["failed_documents"] == []
         assert result["documents"][0].meta == {"error": "timeout", "severity": "high"}
 
+    def test_run_raises_parse_error_when_raise_on_failure_is_true(self, caplog: pytest.LogCaptureFixture) -> None:
+        extractor = LLMMetadataExtractor(
+            prompt="prompt {{document.content}}",
+            expected_keys=["key1"],
+            chat_generator=MockChatGenerator(responses=['{"output": "valid json"}']),
+            raise_on_failure=True,
+        )
+
+        with pytest.raises(ValueError, match="Missing expected keys"):
+            extractor.run(documents=[Document(content="content")])
+        assert "Response from the LLM is not valid JSON or missing expected keys" in caplog.text
+
     @pytest.mark.asyncio
     async def test_run_async_extracted_error_key_is_not_treated_as_failure(self) -> None:
         extractor = LLMMetadataExtractor(
@@ -324,6 +312,18 @@ class TestLLMMetadataExtractor:
 
         assert result["failed_documents"] == []
         assert result["documents"][0].meta == {"error": "timeout", "severity": "high"}
+
+    @pytest.mark.asyncio
+    async def test_run_async_raises_parse_error_when_raise_on_failure_is_true(self) -> None:
+        extractor = LLMMetadataExtractor(
+            prompt="prompt {{document.content}}",
+            expected_keys=["key1"],
+            chat_generator=MockChatGenerator(responses=['{"output": "valid json"}']),
+            raise_on_failure=True,
+        )
+
+        with pytest.raises(ValueError, match="Missing expected keys"):
+            await extractor.run_async(documents=[Document(content="content")])
 
     @pytest.mark.asyncio
     async def test_run_async_clears_failure_metadata_after_successful_empty_json_retry(self) -> None:

--- a/test/components/extractors/test_llm_metadata_extractor.py
+++ b/test/components/extractors/test_llm_metadata_extractor.py
@@ -10,6 +10,7 @@ import pytest
 
 from haystack import Document, Pipeline
 from haystack.components.extractors import LLMMetadataExtractor
+from haystack.components.extractors.llm_metadata_extractor import _MetadataExtractionError
 from haystack.components.generators.chat import MockChatGenerator, OpenAIChatGenerator
 from haystack.components.writers import DocumentWriter
 from haystack.dataclasses import ChatMessage
@@ -163,7 +164,8 @@ class TestLLMMetadataExtractor:
         extractor = LLMMetadataExtractor(
             prompt="prompt {{document.content}}", chat_generator=OpenAIChatGenerator(), expected_keys=["key1"]
         )
-        extractor._extract_metadata(llm_answer='{"output": "valid json"}')
+        with pytest.raises(_MetadataExtractionError, match="Response is not valid JSON or missing keys"):
+            extractor._extract_metadata(llm_answer='{"output": "valid json"}')
         assert "Response from the LLM is not valid JSON or missing expected keys" in caplog.text
 
     def test_prepare_prompts(self, monkeypatch):
@@ -297,6 +299,31 @@ class TestLLMMetadataExtractor:
 
         assert retry_result["failed_documents"] == []
         assert retry_result["documents"][0].meta == {"source": "retry"}
+
+    def test_run_extracted_error_key_is_not_treated_as_failure(self) -> None:
+        extractor = LLMMetadataExtractor(
+            prompt="Extract the error type and severity from this log: {{document.content}}",
+            expected_keys=["error", "severity"],
+            chat_generator=MockChatGenerator(responses=['{"error": "timeout", "severity": "high"}']),
+        )
+
+        result = extractor.run(documents=[Document(content="2026-09-10 ERROR timeout after 30s")])
+
+        assert result["failed_documents"] == []
+        assert result["documents"][0].meta == {"error": "timeout", "severity": "high"}
+
+    @pytest.mark.asyncio
+    async def test_run_async_extracted_error_key_is_not_treated_as_failure(self) -> None:
+        extractor = LLMMetadataExtractor(
+            prompt="Extract the error type and severity from this log: {{document.content}}",
+            expected_keys=["error", "severity"],
+            chat_generator=MockChatGenerator(responses=['{"error": "timeout", "severity": "high"}']),
+        )
+
+        result = await extractor.run_async(documents=[Document(content="2026-09-10 ERROR timeout after 30s")])
+
+        assert result["failed_documents"] == []
+        assert result["documents"][0].meta == {"error": "timeout", "severity": "high"}
 
     @pytest.mark.asyncio
     async def test_run_async_clears_failure_metadata_after_successful_empty_json_retry(self) -> None:


### PR DESCRIPTION
### Related Issues

- fixes #12684

### Proposed Changes:

`LLMMetadataExtractor` signals parse failure by returning a `{"error": ...}` sentinel dict, and `_process_results` checks `if "error" in parsed_metadata`. When the LLM's JSON output legitimately contains an `"error"` key - which happens naturally when `"error"` is a declared `expected_keys` entry, as when extracting error fields from logs - the successful extraction is indistinguishable from the sentinel, so the document lands in `failed_documents` with the extracted value stored as `metadata_extraction_error`.

`_extract_metadata` now raises an internal `_MetadataExtractionError` on parse failure instead of returning the sentinel dict, and `_process_results` catches it and records the failure as before. `run` and `run_async` share `_process_results`, so both paths are fixed.

### How did you test it?

- 2 new regression tests (sync + async): `expected_keys=["error", "severity"]`, LLM returns valid `{"error": ..., "severity": ...}` JSON; both fail on unpatched code and pass with the fix.
- `test/components/extractors/test_llm_metadata_extractor.py`: 31 passed, 2 skipped.
- `ruff check` and `ruff format` clean on the touched files.

### Notes for the reviewer

The private `_extract_metadata` contract changed from return-based to raise-based on parse failure; `test_extract_metadata_missing_key` (which calls it directly) was updated to expect the raise. Behavior through the public `run`/`run_async` API is unchanged for real failures, including the warning log and the `raise_on_failure=True` path.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.