### PR TITLE
fix: validate runtime top_k in in-memory retrievers

### DIFF
--- a/haystack/components/retrievers/in_memory/bm25_retriever.py
+++ b/haystack/components/retrievers/in_memory/bm25_retriever.py
@@ -141,11 +141,14 @@ class InMemoryBM25Retriever:
             The retrieved documents.
 
         :raises ValueError:
-            If the specified DocumentStore is not found or is not a InMemoryDocumentStore instance.
+            If the specified DocumentStore is not found or is not a InMemoryDocumentStore instance, or if the
+            resolved `top_k` is not greater than 0.
         """
         filters = apply_filter_policy(self.filter_policy, self.filters, filters)
         if top_k is None:
             top_k = self.top_k
+        if top_k <= 0:
+            raise ValueError(f"top_k must be greater than 0. Currently, the top_k is {top_k}")
         if scale_score is None:
             scale_score = self.scale_score
 
@@ -176,11 +179,14 @@ class InMemoryBM25Retriever:
             The retrieved documents.
 
         :raises ValueError:
-            If the specified DocumentStore is not found or is not a InMemoryDocumentStore instance.
+            If the specified DocumentStore is not found or is not a InMemoryDocumentStore instance, or if the
+            resolved `top_k` is not greater than 0.
         """
         filters = apply_filter_policy(self.filter_policy, self.filters, filters)
         if top_k is None:
             top_k = self.top_k
+        if top_k <= 0:
+            raise ValueError(f"top_k must be greater than 0. Currently, the top_k is {top_k}")
         if scale_score is None:
             scale_score = self.scale_score
 

--- a/haystack/components/retrievers/in_memory/embedding_retriever.py
+++ b/haystack/components/retrievers/in_memory/embedding_retriever.py
@@ -161,11 +161,14 @@ class InMemoryEmbeddingRetriever:
             The retrieved documents.
 
         :raises ValueError:
-            If the specified DocumentStore is not found or is not an InMemoryDocumentStore instance.
+            If the specified DocumentStore is not found or is not an InMemoryDocumentStore instance, or if the
+            resolved `top_k` is not greater than 0.
         """
         filters = apply_filter_policy(self.filter_policy, self.filters, filters)
         if top_k is None:
             top_k = self.top_k
+        if top_k <= 0:
+            raise ValueError(f"top_k must be greater than 0. Currently, top_k is {top_k}")
         if scale_score is None:
             scale_score = self.scale_score
         if return_embedding is None:
@@ -209,11 +212,14 @@ class InMemoryEmbeddingRetriever:
             The retrieved documents.
 
         :raises ValueError:
-            If the specified DocumentStore is not found or is not an InMemoryDocumentStore instance.
+            If the specified DocumentStore is not found or is not an InMemoryDocumentStore instance, or if the
+            resolved `top_k` is not greater than 0.
         """
         filters = apply_filter_policy(self.filter_policy, self.filters, filters)
         if top_k is None:
             top_k = self.top_k
+        if top_k <= 0:
+            raise ValueError(f"top_k must be greater than 0. Currently, top_k is {top_k}")
         if scale_score is None:
             scale_score = self.scale_score
         if return_embedding is None:

--- a/releasenotes/notes/in-memory-retrievers-runtime-top-k-9d61b6f62f0601d0.yaml
+++ b/releasenotes/notes/in-memory-retrievers-runtime-top-k-9d61b6f62f0601d0.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    ``InMemoryBM25Retriever`` and ``InMemoryEmbeddingRetriever`` now raise a ``ValueError`` when the resolved
+    ``top_k`` is not greater than 0 in ``run`` and ``run_async``. Previously a negative ``top_k`` passed at run time
+    was forwarded to the document store, where it was used as a negative slice and silently returned fewer documents
+    instead of raising an error. This makes the in-memory retrievers consistent with ``DocumentJoiner``,
+    ``AnswerJoiner``, ``LostInTheMiddleRanker``, ``MetaFieldRanker`` and ``LLMRanker``, which already validate
+    ``top_k`` at run time.

--- a/test/components/retrievers/test_in_memory_bm25_retriever.py
+++ b/test/components/retrievers/test_in_memory_bm25_retriever.py
@@ -42,6 +42,29 @@ class TestMemoryBM25Retriever:
         with pytest.raises(ValueError):
             InMemoryBM25Retriever(in_memory_doc_store, top_k=-2)
 
+    @pytest.mark.parametrize("top_k", [-1, -3, 0])
+    def test_run_with_invalid_top_k_parameter(self, in_memory_doc_store, mock_docs, top_k):
+        # Regression: a negative runtime top_k was passed straight to the document store, which used it as a
+        # negative slice and silently returned fewer documents instead of raising.
+        in_memory_doc_store.write_documents(mock_docs)
+        retriever = InMemoryBM25Retriever(in_memory_doc_store)
+        with pytest.raises(ValueError, match="top_k must be greater than 0"):
+            retriever.run(query="Java", top_k=top_k)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("top_k", [-1, 0])
+    async def test_run_async_with_invalid_top_k_parameter(self, in_memory_doc_store, mock_docs, top_k):
+        in_memory_doc_store.write_documents(mock_docs)
+        retriever = InMemoryBM25Retriever(in_memory_doc_store)
+        with pytest.raises(ValueError, match="top_k must be greater than 0"):
+            await retriever.run_async(query="Java", top_k=top_k)
+
+    def test_run_with_valid_top_k_returns_that_many_documents(self, in_memory_doc_store, mock_docs):
+        in_memory_doc_store.write_documents(mock_docs)
+        retriever = InMemoryBM25Retriever(in_memory_doc_store)
+        result = retriever.run(query="popular", top_k=3)
+        assert len(result["documents"]) == 3
+
     def test_to_dict(self):
         MyFakeStore = document_store_class("MyFakeStore", bases=(InMemoryDocumentStore,))
         document_store = MyFakeStore()

--- a/test/components/retrievers/test_in_memory_embedding_retriever.py
+++ b/test/components/retrievers/test_in_memory_embedding_retriever.py
@@ -33,6 +33,36 @@ class TestMemoryEmbeddingRetriever:
         with pytest.raises(ValueError):
             InMemoryEmbeddingRetriever(in_memory_doc_store, top_k=-2)
 
+    @pytest.mark.parametrize("top_k", [-1, -3, 0])
+    def test_run_with_invalid_top_k_parameter(self, top_k):
+        # Regression: a negative runtime top_k was passed straight to the document store, which used it as a
+        # negative slice and silently returned fewer documents instead of raising.
+        ds = InMemoryDocumentStore(embedding_similarity_function="cosine")
+        ds.write_documents(
+            [
+                Document(content="my document", embedding=[0.1, 0.2, 0.3, 0.4]),
+                Document(content="another document", embedding=[1.0, 1.0, 1.0, 1.0]),
+                Document(content="third document", embedding=[0.5, 0.7, 0.5, 0.7]),
+            ]
+        )
+        retriever = InMemoryEmbeddingRetriever(ds)
+        with pytest.raises(ValueError, match="top_k must be greater than 0"):
+            retriever.run(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=top_k)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("top_k", [-1, 0])
+    async def test_run_async_with_invalid_top_k_parameter(self, top_k):
+        ds = InMemoryDocumentStore(embedding_similarity_function="cosine")
+        ds.write_documents(
+            [
+                Document(content="my document", embedding=[0.1, 0.2, 0.3, 0.4]),
+                Document(content="another document", embedding=[1.0, 1.0, 1.0, 1.0]),
+            ]
+        )
+        retriever = InMemoryEmbeddingRetriever(ds)
+        with pytest.raises(ValueError, match="top_k must be greater than 0"):
+            await retriever.run_async(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=top_k)
+
     def test_to_dict(self):
         MyFakeStore = document_store_class("MyFakeStore", bases=(InMemoryDocumentStore,))
         document_store = MyFakeStore()


### PR DESCRIPTION
### Related Issues

- No direct issue. This extends the runtime `top_k` validation pattern established by #12262 (`MetaFieldRanker`) and #11743 (`HuggingFaceTEIRanker`).

### Proposed Changes:

`InMemoryBM25Retriever.run()` / `run_async()` and `InMemoryEmbeddingRetriever.run()` / `run_async()` only did `if top_k is None: top_k = self.top_k` before forwarding the value to the document store. A negative `top_k` therefore reached `sorted(...)[:top_k]` inside `InMemoryDocumentStore`, where Python's negative slicing silently returned *fewer* documents instead of raising:

```python
InMemoryBM25Retriever(ds).run(query="alpha", top_k=-1)   # returned 4 of 5 documents
InMemoryBM25Retriever(ds).run(query="alpha", top_k=-3)   # returned 2 of 5 documents
InMemoryEmbeddingRetriever(ds).run(query_embedding=..., top_k=-1)   # returned 4 of 5 documents
```

Both components already validate `top_k > 0` in `__init__`, so the runtime parameter was the only unguarded entry point — an init/runtime inconsistency that silently produced wrong result counts rather than an error.

The fix adds the same guard immediately after the runtime value is resolved, reusing the message already used by both constructors, and updates the `:raises ValueError:` docstrings.

These two retrievers were the only components in the library missing this guard. Of the eight components that accept a `top_k` parameter in both `__init__` and `run`, `DocumentJoiner`, `AnswerJoiner`, `LostInTheMiddleRanker`, `MetaFieldRanker` and `LLMRanker` already raise at runtime; only these two retrievers did not.

### How did you test it?

New unit tests in `test/components/retrievers/test_in_memory_bm25_retriever.py` and `test/components/retrievers/test_in_memory_embedding_retriever.py`:

- `run` with `top_k` of `-1`, `-3` and `0` raises `ValueError` matching `top_k must be greater than 0`
- `run_async` with `top_k` of `-1` and `0` raises the same error
- a positive `top_k` still returns exactly that many documents

Commands and results:

- `pytest test/components/retrievers/test_in_memory_bm25_retriever.py test/components/retrievers/test_in_memory_embedding_retriever.py test/components/joiners/test_document_joiner.py test/components/retrievers/test_multi_retriever.py -q` → 146 passed, 6 skipped
- `pytest test/components/joiners/ test/components/retrievers/ test/components/rankers/ -q` → 443 passed, 14 skipped
- Reverting only the source change makes the new runtime tests fail, confirming they are real regression tests
- `ruff check` and `ruff format --check` on the touched files
- `python scripts/release_note_backticks.py --check releasenotes/notes/in-memory-retrievers-runtime-top-k-9d61b6f62f0601d0.yaml`

### Notes for the reviewer

- `top_k=0` now raises for these two retrievers, consistent with their own `__init__` validation and with `LostInTheMiddleRanker`, `MetaFieldRanker` and `LLMRanker`. `DocumentJoiner` and `AnswerJoiner` keep their documented `top_k=0` → empty-list behavior; this PR does not touch them.
- Same environment caveat as #12262: the full Hatch environment could not resolve dependencies locally, so the suites above were run in a plain venv with Haystack's core dependencies installed. A full `pytest test/` run reports 241 failures in both the patched and unpatched trees (identical lists), all of them `ModuleNotFoundError` for optional dependency extras that are not installed here.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes. — N/A, there is no related issue.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

---