### PR TITLE
docs: remove duplicate 'a' in ChromaQueryTextRetriever docs

### DIFF
--- a/docs-website/docs/pipeline-components/retrievers/chromaqueryretriever.mdx
+++ b/docs-website/docs/pipeline-components/retrievers/chromaqueryretriever.mdx
@@ -2,12 +2,12 @@
 title: "ChromaQueryTextRetriever"
 id: chromaqueryretriever
 slug: "/chromaqueryretriever"
-description: "This is a a Retriever compatible with the Chroma Document Store."
+description: "This is a Retriever compatible with the Chroma Document Store."
 ---
 
 # ChromaQueryTextRetriever
 
-This is a a Retriever compatible with the Chroma Document Store.
+This is a Retriever compatible with the Chroma Document Store.
 
 <div className="key-value-table">
 


### PR DESCRIPTION
Tiny docs fix: remove duplicate `a` (`a a Retriever` → `a Retriever`) in the ChromaQueryTextRetriever docs (description frontmatter and body).