### PR TITLE
test: fix OpenAI Responses type error in test

### DIFF
--- a/test/components/generators/chat/test_openai_responses_conversion.py
+++ b/test/components/generators/chat/test_openai_responses_conversion.py
@@ -1017,7 +1017,6 @@ class TestConversionToStreamingChunks:
             ResponseFunctionCallArgumentsDoneEvent(
                 arguments='{"city":"Paris"}',
                 item_id="fc_095b57053855eac100690491f6a224819680e2f9c7cbc5a531",
-                name="weather",  # added name here because pydantic complains otherwise API returns a none here
                 output_index=1,
                 sequence_number=10,
                 type="response.function_call_arguments.done",
@@ -1212,7 +1211,6 @@ class TestConversionToStreamingChunks:
                     "received_at": ANY,
                     "arguments": '{"city":"Paris"}',
                     "item_id": "fc_095b57053855eac100690491f6a224819680e2f9c7cbc5a531",
-                    "name": "weather",
                     "output_index": 1,
                     "sequence_number": 10,
                     "type": "response.function_call_arguments.done",


### PR DESCRIPTION
### Related Issues

Failing test: https://github.com/deepset-ai/haystack/actions/runs/34412584320/job/102671434393?pr=12619

Previously `ResponseFunctionCallArgumentsDoneEvent` in OpenAI SDK required a `name` field, in disagreement with the real API. https://github.com/openai/openai-python/issues/3472
OpenAI fixed the issue in https://github.com/openai/openai-python/pull/3801

Our test was built to satisfy the previous SDK model and now fails type checking.


### Proposed Changes:
- remove the `name` field

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.
