### PR TITLE
fix: reject negative weights in DocumentJoiner

### DIFF
--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -107,6 +107,7 @@ class DocumentJoiner:
             This parameter is ignored for
             `concatenate` or `distribution_based_rank_fusion` join modes.
             Weight for each list of documents must match the number of inputs.
+            Each weight must be a non-negative number.
         :param top_k:
             The maximum number of documents to return. Must be `None` or greater than 0.
         :param sort_by_score:
@@ -114,7 +115,8 @@ class DocumentJoiner:
             If a document has no score, it is handled as if its score is -infinity.
 
         :raises ValueError:
-            If `top_k` is not `None` and is less than or equal to 0.
+            If `top_k` is not `None` and is less than or equal to 0,
+            or if any value in `weights` is negative.
         """
         if top_k is not None and top_k <= 0:
             raise ValueError("top_k must be greater than 0.")
@@ -129,6 +131,8 @@ class DocumentJoiner:
         self.join_mode_function = join_mode_functions[join_mode]
         self.join_mode = join_mode
         if weights:
+            if any(weight < 0 for weight in weights):
+                raise ValueError("The provided `weights` must not be negative.")
             weight_sum = sum(weights)
             if weight_sum == 0:
                 raise ValueError("The provided `weights` must not sum to zero.")

--- a/releasenotes/notes/document-joiner-negative-weights-9c308484bbfa0f7f.yaml
+++ b/releasenotes/notes/document-joiner-negative-weights-9c308484bbfa0f7f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    ``DocumentJoiner`` now raises a ``ValueError`` when any value in ``weights`` is negative. Previously negative
+    weights were normalized by their -- possibly negative -- sum, which flipped their sign and could produce
+    negative document scores in ``merge`` mode. For example ``weights=[1, -2]`` was normalized to ``[-1.0, 2.0]``.
+    The existing error for weights that sum to zero is unchanged.

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -31,6 +31,17 @@ class TestDocumentJoiner:
         with pytest.raises(ValueError, match="must not sum to zero"):
             DocumentJoiner(join_mode="merge", weights=[0.0, 0.0, 0.0])
 
+    @pytest.mark.parametrize("weights", [[1.0, -2.0], [-1.0, -1.0], [0.5, -0.1]])
+    def test_init_with_negative_weights_raises(self, weights):
+        # Regression: negative weights were normalized by their (possibly negative) sum, which flipped their sign
+        # and produced negative document scores in merge mode.
+        with pytest.raises(ValueError, match="must not be negative"):
+            DocumentJoiner(join_mode="merge", weights=weights)
+
+    def test_init_with_zero_weight_is_allowed(self):
+        joiner = DocumentJoiner(join_mode="merge", weights=[0.0, 1.0])
+        assert joiner.weights == [0.0, 1.0]
+
     def test_init_with_top_k_none_is_valid(self):
         joiner = DocumentJoiner(top_k=None)
         assert joiner.top_k is None


### PR DESCRIPTION
### Related Issues

- No direct issue. #11629 already fixed the zero-sum case of the same validation; this covers the remaining invalid input.

### Proposed Changes:

`DocumentJoiner.__init__` only rejected weights that sum to zero:

```python
if weights:
    weight_sum = sum(weights)
    if weight_sum == 0:
        raise ValueError("The provided `weights` must not sum to zero.")
    self.weights = [float(i) / weight_sum for i in weights]
```

Negative weights passed that check whenever their sum was non-zero, and because they are then divided by that (possibly negative) sum, the sign flipped. In `merge` mode this produced negative document scores:

```python
joiner = DocumentJoiner(join_mode="merge", weights=[1, -2], sort_by_score=False)
joiner.weights                                   # [-1.0, 2.0]
{d.id: d.score for d in joiner.run([A, B])["documents"]}
# {'b1': 2.0, 'a1': -1.0}
```

`weights=[-1, -1]` is the other half of the problem: the user asked for two negative weights and silently got `[0.5, 0.5]`.

The docstring describes `weights` as assigning *importance* to each list of documents, which has no meaning for a negative value — and the sign flip is not something a caller can observe or reason about. The fix rejects negative entries:

```python
if weights:
    if any(weight < 0 for weight in weights):
        raise ValueError("The provided `weights` must not be negative.")
    ...
```

The negativity check runs before the zero-sum check so the existing zero-sum error (and its test) is unchanged: `weights=[0.0, 0.0, 0.0]` still reports `must not sum to zero`. The `:param weights:` and `:raises ValueError:` docstrings were updated.

### How did you test it?

New unit tests in `test/components/joiners/test_document_joiner.py`:

- `weights` of `[1.0, -2.0]`, `[-1.0, -1.0]` and `[0.5, -0.1]` raise `ValueError` matching `must not be negative`
- `weights=[0.0, 1.0]` is still accepted and stored as-is, so zero weights and mixed zero/non-zero weights keep working
- the existing `test_init_with_zero_sum_weights_raises` still passes unchanged

Commands and results:

- `pytest test/components/joiners/test_document_joiner.py -q` → all pass
- `pytest test/components/joiners/ test/components/retrievers/ test/components/rankers/ -q` → 443 passed, 14 skipped
- A manual run confirms `DocumentJoiner(join_mode="merge", weights=[0.4, 0.6]).run([A, B])` still yields `{'a1': 0.4, 'b1': 0.6}`
- `ruff check` and `ruff format --check` on the touched files
- `python scripts/release_note_backticks.py --check releasenotes/notes/document-joiner-negative-weights-9c308484bbfa0f7f.yaml`

### Notes for the reviewer

- This is validation only; the normalization formula and all join modes are untouched.
- I deliberately kept zero weights valid. Only the sign is rejected, which keeps the change minimal and avoids touching the legitimate "weight this source at 0" case.
- Same environment caveat as #12262: suites were run in a plain venv with Haystack's core dependencies, because the full Hatch environment could not resolve dependencies locally.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes. — N/A, there is no related issue.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.

---