### PR TITLE
docs: cover Haystack Enterprise Platform in Tracing, Get Started, Installation

### DIFF
--- a/docs-website/docs/development/deployment.mdx
+++ b/docs-website/docs/development/deployment.mdx
@@ -17,6 +17,7 @@ These guides focus on tools and techniques that can be used to run Haystack pipe
 
 Here are the currently available guides on Haystack pipeline deployment:
 
+- [Haystack Enterprise Platform](deployment/haystack-enterprise-platform.mdx)
 - [Deploying with Docker](deployment/docker.mdx)
 - [Deploying with Kubernetes](deployment/kubernetes.mdx)
 - [Deploying with OpenShift](deployment/openshift.mdx)

--- a/docs-website/docs/development/deployment/haystack-enterprise-platform.mdx
+++ b/docs-website/docs/development/deployment/haystack-enterprise-platform.mdx
@@ -1,0 +1,22 @@
+---
+title: "Haystack Enterprise Platform"
+id: haystack-enterprise-platform
+slug: "/deployment-haystack-enterprise-platform"
+description: "Learn how to deploy your Haystack pipelines on Haystack Enterprise Platform, without managing your own infrastructure."
+---
+
+# Haystack Enterprise Platform
+
+Learn how to deploy your Haystack pipelines on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform), without managing your own infrastructure.
+
+## Bringing a Pipeline onto the Platform
+
+If you already have a Haystack pipeline defined in code, serialize it to YAML, create an empty pipeline in the platform's Pipeline Builder, switch to YAML view, and paste it in. See [Import a Pipeline](https://docs.cloud.deepset.ai/docs/import-a-pipeline) for the exact steps. You can also build a pipeline from scratch directly in the Builder.
+
+## Deploying a Pipeline
+
+Click **Deploy** on a pipeline to make it available for testing in the Playground. Deploys are zero-downtime: the version already running keeps serving queries until the new version deploys successfully, and Deploy always uses the latest saved version, so there's no draft-versus-version choice to make. See [Deploy a Pipeline](https://docs.cloud.deepset.ai/docs/deploy-a-pipeline) for details.
+
+## Going to Production
+
+A deployed pipeline is ready for testing and internal debugging, but for a stable, production-ready endpoint, publish it to a service. This decouples the endpoint from the pipeline version being developed. The endpoint URL stays the same regardless of which pipeline version you publish, so you can keep iterating without breaking anything calling it. See [Publish a Pipeline to a Service](https://docs.cloud.deepset.ai/docs/publish-pipeline-to-service) for details.

--- a/docs-website/docs/development/deployment/haystack-enterprise-platform.mdx
+++ b/docs-website/docs/development/deployment/haystack-enterprise-platform.mdx
@@ -17,10 +17,6 @@ If you already have a Haystack pipeline defined in code, serialize it to YAML, c
 
 Click **Deploy** on a pipeline to make it available for testing in the Playground. Deploys are zero-downtime: the version already running keeps serving queries until the new version deploys successfully, and Deploy always uses the latest saved version, so there's no draft-versus-version choice to make. See [Deploy a Pipeline](https://docs.cloud.deepset.ai/docs/deploy-a-pipeline) for details.
 
-## Going to Production
-
-A deployed pipeline is ready for testing and internal debugging, but for a stable, production-ready endpoint, publish it to a service in **Gateway**, the platform's home for pipeline services. Publishing decouples the endpoint from the pipeline version being developed: the endpoint URL stays the same regardless of which pipeline version you publish, so you can keep iterating without breaking anything calling it. See [Publish a Pipeline to a Service](https://docs.cloud.deepset.ai/docs/publish-pipeline-to-service) for details.
-
 ## Scaling and Idle Resources
 
 You don't manage servers directly. In the pipeline's Settings tab, you configure a minimum and maximum number of replicas and an idle timeout, the time after which an unused pipeline enters standby mode to save resources; inactive pipelines don't consume the pipeline hours included in your plan. See [Pipelines](https://docs.cloud.deepset.ai/docs/about-pipelines) for details on hosting settings.

--- a/docs-website/docs/development/deployment/haystack-enterprise-platform.mdx
+++ b/docs-website/docs/development/deployment/haystack-enterprise-platform.mdx
@@ -19,4 +19,8 @@ Click **Deploy** on a pipeline to make it available for testing in the Playgroun
 
 ## Going to Production
 
-A deployed pipeline is ready for testing and internal debugging, but for a stable, production-ready endpoint, publish it to a service. This decouples the endpoint from the pipeline version being developed. The endpoint URL stays the same regardless of which pipeline version you publish, so you can keep iterating without breaking anything calling it. See [Publish a Pipeline to a Service](https://docs.cloud.deepset.ai/docs/publish-pipeline-to-service) for details.
+A deployed pipeline is ready for testing and internal debugging, but for a stable, production-ready endpoint, publish it to a service in **Gateway**, the platform's home for pipeline services. Publishing decouples the endpoint from the pipeline version being developed: the endpoint URL stays the same regardless of which pipeline version you publish, so you can keep iterating without breaking anything calling it. See [Publish a Pipeline to a Service](https://docs.cloud.deepset.ai/docs/publish-pipeline-to-service) for details.
+
+## Scaling and Idle Resources
+
+You don't manage servers directly. In the pipeline's Settings tab, you configure a minimum and maximum number of replicas and an idle timeout, the time after which an unused pipeline enters standby mode to save resources; inactive pipelines don't consume the pipeline hours included in your plan. See [Pipelines](https://docs.cloud.deepset.ai/docs/about-pipelines) for details on hosting settings.

--- a/docs-website/docs/development/tracing.mdx
+++ b/docs-website/docs/development/tracing.mdx
@@ -13,7 +13,7 @@ Instrumented applications typically send traces to a trace collector or a tracin
 
 :::info[Tracing on Haystack Enterprise Platform]
 
-Deploy your pipeline on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) and get traces out of the box, no tracer setup needed. See [Haystack Enterprise Platform](tracing/haystack-enterprise-platform.mdx) for details, including how to connect Langfuse or Weights & Biases Weave for deeper tracing.
+Deploy your pipeline on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) and get traces out of the box, no tracer setup needed. See [Haystack Enterprise Platform](tracing/haystack-enterprise-platform.mdx) for details.
 
 :::
 
@@ -21,7 +21,7 @@ Deploy your pipeline on [Haystack Enterprise Platform](https://www.deepset.ai/pr
 
 | Tracer | Description |
 | --- | --- |
-| [Haystack Enterprise Platform](tracing/haystack-enterprise-platform.mdx) | Get pipeline traces automatically when you deploy on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform), no tracer setup needed. Optionally connect the `LangfuseConnector` or `WeaveConnector`. |
+| [Haystack Enterprise Platform](tracing/haystack-enterprise-platform.mdx) | Get pipeline traces automatically when you deploy on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform), no tracer setup needed. |
 | [OpenTelemetry](tracing/opentelemetry.mdx) | Send traces to any [OpenTelemetry](https://opentelemetry.io/)-compatible backend using the `OpenTelemetryTracer` or the `OpenTelemetryConnector` component. Includes a Jaeger setup for local development. |
 | [MLflow](tracing/mlflow.mdx) | Capture traces with [MLflow](https://mlflow.org/)'s native Haystack tracing support. |
 | [Datadog](tracing/datadog.mdx) | Trace your pipelines with [Datadog](https://www.datadoghq.com/) using the `DatadogTracer` or the `DatadogConnector` component. |

--- a/docs-website/docs/development/tracing.mdx
+++ b/docs-website/docs/development/tracing.mdx
@@ -11,10 +11,17 @@ Traces document the flow of requests through your application and are vital for 
 
 Instrumented applications typically send traces to a trace collector or a tracing backend. Haystack provides out-of-the-box support for several backends, and you can also quickly implement support for additional providers of your choosing.
 
+:::info[Tracing on Haystack Enterprise Platform]
+
+Deploy your pipeline on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) and get traces out of the box, no tracer setup needed. See [Haystack Enterprise Platform](tracing/haystack-enterprise-platform.mdx) for details, including how to connect Langfuse or Weights & Biases Weave for deeper tracing.
+
+:::
+
 ## Supported Tracers
 
 | Tracer | Description |
 | --- | --- |
+| [Haystack Enterprise Platform](tracing/haystack-enterprise-platform.mdx) | Get pipeline traces automatically when you deploy on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform), no tracer setup needed. Optionally connect the `LangfuseConnector` or `WeaveConnector`. |
 | [OpenTelemetry](tracing/opentelemetry.mdx) | Send traces to any [OpenTelemetry](https://opentelemetry.io/)-compatible backend using the `OpenTelemetryTracer` or the `OpenTelemetryConnector` component. Includes a Jaeger setup for local development. |
 | [MLflow](tracing/mlflow.mdx) | Capture traces with [MLflow](https://mlflow.org/)'s native Haystack tracing support. |
 | [Datadog](tracing/datadog.mdx) | Trace your pipelines with [Datadog](https://www.datadoghq.com/) using the `DatadogTracer` or the `DatadogConnector` component. |
@@ -23,12 +30,6 @@ Instrumented applications typically send traces to a trace collector or a tracin
 | [Rhesis](tracing/rhesis.mdx) | Trace your pipelines and `Agent` runs in [Rhesis](https://rhesis.ai) using the `RhesisConnector` component, and correlate traces with test runs and conversation turns. |
 | [LoggingTracer](tracing/logging-tracer.mdx) | Inspect the data flowing through your pipeline in real time through logs, with no backend setup. |
 | [Custom Tracer](tracing/custom-tracer.mdx) | Connect any tracing backend by implementing the `Tracer` interface. |
-
-:::info[Tracing on Haystack Enterprise Platform]
-
-If you build and deploy your pipeline on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform), you get pipeline traces out of the box in the Builder's Analytics tab, no tracer setup needed. You can also connect [Langfuse](https://docs.cloud.deepset.ai/docs/trace-with-langfuse) or [Weights & Biases Weave](https://docs.cloud.deepset.ai/docs/use-weights-and-biases) through the platform's connectors for deeper, cross-service tracing. See [Trace Your Pipelines](https://docs.cloud.deepset.ai/docs/trace-your-pipelines) and [Monitor Pipeline Performance](https://docs.cloud.deepset.ai/docs/pipeline-performance) for details.
-
-:::
 
 ## Enabling and Disabling Tracing
 

--- a/docs-website/docs/development/tracing.mdx
+++ b/docs-website/docs/development/tracing.mdx
@@ -24,9 +24,11 @@ Instrumented applications typically send traces to a trace collector or a tracin
 | [LoggingTracer](tracing/logging-tracer.mdx) | Inspect the data flowing through your pipeline in real time through logs, with no backend setup. |
 | [Custom Tracer](tracing/custom-tracer.mdx) | Connect any tracing backend by implementing the `Tracer` interface. |
 
-## Tracing on Haystack Enterprise Platform
+:::info[Tracing on Haystack Enterprise Platform]
 
 If you build and deploy your pipeline on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform), you get pipeline traces out of the box in the Builder's Analytics tab, no tracer setup needed. You can also connect [Langfuse](https://docs.cloud.deepset.ai/docs/trace-with-langfuse) or [Weights & Biases Weave](https://docs.cloud.deepset.ai/docs/use-weights-and-biases) through the platform's connectors for deeper, cross-service tracing. See [Trace Your Pipelines](https://docs.cloud.deepset.ai/docs/trace-your-pipelines) and [Monitor Pipeline Performance](https://docs.cloud.deepset.ai/docs/pipeline-performance) for details.
+
+:::
 
 ## Enabling and Disabling Tracing
 

--- a/docs-website/docs/development/tracing.mdx
+++ b/docs-website/docs/development/tracing.mdx
@@ -24,6 +24,10 @@ Instrumented applications typically send traces to a trace collector or a tracin
 | [LoggingTracer](tracing/logging-tracer.mdx) | Inspect the data flowing through your pipeline in real time through logs, with no backend setup. |
 | [Custom Tracer](tracing/custom-tracer.mdx) | Connect any tracing backend by implementing the `Tracer` interface. |
 
+## Tracing on Haystack Enterprise Platform
+
+If you build and deploy your pipeline on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform), you get pipeline traces out of the box in the Builder's Analytics tab, no tracer setup needed. You can also connect [Langfuse](https://docs.cloud.deepset.ai/docs/trace-with-langfuse) or [Weights & Biases Weave](https://docs.cloud.deepset.ai/docs/use-weights-and-biases) through the platform's connectors for deeper, cross-service tracing. See [Trace Your Pipelines](https://docs.cloud.deepset.ai/docs/trace-your-pipelines) and [Monitor Pipeline Performance](https://docs.cloud.deepset.ai/docs/pipeline-performance) for details.
+
 ## Enabling and Disabling Tracing
 
 Haystack never enables tracing automatically. To enable it, either call `haystack.tracing.enable_tracing(...)` with the tracer of your choice, or add a tracing connector component such as the [`OpenTelemetryConnector`](tracing/opentelemetry.mdx) or the [`DatadogConnector`](tracing/datadog.mdx) to your pipeline.

--- a/docs-website/docs/development/tracing/haystack-enterprise-platform.mdx
+++ b/docs-website/docs/development/tracing/haystack-enterprise-platform.mdx
@@ -1,0 +1,40 @@
+---
+title: "Haystack Enterprise Platform"
+id: haystack-enterprise-platform
+slug: "/tracing-haystack-enterprise-platform"
+description: "Learn how pipeline tracing works out of the box on Haystack Enterprise Platform, and how to connect Langfuse or Weights & Biases Weave for deeper tracing."
+---
+
+# Haystack Enterprise Platform
+
+Learn how pipeline tracing works out of the box on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform), and how to connect Langfuse or Weights & Biases Weave for deeper tracing.
+
+<div className="key-value-table">
+
+|  |  |
+| --- | --- |
+| **How to enable** | Built in — every deployed pipeline is traced automatically |
+| **Content tracing** | Captured automatically: query transformations, embeddings, retrieved documents, scoring decisions, latencies, and errors |
+| **Optional connectors** | `LangfuseConnector`, `WeaveConnector` |
+| **Platform docs** | [Trace Your Pipelines](https://docs.cloud.deepset.ai/docs/trace-your-pipelines) |
+
+</div>
+
+## Overview
+
+Haystack Enterprise Platform traces every pipeline you deploy without any setup: no tracer to enable, no content-tracing flag to flip. Traces capture the full journey of a query through your pipeline, including timestamps, query transformations, generated embeddings, retrieved documents, scoring and ranking decisions, and any errors or latency issues.
+
+## Built-in Tracing
+
+Open a pipeline in the Builder and check the **Analytics** tab to inspect traces for individual runs, alongside pipeline-level metrics like request volume and latency. See [Monitor Pipeline Performance](https://docs.cloud.deepset.ai/docs/pipeline-performance) for details on the available dashboards.
+
+## Connecting Langfuse or Weave
+
+For deeper, cross-service tracing, for example to correlate Haystack traces with the rest of your observability stack, connect one of the platform's tracing connectors:
+
+- **[Langfuse](https://docs.cloud.deepset.ai/docs/trace-with-langfuse)**: add the `LangfuseConnector` to your pipeline to send detailed spans and latency data to your Langfuse project.
+- **[Weights & Biases Weave](https://docs.cloud.deepset.ai/docs/use-weights-and-biases)**: add the `WeaveConnector` to send pipeline traces, including token counts, to your W&B project.
+
+:::info
+See the [`LangfuseConnector`](../../pipeline-components/connectors/langfuseconnector.mdx) and [`WeaveConnector`](../../pipeline-components/connectors/weaveconnector.mdx) component docs for configuring these connectors directly in a pipeline you bring to the platform.
+:::

--- a/docs-website/docs/development/tracing/haystack-enterprise-platform.mdx
+++ b/docs-website/docs/development/tracing/haystack-enterprise-platform.mdx
@@ -25,4 +25,4 @@ Haystack Enterprise Platform traces every pipeline you deploy without any setup:
 
 ## Built-in Tracing
 
-Open a pipeline in the Builder and check the **Analytics** tab to inspect traces for individual runs, alongside pipeline-level metrics like request volume and latency. See [Monitor Pipeline Performance](https://docs.cloud.deepset.ai/docs/pipeline-performance) for details on the available dashboards.
+Open a pipeline in the Builder and check the **Analytics** tab to inspect traces for individual runs, alongside pipeline-level metrics like request volume and latency. See [Monitor Pipeline Performance](https://docs.cloud.deepset.ai/docs/monitor-pipeline-performance) for details on the available dashboards.

--- a/docs-website/docs/development/tracing/haystack-enterprise-platform.mdx
+++ b/docs-website/docs/development/tracing/haystack-enterprise-platform.mdx
@@ -2,12 +2,12 @@
 title: "Haystack Enterprise Platform"
 id: haystack-enterprise-platform
 slug: "/tracing-haystack-enterprise-platform"
-description: "Learn how pipeline tracing works out of the box on Haystack Enterprise Platform, and how to connect Langfuse or Weights & Biases Weave for deeper tracing."
+description: "Learn how pipeline tracing works out of the box on Haystack Enterprise Platform."
 ---
 
 # Haystack Enterprise Platform
 
-Learn how pipeline tracing works out of the box on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform), and how to connect Langfuse or Weights & Biases Weave for deeper tracing.
+Learn how pipeline tracing works out of the box on [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform).
 
 <div className="key-value-table">
 
@@ -15,7 +15,6 @@ Learn how pipeline tracing works out of the box on [Haystack Enterprise Platform
 | --- | --- |
 | **How to enable** | Built in — every deployed pipeline is traced automatically |
 | **Content tracing** | Captured automatically: query transformations, embeddings, retrieved documents, scoring decisions, latencies, and errors |
-| **Optional connectors** | `LangfuseConnector`, `WeaveConnector` |
 | **Platform docs** | [Trace Your Pipelines](https://docs.cloud.deepset.ai/docs/trace-your-pipelines) |
 
 </div>
@@ -27,14 +26,3 @@ Haystack Enterprise Platform traces every pipeline you deploy without any setup:
 ## Built-in Tracing
 
 Open a pipeline in the Builder and check the **Analytics** tab to inspect traces for individual runs, alongside pipeline-level metrics like request volume and latency. See [Monitor Pipeline Performance](https://docs.cloud.deepset.ai/docs/pipeline-performance) for details on the available dashboards.
-
-## Connecting Langfuse or Weave
-
-For deeper, cross-service tracing, for example to correlate Haystack traces with the rest of your observability stack, connect one of the platform's tracing connectors:
-
-- **[Langfuse](https://docs.cloud.deepset.ai/docs/trace-with-langfuse)**: add the `LangfuseConnector` to your pipeline to send detailed spans and latency data to your Langfuse project.
-- **[Weights & Biases Weave](https://docs.cloud.deepset.ai/docs/use-weights-and-biases)**: add the `WeaveConnector` to send pipeline traces, including token counts, to your W&B project.
-
-:::info
-See the [`LangfuseConnector`](../../pipeline-components/connectors/langfuseconnector.mdx) and [`WeaveConnector`](../../pipeline-components/connectors/weaveconnector.mdx) component docs for configuring these connectors directly in a pipeline you bring to the platform.
-:::

--- a/docs-website/docs/overview/get-started.mdx
+++ b/docs-website/docs/overview/get-started.mdx
@@ -12,9 +12,9 @@ import TabItem from '@theme/TabItem';
 
 Have a look at this page to learn how to quickly get up and running with Haystack. It contains instructions for installing Haystack, building your first RAG pipeline, and creating a tool-calling Agent.
 
-:::info[Prefer a hosted, no-code start?]
+:::info[Ready to scale with confidence?]
 
-You don't have to install Haystack or write code to get a pipeline running. [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) gives you the same Haystack components in a visual Pipeline Builder: create a workspace, upload files (or use a sample dataset), pick a pipeline template, and test it in the Playground, all in the browser. Follow the [Quick Start Guide](https://docs.cloud.deepset.ai/docs/quick-start-guide) to try it.
+[Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) hosts the same Haystack components for you, with a visual Pipeline Builder, a [REST API](https://docs.cloud.deepset.ai/docs/create-a-pipeline-with-rest-api) for publishing pipeline YAML straight from your codebase, and support for [custom Python components](https://docs.cloud.deepset.ai/docs/upload-a-custom-component-to-deepset-cloud). Get zero-downtime deploys, managed scaling, and built-in tracing without running your own infrastructure. Follow the [Quick Start Guide](https://docs.cloud.deepset.ai/docs/quick-start-guide) to try it.
 
 :::
 

--- a/docs-website/docs/overview/get-started.mdx
+++ b/docs-website/docs/overview/get-started.mdx
@@ -12,6 +12,12 @@ import TabItem from '@theme/TabItem';
 
 Have a look at this page to learn how to quickly get up and running with Haystack. It contains instructions for installing Haystack, building your first RAG pipeline, and creating a tool-calling Agent.
 
+:::tip[Prefer a hosted, no-code start?]
+
+You don't have to install Haystack or write code to get a pipeline running. [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) gives you the same Haystack components in a visual Pipeline Builder: create a workspace, upload files (or use a sample dataset), pick a pipeline template, and test it in the Playground, all in the browser. Follow the [Quick Start Guide](https://docs.cloud.deepset.ai/docs/quick-start-guide) to try it.
+
+:::
+
 ## Build your first RAG application
 
 Let's build your first Retrieval Augmented Generation (RAG) pipeline and see how Haystack answers questions.

--- a/docs-website/docs/overview/get-started.mdx
+++ b/docs-website/docs/overview/get-started.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 Have a look at this page to learn how to quickly get up and running with Haystack. It contains instructions for installing Haystack, building your first RAG pipeline, and creating a tool-calling Agent.
 
-:::tip[Prefer a hosted, no-code start?]
+:::info[Prefer a hosted, no-code start?]
 
 You don't have to install Haystack or write code to get a pipeline running. [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) gives you the same Haystack components in a visual Pipeline Builder: create a workspace, upload files (or use a sample dataset), pick a pipeline template, and test it in the Playground, all in the browser. Follow the [Quick Start Guide](https://docs.cloud.deepset.ai/docs/quick-start-guide) to try it.
 

--- a/docs-website/docs/overview/installation.mdx
+++ b/docs-website/docs/overview/installation.mdx
@@ -45,9 +45,9 @@ If you use a feature that requires an optional dependency that hasn't been insta
 ImportError: "Haystack failed to import the optional dependency 'pypdf'. Run 'pip install pypdf'.
 ```
 
-:::info[Skip the Local Install]
+:::info[Ready to scale with confidence?]
 
-If you'd rather not manage a local Python environment, [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) lets you build and run Haystack pipelines entirely in the browser, with no `pip install` required. Log in, upload files (or use a sample dataset), and assemble pipelines visually in the Pipeline Builder. See the [Quick Start Guide](https://docs.cloud.deepset.ai/docs/quick-start-guide) to get a pipeline running in minutes.
+Rather than self-hosting, [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) runs your pipelines for you: build them visually in the Pipeline Builder, publish pipeline YAML through the [REST API](https://docs.cloud.deepset.ai/docs/create-a-pipeline-with-rest-api), or bring your own [custom Python components](https://docs.cloud.deepset.ai/docs/upload-a-custom-component-to-deepset-cloud). You get zero-downtime deploys, managed scaling, and built-in tracing out of the box. See the [Quick Start Guide](https://docs.cloud.deepset.ai/docs/quick-start-guide) to get a pipeline running in minutes.
 
 :::
 

--- a/docs-website/docs/overview/installation.mdx
+++ b/docs-website/docs/overview/installation.mdx
@@ -45,9 +45,11 @@ If you use a feature that requires an optional dependency that hasn't been insta
 ImportError: "Haystack failed to import the optional dependency 'pypdf'. Run 'pip install pypdf'.
 ```
 
-## Skip the Local Install
+:::info[Skip the Local Install]
 
 If you'd rather not manage a local Python environment, [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) lets you build and run Haystack pipelines entirely in the browser, with no `pip install` required. Log in, upload files (or use a sample dataset), and assemble pipelines visually in the Pipeline Builder. See the [Quick Start Guide](https://docs.cloud.deepset.ai/docs/quick-start-guide) to get a pipeline running in minutes.
+
+:::
 
 ## Contributing to Haystack
 

--- a/docs-website/docs/overview/installation.mdx
+++ b/docs-website/docs/overview/installation.mdx
@@ -45,6 +45,10 @@ If you use a feature that requires an optional dependency that hasn't been insta
 ImportError: "Haystack failed to import the optional dependency 'pypdf'. Run 'pip install pypdf'.
 ```
 
+## Skip the Local Install
+
+If you'd rather not manage a local Python environment, [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) lets you build and run Haystack pipelines entirely in the browser, with no `pip install` required. Log in, upload files (or use a sample dataset), and assemble pipelines visually in the Pipeline Builder. See the [Quick Start Guide](https://docs.cloud.deepset.ai/docs/quick-start-guide) to get a pipeline running in minutes.
+
 ## Contributing to Haystack
 
 If you would like to contribute to the Haystack, check our [Contributor Guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) first

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -837,6 +837,7 @@ export default {
             id: 'development/tracing'
           },
           items: [
+            'development/tracing/haystack-enterprise-platform',
             'development/tracing/opentelemetry',
             'development/tracing/mlflow',
             'development/tracing/datadog',

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -858,6 +858,7 @@ export default {
             id: 'development/deployment'
           },
           items: [
+            'development/deployment/haystack-enterprise-platform',
             'development/deployment/docker',
             'development/deployment/kubernetes',
             'development/deployment/openshift',


### PR DESCRIPTION
## Summary
- Top-traffic docs pages didn't mention Haystack Enterprise Platform at all.
- Added a Platform callout to each of the three pages, pointing at the hosted/no-install path alongside the existing OSS instructions:
  - `overview/installation.mdx`: Platform lets you skip the local `pip install` entirely (Quick Start Guide).
  - `overview/get-started.mdx`: Platform's visual Pipeline Builder as a no-code alternative to the code-first RAG/Agent walkthroughs.
  - `development/tracing.mdx`: Platform's built-in Analytics tab tracing plus Langfuse/W&B Weave connectors, alongside the OSS tracer table.
- Content sourced from https://docs.cloud.deepset.ai/ (quick-start-guide, trace-your-pipelines, getting-started) to avoid inventing product claims; naming/link style (`Haystack Enterprise Platform` -> deepset.ai product page) follows the existing convention already used in `intro.mdx`, `deployment.mdx`, and `visualizing-pipelines.mdx`.
- Scope limited to `docs-website` per request (no separate marketing website repo in this checkout); existing OSS content left intact, Platform content added as additive callouts only.

## Test plan
- [ ] Docs-only change; no code/tests affected, no release note required per `AGENTS.md`.
- [ ] Visual check: render `docs-website` locally (`docusaurus start`) and confirm the three callouts render correctly and links resolve.