### PR TITLE
docs: link Haystack Enterprise Platform from Enterprise Components page

### DIFF
--- a/docs-website/docs/overview/platform-components.mdx
+++ b/docs-website/docs/overview/platform-components.mdx
@@ -7,7 +7,7 @@ description: "A complete list of Haystack components available on the Haystack E
 
 # Haystack Enterprise Components
 
-The Haystack Enterprise Platform currently supports **253 components** and **80 integrations**. The following table lists them grouped by integration partner.
+The [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform) currently supports **253 components** and **80 integrations**. The following table lists them grouped by integration partner.
 
 ## Core Components
 

--- a/scripts/generate_platform_components_table.py
+++ b/scripts/generate_platform_components_table.py
@@ -310,7 +310,8 @@ def build_mdx(
         "",
         "# Haystack Enterprise Components",
         "",
-        f"The Haystack Enterprise Platform currently supports **{visible_count} components**"
+        "The [Haystack Enterprise Platform](https://www.deepset.ai/products-and-services/haystack-enterprise-platform)"
+        f" currently supports **{visible_count} components**"
         f" and **{len(partner_components)} integrations**."
         " The following table lists them grouped by integration partner.",
         "",


### PR DESCRIPTION
## Summary
- The Enterprise Components page (`docs-website/docs/overview/platform-components.mdx`) is auto-regenerated by the [update-platform-components](https://github.com/deepset-ai/haystack/blob/main/.github/workflows/update-platform-components.yml) workflow via `scripts/generate_platform_components_table.py`, so editing the `.mdx` by hand would have been overwritten on the next scheduled/dispatched run.
- Linked "Haystack Enterprise Platform" to https://www.deepset.ai/products-and-services/haystack-enterprise-platform in the generator script itself (matching how it's linked elsewhere in the docs, e.g. `intro.mdx`, `development/deployment.mdx`), and regenerated the current `.mdx` to match.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('scripts/generate_platform_components_table.py').read())"` — script parses
- [x] Confirmed generated line matches the hand-verified `.mdx` output
- [x] `hatch run fmt` pre-commit hooks passed (ruff, codespell, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)