### PR TITLE
docs: fix top 404s (legacy URL scheme + renamed reference API pages)

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -256,6 +256,22 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             from: '/docs/function-calling',
             to: '/docs/tool',
           },
+          {
+            from: '/docs/fastembedcolbertranker',
+            to: '/docs/fastembedlateinteractionranker',
+          },
+          {
+            from: '/docs/sentencewindowretrieval',
+            to: '/docs/sentencewindowretriever',
+          },
+          {
+            from: '/docs/pipeline-templates',
+            to: '/docs/pipelines',
+          },
+          {
+            from: '/docs/external-integrations-converters',
+            to: '/docs/converters',
+          },
         ],
       },
     ],

--- a/docs-website/vercel.json
+++ b/docs-website/vercel.json
@@ -12,6 +12,11 @@
       "permanent": true
     },
     {
+      "source": "/docs/api/:path*",
+      "destination": "/reference/",
+      "permanent": true
+    },
+    {
       "source": "/reference/category/experiments-api",
       "destination": "/reference/",
       "permanent": true

--- a/docs-website/vercel.json
+++ b/docs-website/vercel.json
@@ -118,17 +118,17 @@
     },
     {
       "source": "/reference/audio-api",
-      "destination": "/reference/",
+      "destination": "/docs/audio",
       "permanent": true
     },
     {
       "source": "/reference/readers-api",
-      "destination": "/reference/",
+      "destination": "/docs/readers",
       "permanent": true
     },
     {
       "source": "/reference/reader-api",
-      "destination": "/reference/",
+      "destination": "/docs/readers",
       "permanent": true
     },
     {
@@ -173,17 +173,17 @@
     },
     {
       "source": "/reference/experimental-generators-api",
-      "destination": "/reference/",
+      "destination": "/reference/generators-api",
       "permanent": true
     },
     {
       "source": "/reference/experimental-preprocessors-api",
-      "destination": "/reference/",
+      "destination": "/reference/preprocessors-api",
       "permanent": true
     },
     {
       "source": "/reference/experimental-retrievers-api",
-      "destination": "/reference/",
+      "destination": "/reference/retrievers-api",
       "permanent": true
     },
     {
@@ -193,7 +193,7 @@
     },
     {
       "source": "/reference/experimental-writers-api",
-      "destination": "/reference/",
+      "destination": "/reference/document-writers-api",
       "permanent": true
     },
     {

--- a/docs-website/vercel.json
+++ b/docs-website/vercel.json
@@ -133,7 +133,7 @@
     },
     {
       "source": "/reference/experimental-supercomponents-api",
-      "destination": "/reference/",
+      "destination": "/docs/supercomponents",
       "permanent": true
     },
     {

--- a/docs-website/vercel.json
+++ b/docs-website/vercel.json
@@ -17,6 +17,141 @@
       "permanent": true
     },
     {
+      "source": "/v:ver/docs/:slug*",
+      "destination": "/docs/:slug*",
+      "permanent": true
+    },
+    {
+      "source": "/v:ver/reference/:slug*",
+      "destination": "/reference/:slug*",
+      "permanent": true
+    },
+    {
+      "source": "/v:ver/edit/:slug*",
+      "destination": "/docs/:slug*",
+      "permanent": true
+    },
+    {
+      "source": "/edit/:slug*",
+      "destination": "/docs/:slug*",
+      "permanent": true
+    },
+    {
+      "source": "/docs/:ver-unstable/:slug*",
+      "destination": "/docs/:slug*",
+      "permanent": true
+    },
+    {
+      "source": "/reference/:ver-unstable/:slug*",
+      "destination": "/reference/:slug*",
+      "permanent": true
+    },
+    {
+      "source": "/docs/next/:slug*",
+      "destination": "/docs/:slug*",
+      "permanent": true
+    },
+    {
+      "source": "/reference/next/:slug*",
+      "destination": "/reference/:slug*",
+      "permanent": true
+    },
+    {
+      "source": "/docs/latest/:slug*",
+      "destination": "/docs/:slug*",
+      "permanent": true
+    },
+    {
+      "source": "/reference/agent-api",
+      "destination": "/reference/agents-api",
+      "permanent": true
+    },
+    {
+      "source": "/reference/document-store-api",
+      "destination": "/reference/document-stores-api",
+      "permanent": true
+    },
+    {
+      "source": "/reference/pipelines-api",
+      "destination": "/reference/pipeline-api",
+      "permanent": true
+    },
+    {
+      "source": "/reference/tool-components-api",
+      "destination": "/reference/agents-api",
+      "permanent": true
+    },
+    {
+      "source": "/reference/human-in-the-loop-api",
+      "destination": "/reference/hooks-api",
+      "permanent": true
+    },
+    {
+      "source": "/reference/primitives-api",
+      "destination": "/reference/data-classes-api",
+      "permanent": true
+    },
+    {
+      "source": "/reference/shaper-api",
+      "destination": "/reference/converters-api",
+      "permanent": true
+    },
+    {
+      "source": "/reference/classifiers-api",
+      "destination": "/reference/routers-api",
+      "permanent": true
+    },
+    {
+      "source": "/reference/connectors-api",
+      "destination": "/reference/tools-api",
+      "permanent": true
+    },
+    {
+      "source": "/reference/websearch-api",
+      "destination": "/reference/integrations-api",
+      "permanent": true
+    },
+    {
+      "source": "/reference/integrations",
+      "destination": "/reference/integrations-api",
+      "permanent": true
+    },
+    {
+      "source": "/reference/audio-api",
+      "destination": "/reference/",
+      "permanent": true
+    },
+    {
+      "source": "/reference/readers-api",
+      "destination": "/reference/",
+      "permanent": true
+    },
+    {
+      "source": "/reference/reader-api",
+      "destination": "/reference/",
+      "permanent": true
+    },
+    {
+      "source": "/reference/experimental-supercomponents-api",
+      "destination": "/reference/",
+      "permanent": true
+    },
+    {
+      "source": "/reference/component-api",
+      "destination": "/reference/",
+      "permanent": true
+    },
+    {
+      "source": "/reference/components",
+      "destination": "/reference/",
+      "permanent": true
+    },
+    {
+      "source": "/docs/retrieval-augmented-generation",
+      "destination": "/docs/advanced-rag-techniques",
+      "permanent": true
+    },
+    {
       "source": "/reference/category/experiments-api",
       "destination": "/reference/",
       "permanent": true


### PR DESCRIPTION
## Summary
GA4 showed the 404 page as the site's most-viewed page. Root cause was mostly a legacy pre-Docusaurus URL scheme (`/vX.Y/docs/*`, `/vX.Y/reference/*`, `/vX.Y/edit/*`) plus retired `-unstable`/`next` version-preview segments still hit by old backlinks/bookmarks — not a redirect (static-host 404), so the browser URL stays on the broken link.

- Missing redirects for a few renamed/deleted current doc pages (`fastembedcolbertranker`, `sentencewindowretrieval`, `pipeline-templates`, `external-integrations-converters`) plus a wildcard for the legacy `/docs/api/*` reference structure.
- Wildcard redirects stripping the legacy `/vX.Y/`, `-unstable`, `/next` prefixes onto current `/docs/`/`/reference/` routes.
- Specific reference API renames verified against `pydoc/*.yml` and git history (e.g. `agent-api` → `agents-api`, `human-in-the-loop-api` → `hooks-api` after HITL moved under Hooks, `classifiers-api` → `routers-api` after langdetect components were removed, `experimental-supercomponents-api` → `/docs/supercomponents` since SuperComponent still exists as a concept page). Falls back to `/reference/` where no successor exists (e.g. `audio-api`, after Whisper components were fully removed).

Not fixed here (low value, on purpose): long tail of 1-view legacy Haystack 1.x topic pages with no current equivalent, and a batch of `.mdx`-suffixed hits matching raw repo file paths that look like bot/crawler traffic rather than real users.

## Test plan
- [x] `npm run build` passes (`onBrokenLinks: 'throw'`) after each change
- [x] New redirect regex patterns verified against real logged 404 paths using `path-to-regexp` (the engine Vercel uses)
- [ ] Spot-check a handful of the redirected URLs in a Vercel preview deploy once available