### PR TITLE
fix: validate top_k in MultiRetriever

### DIFF
--- a/haystack/components/retrievers/multi_retriever.py
+++ b/haystack/components/retrievers/multi_retriever.py
@@ -109,7 +109,14 @@ class MultiRetriever:
             How to merge results from multiple retrievers. Available modes:
             - `concatenate`: Combines all results into a single list and deduplicates.
             - `reciprocal_rank_fusion`: Deduplicates and assigns scores based on reciprocal rank fusion.
+
+        :raises ValueError:
+            If `top_k` or `top_k_per_retriever` is not `None` and is less than or equal to 0.
         """
+        if top_k is not None and top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {top_k}")
+        if top_k_per_retriever is not None and top_k_per_retriever <= 0:
+            raise ValueError(f"top_k_per_retriever must be > 0, but got {top_k_per_retriever}")
         self.retrievers = retrievers
         self.filters = filters
         self.top_k_per_retriever = top_k_per_retriever
@@ -226,7 +233,8 @@ class MultiRetriever:
                 - "documents": A deduplicated list of retrieved documents.
 
         :raises ValueError:
-            If any name in `active_retrievers` does not match a retriever name.
+            If any name in `active_retrievers` does not match a retriever name,
+            or if the resolved `top_k`/`top_k_per_retriever` is less than or equal to 0.
         """
         self.warm_up()
 
@@ -234,6 +242,10 @@ class MultiRetriever:
             top_k_per_retriever if top_k_per_retriever is not None else self.top_k_per_retriever
         )
         resolved_top_k = top_k if top_k is not None else self.top_k
+        if resolved_top_k is not None and resolved_top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {resolved_top_k}")
+        if resolved_top_k_per_retriever is not None and resolved_top_k_per_retriever <= 0:
+            raise ValueError(f"top_k_per_retriever must be > 0, but got {resolved_top_k_per_retriever}")
         resolved_filters = filters if filters is not None else self.filters
 
         retrievers_to_run = self._resolve_retrievers(active_retrievers)
@@ -295,7 +307,8 @@ class MultiRetriever:
                 - "documents": A deduplicated list of retrieved documents.
 
         :raises ValueError:
-            If any name in `active_retrievers` does not match a retriever name.
+            If any name in `active_retrievers` does not match a retriever name,
+            or if the resolved `top_k`/`top_k_per_retriever` is less than or equal to 0.
         """
         await self.warm_up_async()
 
@@ -303,6 +316,10 @@ class MultiRetriever:
             top_k_per_retriever if top_k_per_retriever is not None else self.top_k_per_retriever
         )
         resolved_top_k = top_k if top_k is not None else self.top_k
+        if resolved_top_k is not None and resolved_top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {resolved_top_k}")
+        if resolved_top_k_per_retriever is not None and resolved_top_k_per_retriever <= 0:
+            raise ValueError(f"top_k_per_retriever must be > 0, but got {resolved_top_k_per_retriever}")
         resolved_filters = filters if filters is not None else self.filters
 
         retrievers_to_run = self._resolve_retrievers(active_retrievers)

--- a/releasenotes/notes/multi-retriever-top-k-73729fbab0e4259e.yaml
+++ b/releasenotes/notes/multi-retriever-top-k-73729fbab0e4259e.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    ``MultiRetriever`` now validates ``top_k`` and ``top_k_per_retriever``, raising a ``ValueError`` when they are
+    not greater than 0. Previously a negative value was applied as a negative slice on the merged results, which
+    silently dropped the last documents instead of raising an error.

--- a/test/components/retrievers/test_multi_retriever.py
+++ b/test/components/retrievers/test_multi_retriever.py
@@ -221,6 +221,32 @@ class TestMultiRetriever:
         retriever.run(query="energy", top_k=5)
         assert received.get("top_k") is None
 
+    @pytest.mark.parametrize("top_k", [-1, -3, 0])
+    def test_init_with_invalid_top_k_raises(self, top_k):
+        retrievers: dict[str, TextRetriever] = {"mock": MockRetriever()}
+        with pytest.raises(ValueError, match="top_k must be > 0"):
+            MultiRetriever(retrievers=retrievers, top_k=top_k)
+
+    @pytest.mark.parametrize("top_k_per_retriever", [-1, 0])
+    def test_init_with_invalid_top_k_per_retriever_raises(self, top_k_per_retriever):
+        retrievers: dict[str, TextRetriever] = {"mock": MockRetriever()}
+        with pytest.raises(ValueError, match="top_k_per_retriever must be > 0"):
+            MultiRetriever(retrievers=retrievers, top_k_per_retriever=top_k_per_retriever)
+
+    @pytest.mark.parametrize("top_k", [-1, -2, 0])
+    def test_run_with_invalid_top_k_raises(self, sample_documents, top_k):
+        # Regression: a negative top_k was used as a negative slice on the merged list, silently dropping the
+        # last documents instead of raising.
+        retriever = MultiRetriever(retrievers={"a": MockRetriever(documents=sample_documents)})
+        with pytest.raises(ValueError, match="top_k must be > 0"):
+            retriever.run(query="energy", top_k=top_k)
+
+    @pytest.mark.parametrize("top_k_per_retriever", [-1, 0])
+    def test_run_with_invalid_top_k_per_retriever_raises(self, sample_documents, top_k_per_retriever):
+        retriever = MultiRetriever(retrievers={"a": MockRetriever(documents=sample_documents)})
+        with pytest.raises(ValueError, match="top_k_per_retriever must be > 0"):
+            retriever.run(query="energy", top_k_per_retriever=top_k_per_retriever)
+
     def test_run_top_k_truncates_merged_results(self, sample_documents):
         retriever = MultiRetriever(
             retrievers={
@@ -536,6 +562,20 @@ class TestMultiRetrieverAsync:
         result = await retriever.run_async(query="energy", top_k=2)
         assert len(result["documents"]) == 2
         assert all(doc.score is not None for doc in result["documents"])
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("top_k", [-1, 0])
+    async def test_run_async_with_invalid_top_k_raises(self, sample_documents, top_k):
+        retriever = MultiRetriever(retrievers={"a": MockRetriever(documents=sample_documents)})
+        with pytest.raises(ValueError, match="top_k must be > 0"):
+            await retriever.run_async(query="energy", top_k=top_k)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("top_k_per_retriever", [-1, 0])
+    async def test_run_async_with_invalid_top_k_per_retriever_raises(self, sample_documents, top_k_per_retriever):
+        retriever = MultiRetriever(retrievers={"a": MockRetriever(documents=sample_documents)})
+        with pytest.raises(ValueError, match="top_k_per_retriever must be > 0"):
+            await retriever.run_async(query="energy", top_k_per_retriever=top_k_per_retriever)
 
     @pytest.mark.asyncio
     async def test_run_async_with_active_retrievers(self, sample_documents):


### PR DESCRIPTION
### Related Issues

- No direct issue. Follow-up to the runtime `top_k` validation work in #12262 and #11743.

### Proposed Changes:

`MultiRetriever` never validated `top_k` or `top_k_per_retriever` — not in `__init__`, not in `run`/`run_async`. Both values end up in a slice of the merged result list (`_merge_results` does `merged[:top_k]`), so a negative value silently dropped documents from the end instead of raising:

```python
MultiRetriever(retrievers={"a": dummy}).run(query="q", top_k=-1)                  # 5 docs -> 4
MultiRetriever(retrievers={"a": dummy}).run(query="q", top_k=-2)                  # 5 docs -> 3
MultiRetriever(retrievers={"a": dummy}).run(query="q", top_k_per_retriever=-1)     # 5 docs -> 4
```

`top_k_per_retriever` is forwarded to each sub-retriever as its `top_k` argument, which makes the missing validation visibly inconsistent: the in-memory retrievers reject `top_k <= 0` in their own constructors, so `MultiRetriever(..., top_k_per_retriever=0)` previously returned an empty result, and after this change the same value is rejected up front with a message that names the offending parameter instead of surfacing an error from inside a worker thread.

The fix validates both parameters in `__init__` and again after the runtime values are resolved in `run` and `run_async`, using the wording already used by `LostInTheMiddleRanker`, `MetaFieldRanker` and `LLMRanker` (`top_k must be > 0, but got {top_k}`).

### How did you test it?

New unit tests in `test/components/retrievers/test_multi_retriever.py`, mirrored across `TestMultiRetriever` and `TestMultiRetrieverAsync`:

- `__init__` rejects `top_k` of `-1`, `-3`, `0` and `top_k_per_retriever` of `-1`, `0`
- `run` and `run_async` reject the same values when passed at runtime
- `top_k=3` still truncates to 3 documents, `top_k=None` still returns everything

Commands and results:

- `pytest test/components/retrievers/test_multi_retriever.py -q` → all pass
- `pytest test/components/joiners/ test/components/retrievers/ test/components/rankers/ -q` → 443 passed, 14 skipped
- Reverting only the source change makes the new tests fail, confirming they are real regression tests
- `ruff check` and `ruff format --check` on the touched files
- `python scripts/release_note_backticks.py --check releasenotes/notes/multi-retriever-top-k-73729fbab0e4259e.yaml`

### Notes for the reviewer

- This is the only behaviour change worth calling out: `top_k=0` and `top_k_per_retriever=0` now raise instead of returning an empty list. I chose this for consistency with every other retriever and ranker in the library, all of which require `top_k > 0`; if you would rather keep `0` as a valid "return nothing" value for `MultiRetriever`, the guard can be narrowed to `< 0` and I am happy to change it.
- The check runs after resolving runtime-over-`__init__` precedence, so the error always reports the value that would actually be used.
- Same environment caveat as #12262: suites were run in a plain venv with Haystack's core dependencies, because the full Hatch environment could not resolve dependencies locally.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
- I have updated the related issue with new insights and changes. — N/A, there is no related issue.
- I have added unit tests and updated the docstrings.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`.
- I have documented my code.
- I have added a release note file, following the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#release-notes).
- I have run [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue.

This PR was fully generated with an AI assistant. I have reviewed the changes and run the relevant tests.