### PR TITLE
fix: skip overlap-only trailing chunks in character-based split modes

### DIFF
--- a/haystack/components/preprocessors/document_splitter.py
+++ b/haystack/components/preprocessors/document_splitter.py
@@ -385,18 +385,33 @@ class DocumentSplitter:
         Keeps track of the original page number that each element belongs. If the length of the current units is less
         than the pre-defined `split_threshold`, it does not create a new split. Instead, it concatenates the current
         units with the last split, preventing the creation of excessively small splits.
+        A trailing segment that adds no new text beyond the already covered units (an overlap-only window,
+        or a window holding only the empty artifact of a trailing delimiter) is skipped instead of
+        creating a redundant chunk.
         """
+        step = split_length - split_overlap
 
         text_splits: list[str] = []
         splits_pages: list[int] = []
         splits_start_idxs: list[int] = []
         cur_start_idx = 0
         cur_page = 1
-        segments = windowed(elements, n=split_length, step=split_length - split_overlap)
+        segments = windowed(elements, n=split_length, step=step)
+        # Number of leading units already covered by previous segments. The yielded segments advance by
+        # `step`, so the segment at index i starts at unit i * step.
+        covered_unit_count = 0
 
-        for seg in segments:
+        for seg_index, seg in enumerate(segments):
             current_units = [unit for unit in seg if unit is not None]
             txt = "".join(current_units)
+
+            # Skip a segment that adds no new text: every unit past the already covered ones is empty.
+            # Emitting it would create a chunk fully contained in a previous chunk. This mirrors the
+            # overlap-only trailing chunk fix of `_split_by_token` for the character-based split modes.
+            new_units = current_units[max(0, covered_unit_count - seg_index * step) :]
+            if split_overlap > 0 and text_splits and not "".join(new_units):
+                continue
+            covered_unit_count = max(covered_unit_count, seg_index * step + len(current_units))
 
             # check if length of current units is below split_threshold
             if len(current_units) < split_threshold and len(text_splits) > 0:

--- a/releasenotes/notes/skip-overlap-only-trailing-chunks-char-modes-3f9a2c1d7e4b8a05.yaml
+++ b/releasenotes/notes/skip-overlap-only-trailing-chunks-char-modes-3f9a2c1d7e4b8a05.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix ``DocumentSplitter`` with ``split_by="word"``, ``"period"``,
+    ``"page"``, ``"passage"``, ``"line"`` or ``"sentence"`` generating
+    redundant trailing chunks containing only overlap. Segments that add no
+    new text beyond the already covered units are now skipped, mirroring the
+    ``split_by="token"`` fix.

--- a/test/components/preprocessors/test_document_splitter.py
+++ b/test/components/preprocessors/test_document_splitter.py
@@ -124,6 +124,50 @@ class TestSplittingByFunctionOrCharacterRegex:
             assert content in text, f"chunk {content!r} is not present in the source text"
         assert contents == ["a b c ", "c d e f"]
 
+    @pytest.mark.parametrize(
+        "split_by,split_length,split_overlap,content,expected_splits",
+        [
+            pytest.param("word", 3, 1, "t1 t2 t3", ["t1 t2 t3"], id="word-exact-fit-creates-one-chunk"),
+            pytest.param("word", 3, 1, "t1 t2 t3 ", ["t1 t2 t3 "], id="word-trailing-delimiter-creates-one-chunk"),
+            pytest.param("word", 3, 1, "t1 t2 t3 t4", ["t1 t2 t3 ", "t3 t4"], id="word-partial-final-chunk-is-kept"),
+            pytest.param(
+                "word",
+                3,
+                2,
+                "t1 t2 t3 t4",
+                ["t1 t2 t3 ", "t2 t3 t4"],
+                id="word-high-overlap-partial-final-chunk-is-kept",
+            ),
+            pytest.param(
+                "line", 3, 1, "l1\nl2\nl3\n", ["l1\nl2\nl3\n"], id="line-trailing-delimiter-creates-one-chunk"
+            ),
+            pytest.param(
+                "passage",
+                3,
+                1,
+                "p1\n\np2\n\np3\n\n",
+                ["p1\n\np2\n\np3\n\n"],
+                id="passage-trailing-delimiter-creates-one-chunk",
+            ),
+            pytest.param("period", 3, 1, "s1.s2.s3.", ["s1.s2.s3."], id="period-trailing-delimiter-creates-one-chunk"),
+            pytest.param(
+                "period",
+                3,
+                2,
+                "s1.s2.s3.s4.",
+                ["s1.s2.s3.", "s2.s3.s4."],
+                id="period-high-overlap-does-not-create-overlap-only-chunk",
+            ),
+            pytest.param("page", 3, 1, "a\fb\fc\f", ["a\fb\fc\f"], id="page-trailing-delimiter-creates-one-chunk"),
+        ],
+    )
+    def test_split_by_character_modes_skip_overlap_only_trailing_chunk(
+        self, split_by, split_length, split_overlap, content, expected_splits
+    ):
+        splitter = DocumentSplitter(split_by=split_by, split_length=split_length, split_overlap=split_overlap)
+        docs = splitter.run(documents=[Document(content=content)])["documents"]
+        assert [d.content for d in docs] == expected_splits
+
     def test_split_by_word_multiple_input_docs(self):
         splitter = DocumentSplitter(split_by="word", split_length=10)
         text1 = "This is a text with some words. There is a second sentence. And there is a third sentence."
@@ -453,7 +497,10 @@ class TestSplittingByFunctionOrCharacterRegex:
         doc2 = Document(content="This content has two.\f\f page brakes. More text.")
         result = splitter.run(documents=[doc1, doc2])
 
-        expected_pages = [1, 1, 1, 2, 1, 1, 3]
+        # No overlap-only trailing chunks: " End." is fully contained in doc1's previous chunk and
+        # " More text." in doc2's previous chunk, so both are skipped instead of creating redundant
+        # chunks (the latter even carried a wrong page number).
+        expected_pages = [1, 1, 1, 1, 1]
         for doc, p in zip(result["documents"], expected_pages, strict=True):
             assert doc.meta["page_number"] == p
 


### PR DESCRIPTION
### Related Issues

- fixes #12686 (follow-up to #12661, which fixed `split_by="token"` only)

### Proposed Changes:

`_concatenate_units` (shared by `word`/`period`/`page`/`passage`/`line`/`sentence` modes) emitted every trailing `windowed` window as long as its text was non-empty, without checking whether the window reaches beyond the already covered units. A trailing window holding only already-covered overlap units (plus the empty artifact of a trailing delimiter) became a redundant chunk fully contained in the previous chunk.

Track the covered unit count across windows (segment `i` starts at unit `i * step`) and skip a non-first segment whose units past the covered boundary are all empty. Threshold merging of genuine partial tails, `split_overlap=0` behavior, and empty-document handling are unchanged. One existing page-metadata expectation is updated: the two dropped phantom chunks (`" End."`, `" More text."`) were byte-contained in their predecessors (one even carried a wrong `page_number`).

## Root Cause
Overlap-only tail windows in `_concatenate_units` were emitted instead of skipped; the token-mode loop got the analogous guard in #12661 but the character-based modes did not.

## Fix
Covered-unit tracking + skip of zero-new-text trailing segments in `_concatenate_units` (+17/-2), mirroring `_split_by_token`.

## Test
- New parametrized regression test `test_split_by_character_modes_skip_overlap_only_trailing_chunk` (9 cases: exact-fit / trailing-delimiter / high-overlap / partial-final controls across word/line/passage/period/page).
- pre-fix FAIL实证: 6 failed, 3 passed (controls) on unmodified `b20727a`.
- post-fix: `test/components/preprocessors/test_document_splitter.py` 89 passed; consumer suites (`sentence_window` x2, `auto_merging` x2, `recursive_splitter`) 127 passed.
- `ruff check` + `ruff format --check` clean; `mypy` clean on the changed source file.
- Upstream `main` CI was green at submission time.

## Diff scope
3 files, +73/-3 (src +17/-2, tests +48/-1, 1 reno fragment).

**AI disclosure:** this patch and its tests were prepared with an AI coding assistant. I have reviewed the changes and run the relevant tests.

### How did you test it?

See Test section above (unit + regression + consumer suites, local `pytest` runs).

### Notes for the reviewer

Affected inputs produce fewer chunks. The dropped chunks were fully contained in a previous chunk, so no information is lost. No retrieval-quality or latency improvement is claimed.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [x] I have updated the related issue with new insights and changes.
- [x] I have added unit tests and updated the docstrings.
- [x] I have used one of the conventional commit types for my PR title: `fix:`.
- [x] I have documented my code.
- [x] I have added a release note file, following the contributors guidelines.
- [x] I have run pre-commit hooks (ruff check / ruff format) and fixed any issue.