### PR TITLE
fix: isolate Markdown secondary split header metadata

### DIFF
--- a/haystack/components/preprocessors/markdown_header_splitter.py
+++ b/haystack/components/preprocessors/markdown_header_splitter.py
@@ -276,7 +276,7 @@ class MarkdownHeaderSplitter:
                 if not self.keep_headers:
                     for key in ["header", "parent_headers"]:
                         if key in doc.meta:
-                            split.meta[key] = doc.meta[key]
+                            split.meta[key] = deepcopy(doc.meta[key])
 
                 result_docs.append(split)
 

--- a/releasenotes/notes/fix-markdown-secondary-header-metadata-616519d8985f832f.yaml
+++ b/releasenotes/notes/fix-markdown-secondary-header-metadata-616519d8985f832f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix shared ``parent_headers`` metadata in ``MarkdownHeaderSplitter`` when
+    ``keep_headers=False`` and secondary splitting is enabled. Editing one
+    chunk's parent headers no longer changes its siblings' metadata.

--- a/test/components/preprocessors/test_markdown_header_splitter.py
+++ b/test/components/preprocessors/test_markdown_header_splitter.py
@@ -269,6 +269,71 @@ def test_nested_metadata_is_not_shared_between_splits():
     assert doc.meta["tags"] == ["docs"]
 
 
+@pytest.mark.parametrize(
+    "keep_headers, prefix, parent_headers, expected_content",
+    [
+        (False, "# Top\n## Child\n", ["Top"], ["\none two three ", "four five six"]),
+        (False, "# Child\n", [], ["\none two three ", "four five six"]),
+        (True, "# Top\n## Child\n", ["Top"], ["# Top\n## Child\none ", "two three four ", "five six"]),
+        (True, "# Child\n", [], ["# Child\none two ", "three four five ", "six"]),
+    ],
+)
+def test_secondary_splits_have_independent_header_metadata(keep_headers, prefix, parent_headers, expected_content):
+    body = "one two three four five six"
+    doc = Document(content=prefix + body, meta={"tags": ["docs"]})
+    splitter = MarkdownHeaderSplitter(keep_headers=keep_headers, secondary_split="word", split_length=3)
+
+    split_docs = splitter.run(documents=[doc])["documents"]
+
+    assert [split.content for split in split_docs] == expected_content
+    assert "".join(expected_content) == (doc.content if keep_headers else "\n" + body)
+    offset = 0
+    for split_id, (split, content) in enumerate(zip(split_docs, expected_content, strict=True)):
+        assert split.meta == {
+            "tags": ["docs"],
+            "source_id": doc.id,
+            "page_number": 1,
+            "header": "Child",
+            "parent_headers": parent_headers,
+            "split_id": split_id,
+            "split_idx_start": offset,
+        }
+        offset += len(content)
+
+    split_docs[0].meta["parent_headers"].append("changed")
+    split_docs[0].meta["tags"].append("changed")
+
+    for sibling in split_docs[1:]:
+        assert sibling.meta["parent_headers"] == parent_headers
+        assert sibling.meta["tags"] == ["docs"]
+    assert doc.meta == {"tags": ["docs"]}
+
+
+@pytest.mark.parametrize("keep_headers", [False, True])
+def test_secondary_splits_without_headings_preserve_independent_input_header_metadata(keep_headers):
+    doc = Document(content="one two three four five six", meta={"header": "Existing", "parent_headers": ["Original"]})
+    splitter = MarkdownHeaderSplitter(keep_headers=keep_headers, secondary_split="word", split_length=3)
+
+    split_docs = splitter.run(documents=[doc])["documents"]
+
+    assert [split.content for split in split_docs] == ["one two three ", "four five six"]
+    assert "".join(split.content or "" for split in split_docs) == doc.content
+    for split_id, split in enumerate(split_docs):
+        assert split.meta == {
+            "header": "Existing",
+            "parent_headers": ["Original"],
+            "source_id": doc.id,
+            "page_number": 1,
+            "split_id": split_id,
+            "split_idx_start": split_id * len("one two three "),
+        }
+
+    split_docs[0].meta["parent_headers"].append("changed")
+
+    assert split_docs[1].meta["parent_headers"] == ["Original"]
+    assert doc.meta == {"header": "Existing", "parent_headers": ["Original"]}
+
+
 def test_secondary_split_keeps_content_before_embedded_header():
     """With keep_headers=False, prose before an embedded lower-level header must
     not be dropped during the secondary split."""


### PR DESCRIPTION
### Related Issues

- Fixes #12691

### Proposed Changes:

Deep-copy restored header metadata during secondary splitting. With `keep_headers=False`, the previous assignment replaced each chunk's independent `parent_headers` copy with the parent's shared list.

Regression tests cover populated and empty parent headers, input header metadata when there are no Markdown headings, and the unchanged `keep_headers=True` behavior. Chunk content, offsets, IDs and source metadata are also checked. Page-number/overlap behavior in #12619 is out of scope.

### How did you test it?

Windows, Python 3.12, Hatch:

- Reporter reproduction on main: mutation leaked only with `keep_headers=False`. New regression cases before the fix: 3 failed, 3 controls passed.
- `hatch run test:unit test/components/preprocessors/test_markdown_header_splitter.py --cov-branch`: 49 passed; the modified executable line is covered (1/1).
- `hatch run test:unit test/components/preprocessors --no-cov`: 397 passed, 28 integration cases deselected.
- `hatch run test:types`: passed, 502 files.
- Changed-file Ruff lint/format and pre-commit: passed. `hatch run python .github/utils/check_imports.py`: 262 modules imported successfully.
- `hatch run test:unit test --no-cov`: 6388 passed, 1 failed, 43 skipped, 332 integration cases deselected. The sole failure is the existing CSV MIME-type test: this Windows machine reports `application/vnd.ms-excel` instead of `text/csv`. The exact test fails identically on clean main (6cc03fe6). No unrelated MIME-type change is included.
- Initial five failures came from the local SOCKS proxy environment, reproduced identically on clean main. All five pass with proxy variables cleared only for the test process; the broader run above used the same process-local setting. No repository configuration/dependencies changed.

### Notes for the reviewer

Fully AI-generated implementation and tests, with independent Codex diff review (no actionable findings). Local test execution was performed by the implementing assistant; this is not a claim of human review. Keeping this PR in Draft pending upstream CI and any CLA requirements. The local full suite is not entirely green, as detailed above.

This restores metadata isolation without changing the public API or requiring migration. A bug-fix release note is included; existing public docstrings remain accurate.

### Checklist

- [x] Read the contributing guidelines and code of conduct.
- [x] Updated the related issue with reproduction and scope.
- [x] Added regression tests; existing public docstrings remain accurate.
- [x] Used a conventional commit PR title; no breaking API change.
- [x] Documented the behavior in the release note.
- [x] Added a release note generated through Hatch/Reno.
- [x] Ran changed-file pre-commit hooks successfully.
- [x] Completed the broader local unit run and disclosed its baseline-reproducible failure.
- [ ] Upstream CI complete.
- [x] CLA status confirmed by the contributor.
