### PR TITLE
fix(evaluators): raise ValueError on empty input in four Document/Answer evaluators

### DIFF
--- a/haystack/components/evaluators/answer_exact_match.py
+++ b/haystack/components/evaluators/answer_exact_match.py
@@ -56,6 +56,9 @@ class AnswerExactMatchEvaluator:
         if not len(ground_truth_answers) == len(predicted_answers):
             raise ValueError("The length of ground_truth_answers and predicted_answers must be the same.")
 
+        if len(ground_truth_answers) == 0:
+            raise ValueError("ground_truth_answers and predicted_answers must be provided.")
+
         matches = []
         for truth, extracted in zip(ground_truth_answers, predicted_answers, strict=True):
             if truth == extracted:

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -112,6 +112,10 @@ class DocumentMAPEvaluator:
             msg = "The length of ground_truth_documents and retrieved_documents must be the same."
             raise ValueError(msg)
 
+        if len(ground_truth_documents) == 0:
+            msg = "ground_truth_documents and retrieved_documents must be provided."
+            raise ValueError(msg)
+
         individual_scores = []
 
         for ground_truth, retrieved in zip(ground_truth_documents, retrieved_documents, strict=True):

--- a/haystack/components/evaluators/document_mrr.py
+++ b/haystack/components/evaluators/document_mrr.py
@@ -110,6 +110,10 @@ class DocumentMRREvaluator:
             msg = "The length of ground_truth_documents and retrieved_documents must be the same."
             raise ValueError(msg)
 
+        if len(ground_truth_documents) == 0:
+            msg = "ground_truth_documents and retrieved_documents must be provided."
+            raise ValueError(msg)
+
         individual_scores = []
 
         for ground_truth, retrieved in zip(ground_truth_documents, retrieved_documents, strict=True):

--- a/haystack/components/evaluators/document_recall.py
+++ b/haystack/components/evaluators/document_recall.py
@@ -176,6 +176,10 @@ class DocumentRecallEvaluator:
             msg = "The length of ground_truth_documents and retrieved_documents must be the same."
             raise ValueError(msg)
 
+        if len(ground_truth_documents) == 0:
+            msg = "ground_truth_documents and retrieved_documents must be provided."
+            raise ValueError(msg)
+
         if self.mode == RecallMode.SINGLE_HIT:
             mode_function = self._recall_single_hit
         elif self.mode == RecallMode.MULTI_HIT:

--- a/test/components/evaluators/test_answer_exact_match.py
+++ b/test/components/evaluators/test_answer_exact_match.py
@@ -71,3 +71,9 @@ def test_run_with_different_lengths():
 
     with pytest.raises(ValueError):
         evaluator.run(ground_truth_answers=["Berlin", "Paris"], predicted_answers=["Berlin"])
+
+
+def test_run_with_empty_input():
+    evaluator = AnswerExactMatchEvaluator()
+    with pytest.raises(ValueError, match="must be provided"):
+        evaluator.run(ground_truth_answers=[], predicted_answers=[])

--- a/test/components/evaluators/test_document_map.py
+++ b/test/components/evaluators/test_document_map.py
@@ -172,3 +172,9 @@ def test_run_with_different_lengths():
             ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
             retrieved_documents=[[Document(content="Berlin")]],
         )
+
+
+def test_run_with_empty_input():
+    evaluator = DocumentMAPEvaluator()
+    with pytest.raises(ValueError, match="must be provided"):
+        evaluator.run(ground_truth_documents=[], retrieved_documents=[])

--- a/test/components/evaluators/test_document_mrr.py
+++ b/test/components/evaluators/test_document_mrr.py
@@ -150,3 +150,9 @@ def test_run_with_different_lengths():
             ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
             retrieved_documents=[[Document(content="Berlin")]],
         )
+
+
+def test_run_with_empty_input():
+    evaluator = DocumentMRREvaluator()
+    with pytest.raises(ValueError, match="must be provided"):
+        evaluator.run(ground_truth_documents=[], retrieved_documents=[])

--- a/test/components/evaluators/test_document_recall.py
+++ b/test/components/evaluators/test_document_recall.py
@@ -321,3 +321,10 @@ class TestDocumentRecallEvaluatorMultiHit:
             retrieved_documents=[[Document(meta={"file_id": "f1"})]],
         )
         assert result == {"individual_scores": [1.0], "score": 1.0}
+
+
+def test_run_with_empty_input():
+    for mode in (RecallMode.SINGLE_HIT, RecallMode.MULTI_HIT):
+        evaluator = DocumentRecallEvaluator(mode=mode)
+        with pytest.raises(ValueError, match="must be provided"):
+            evaluator.run(ground_truth_documents=[], retrieved_documents=[])


### PR DESCRIPTION
## Summary

Closes #12543.

Four of the five `Document*Evaluator`s crash with `ZeroDivisionError` when both input lists are empty because they divide by their length without a prior empty-input guard.

`DocumentNDCGEvaluator` already raises a descriptive `ValueError` for this case (via `_validate_inputs`). This PR aligns the other four evaluators — `DocumentMAPEvaluator`, `DocumentMRREvaluator`, `DocumentRecallEvaluator`, and `AnswerExactMatchEvaluator` — to the same contract, using the same message pattern.

## Changes

Each of the four affected evaluators gains an empty-input guard immediately after the length-equality check:

```python
if len(ground_truth_documents) == 0:
    msg = "ground_truth_documents and retrieved_documents must be provided."
    raise ValueError(msg)
```

`AnswerExactMatchEvaluator` uses its own parameter names (`ground_truth_answers`, `predicted_answers`).

Each evaluator's test file gains one new test case asserting that an empty call raises `ValueError` with the expected message.

## Test plan

- [ ] `test_run_with_empty_input` in `test_document_map.py` — passes
- [ ] `test_run_with_empty_input` in `test_document_mrr.py` — passes
- [ ] `test_run_with_empty_input` in `test_document_recall.py` — passes for both `SINGLE_HIT` and `MULTI_HIT`
- [ ] `test_run_with_empty_input` in `test_answer_exact_match.py` — passes