### PR TITLE
fix: don't raise IndexError when a stream emits no chunks

### DIFF
--- a/haystack/components/generators/utils.py
+++ b/haystack/components/generators/utils.py
@@ -183,11 +183,18 @@ def _convert_streaming_chunks_to_chat_message(chunks: list[StreamingChunk]) -> C
             usage = chunk_usage
             break
 
+    # A provider can close a stream without emitting a single chunk. Everything above already
+    # handles that (joining an empty list, iterating an empty list, the `if finish_reasons else`
+    # guard), so only these two positional reads would raise -- turning an empty completion into
+    # an IndexError several frames away from the provider that produced it.
+    first_chunk_meta = chunks[0].meta if chunks else {}
+    last_chunk_meta = chunks[-1].meta if chunks else {}
+
     meta = {
-        "model": chunks[-1].meta.get("model"),
+        "model": last_chunk_meta.get("model"),
         "index": 0,
         "finish_reason": finish_reason,
-        "completion_start_time": chunks[0].meta.get("received_at"),  # first chunk received
+        "completion_start_time": first_chunk_meta.get("received_at"),  # first chunk received
         "usage": usage,
     }
 

--- a/releasenotes/notes/streaming-chunks-empty-list-1d3d4167c608fdc5.yaml
+++ b/releasenotes/notes/streaming-chunks-empty-list-1d3d4167c608fdc5.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fix an `IndexError: list index out of range` when a chat generator's stream completes
+    without emitting any chunks. `_convert_streaming_chunks_to_chat_message` already handled
+    an empty chunk list everywhere except the two positional reads that populate `meta`
+    (`model` and `completion_start_time`), so an empty completion surfaced as an `IndexError`
+    far from the provider that produced it. It now returns an assistant message with empty
+    content and `None` metadata instead.

--- a/test/components/generators/test_utils.py
+++ b/test/components/generators/test_utils.py
@@ -858,3 +858,23 @@ def test_normalize_messages():
 
     with pytest.raises(TypeError):
         _normalize_messages(123)  # type: ignore[arg-type]
+
+
+def test_convert_streaming_chunks_to_chat_message_no_chunks():
+    """
+    Test that an empty chunk list yields an empty assistant message instead of raising.
+
+    A provider can close a stream without emitting a single chunk -- Amazon Bedrock's
+    `converse_stream` does it for an empty completion -- and the positional reads that build
+    `meta` used to turn that into an `IndexError: list index out of range`, several frames away
+    from the provider that produced it.
+    """
+    message = _convert_streaming_chunks_to_chat_message(chunks=[])
+
+    assert message.text is None
+    assert message.tool_calls == []
+    assert message.reasoning is None
+    assert message.meta["model"] is None
+    assert message.meta["finish_reason"] is None
+    assert message.meta["completion_start_time"] is None
+    assert message.meta["usage"] is None


### PR DESCRIPTION
### Related Issues

Found while debugging a CI failure in deepset Cloud's system tests, where a Bedrock-backed pipeline failed on every request with an error that pointed nowhere useful:

```
Component name: 'chat_generator'
Component type: 'AmazonBedrockChatGenerator'
Error: list index out of range
```

### Proposed Changes

`_convert_streaming_chunks_to_chat_message` handles an empty `chunks` list everywhere except the two positional reads that build `meta`:

```python
text = "".join([chunk.content for chunk in chunks])                  # fine on []
reasoning_parts = [... for chunk in chunks if chunk.reasoning]       # fine on []
finish_reason = finish_reasons[-1] if finish_reasons else None       # guarded
usage = None                                                         # guarded
...
meta = {
    "model": chunks[-1].meta.get("model"),                           # IndexError
    "completion_start_time": chunks[0].meta.get("received_at"),      # IndexError
}
```

The `finish_reason` and `usage` lookups are already written for the empty case, so supporting it is clearly the intent — these two reads were just missed.

This matters because a provider can close a stream without emitting a single chunk. Amazon Bedrock's `converse_stream` does exactly that for an empty completion, and `amazon-bedrock-haystack`'s `_convert_chunks_to_messages` calls straight into this helper (it even guards its own `chunks[-1]` access with `if chunks else None` on the very next line). The result is an `IndexError` several frames below the provider that produced it, with nothing in the message about the empty completion that actually caused it.

The change reads the first and last chunk's meta through the same `if chunks else` guard the rest of the function uses, so an empty stream produces an assistant message with empty content and `None` metadata instead of raising.

### How did you test it?

Added `test_convert_streaming_chunks_to_chat_message_no_chunks` to `test/components/generators/test_utils.py`.

Verified it is a real regression test, not just a passing assertion — on unpatched `main` it reproduces the production failure exactly:

```
E       IndexError: list index out of range
haystack/components/generators/utils.py:187: IndexError
============ 1 failed, 4 passed, 11 deselected ============
```

and with the change:

```
================= 5 passed, 11 deselected =================
```

### Notes for the reviewer

One judgement call worth flagging: this returns an empty assistant message rather than raising a descriptive error. I went with the empty message because it matches what the rest of the function already does with no chunks (empty text, `None` finish_reason, `None` usage) and keeps the helper total. If you'd rather an empty stream be an explicit, named error at this boundary, that's a reasonable alternative and I'm happy to switch it — it would be a behaviour change for any caller currently relying on the empty-ish path, which this is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
