### PR TITLE
docs: add Haystack Enterprise Platform link to top nav

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -310,8 +310,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             position: 'left',
           },
           {
-            href: 'https://landing.deepset.ai/deepset-studio-signup',
-            label: 'Enterprise',
+            href: 'https://cloud.deepset.ai',
+            label: 'Haystack Enterprise Platform',
             position: 'right',
           },
           {

--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -310,6 +310,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             position: 'left',
           },
           {
+            href: 'https://landing.deepset.ai/deepset-studio-signup',
+            label: 'Enterprise',
+            position: 'right',
+          },
+          {
             href: 'https://github.com/deepset-ai/haystack/blob/main/docs-website/CONTRIBUTING.md',
             label: 'Contribute',
             position: 'right',

--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -310,7 +310,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             position: 'left',
           },
           {
-            href: 'https://cloud.deepset.ai',
+            href: 'https://www.deepset.ai/products-and-services/haystack-enterprise-platform',
             label: 'Haystack Enterprise Platform',
             position: 'right',
           },


### PR DESCRIPTION
### Related Issues

- N/A

### Proposed Changes:

Adds a "Haystack Enterprise Platform" link to the docs site top navbar (right side, before "Contribute"), pointing to https://www.deepset.ai/products-and-services/haystack-enterprise-platform.

### How did you test it?

Ran the Docusaurus dev server locally and confirmed the link renders and points to the right URL.

### Notes for the reviewer

Docs-only change, no release note needed.

### Checklist

- [x] I have read the contributors guidelines and the code of conduct.
- [ ] I have updated the related issue with new insights and changes.
- [ ] I have added unit tests and updated the docstrings.
- [x] I've used one of the conventional commit types for my PR title.
- [x] I have documented my code.
- [ ] I have added a release note file (docs-only change, not required).
- [x] I have run pre-commit hooks and fixed any issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)